### PR TITLE
feat(helius): add the Helius Rings shielded wallet module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,9 @@ ASSET_PROFILES_ENABLED=true
 # reconcilers, and the dashboard workspace. Requires
 # SPC_CREDENTIAL_ENCRYPTION_KEY below when enabled.
 PRIVATE_CHANNELS_ENABLED=false
+# Helius Rings (opt-in, devnet-only). Gates the shielded-wallet API routes
+# and the dashboard workspace.
+HELIUS_RINGS_ENABLED=false
 SDP_FLAG_ASSET_PROFILES=true
 PRIVY_BYOK_ENABLED=false
 SELF_HOSTED_STORED_CONNECTION_SETUP_ENABLED=false

--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,8 @@ PRIVATE_CHANNELS_ENABLED=false
 # Helius Rings (opt-in, devnet-only). Gates the shielded-wallet API routes
 # and the dashboard workspace.
 HELIUS_RINGS_ENABLED=false
+# Rings gateway selector; only "http" activates the live adapter (Track B).
+HELIUS_RINGS_ADAPTER=none
 SDP_FLAG_ASSET_PROFILES=true
 PRIVY_BYOK_ENABLED=false
 SELF_HOSTED_STORED_CONNECTION_SETUP_ENABLED=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,12 @@ jobs:
       - name: Scripts tests
         run: pnpm test:scripts
 
+      # Runs here rather than in the Module Boundaries job because it parses
+      # TypeScript with the compiler's own parser, and that job installs no
+      # dependencies.
+      - name: Check SecretRef serialization
+        run: pnpm check:secretref-serialization
+
   build_api:
     name: Build API
     runs-on: ubuntu-latest

--- a/apps/sdp-api/Dockerfile
+++ b/apps/sdp-api/Dockerfile
@@ -19,6 +19,7 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json tsconfig.json ./
 COPY apps/sdp-api/package.json ./apps/sdp-api/
 COPY packages/sdp-types/package.json ./packages/sdp-types/
 COPY packages/sdp-env-config/package.json ./packages/sdp-env-config/
+COPY packages/sdp-helius-rings/package.json ./packages/sdp-helius-rings/
 COPY packages/sdp-earn/package.json ./packages/sdp-earn/
 COPY packages/sdp-payments/package.json ./packages/sdp-payments/
 COPY packages/sdp-rpc/package.json ./packages/sdp-rpc/
@@ -43,6 +44,7 @@ COPY --from=deps /repo /repo
 COPY apps/sdp-api ./apps/sdp-api
 COPY packages/sdp-types ./packages/sdp-types
 COPY packages/sdp-env-config ./packages/sdp-env-config
+COPY packages/sdp-helius-rings ./packages/sdp-helius-rings
 COPY packages/sdp-earn ./packages/sdp-earn
 COPY packages/sdp-payments ./packages/sdp-payments
 COPY packages/sdp-rpc ./packages/sdp-rpc

--- a/apps/sdp-api/Dockerfile.dockerignore
+++ b/apps/sdp-api/Dockerfile.dockerignore
@@ -19,6 +19,7 @@ packages/*
 !packages/sdp-types
 !packages/sdp-env-config
 !packages/sdp-earn
+!packages/sdp-helius-rings
 !packages/sdp-rpc
 !packages/sdp-custody
 !packages/sdp-solana

--- a/apps/sdp-api/package.json
+++ b/apps/sdp-api/package.json
@@ -50,6 +50,7 @@
     "@sdp/custody": "workspace:*",
     "@sdp/earn": "workspace:*",
     "@sdp/env-config": "workspace:*",
+    "@sdp/helius-rings": "workspace:*",
     "@sdp/issuance": "workspace:*",
     "@sdp/kamino": "workspace:*",
     "@sdp/payments": "workspace:*",

--- a/apps/sdp-api/src/app.ts
+++ b/apps/sdp-api/src/app.ts
@@ -36,6 +36,7 @@ import wallets from "@/routes/custody";
 import docs from "@/routes/docs";
 import earn from "@/routes/earn";
 import health from "@/routes/health";
+import heliusRings from "@/routes/helius-rings";
 import internalCustody from "@/routes/internal-custody";
 import internalRpc from "@/routes/internal-rpc";
 import issuance from "@/routes/issuance";
@@ -364,6 +365,7 @@ export function createApp(deps: AppDeps): Hono<{ Bindings: Env }> {
   v1.route("/places", places);
   v1.route("/policies", policies);
   v1.route("/private-channels", privateChannels);
+  v1.route("/helius-rings", heliusRings);
   v1.route("/compliance", compliance);
 
   const registeredPluginNames = new Set<string>();

--- a/apps/sdp-api/src/cron/rings-indexing.ts
+++ b/apps/sdp-api/src/cron/rings-indexing.ts
@@ -1,0 +1,35 @@
+/**
+ * Rings indexing-poll entrypoint.
+ *
+ * Mirrors `pending-deposits`: wraps `pollRingsIndexing` with a Sentry cron
+ * monitor when observability is supplied and hands the promise to the
+ * BackgroundRunner. The job itself early-returns unless the rings flag is on
+ * and HELIUS_RINGS_ADAPTER is "http" (the Track B live-gateway selector), so
+ * scheduling it everywhere is free.
+ */
+
+import type { BackgroundRunner } from "@/runtime/background";
+import type { Observability } from "@/runtime/observability";
+import { pollRingsIndexing } from "@/services/jobs/poll-rings-indexing";
+import type { Env } from "@/types/env";
+
+export const RINGS_INDEXING_MONITOR = "sdp-api-poll-rings-indexing";
+export const RINGS_INDEXING_CRON = "* * * * *";
+
+export interface RingsIndexingPollDeps {
+  env: Env;
+  bg: BackgroundRunner;
+  observability?: Observability;
+}
+
+export function runRingsIndexingPoll(deps: RingsIndexingPollDeps): void {
+  const work = () => pollRingsIndexing(deps.env);
+
+  const promise = deps.observability
+    ? deps.observability.withMonitor(RINGS_INDEXING_MONITOR, work, {
+        schedule: { type: "crontab", value: RINGS_INDEXING_CRON },
+      })
+    : Promise.resolve().then(work);
+
+  deps.bg.run(promise);
+}

--- a/apps/sdp-api/src/cron/runner.node.test.ts
+++ b/apps/sdp-api/src/cron/runner.node.test.ts
@@ -17,6 +17,7 @@ import {
   RECURRING_PAYMENTS_COLLECTION_CRON,
   runRecurringPaymentsCollection,
 } from "./recurring-payments";
+import { RINGS_INDEXING_CRON, runRingsIndexingPoll } from "./rings-indexing";
 import { startCron } from "./runner";
 import { runWorkflowExecutions, WORKFLOW_EXECUTIONS_CRON } from "./workflow-executions";
 import {
@@ -88,6 +89,15 @@ vi.mock("./workflow-executions", () => ({
   runWorkflowExecutions: vi.fn(),
 }));
 
+// The rings poll pulls the rings service and through it the Solana signer stack;
+// mocked like the other wrappers. Registered unconditionally (the job itself
+// early-returns unless the rings flag and the http adapter are set), so it is
+// part of every schedule count below.
+vi.mock("./rings-indexing", () => ({
+  RINGS_INDEXING_CRON: "* * * * *",
+  runRingsIndexingPoll: vi.fn(),
+}));
+
 // Pulls in the credential secret store (and through it the custody cipher); mocked for
 // the same reason as the wrappers above.
 vi.mock("./workflow-secret-retirements", () => ({
@@ -116,6 +126,7 @@ describe("startCron", () => {
     vi.mocked(runEarnVaultMovementsReconciliation).mockReset();
     vi.mocked(runPendingTransfersReconciliation).mockReset();
     vi.mocked(runRecurringPaymentsCollection).mockReset();
+    vi.mocked(runRingsIndexingPoll).mockReset();
     vi.mocked(runWorkflowExecutions).mockReset();
     vi.mocked(runWorkflowSecretRetirements).mockReset();
   });
@@ -144,13 +155,14 @@ describe("startCron", () => {
 
   it("schedules a task with PENDING_TRANSFERS_CRON when DISABLE_CRON is unset", () => {
     startCron({ env: {} as Env, bg: makeBg() });
-    expect(scheduleMock).toHaveBeenCalledTimes(6);
+    expect(scheduleMock).toHaveBeenCalledTimes(7);
     expect(scheduleMock.mock.calls[0][0]).toBe(APPROVED_WALLET_OPERATIONS_CRON);
     expect(scheduleMock.mock.calls[1][0]).toBe(PENDING_TRANSFERS_CRON);
     expect(scheduleMock.mock.calls[2][0]).toBe(RECURRING_PAYMENTS_COLLECTION_CRON);
     expect(scheduleMock.mock.calls[3][0]).toBe(WORKFLOW_EXECUTIONS_CRON);
-    expect(scheduleMock.mock.calls[4][0]).toBe(WORKFLOW_SECRET_RETIREMENTS_CRON);
-    expect(scheduleMock.mock.calls[5][0]).toBe(EARN_VAULT_MOVEMENTS_CRON);
+    expect(scheduleMock.mock.calls[4][0]).toBe(RINGS_INDEXING_CRON);
+    expect(scheduleMock.mock.calls[5][0]).toBe(WORKFLOW_SECRET_RETIREMENTS_CRON);
+    expect(scheduleMock.mock.calls[6][0]).toBe(EARN_VAULT_MOVEMENTS_CRON);
   });
 
   it("schedules workflow executions by default, and its tick runs the engine", () => {
@@ -169,7 +181,7 @@ describe("startCron", () => {
   it("omits workflow executions when asset profiles is off", () => {
     startCron({ env: SELF_HOSTED_NO_PROFILES, bg: makeBg() });
 
-    expect(scheduleMock).toHaveBeenCalledTimes(5);
+    expect(scheduleMock).toHaveBeenCalledTimes(6);
     for (const call of scheduleMock.mock.calls) {
       (call[1] as () => void)();
     }
@@ -209,7 +221,7 @@ describe("startCron", () => {
       env: { K_SERVICE: "sdp-api", DISABLE_CRON: "false" } as Env,
       bg: makeBg(),
     });
-    expect(scheduleMock).toHaveBeenCalledTimes(6);
+    expect(scheduleMock).toHaveBeenCalledTimes(7);
     expect(scheduleMock.mock.calls[0][0]).toBe(APPROVED_WALLET_OPERATIONS_CRON);
     expect(scheduleMock.mock.calls[1][0]).toBe(PENDING_TRANSFERS_CRON);
   });
@@ -219,7 +231,7 @@ describe("startCron", () => {
   it("schedules recurring collection unconditionally", () => {
     startCron({ env: {} as Env, bg: makeBg() });
 
-    expect(scheduleMock).toHaveBeenCalledTimes(6);
+    expect(scheduleMock).toHaveBeenCalledTimes(7);
     expect(scheduleMock.mock.calls[2][0]).toBe(RECURRING_PAYMENTS_COLLECTION_CRON);
   });
 
@@ -229,8 +241,8 @@ describe("startCron", () => {
     startCron({ env, bg });
 
     // approved-operation recovery + transfers + recurring + workflow executions +
-    // deposits + withdrawals + retirements + vault movements.
-    expect(scheduleMock).toHaveBeenCalledTimes(8);
+    // deposits + withdrawals + rings poll + retirements + vault movements.
+    expect(scheduleMock).toHaveBeenCalledTimes(9);
 
     // Fire every scheduled tick; the two private-channels reconcilers must run.
     for (const call of scheduleMock.mock.calls) {
@@ -251,7 +263,7 @@ describe("startCron", () => {
   it("schedules when DISABLE_CRON is set to a recognised falsy value ('false' / '0')", () => {
     startCron({ env: { DISABLE_CRON: "false" } as Env, bg: makeBg() });
     startCron({ env: { DISABLE_CRON: "0" } as Env, bg: makeBg() });
-    expect(scheduleMock).toHaveBeenCalledTimes(12);
+    expect(scheduleMock).toHaveBeenCalledTimes(14);
   });
 
   it("throws on an unrecognised DISABLE_CRON value to surface env typos", () => {
@@ -347,7 +359,7 @@ describe("startCron", () => {
     const handle = startCron({ env: {} as Env, bg: makeBg() });
     expect(handle).not.toBeNull();
     await handle?.stop();
-    expect(stopMock).toHaveBeenCalledTimes(6);
+    expect(stopMock).toHaveBeenCalledTimes(7);
   });
 
   it("returned handle.stop() stops every scheduled task", async () => {
@@ -357,6 +369,16 @@ describe("startCron", () => {
     });
     expect(handle).not.toBeNull();
     await handle?.stop();
-    expect(stopMock).toHaveBeenCalledTimes(8);
+    expect(stopMock).toHaveBeenCalledTimes(9);
+  });
+
+  it("tick invokes the rings indexing poll with the supplied deps", () => {
+    const bg = makeBg();
+    const env = {} as Env;
+    const observability = makeObservability();
+    startCron({ env, bg, observability });
+    const tick = scheduleMock.mock.calls[4][1] as () => void;
+    tick();
+    expect(runRingsIndexingPoll).toHaveBeenCalledWith({ env, bg, observability });
   });
 });

--- a/apps/sdp-api/src/cron/runner.ts
+++ b/apps/sdp-api/src/cron/runner.ts
@@ -38,6 +38,7 @@ import {
   RECURRING_PAYMENTS_COLLECTION_CRON,
   runRecurringPaymentsCollection,
 } from "./recurring-payments";
+import { RINGS_INDEXING_CRON, runRingsIndexingPoll } from "./rings-indexing";
 import { runWorkflowExecutions, WORKFLOW_EXECUTIONS_CRON } from "./workflow-executions";
 import {
   runWorkflowSecretRetirements,
@@ -169,6 +170,21 @@ export function startCron(deps: CronDeps): CronHandle | null {
       })
     );
   }
+
+  // Cheap to schedule unconditionally: the job early-returns unless the rings
+  // flag is on and the live gateway adapter is selected.
+  tasks.push(
+    schedule(RINGS_INDEXING_CRON, () => {
+      if (stopping) {
+        return;
+      }
+      runRingsIndexingPoll({
+        env: deps.env,
+        bg: deps.bg,
+        observability: deps.observability,
+      });
+    })
+  );
 
   if (isEarnEnabled(deps.env)) {
     tasks.push(

--- a/apps/sdp-api/src/db/migrations/0057_helius_rings.migration.test.ts
+++ b/apps/sdp-api/src/db/migrations/0057_helius_rings.migration.test.ts
@@ -1,0 +1,537 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "pg";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { env } from "@/test/helpers/env";
+
+// The test database is already fully migrated by src/test/node-global-setup.ts,
+// so 0057's tables exist before this file runs. That makes the assertions here
+// behavioural rather than structural-only: every test opens a transaction,
+// inserts real rows against the real schema, and rolls back.
+
+const migrationPath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "postgres/0057_helius_rings.sql"
+);
+const migrationSql = readFileSync(migrationPath, "utf8");
+
+const TABLES = [
+  "helius_rings_wallets",
+  "helius_rings_key_refs",
+  "helius_rings_zones",
+  "helius_rings_operations",
+  "helius_rings_timelocks",
+  "helius_rings_events",
+  "helius_rings_asset_allowlist",
+  "helius_rings_runtime_health",
+];
+
+let client: Client;
+
+/** Postgres SQLSTATEs the constraint assertions below distinguish between. */
+const UNIQUE_VIOLATION = "23505";
+const FK_VIOLATION = "23503";
+const CHECK_VIOLATION = "23514";
+
+/**
+ * Runs a statement expected to violate a constraint. The savepoint is taken
+ * immediately before the statement — a failed statement poisons the whole
+ * transaction, and rolling back to a savepoint created any earlier would
+ * discard the fixtures the caller just seeded.
+ *
+ * Takes a thunk rather than a promise so the statement cannot be queued on the
+ * client ahead of the SAVEPOINT.
+ */
+async function expectSqlstate(work: () => Promise<unknown>, sqlstate: string): Promise<void> {
+  await client.query("SAVEPOINT probe");
+  await expect(work()).rejects.toMatchObject({ code: sqlstate });
+  await client.query("ROLLBACK TO SAVEPOINT probe");
+}
+
+/**
+ * Seeds an org, project and Rings wallet, returning their ids. `tag` keeps the
+ * org slug unique across tests since only the transaction is rolled back, not
+ * the sequence of ids.
+ */
+async function seedWallet(tag: string): Promise<{
+  organizationId: string;
+  projectId: string;
+  walletId: string;
+}> {
+  const organizationId = `org_${tag}`;
+  const projectId = `proj_${tag}`;
+  const userId = `user_${tag}`;
+  const walletId = `hrw_${tag}`;
+
+  await client.query("INSERT INTO organizations (id, name, slug) VALUES ($1, $1, $1)", [
+    organizationId,
+  ]);
+  await client.query("INSERT INTO users (id, email) VALUES ($1, $2)", [
+    userId,
+    `${tag}@example.test`,
+  ]);
+  await client.query(
+    "INSERT INTO projects (id, organization_id, name, slug, created_by) VALUES ($1, $2, $1, $1, $3)",
+    [projectId, organizationId, userId]
+  );
+  await client.query(
+    `INSERT INTO helius_rings_wallets (id, organization_id, project_id, sdp_wallet_id, name)
+     VALUES ($1, $2, $3, $4, 'Treasury')`,
+    [walletId, organizationId, projectId, `sdpw_${tag}`]
+  );
+
+  return { organizationId, projectId, walletId };
+}
+
+async function insertOperation(
+  overrides: Record<string, string | boolean | null> & {
+    id: string;
+    organization_id: string;
+    project_id: string;
+    wallet_id: string;
+    intent_key: string;
+  }
+): Promise<void> {
+  const row: Record<string, string | boolean | null> = { op_type: "shield", ...overrides };
+  const columns = Object.keys(row);
+  const placeholders = columns.map((_, index) => `$${index + 1}`).join(", ");
+  await client.query(
+    `INSERT INTO helius_rings_operations (${columns.join(", ")}) VALUES (${placeholders})`,
+    columns.map((column) => row[column])
+  );
+}
+
+beforeAll(async () => {
+  client = new Client({ connectionString: env.DATABASE_URL });
+  await client.connect();
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+beforeEach(async () => {
+  await client.query("BEGIN");
+});
+
+afterEach(async () => {
+  await client.query("ROLLBACK");
+});
+
+describe("0057_helius_rings schema", () => {
+  it("creates every table and the indexes the module reads through", async () => {
+    const tables = await client.query<{ table_name: string }>(
+      `SELECT table_name FROM information_schema.tables
+       WHERE table_schema = 'public' AND table_name = ANY($1)
+       ORDER BY table_name`,
+      [TABLES]
+    );
+    expect(tables.rows.map((row) => row.table_name)).toEqual([...TABLES].sort());
+
+    const indexes = await client.query<{ indexname: string }>(
+      `SELECT indexname FROM pg_indexes
+       WHERE schemaname = 'public' AND tablename LIKE 'helius_rings%'`
+    );
+    const names = indexes.rows.map((row) => row.indexname);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "idx_helius_rings_wallets_project_sdp",
+        "idx_helius_rings_key_refs_wallet_kind",
+        "helius_rings_zones_wallet_name_key",
+        "idx_helius_rings_operations_intent_key",
+        "idx_helius_rings_operations_wallet_created",
+        "idx_helius_rings_operations_in_flight",
+        "idx_helius_rings_timelocks_pending",
+        "idx_helius_rings_events_operation_created",
+      ])
+    );
+  });
+
+  it("re-running the migration is a no-op", async () => {
+    const before = await client.query<{ count: string }>(
+      "SELECT count(*)::text AS count FROM helius_rings_asset_allowlist"
+    );
+
+    // Every statement is IF NOT EXISTS and the seed is ON CONFLICT DO NOTHING,
+    // so a second application must neither throw nor duplicate the seed.
+    await expect(client.query(migrationSql)).resolves.toBeDefined();
+
+    const after = await client.query<{ count: string }>(
+      "SELECT count(*)::text AS count FROM helius_rings_asset_allowlist"
+    );
+    expect(after.rows[0]?.count).toBe(before.rows[0]?.count);
+  });
+
+  it("seeds the allowlist with SOL and devnet USDC only", async () => {
+    const seeded = await client.query<{ mint: string; symbol: string; decimals: number }>(
+      "SELECT mint, symbol, decimals FROM helius_rings_asset_allowlist ORDER BY symbol"
+    );
+    expect(seeded.rows).toEqual([
+      { mint: "So11111111111111111111111111111111111111112", symbol: "SOL", decimals: 9 },
+      { mint: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU", symbol: "USDC", decimals: 6 },
+    ]);
+  });
+});
+
+describe("0057_helius_rings idempotency contract", () => {
+  it("rejects a second operation reusing an intent_key", async () => {
+    const { organizationId, projectId, walletId } = await seedWallet("intent");
+    const base = {
+      organization_id: organizationId,
+      project_id: projectId,
+      wallet_id: walletId,
+      intent_key: "intent_abc",
+    };
+
+    await insertOperation({ id: "hro_first", ...base });
+    await expectSqlstate(() => insertOperation({ id: "hro_second", ...base }), UNIQUE_VIOLATION);
+
+    // The reserved row is untouched — this is what lets reserveIntent() return
+    // the pre-existing operation instead of creating a ghost duplicate.
+    const rows = await client.query<{ id: string }>(
+      "SELECT id FROM helius_rings_operations WHERE intent_key = $1",
+      ["intent_abc"]
+    );
+    expect(rows.rows.map((row) => row.id)).toEqual(["hro_first"]);
+  });
+
+  it("keeps the retry chain when a retried operation is deleted", async () => {
+    const { organizationId, projectId, walletId } = await seedWallet("lineage");
+    const base = { organization_id: organizationId, project_id: projectId, wallet_id: walletId };
+
+    await insertOperation({ id: "hro_original", intent_key: "intent_original", ...base });
+    await insertOperation({
+      id: "hro_retry",
+      intent_key: "intent_retry",
+      retry_of_operation_id: "hro_original",
+      ...base,
+    });
+
+    await client.query("DELETE FROM helius_rings_operations WHERE id = 'hro_original'");
+
+    // SET NULL, not CASCADE: the retry survives its parent's deletion so the
+    // audit trail does not evaporate.
+    const retry = await client.query<{ id: string; retry_of_operation_id: string | null }>(
+      "SELECT id, retry_of_operation_id FROM helius_rings_operations WHERE id = 'hro_retry'"
+    );
+    expect(retry.rows).toEqual([{ id: "hro_retry", retry_of_operation_id: null }]);
+  });
+
+  it("refuses an operation that is its own retry", async () => {
+    const { organizationId, projectId, walletId } = await seedWallet("selfretry");
+    await expectSqlstate(
+      () =>
+        insertOperation({
+          id: "hro_self",
+          organization_id: organizationId,
+          project_id: projectId,
+          wallet_id: walletId,
+          intent_key: "intent_self",
+          retry_of_operation_id: "hro_self",
+        }),
+      CHECK_VIOLATION
+    );
+  });
+});
+
+describe("0057_helius_rings tenant isolation", () => {
+  it("refuses an operation pointing at a wallet in another project", async () => {
+    const owner = await seedWallet("owner");
+    const other = await seedWallet("other");
+
+    // The composite (wallet_id, organization_id, project_id) FK is what makes
+    // this a foreign-key error rather than a silently accepted cross-tenant row.
+    await expectSqlstate(
+      () =>
+        insertOperation({
+          id: "hro_crosstenant",
+          organization_id: other.organizationId,
+          project_id: other.projectId,
+          wallet_id: owner.walletId,
+          intent_key: "intent_crosstenant",
+        }),
+      FK_VIOLATION
+    );
+  });
+
+  it("cascades wallets, key refs, operations and events when the project goes", async () => {
+    const { organizationId, projectId, walletId } = await seedWallet("cascade");
+    await insertOperation({
+      id: "hro_cascade",
+      organization_id: organizationId,
+      project_id: projectId,
+      wallet_id: walletId,
+      intent_key: "intent_cascade",
+    });
+    await client.query(
+      `INSERT INTO helius_rings_key_refs (id, wallet_id, kind, ciphertext, key_version, material_tag)
+       VALUES ('hrk_cascade', $1, 'viewing', 'ct', 'v1', 'simulated')`,
+      [walletId]
+    );
+    await client.query(
+      `INSERT INTO helius_rings_events (id, operation_id, kind, payload)
+       VALUES ('hre_cascade', 'hro_cascade', 'created', '{"note":"ok"}'::jsonb)`
+    );
+
+    await client.query("DELETE FROM projects WHERE id = $1", [projectId]);
+
+    for (const table of ["helius_rings_wallets", "helius_rings_operations"]) {
+      const rows = await client.query<{ count: string }>(
+        `SELECT count(*)::text AS count FROM ${table} WHERE project_id = $1`,
+        [projectId]
+      );
+      expect(rows.rows[0]?.count).toBe("0");
+    }
+    for (const table of ["helius_rings_key_refs", "helius_rings_events"]) {
+      const rows = await client.query<{ count: string }>(
+        `SELECT count(*)::text AS count FROM ${table}`
+      );
+      expect(rows.rows[0]?.count).toBe("0");
+    }
+  });
+
+  it("holds one Rings wallet per SDP custody wallet per project", async () => {
+    const { organizationId, projectId } = await seedWallet("onewallet");
+    await expectSqlstate(
+      () =>
+        client.query(
+          `INSERT INTO helius_rings_wallets (id, organization_id, project_id, sdp_wallet_id, name)
+         VALUES ('hrw_dupe', $1, $2, 'sdpw_onewallet', 'Second')`,
+          [organizationId, projectId]
+        ),
+      UNIQUE_VIOLATION
+    );
+  });
+
+  it("holds one viewing key and one nullifier key per wallet", async () => {
+    const { walletId } = await seedWallet("keyrefs");
+    const insert = (id: string, kind: string) =>
+      client.query(
+        `INSERT INTO helius_rings_key_refs (id, wallet_id, kind, ciphertext, key_version, material_tag)
+         VALUES ($1, $2, $3, 'ct', 'v1', 'simulated')`,
+        [id, walletId, kind]
+      );
+
+    await insert("hrk_viewing", "viewing");
+    await insert("hrk_nullifier", "nullifier");
+    await expectSqlstate(() => insert("hrk_viewing_dupe", "viewing"), UNIQUE_VIOLATION);
+  });
+});
+
+describe("0057_helius_rings value-set and coherence constraints", () => {
+  it("pins network to devnet", async () => {
+    const { organizationId, projectId } = await seedWallet("network");
+    await expectSqlstate(
+      () =>
+        client.query(
+          `INSERT INTO helius_rings_wallets (id, organization_id, project_id, sdp_wallet_id, name, network)
+         VALUES ('hrw_mainnet', $1, $2, 'sdpw_mainnet', 'Mainnet', 'mainnet-beta')`,
+          [organizationId, projectId]
+        ),
+      CHECK_VIOLATION
+    );
+  });
+
+  it("rejects states and op types outside the domain constants", async () => {
+    const { organizationId, projectId, walletId } = await seedWallet("valuesets");
+    const base = {
+      organization_id: organizationId,
+      project_id: projectId,
+      wallet_id: walletId,
+    };
+
+    await expectSqlstate(
+      () =>
+        insertOperation({ id: "hro_badstate", intent_key: "i1", state: "teleporting", ...base }),
+      CHECK_VIOLATION
+    );
+    await expectSqlstate(
+      () => insertOperation({ id: "hro_badtype", intent_key: "i2", op_type: "rugpull", ...base }),
+      CHECK_VIOLATION
+    );
+    await expectSqlstate(
+      () =>
+        insertOperation({
+          id: "hro_badproof",
+          intent_key: "i3",
+          proof_source: "vibes",
+          ...base,
+        }),
+      CHECK_VIOLATION
+    );
+  });
+
+  it("keeps transfer_mode consistent with op_type", async () => {
+    const { organizationId, projectId, walletId } = await seedWallet("mode");
+    const base = {
+      organization_id: organizationId,
+      project_id: projectId,
+      wallet_id: walletId,
+    };
+
+    // An anonymous transfer recorded as registered would tell the operator
+    // their counterparty was disclosed when it was not.
+    await expectSqlstate(
+      () =>
+        insertOperation({
+          id: "hro_mismatch",
+          intent_key: "m1",
+          op_type: "transfer_anonymous",
+          transfer_mode: "registered",
+          ...base,
+        }),
+      CHECK_VIOLATION
+    );
+    // A shield carries no transfer mode at all.
+    await expectSqlstate(
+      () =>
+        insertOperation({
+          id: "hro_straymode",
+          intent_key: "m2",
+          op_type: "shield",
+          transfer_mode: "registered",
+          ...base,
+        }),
+      CHECK_VIOLATION
+    );
+
+    await insertOperation({
+      id: "hro_anon",
+      intent_key: "m3",
+      op_type: "transfer_anonymous",
+      transfer_mode: "anonymous",
+      ...base,
+    });
+    const stored = await client.query<{ transfer_mode: string }>(
+      "SELECT transfer_mode FROM helius_rings_operations WHERE id = 'hro_anon'"
+    );
+    expect(stored.rows).toEqual([{ transfer_mode: "anonymous" }]);
+  });
+
+  it("ties failure detail to the failed state", async () => {
+    const { organizationId, projectId, walletId } = await seedWallet("failure");
+    const base = {
+      organization_id: organizationId,
+      project_id: projectId,
+      wallet_id: walletId,
+    };
+
+    // failed without a code is unactionable in the recovery UI.
+    await expectSqlstate(
+      () => insertOperation({ id: "hro_bare", intent_key: "f1", state: "failed", ...base }),
+      CHECK_VIOLATION
+    );
+    // A live operation carrying failure text misreports itself as broken.
+    await expectSqlstate(
+      () =>
+        insertOperation({
+          id: "hro_stale",
+          intent_key: "f2",
+          state: "proving",
+          failure_code: "proof_failed",
+          failure_message: "boom",
+          retryable: true,
+          ...base,
+        }),
+      CHECK_VIOLATION
+    );
+    await expectSqlstate(
+      () =>
+        insertOperation({
+          id: "hro_unknowncode",
+          intent_key: "f3",
+          state: "failed",
+          failure_code: "cosmic_rays",
+          failure_message: "boom",
+          retryable: false,
+          ...base,
+        }),
+      CHECK_VIOLATION
+    );
+
+    await insertOperation({
+      id: "hro_failed",
+      intent_key: "f4",
+      state: "failed",
+      failure_code: "indexing_timeout",
+      failure_message: "photon did not index in time",
+      retryable: true,
+      ...base,
+    });
+    const stored = await client.query<{ failure_code: string; retryable: boolean }>(
+      "SELECT failure_code, retryable FROM helius_rings_operations WHERE id = 'hro_failed'"
+    );
+    expect(stored.rows).toEqual([{ failure_code: "indexing_timeout", retryable: true }]);
+  });
+
+  it("refuses a timelock released before it unlocks", async () => {
+    const { organizationId, projectId, walletId } = await seedWallet("timelock");
+    await insertOperation({
+      id: "hro_timelock",
+      organization_id: organizationId,
+      project_id: projectId,
+      wallet_id: walletId,
+      intent_key: "t1",
+      op_type: "timelock_create",
+    });
+
+    const insertTimelock = (releasedAt: string | null) =>
+      client.query(
+        `INSERT INTO helius_rings_timelocks (operation_id, unlock_at, released_at, beneficiary_addr)
+         VALUES ('hro_timelock', '2026-09-01T00:00:00.000Z', $1, 'beneficiary')`,
+        [releasedAt]
+      );
+
+    await expectSqlstate(() => insertTimelock("2026-08-01T00:00:00.000Z"), CHECK_VIOLATION);
+    await expect(insertTimelock("2026-09-02T00:00:00.000Z")).resolves.toBeDefined();
+  });
+
+  it("requires event payloads to be JSON objects", async () => {
+    const { organizationId, projectId, walletId } = await seedWallet("events");
+    await insertOperation({
+      id: "hro_events",
+      organization_id: organizationId,
+      project_id: projectId,
+      wallet_id: walletId,
+      intent_key: "e1",
+    });
+
+    await expectSqlstate(
+      () =>
+        client.query(
+          `INSERT INTO helius_rings_events (id, operation_id, kind, payload)
+         VALUES ('hre_scalar', 'hro_events', 'noted', '"just a string"'::jsonb)`
+        ),
+      CHECK_VIOLATION
+    );
+    await expect(
+      client.query(
+        `INSERT INTO helius_rings_events (id, operation_id, kind, payload)
+         VALUES ('hre_null', 'hro_events', 'noted', NULL)`
+      )
+    ).resolves.toBeDefined();
+  });
+
+  it("stores one runtime health row per project and component", async () => {
+    const { projectId } = await seedWallet("health");
+    const upsert = (component: string, status: string) =>
+      client.query(
+        `INSERT INTO helius_rings_runtime_health (project_id, component, status)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (project_id, component) DO UPDATE SET status = EXCLUDED.status`,
+        [projectId, component, status]
+      );
+
+    await upsert("photon", "green");
+    await upsert("photon", "red");
+    await expectSqlstate(() => upsert("telepathy", "green"), CHECK_VIOLATION);
+    await expectSqlstate(() => upsert("photon", "chartreuse"), CHECK_VIOLATION);
+
+    const rows = await client.query<{ component: string; status: string }>(
+      "SELECT component, status FROM helius_rings_runtime_health WHERE project_id = $1",
+      [projectId]
+    );
+    expect(rows.rows).toEqual([{ component: "photon", status: "red" }]);
+  });
+});

--- a/apps/sdp-api/src/db/migrations/0057_helius_rings.migration.test.ts
+++ b/apps/sdp-api/src/db/migrations/0057_helius_rings.migration.test.ts
@@ -255,6 +255,64 @@ describe("0057_helius_rings tenant isolation", () => {
     );
   });
 
+  it("refuses an operation pointing at another wallet's zone", async () => {
+    const owner = await seedWallet("zoneowner");
+    const other = await seedWallet("zoneother");
+    await client.query(
+      "INSERT INTO helius_rings_zones (id, wallet_id, name) VALUES ('hrz_owner', $1, 'Payroll')",
+      [owner.walletId]
+    );
+
+    // The composite (zone_id, wallet_id) FK rejects the cross-wallet reference.
+    await expectSqlstate(
+      () =>
+        insertOperation({
+          id: "hro_crosszone",
+          organization_id: other.organizationId,
+          project_id: other.projectId,
+          wallet_id: other.walletId,
+          zone_id: "hrz_owner",
+          intent_key: "intent_crosszone",
+        }),
+      FK_VIOLATION
+    );
+
+    await expect(
+      insertOperation({
+        id: "hro_ownzone",
+        organization_id: owner.organizationId,
+        project_id: owner.projectId,
+        wallet_id: owner.walletId,
+        zone_id: "hrz_owner",
+        intent_key: "intent_ownzone",
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("clears only zone_id when a referenced zone is deleted", async () => {
+    const { organizationId, projectId, walletId } = await seedWallet("zonedel");
+    await client.query(
+      "INSERT INTO helius_rings_zones (id, wallet_id, name) VALUES ('hrz_del', $1, 'Payroll')",
+      [walletId]
+    );
+    await insertOperation({
+      id: "hro_zonedel",
+      organization_id: organizationId,
+      project_id: projectId,
+      wallet_id: walletId,
+      zone_id: "hrz_del",
+      intent_key: "intent_zonedel",
+    });
+
+    await client.query("DELETE FROM helius_rings_zones WHERE id = 'hrz_del'");
+
+    // The SET NULL column list must not null wallet_id along with zone_id.
+    const { rows } = await client.query(
+      "SELECT wallet_id, zone_id FROM helius_rings_operations WHERE id = 'hro_zonedel'"
+    );
+    expect(rows[0]).toEqual({ wallet_id: walletId, zone_id: null });
+  });
+
   it("cascades wallets, key refs, operations and events when the project goes", async () => {
     const { organizationId, projectId, walletId } = await seedWallet("cascade");
     await insertOperation({
@@ -485,6 +543,50 @@ describe("0057_helius_rings value-set and coherence constraints", () => {
 
     await expectSqlstate(() => insertTimelock("2026-08-01T00:00:00.000Z"), CHECK_VIOLATION);
     await expect(insertTimelock("2026-09-02T00:00:00.000Z")).resolves.toBeDefined();
+  });
+
+  it("rejects timelock timestamps that are not fixed-width UTC", async () => {
+    const { organizationId, projectId, walletId } = await seedWallet("tlformat");
+    await insertOperation({
+      id: "hro_tlformat",
+      organization_id: organizationId,
+      project_id: projectId,
+      wallet_id: walletId,
+      intent_key: "tf1",
+      op_type: "timelock_create",
+    });
+
+    const insertTimelock = (unlockAt: string, releasedAt: string | null) =>
+      client.query(
+        `INSERT INTO helius_rings_timelocks (operation_id, unlock_at, released_at, beneficiary_addr)
+         VALUES ('hro_tlformat', $1, $2, 'beneficiary')`,
+        [unlockAt, releasedAt]
+      );
+
+    // An offset value sorts lexically before a Z value it chronologically follows.
+    await expectSqlstate(
+      () => insertTimelock("2026-08-31T23:30:00.000-01:00", null),
+      CHECK_VIOLATION
+    );
+    await expectSqlstate(
+      () => insertTimelock("2026-09-01T00:00:00.000Z", "2026-09-01T23:30:00.000-01:00"),
+      CHECK_VIOLATION
+    );
+    await expectSqlstate(() => insertTimelock("2026-09-01T00:00:00Z", null), CHECK_VIOLATION);
+
+    await expectSqlstate(
+      () =>
+        insertOperation({
+          id: "hro_tlformat2",
+          organization_id: organizationId,
+          project_id: projectId,
+          wallet_id: walletId,
+          intent_key: "tf2",
+          op_type: "timelock_create",
+          timelock_unlock_at: "2026-08-31T23:30:00.000-01:00",
+        }),
+      CHECK_VIOLATION
+    );
   });
 
   it("requires event payloads to be JSON objects", async () => {

--- a/apps/sdp-api/src/db/migrations/postgres/0057_helius_rings.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0057_helius_rings.sql
@@ -279,8 +279,16 @@ CREATE TABLE IF NOT EXISTS helius_rings_operations (
 );
 
 -- The idempotency contract. This index is what makes retry-safety real:
--- reserveIntent() is an INSERT ... ON CONFLICT (intent_key) DO NOTHING that
--- returns the pre-existing row, and that only works because of this index.
+-- reserveIntent() inserts with ON CONFLICT (intent_key), and on a replay it has
+-- to hand back the operation already reserved rather than a second one.
+--
+-- Note for whoever writes that query: the conflict action must be a no-op
+-- DO UPDATE, not DO NOTHING. `ON CONFLICT DO NOTHING ... RETURNING *` emits
+-- zero rows on conflict, so a retry would read back null and look like a failure
+-- instead of an already-reserved intent. The idiom the repo already uses for
+-- this is `DO UPDATE SET updated_at = helius_rings_operations.updated_at
+-- RETURNING *` — see the approval_requests insert in
+-- db/repositories/policy.repository.postgres.ts.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_helius_rings_operations_intent_key
     ON helius_rings_operations(intent_key);
 

--- a/apps/sdp-api/src/db/migrations/postgres/0057_helius_rings.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0057_helius_rings.sql
@@ -141,6 +141,9 @@ CREATE TABLE IF NOT EXISTS helius_rings_zones (
     created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
     CONSTRAINT helius_rings_zones_kind_check
         CHECK (kind IN ('treasury', 'public')),
+    -- Lets operations FK on (zone_id, wallet_id) so an operation cannot
+    -- reference another wallet's zone.
+    CONSTRAINT helius_rings_zones_id_wallet_key UNIQUE (id, wallet_id),
     FOREIGN KEY (wallet_id) REFERENCES helius_rings_wallets(id) ON DELETE CASCADE
 );
 
@@ -267,12 +270,23 @@ CREATE TABLE IF NOT EXISTS helius_rings_operations (
     -- the retry-depth cap in A21 loop forever.
     CONSTRAINT helius_rings_operations_retry_not_self_check
         CHECK (retry_of_operation_id IS NULL OR retry_of_operation_id <> id),
+    -- Same fixed-width-UTC pin as helius_rings_timelocks; the Activity table
+    -- sorts on this column.
+    CONSTRAINT helius_rings_operations_timelock_unlock_at_format_check
+        CHECK (
+            timelock_unlock_at IS NULL
+            OR timelock_unlock_at ~ '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$'
+        ),
     FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
     FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
     FOREIGN KEY (wallet_id, organization_id, project_id)
         REFERENCES helius_rings_wallets(id, organization_id, project_id)
         ON DELETE CASCADE,
-    FOREIGN KEY (zone_id) REFERENCES helius_rings_zones(id) ON DELETE SET NULL,
+    -- Composite: the zone must belong to this operation's wallet. The SET
+    -- NULL column list (Postgres 15+) clears only zone_id, not wallet_id.
+    FOREIGN KEY (zone_id, wallet_id)
+        REFERENCES helius_rings_zones(id, wallet_id)
+        ON DELETE SET NULL (zone_id),
     -- SET NULL, never CASCADE: see decision 2 in the header.
     FOREIGN KEY (retry_of_operation_id)
         REFERENCES helius_rings_operations(id) ON DELETE SET NULL
@@ -331,9 +345,17 @@ CREATE TABLE IF NOT EXISTS helius_rings_timelocks (
     unlock_at TEXT NOT NULL,
     released_at TEXT,
     beneficiary_addr TEXT NOT NULL,
-    -- ISO-8601 UTC strings from sdp_iso_now() are fixed-width, so lexical
-    -- comparison is chronological. Releasing before the unlock time is the
-    -- whole failure this table exists to prevent.
+    -- The ordering check compares text; lexical order is only chronological
+    -- when every value is the fixed-width UTC shape sdp_iso_now() emits. A
+    -- caller-supplied offset value ('...T23:30:00.000-01:00') would sort
+    -- wrong and let an early release through, so the format is a constraint.
+    CONSTRAINT helius_rings_timelocks_unlock_at_format_check
+        CHECK (unlock_at ~ '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$'),
+    CONSTRAINT helius_rings_timelocks_released_at_format_check
+        CHECK (
+            released_at IS NULL
+            OR released_at ~ '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$'
+        ),
     CONSTRAINT helius_rings_timelocks_released_after_unlock_check
         CHECK (released_at IS NULL OR released_at >= unlock_at),
     FOREIGN KEY (operation_id)

--- a/apps/sdp-api/src/db/migrations/postgres/0057_helius_rings.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0057_helius_rings.sql
@@ -1,0 +1,430 @@
+-- Helius Rings: the whole module's schema, in one migration.
+--
+-- Rings is the shielded-transfer module: a private wallet is bound to an SDP
+-- custody wallet, and every shielded action runs through a persisted state
+-- machine (draft -> preparing -> approval_required -> proving -> ready_to_sign
+-- -> submitted -> indexing -> completed, with a typed `failed` edge from every
+-- non-terminal state).
+--
+-- Tables are declared in dependency order — the wallet, then its key material
+-- and zones, then operations, their timelocks and event feed, then the
+-- platform-level asset allowlist and runtime health board. Every statement is
+-- IF NOT EXISTS, so re-running is a no-op.
+--
+-- Three decisions worth stating up front, because they are the ones that are
+-- expensive to retrofit:
+--
+--   1. `intent_key` carries a UNIQUE index. It is the idempotency contract:
+--      hash(walletId, opType, canonical(inputs), clientNonce). Without the
+--      index, a retried request creates a ghost duplicate operation that only
+--      ever surfaces in production, on the money path, under load.
+--
+--   2. `retry_of_operation_id` is ON DELETE SET NULL, never CASCADE. A retry
+--      chain is audit evidence; cascading would let the deletion of one
+--      operation recursively erase the whole lineage that explains it.
+--
+--   3. Operations reference their wallet through the composite
+--      (wallet_id, organization_id, project_id) key, following the pattern
+--      0048_earn.sql established for earn_movements. A plain wallet_id FK
+--      would happily let an operation in project A point at a wallet in
+--      project B; for a privacy module that is a tenant-isolation break, not
+--      merely a data-quality one.
+--
+-- Closed value sets are named CHECK constraints on TEXT rather than
+-- CREATE TYPE enums — the repo has no enums anywhere. Each set below mirrors an
+-- `as const` array in packages/sdp-helius-rings/src/constants.ts, which is the
+-- runtime source of truth; the CHECK is the schema-level twin. These sets are
+-- closed by compile-time unions, so widening one already requires a code
+-- change, and pairing it with a migration is the point rather than the cost.
+-- (Contrast the ADR 0001 asset-profiles pattern used for open registries like
+-- earn providers, which deliberately carry no CHECK.)
+--
+-- Timestamps are TEXT ISO-8601 via sdp_iso_now() — never NOW(), never
+-- timestamptz. Amounts are string-encoded u64, never numeric/float.
+
+
+-- ==========================================================================
+-- Wallets
+-- ==========================================================================
+
+-- Binds one Rings shielded identity to one SDP custody wallet within a project.
+--   status: pending until the identity is provisioned, ready once it is,
+--   paused when runtime health goes red and the module stops accepting work.
+--   material_tag records whether the key material behind this wallet is real
+--   ('live') or a placeholder from a pre-integration environment
+--   ('simulated'), so a simulated wallet can never be mistaken for a funded one.
+CREATE TABLE IF NOT EXISTS helius_rings_wallets (
+    id TEXT PRIMARY KEY,
+    organization_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    sdp_wallet_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    network TEXT NOT NULL DEFAULT 'devnet',
+    status TEXT NOT NULL DEFAULT 'pending',
+    shielded_address TEXT,
+    sync_cursor TEXT,
+    material_tag TEXT NOT NULL DEFAULT 'simulated',
+    created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    updated_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    -- The schema-level twin of the runtime devnet guard in HeliusRingsService.
+    -- Rings is devnet-only for this scope; going to mainnet is a deliberate
+    -- forward migration that drops this constraint, not a config flip.
+    CONSTRAINT helius_rings_wallets_network_check CHECK (network = 'devnet'),
+    CONSTRAINT helius_rings_wallets_status_check
+        CHECK (status IN ('pending', 'ready', 'paused')),
+    CONSTRAINT helius_rings_wallets_material_tag_check
+        CHECK (material_tag IN ('simulated', 'live')),
+    -- Lets helius_rings_operations FK on (wallet_id, organization_id,
+    -- project_id) so an operation can never point at a wallet in a different
+    -- org/project. Mirrors earn_positions_id_org_project_key in 0048.
+    CONSTRAINT helius_rings_wallets_id_org_project_key
+        UNIQUE (id, organization_id, project_id),
+    FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+);
+
+-- One Rings wallet per SDP custody wallet per project: provisioning is
+-- idempotent, and a second shielded identity over the same custody wallet
+-- would split its shielded balance across two identities that cannot see
+-- each other.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_helius_rings_wallets_project_sdp
+    ON helius_rings_wallets(project_id, sdp_wallet_id);
+
+CREATE INDEX IF NOT EXISTS idx_helius_rings_wallets_project_created
+    ON helius_rings_wallets(project_id, created_at DESC, id DESC);
+
+
+-- ==========================================================================
+-- Key material
+-- ==========================================================================
+
+-- Ciphertext blobs holding viewing and nullifier material, encrypted with
+-- custody-cipher (AES-256-GCM under CUSTODY_ENCRYPTION_KEY). Plaintext key
+-- material never lands in this table, and repositories pass ciphertext
+-- through untouched — ciphertext in, ciphertext out, never SecretRef.reveal.
+--
+-- key_version is the cipher key generation that sealed this blob, so a key
+-- rotation can re-wrap rows without guessing which generation each one used.
+CREATE TABLE IF NOT EXISTS helius_rings_key_refs (
+    id TEXT PRIMARY KEY,
+    wallet_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    ciphertext TEXT NOT NULL,
+    key_version TEXT NOT NULL,
+    material_tag TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    CONSTRAINT helius_rings_key_refs_kind_check
+        CHECK (kind IN ('viewing', 'nullifier')),
+    CONSTRAINT helius_rings_key_refs_material_tag_check
+        CHECK (material_tag IN ('simulated', 'live')),
+    FOREIGN KEY (wallet_id) REFERENCES helius_rings_wallets(id) ON DELETE CASCADE
+);
+
+-- Exactly one viewing key and one nullifier key per wallet. Provisioning
+-- returns both together, so a duplicate here means a re-provision raced and
+-- one of the two identities is now unreachable.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_helius_rings_key_refs_wallet_kind
+    ON helius_rings_key_refs(wallet_id, kind);
+
+
+-- ==========================================================================
+-- Zones
+-- ==========================================================================
+
+-- Named destinations within a wallet. A treasury zone holds shielded value;
+-- a public zone is the declared exit point back to transparent addresses.
+CREATE TABLE IF NOT EXISTS helius_rings_zones (
+    id TEXT PRIMARY KEY,
+    wallet_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    kind TEXT NOT NULL DEFAULT 'treasury',
+    created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    CONSTRAINT helius_rings_zones_kind_check
+        CHECK (kind IN ('treasury', 'public')),
+    FOREIGN KEY (wallet_id) REFERENCES helius_rings_wallets(id) ON DELETE CASCADE
+);
+
+-- Zone names are the operator's handle for a destination; two zones sharing a
+-- name inside one wallet makes the Send composer ambiguous.
+CREATE UNIQUE INDEX IF NOT EXISTS helius_rings_zones_wallet_name_key
+    ON helius_rings_zones(wallet_id, name);
+
+
+-- ==========================================================================
+-- Operations — the state machine
+-- ==========================================================================
+
+-- One row per shielded action, carrying its whole lifecycle. `state` is the
+-- persisted state machine; transitions are applied under SELECT ... FOR UPDATE
+-- inside a transaction so two workers cannot advance the same operation twice.
+--
+-- proof_ref is an opaque handle the gateway hands back, not proof material —
+-- it is wrapped in SecretRef at the API boundary and must never be logged or
+-- serialized into a response.
+CREATE TABLE IF NOT EXISTS helius_rings_operations (
+    id TEXT PRIMARY KEY,
+    organization_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    wallet_id TEXT NOT NULL,
+    op_type TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'draft',
+    asset_mint TEXT,
+    amount_raw TEXT,
+    from_addr TEXT,
+    to_addr TEXT,
+    zone_id TEXT,
+    transfer_mode TEXT,
+    intent_key TEXT NOT NULL,
+    approval_request_id TEXT,
+    policy_evaluation_id TEXT,
+    proof_source TEXT,
+    proof_ref TEXT,
+    outer_tx_signature TEXT,
+    photon_indexed_at TEXT,
+    failure_code TEXT,
+    failure_message TEXT,
+    retryable BOOLEAN,
+    retry_of_operation_id TEXT,
+    -- Denormalized from helius_rings_timelocks so the Activity table can sort
+    -- and filter by unlock time without joining. The timelocks row remains
+    -- the authority; this column is a read optimization.
+    timelock_unlock_at TEXT,
+    created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    updated_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    CONSTRAINT helius_rings_operations_op_type_check
+        CHECK (op_type IN (
+            'shield',
+            'transfer_registered',
+            'transfer_anonymous',
+            'withdraw',
+            'merge',
+            'timelock_create',
+            'timelock_settle',
+            'zone_create'
+        )),
+    CONSTRAINT helius_rings_operations_state_check
+        CHECK (state IN (
+            'draft',
+            'preparing',
+            'approval_required',
+            'proving',
+            'ready_to_sign',
+            'submitted',
+            'indexing',
+            'completed',
+            'failed'
+        )),
+    CONSTRAINT helius_rings_operations_proof_source_check
+        CHECK (proof_source IS NULL OR proof_source IN ('simulated', 'live')),
+    -- transfer_mode is derivable from op_type, and the two disagreeing is a
+    -- privacy bug rather than a cosmetic one: an anonymous transfer rendered
+    -- as registered tells the operator their counterparty was disclosed when
+    -- it was not, or the reverse. Pin them together.
+    CONSTRAINT helius_rings_operations_transfer_mode_check
+        CHECK (
+            (op_type = 'transfer_registered' AND transfer_mode = 'registered')
+            OR (op_type = 'transfer_anonymous' AND transfer_mode = 'anonymous')
+            OR (
+                op_type NOT IN ('transfer_registered', 'transfer_anonymous')
+                AND transfer_mode IS NULL
+            )
+        ),
+    -- Failure detail exists exactly when the operation failed. The three
+    -- columns move together: a `failed` row without a code is unactionable in
+    -- the recovery UI, and a live row carrying stale failure text misreports
+    -- a healthy operation as broken.
+    CONSTRAINT helius_rings_operations_failure_check
+        CHECK (
+            (
+                state = 'failed'
+                AND failure_code IS NOT NULL
+                AND failure_message IS NOT NULL
+                AND retryable IS NOT NULL
+            )
+            OR (
+                state <> 'failed'
+                AND failure_code IS NULL
+                AND failure_message IS NULL
+                AND retryable IS NULL
+            )
+        ),
+    CONSTRAINT helius_rings_operations_failure_code_check
+        CHECK (
+            failure_code IS NULL
+            OR failure_code IN (
+                'policy_denied',
+                'approval_rejected',
+                'proof_failed',
+                'signer_failed',
+                'submit_failed',
+                'indexing_timeout',
+                'gateway_unavailable',
+                'invalid_input',
+                'insufficient_balance'
+            )
+        ),
+    -- An operation cannot be its own retry; a self-referencing lineage makes
+    -- the retry-depth cap in A21 loop forever.
+    CONSTRAINT helius_rings_operations_retry_not_self_check
+        CHECK (retry_of_operation_id IS NULL OR retry_of_operation_id <> id),
+    FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+    FOREIGN KEY (wallet_id, organization_id, project_id)
+        REFERENCES helius_rings_wallets(id, organization_id, project_id)
+        ON DELETE CASCADE,
+    FOREIGN KEY (zone_id) REFERENCES helius_rings_zones(id) ON DELETE SET NULL,
+    -- SET NULL, never CASCADE: see decision 2 in the header.
+    FOREIGN KEY (retry_of_operation_id)
+        REFERENCES helius_rings_operations(id) ON DELETE SET NULL
+);
+
+-- The idempotency contract. This index is what makes retry-safety real:
+-- reserveIntent() is an INSERT ... ON CONFLICT (intent_key) DO NOTHING that
+-- returns the pre-existing row, and that only works because of this index.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_helius_rings_operations_intent_key
+    ON helius_rings_operations(intent_key);
+
+-- Activity table: newest first. The id tiebreaker matters because operations
+-- created in one request share a single sdp_iso_now() value — the lesson of
+-- payment_transfers 0028-0031.
+CREATE INDEX IF NOT EXISTS idx_helius_rings_operations_wallet_created
+    ON helius_rings_operations(wallet_id, created_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_helius_rings_operations_project_created
+    ON helius_rings_operations(project_id, created_at DESC, id DESC);
+
+-- Partial index for the resume/poll sweep, which only ever looks at operations
+-- still in flight. Terminal rows accumulate forever and would otherwise
+-- dominate the index.
+CREATE INDEX IF NOT EXISTS idx_helius_rings_operations_in_flight
+    ON helius_rings_operations(state, updated_at)
+    WHERE state IN (
+        'preparing',
+        'approval_required',
+        'proving',
+        'ready_to_sign',
+        'submitted',
+        'indexing'
+    );
+
+CREATE INDEX IF NOT EXISTS idx_helius_rings_operations_retry_of
+    ON helius_rings_operations(retry_of_operation_id)
+    WHERE retry_of_operation_id IS NOT NULL;
+
+
+-- ==========================================================================
+-- Timelocks
+-- ==========================================================================
+
+-- Escrow leg of a timelock operation. One row per timelock_create operation;
+-- released_at is stamped when the matching timelock_settle completes.
+CREATE TABLE IF NOT EXISTS helius_rings_timelocks (
+    operation_id TEXT PRIMARY KEY,
+    unlock_at TEXT NOT NULL,
+    released_at TEXT,
+    beneficiary_addr TEXT NOT NULL,
+    -- ISO-8601 UTC strings from sdp_iso_now() are fixed-width, so lexical
+    -- comparison is chronological. Releasing before the unlock time is the
+    -- whole failure this table exists to prevent.
+    CONSTRAINT helius_rings_timelocks_released_after_unlock_check
+        CHECK (released_at IS NULL OR released_at >= unlock_at),
+    FOREIGN KEY (operation_id)
+        REFERENCES helius_rings_operations(id) ON DELETE CASCADE
+);
+
+-- The release sweep only cares about escrows still held.
+CREATE INDEX IF NOT EXISTS idx_helius_rings_timelocks_pending
+    ON helius_rings_timelocks(unlock_at)
+    WHERE released_at IS NULL;
+
+
+-- ==========================================================================
+-- Event feed
+-- ==========================================================================
+
+-- Immutable, append-only timeline powering the operation detail panel.
+--
+-- payload is JSONB rather than the TEXT the design sketch called for: the
+-- domain type is `payload?: unknown`, and JSONB both validates the JSON on
+-- write and stays queryable. It must never contain SecretRef material —
+-- event.service.ts in private-channels is the precedent, redacting the payload
+-- before persist. `kind` is intentionally open TEXT: event kinds are additive
+-- documentation of what happened, and gating each new one behind a migration
+-- would be the reason someone logs it somewhere worse instead.
+CREATE TABLE IF NOT EXISTS helius_rings_events (
+    id TEXT PRIMARY KEY,
+    operation_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    payload JSONB,
+    created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    CONSTRAINT helius_rings_events_payload_is_object_check
+        CHECK (payload IS NULL OR jsonb_typeof(payload) = 'object'),
+    FOREIGN KEY (operation_id)
+        REFERENCES helius_rings_operations(id) ON DELETE CASCADE
+);
+
+-- Timeline order, oldest first, with the id tiebreaker for events appended
+-- inside a single transition.
+CREATE INDEX IF NOT EXISTS idx_helius_rings_events_operation_created
+    ON helius_rings_events(operation_id, created_at, id);
+
+
+-- ==========================================================================
+-- Asset allowlist (platform-level)
+-- ==========================================================================
+
+-- Which mints Rings will move. Platform-level, not tenant-scoped: the
+-- constraint is what the shielded pool and prover actually support, which is a
+-- property of the deployment rather than of a customer. Adding a mint requires
+-- joint validation with Helius — an unsupported mint does not fail loudly, it
+-- produces an operation that proves and submits and then never indexes.
+CREATE TABLE IF NOT EXISTS helius_rings_asset_allowlist (
+    mint TEXT PRIMARY KEY,
+    symbol TEXT NOT NULL,
+    decimals INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    updated_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    CONSTRAINT helius_rings_asset_allowlist_status_check
+        CHECK (status IN ('active', 'disabled')),
+    CONSTRAINT helius_rings_asset_allowlist_decimals_check
+        CHECK (decimals BETWEEN 0 AND 18)
+);
+
+-- Seed: wrapped SOL and devnet USDC only. Both mints and their decimals are
+-- taken from packages/sdp-types/src/well-known-tokens.ts (SOL_MINT at 9
+-- decimals; USDC devnet at 6) rather than retyped, so the allowlist cannot
+-- drift from the registry the rest of the platform resolves against.
+--
+-- ON CONFLICT DO NOTHING keeps the re-run a no-op and, more importantly, means
+-- this migration never revives a mint an operator has since disabled.
+INSERT INTO helius_rings_asset_allowlist (mint, symbol, decimals, status)
+VALUES
+    ('So11111111111111111111111111111111111111112', 'SOL', 9, 'active'),
+    ('4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU', 'USDC', 6, 'active')
+ON CONFLICT (mint) DO NOTHING;
+
+
+-- ==========================================================================
+-- Runtime health
+-- ==========================================================================
+
+-- Latest observed health of each upstream Rings depends on, one row per
+-- component per project. Overwritten in place rather than appended: this is a
+-- status board the diagnostics page and the red-state action gate read, not a
+-- history. The event feed is where durable history lives.
+CREATE TABLE IF NOT EXISTS helius_rings_runtime_health (
+    project_id TEXT NOT NULL,
+    component TEXT NOT NULL,
+    status TEXT NOT NULL,
+    observed_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    detail JSONB,
+    PRIMARY KEY (project_id, component),
+    CONSTRAINT helius_rings_runtime_health_component_check
+        CHECK (component IN ('rpc', 'prover', 'photon', 'gateway')),
+    CONSTRAINT helius_rings_runtime_health_status_check
+        CHECK (status IN ('green', 'amber', 'red')),
+    CONSTRAINT helius_rings_runtime_health_detail_is_object_check
+        CHECK (detail IS NULL OR jsonb_typeof(detail) = 'object'),
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+);

--- a/apps/sdp-api/src/db/repositories/helius-rings-event.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-event.repository.postgres.ts
@@ -1,0 +1,59 @@
+import type { AppDb } from "@/db";
+import {
+  type AppendHeliusRingsEventInput,
+  DEFAULT_RINGS_EVENT_LIST_LIMIT,
+  generateHeliusRingsEventId,
+  type HeliusRingsEventRepository,
+  type HeliusRingsEventRow,
+  type ListHeliusRingsEventsInput,
+  redactHeliusRingsEventPayload,
+} from "./helius-rings-event.repository";
+
+function mapRow(row: Record<string, unknown>): HeliusRingsEventRow {
+  return {
+    id: row.id as string,
+    operation_id: row.operation_id as string,
+    kind: row.kind as string,
+    payload: (row.payload ?? null) as Record<string, unknown> | null,
+    created_at: row.created_at as string,
+  };
+}
+
+export function createPostgresHeliusRingsEventRepository(db: AppDb): HeliusRingsEventRepository {
+  return {
+    async append(input: AppendHeliusRingsEventInput) {
+      const id = generateHeliusRingsEventId();
+      // Redact before the value ever reaches the driver, so nothing sensitive
+      // exists in a query log or a statement parameter either.
+      const payload =
+        input.payload === undefined || input.payload === null
+          ? null
+          : JSON.stringify(redactHeliusRingsEventPayload(input.payload));
+      const row = await db
+        .prepare(
+          `INSERT INTO helius_rings_events (id, operation_id, kind, payload)
+           VALUES (?, ?, ?, ?::jsonb)
+           RETURNING *`
+        )
+        .bind(id, input.operationId, input.kind, payload)
+        .first<Record<string, unknown>>();
+      if (!row) {
+        throw new Error("helius rings event append returned no row");
+      }
+      return mapRow(row);
+    },
+
+    async listByOperation(input: ListHeliusRingsEventsInput) {
+      const result = await db
+        .prepare(
+          `SELECT * FROM helius_rings_events
+            WHERE operation_id = ?
+            ORDER BY created_at ASC, id ASC
+            LIMIT ?`
+        )
+        .bind(input.operationId, input.limit ?? DEFAULT_RINGS_EVENT_LIST_LIMIT)
+        .all<Record<string, unknown>>();
+      return result.results.map(mapRow);
+    },
+  };
+}

--- a/apps/sdp-api/src/db/repositories/helius-rings-event.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-event.repository.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import { REDACTION_CENSOR } from "@/runtime/log-redaction";
+import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import type { HeliusRingsEventRepository } from "./helius-rings-event.repository";
+import {
+  mapHeliusRingsEventRow,
+  redactHeliusRingsEventPayload,
+} from "./helius-rings-event.repository";
+import { createPostgresHeliusRingsEventRepository } from "./helius-rings-event.repository.postgres";
+import type { HeliusRingsOperationRepository } from "./helius-rings-operation.repository";
+import { createPostgresHeliusRingsOperationRepository } from "./helius-rings-operation.repository.postgres";
+import { createPostgresHeliusRingsWalletRepository } from "./helius-rings-wallet.repository.postgres";
+
+const TEST_PROJECT_ID = "prj_hre_repo_test";
+const scope = { organizationId: TEST_ORG.id, projectId: TEST_PROJECT_ID };
+
+describe("redactHeliusRingsEventPayload", () => {
+  it("censors rings key material wherever it appears", () => {
+    const redacted = redactHeliusRingsEventPayload({
+      viewingKey: "vk-secret",
+      nullifierKey: "nk-secret",
+      ringsMetadata: { anything: "opaque" },
+      amountRaw: "1000",
+    });
+
+    expect(redacted).toEqual({
+      viewingKey: REDACTION_CENSOR,
+      nullifierKey: REDACTION_CENSOR,
+      ringsMetadata: REDACTION_CENSOR,
+      amountRaw: "1000",
+    });
+  });
+
+  it("censors at arbitrary depth, unlike the one-level pino registry", () => {
+    const redacted = redactHeliusRingsEventPayload({
+      a: { b: { c: { viewingKey: "vk-secret", label: "keep" } } },
+    });
+
+    expect(redacted).toEqual({
+      a: { b: { c: { viewingKey: REDACTION_CENSOR, label: "keep" } } },
+    });
+  });
+
+  it("censors through arrays", () => {
+    const redacted = redactHeliusRingsEventPayload({
+      keyRefs: [{ material: "sealed", kind: "viewing" }],
+    });
+
+    expect(redacted).toEqual({
+      keyRefs: [{ material: REDACTION_CENSOR, kind: "viewing" }],
+    });
+  });
+
+  it("censors proof internals but keeps the rest of the proof readable", () => {
+    const redacted = redactHeliusRingsEventPayload({
+      proof: { ref: "opaque-handle", internal: "witness", source: "simulated" },
+      // `ref` outside a proof parent is an ordinary reference, not a secret.
+      ref: "operation-ref",
+    });
+
+    expect(redacted).toEqual({
+      proof: { ref: REDACTION_CENSOR, internal: REDACTION_CENSOR, source: "simulated" },
+      ref: "operation-ref",
+    });
+  });
+
+  it("breaks cycles rather than throwing", () => {
+    const payload: Record<string, unknown> = { kind: "loop" };
+    payload.self = payload;
+
+    // A malformed payload must not fail the state transition trying to record
+    // itself.
+    expect(redactHeliusRingsEventPayload(payload)).toEqual({
+      kind: "loop",
+      self: "[Circular]",
+    });
+  });
+
+  it("passes primitives through untouched", () => {
+    expect(redactHeliusRingsEventPayload("plain")).toBe("plain");
+    expect(redactHeliusRingsEventPayload(null)).toBeNull();
+    expect(redactHeliusRingsEventPayload(7)).toBe(7);
+  });
+});
+
+describe("HeliusRingsEventRepository (postgres)", () => {
+  let repo: HeliusRingsEventRepository;
+  let operationRepo: HeliusRingsOperationRepository;
+  let operationId: string;
+
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    const db = getDb(env);
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
+      )
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
+      .run();
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')"
+      )
+      .bind(TEST_USER.id, TEST_USER.email)
+      .run();
+
+    await db
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, 'Test Project', ?, 'sandbox', 'active', ?)`
+      )
+      .bind(TEST_PROJECT_ID, TEST_ORG.id, TEST_PROJECT_ID, TEST_USER.id)
+      .run();
+
+    const wallet = await createPostgresHeliusRingsWalletRepository(db).createWallet({
+      ...scope,
+      sdpWalletId: "wal_hre_repo_test",
+      name: "Treasury",
+      materialTag: "simulated",
+    });
+    if (!wallet) throw new Error("wallet fixture was not created");
+
+    operationRepo = createPostgresHeliusRingsOperationRepository(db);
+    const { operation } = await operationRepo.reserveIntent({
+      ...scope,
+      walletId: wallet.id,
+      opType: "shield",
+      intentKey: "sha256:event-test",
+    });
+    operationId = operation.id;
+
+    repo = createPostgresHeliusRingsEventRepository(db);
+  });
+
+  it("appends an event with its payload", async () => {
+    const event = await repo.append({
+      operationId,
+      kind: "state.transitioned",
+      payload: { from: "draft", to: "preparing" },
+    });
+
+    expect(event).toMatchObject({
+      operation_id: operationId,
+      kind: "state.transitioned",
+      payload: { from: "draft", to: "preparing" },
+    });
+  });
+
+  it("redacts key material before it reaches the table", async () => {
+    await repo.append({
+      operationId,
+      kind: "wallet.provisioned",
+      payload: { viewingKey: "vk-secret", shieldedAddress: "shielded-1" },
+    });
+
+    const [stored] = await repo.listByOperation({ operationId });
+    expect(stored.payload).toEqual({
+      viewingKey: REDACTION_CENSOR,
+      shieldedAddress: "shielded-1",
+    });
+
+    // Belt and braces: the literal secret is nowhere in the column.
+    const raw = await getDb(env)
+      .prepare("SELECT payload::text AS payload FROM helius_rings_events WHERE operation_id = ?")
+      .bind(operationId)
+      .first<{ payload: string }>();
+    expect(raw?.payload).not.toContain("vk-secret");
+  });
+
+  it("accepts an event with no payload", async () => {
+    const event = await repo.append({ operationId, kind: "operation.created" });
+
+    expect(event.payload).toBeNull();
+  });
+
+  it("lists the timeline oldest first", async () => {
+    await repo.append({ operationId, kind: "first" });
+    await repo.append({ operationId, kind: "second" });
+    await repo.append({ operationId, kind: "third" });
+    const db = getDb(env);
+    await db
+      .prepare("UPDATE helius_rings_events SET created_at = ? WHERE kind = ?")
+      .bind("2026-01-01T00:00:00.000Z", "first")
+      .run();
+    await db
+      .prepare("UPDATE helius_rings_events SET created_at = ? WHERE kind = ?")
+      .bind("2026-02-01T00:00:00.000Z", "second")
+      .run();
+    await db
+      .prepare("UPDATE helius_rings_events SET created_at = ? WHERE kind = ?")
+      .bind("2026-03-01T00:00:00.000Z", "third")
+      .run();
+
+    const events = await repo.listByOperation({ operationId });
+    expect(events.map((event) => event.kind)).toEqual(["first", "second", "third"]);
+  });
+
+  it("honours the list limit", async () => {
+    await repo.append({ operationId, kind: "first" });
+    await repo.append({ operationId, kind: "second" });
+
+    expect(await repo.listByOperation({ operationId, limit: 1 })).toHaveLength(1);
+  });
+
+  it("maps a row onto the domain event", async () => {
+    const event = await repo.append({ operationId, kind: "state.transitioned", payload: null });
+
+    expect(mapHeliusRingsEventRow(event)).toEqual({
+      kind: "state.transitioned",
+      createdAt: event.created_at,
+      payload: undefined,
+    });
+  });
+});

--- a/apps/sdp-api/src/db/repositories/helius-rings-event.repository.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-event.repository.ts
@@ -1,0 +1,114 @@
+import type { OperationEvent } from "@sdp/helius-rings";
+import { REDACTED_LEAF_FIELDS, REDACTION_CENSOR } from "@/runtime/log-redaction";
+import type { RepositoryDbClient } from "./base";
+
+export function generateHeliusRingsEventId(): string {
+  return `hre_${crypto.randomUUID()}`;
+}
+
+/** Upper bound on an unpaginated timeline read. */
+export const DEFAULT_RINGS_EVENT_LIST_LIMIT = 200;
+
+export interface HeliusRingsEventRow {
+  id: string;
+  operation_id: string;
+  /**
+   * Free-form. Event kinds are additive documentation of what happened, and the
+   * DB deliberately carries no CHECK on them — gating each new kind behind a
+   * migration is how you end up with someone logging it somewhere worse.
+   */
+  kind: string;
+  payload: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export interface AppendHeliusRingsEventInput {
+  operationId: string;
+  kind: string;
+  /** Redacted by `append` before it is written. */
+  payload?: Record<string, unknown> | null;
+}
+
+export interface ListHeliusRingsEventsInput {
+  operationId: string;
+  limit?: number;
+}
+
+export interface HeliusRingsEventRepositoryContext {
+  db: RepositoryDbClient;
+}
+
+export interface HeliusRingsEventRepository {
+  /**
+   * Appends one timeline entry. The payload is redacted on the way in, so the
+   * table cannot accumulate secret material even if a caller passes something it
+   * should not have.
+   */
+  append(input: AppendHeliusRingsEventInput): Promise<HeliusRingsEventRow>;
+  listByOperation(input: ListHeliusRingsEventsInput): Promise<HeliusRingsEventRow[]>;
+}
+
+/**
+ * Keys censored wherever they appear in an event payload.
+ *
+ * The Rings key domain comes from the log redaction registry rather than being
+ * retyped here — two copies of a security-critical list is how one of them goes
+ * stale. `material` is added because that is the key ref field name, and
+ * `ciphertext` because a sealed blob is still not timeline material.
+ */
+const CENSORED_KEYS = new Set<string>([...REDACTED_LEAF_FIELDS, "material", "ciphertext"]);
+
+/** Keys censored only under a `proof` parent, where they mean proof internals. */
+const CENSORED_PROOF_KEYS = new Set(["ref", "internal"]);
+
+function shouldCensor(key: string, parentKey: string | null): boolean {
+  return CENSORED_KEYS.has(key) || (parentKey === "proof" && CENSORED_PROOF_KEYS.has(key));
+}
+
+/**
+ * Deep-copies a payload, replacing sensitive values with the censor.
+ *
+ * Unlike the pino registry — which is bounded to one nesting level by
+ * fast-redact — this walks to arbitrary depth, because an event payload is
+ * written once and then read back forever, so the cost is paid on write rather
+ * than on every log line. Cycles are broken with a seen-set rather than
+ * throwing, since a malformed payload should not fail the state transition that
+ * is trying to record itself.
+ */
+export function redactHeliusRingsEventPayload(value: unknown, seen = new WeakSet()): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (seen.has(value)) return "[Circular]";
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactHeliusRingsEventPayload(entry, seen));
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (shouldCensor(key, null)) {
+      result[key] = REDACTION_CENSOR;
+      continue;
+    }
+    if (key === "proof" && entry !== null && typeof entry === "object" && !Array.isArray(entry)) {
+      const proof: Record<string, unknown> = {};
+      for (const [proofKey, proofEntry] of Object.entries(entry as Record<string, unknown>)) {
+        proof[proofKey] = shouldCensor(proofKey, "proof")
+          ? REDACTION_CENSOR
+          : redactHeliusRingsEventPayload(proofEntry, seen);
+      }
+      result[key] = proof;
+      continue;
+    }
+    result[key] = redactHeliusRingsEventPayload(entry, seen);
+  }
+  return result;
+}
+
+export function mapHeliusRingsEventRow(row: HeliusRingsEventRow): OperationEvent {
+  return {
+    kind: row.kind,
+    createdAt: row.created_at,
+    payload: row.payload ?? undefined,
+  };
+}

--- a/apps/sdp-api/src/db/repositories/helius-rings-health.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-health.repository.postgres.ts
@@ -1,0 +1,58 @@
+import type { AppDb } from "@/db";
+import type {
+  HeliusRingsHealthRepository,
+  HeliusRingsRuntimeHealthRow,
+  RecordHeliusRingsHealthInput,
+} from "./helius-rings-health.repository";
+
+function mapRow(row: Record<string, unknown>): HeliusRingsRuntimeHealthRow {
+  return {
+    project_id: row.project_id as string,
+    component: row.component as HeliusRingsRuntimeHealthRow["component"],
+    status: row.status as HeliusRingsRuntimeHealthRow["status"],
+    observed_at: row.observed_at as string,
+    detail: (row.detail ?? null) as Record<string, string> | null,
+  };
+}
+
+export function createPostgresHeliusRingsHealthRepository(db: AppDb): HeliusRingsHealthRepository {
+  return {
+    async recordHealth(input: RecordHeliusRingsHealthInput) {
+      const detail =
+        input.detail === undefined || input.detail === null ? null : JSON.stringify(input.detail);
+      const row = await db
+        .prepare(
+          `INSERT INTO helius_rings_runtime_health (project_id, component, status, observed_at, detail)
+           VALUES (?, ?, ?, sdp_iso_now(), ?::jsonb)
+           ON CONFLICT (project_id, component)
+           -- Overwrite in place: this table is a status board, not a history.
+           -- observed_at moves even when the status is unchanged, because "still
+           -- green as of a minute ago" and "green, last checked on Tuesday" are
+           -- different answers for the operator staring at the diagnostics page.
+           DO UPDATE SET
+             status = EXCLUDED.status,
+             observed_at = EXCLUDED.observed_at,
+             detail = EXCLUDED.detail
+           RETURNING *`
+        )
+        .bind(input.projectId, input.component, input.status, detail)
+        .first<Record<string, unknown>>();
+      if (!row) {
+        throw new Error("helius rings recordHealth returned no row");
+      }
+      return mapRow(row);
+    },
+
+    async listHealthByProject(input: { projectId: string }) {
+      const result = await db
+        .prepare(
+          `SELECT * FROM helius_rings_runtime_health
+            WHERE project_id = ?
+            ORDER BY component ASC`
+        )
+        .bind(input.projectId)
+        .all<Record<string, unknown>>();
+      return result.results.map(mapRow);
+    },
+  };
+}

--- a/apps/sdp-api/src/db/repositories/helius-rings-health.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-health.repository.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import type {
+  HeliusRingsHealthRepository,
+  HeliusRingsRuntimeHealthRow,
+} from "./helius-rings-health.repository";
+import { mapHeliusRingsHealthRows } from "./helius-rings-health.repository";
+import { createPostgresHeliusRingsHealthRepository } from "./helius-rings-health.repository.postgres";
+
+const TEST_PROJECT_ID = "prj_hrh_repo_test";
+
+function row(overrides: Partial<HeliusRingsRuntimeHealthRow> = {}): HeliusRingsRuntimeHealthRow {
+  return {
+    project_id: TEST_PROJECT_ID,
+    component: "rpc",
+    status: "green",
+    observed_at: "2026-08-17T00:00:00.000Z",
+    detail: null,
+    ...overrides,
+  };
+}
+
+describe("mapHeliusRingsHealthRows", () => {
+  it("reads an unobserved component as red, not green", () => {
+    // Never having checked an upstream is not evidence that it is healthy, and
+    // the action gate keys off this value.
+    expect(mapHeliusRingsHealthRows([])).toEqual({
+      rpc: "red",
+      prover: "red",
+      photon: "red",
+      gateway: "red",
+    });
+  });
+
+  it("reports each observed component's stored status", () => {
+    const health = mapHeliusRingsHealthRows([
+      row({ component: "rpc", status: "green" }),
+      row({ component: "prover", status: "amber" }),
+      row({ component: "photon", status: "red" }),
+    ]);
+
+    expect(health).toEqual({
+      rpc: "green",
+      prover: "amber",
+      photon: "red",
+      gateway: "red",
+    });
+  });
+
+  it("prefixes detail keys with their component so they cannot collide", () => {
+    const health = mapHeliusRingsHealthRows([
+      row({ component: "rpc", detail: { reason: "slow" } }),
+      row({ component: "prover", detail: { reason: "queue depth" } }),
+    ]);
+
+    expect(health.detail).toEqual({
+      "rpc.reason": "slow",
+      "prover.reason": "queue depth",
+    });
+  });
+
+  it("omits detail entirely when no row carries any", () => {
+    expect(mapHeliusRingsHealthRows([row()])).not.toHaveProperty("detail");
+  });
+});
+
+describe("HeliusRingsHealthRepository (postgres)", () => {
+  let repo: HeliusRingsHealthRepository;
+
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    const db = getDb(env);
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
+      )
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
+      .run();
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')"
+      )
+      .bind(TEST_USER.id, TEST_USER.email)
+      .run();
+
+    await db
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, 'Test Project', ?, 'sandbox', 'active', ?)`
+      )
+      .bind(TEST_PROJECT_ID, TEST_ORG.id, TEST_PROJECT_ID, TEST_USER.id)
+      .run();
+
+    repo = createPostgresHeliusRingsHealthRepository(db);
+  });
+
+  it("records an observation with its detail", async () => {
+    const recorded = await repo.recordHealth({
+      projectId: TEST_PROJECT_ID,
+      component: "prover",
+      status: "amber",
+      detail: { reason: "queue depth 40" },
+    });
+
+    expect(recorded).toMatchObject({
+      component: "prover",
+      status: "amber",
+      detail: { reason: "queue depth 40" },
+    });
+    expect(recorded.observed_at).toBeTruthy();
+  });
+
+  it("overwrites in place rather than appending a history", async () => {
+    await repo.recordHealth({ projectId: TEST_PROJECT_ID, component: "rpc", status: "red" });
+    const updated = await repo.recordHealth({
+      projectId: TEST_PROJECT_ID,
+      component: "rpc",
+      status: "green",
+    });
+
+    expect(updated.status).toBe("green");
+    const rows = await repo.listHealthByProject({ projectId: TEST_PROJECT_ID });
+    expect(rows).toHaveLength(1);
+  });
+
+  it("clears stale detail when a later observation carries none", async () => {
+    await repo.recordHealth({
+      projectId: TEST_PROJECT_ID,
+      component: "rpc",
+      status: "red",
+      detail: { reason: "timeout" },
+    });
+    const recovered = await repo.recordHealth({
+      projectId: TEST_PROJECT_ID,
+      component: "rpc",
+      status: "green",
+    });
+
+    // A green row still carrying the old failure text misreports a healthy
+    // upstream as broken.
+    expect(recovered.detail).toBeNull();
+  });
+
+  it("keeps components independent", async () => {
+    await repo.recordHealth({ projectId: TEST_PROJECT_ID, component: "rpc", status: "green" });
+    await repo.recordHealth({ projectId: TEST_PROJECT_ID, component: "photon", status: "amber" });
+
+    const health = mapHeliusRingsHealthRows(
+      await repo.listHealthByProject({ projectId: TEST_PROJECT_ID })
+    );
+    expect(health).toMatchObject({ rpc: "green", photon: "amber", prover: "red", gateway: "red" });
+  });
+
+  it("rejects a component outside the known set", async () => {
+    await expect(
+      repo.recordHealth({
+        projectId: TEST_PROJECT_ID,
+        // Deliberately outside RUNTIME_HEALTH_COMPONENTS: the DB CHECK is the
+        // backstop for a component added in code but not in a migration.
+        component: "sidecar" as never,
+        status: "green",
+      })
+    ).rejects.toMatchObject({ message: expect.stringContaining("component_check") });
+  });
+});

--- a/apps/sdp-api/src/db/repositories/helius-rings-health.repository.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-health.repository.ts
@@ -1,0 +1,57 @@
+import type { RuntimeHealth, RuntimeHealthComponent, RuntimeHealthStatus } from "@sdp/helius-rings";
+import { RUNTIME_HEALTH_COMPONENTS } from "@sdp/helius-rings";
+import type { RepositoryDbClient } from "./base";
+
+/**
+ * One row per (project, component). Overwritten in place rather than appended:
+ * this is the status board the diagnostics page and the red-state action gate
+ * read, not a history. Durable history lives in the event feed.
+ */
+export interface HeliusRingsRuntimeHealthRow {
+  project_id: string;
+  component: RuntimeHealthComponent;
+  status: RuntimeHealthStatus;
+  observed_at: string;
+  detail: Record<string, string> | null;
+}
+
+export interface RecordHeliusRingsHealthInput {
+  projectId: string;
+  component: RuntimeHealthComponent;
+  status: RuntimeHealthStatus;
+  detail?: Record<string, string> | null;
+}
+
+export interface HeliusRingsHealthRepositoryContext {
+  db: RepositoryDbClient;
+}
+
+export interface HeliusRingsHealthRepository {
+  /** Upserts the latest observation for one component. */
+  recordHealth(input: RecordHeliusRingsHealthInput): Promise<HeliusRingsRuntimeHealthRow>;
+  listHealthByProject(input: { projectId: string }): Promise<HeliusRingsRuntimeHealthRow[]>;
+}
+
+/**
+ * Collapses the stored rows into the domain's component-to-status map.
+ *
+ * A component with no row yet reads as `red`, not `green`: never having observed
+ * an upstream is not evidence that it is healthy, and the action gate keys off
+ * this value.
+ */
+export function mapHeliusRingsHealthRows(rows: HeliusRingsRuntimeHealthRow[]): RuntimeHealth {
+  const byComponent = new Map(rows.map((row) => [row.component, row]));
+  const detail: Record<string, string> = {};
+  for (const row of rows) {
+    for (const [key, value] of Object.entries(row.detail ?? {})) {
+      detail[`${row.component}.${key}`] = value;
+    }
+  }
+
+  const health = {} as Record<RuntimeHealthComponent, RuntimeHealthStatus>;
+  for (const component of RUNTIME_HEALTH_COMPONENTS) {
+    health[component] = byComponent.get(component)?.status ?? "red";
+  }
+
+  return Object.keys(detail).length > 0 ? { ...health, detail } : { ...health };
+}

--- a/apps/sdp-api/src/db/repositories/helius-rings-key-ref.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-key-ref.repository.postgres.ts
@@ -1,0 +1,65 @@
+import type { KeyKind } from "@sdp/helius-rings";
+import type { AppDb } from "@/db";
+import {
+  type CreateHeliusRingsKeyRefInput,
+  generateHeliusRingsKeyRefId,
+  type HeliusRingsKeyRefRepository,
+  type HeliusRingsKeyRefRow,
+} from "./helius-rings-key-ref.repository";
+
+function mapRow(row: Record<string, unknown>): HeliusRingsKeyRefRow {
+  return {
+    id: row.id as string,
+    wallet_id: row.wallet_id as string,
+    kind: row.kind as HeliusRingsKeyRefRow["kind"],
+    ciphertext: row.ciphertext as string,
+    key_version: row.key_version as string,
+    material_tag: row.material_tag as HeliusRingsKeyRefRow["material_tag"],
+    created_at: row.created_at as string,
+  };
+}
+
+export function createPostgresHeliusRingsKeyRefRepository(db: AppDb): HeliusRingsKeyRefRepository {
+  return {
+    async createKeyRef(input: CreateHeliusRingsKeyRefInput) {
+      const id = generateHeliusRingsKeyRefId();
+      const row = await db
+        .prepare(
+          `INSERT INTO helius_rings_key_refs (
+             id,
+             wallet_id,
+             kind,
+             ciphertext,
+             key_version,
+             material_tag
+           ) VALUES (?, ?, ?, ?, ?, ?)
+           ON CONFLICT (wallet_id, kind)
+           -- Self-assignment returns the blob already sealed. Note it assigns
+           -- created_at to itself rather than the incoming ciphertext: a replay
+           -- must not overwrite sealed material, because the first blob is the
+           -- one the shielded identity was derived from.
+           DO UPDATE SET created_at = helius_rings_key_refs.created_at
+           RETURNING *`
+        )
+        .bind(id, input.walletId, input.kind, input.ciphertext, input.keyVersion, input.materialTag)
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+
+    async getKeyRef(input: { walletId: string; kind: KeyKind }) {
+      const row = await db
+        .prepare(`SELECT * FROM helius_rings_key_refs WHERE wallet_id = ? AND kind = ?`)
+        .bind(input.walletId, input.kind)
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+
+    async listKeyRefsByWallet(input: { walletId: string }) {
+      const result = await db
+        .prepare(`SELECT * FROM helius_rings_key_refs WHERE wallet_id = ? ORDER BY kind ASC`)
+        .bind(input.walletId)
+        .all<Record<string, unknown>>();
+      return result.results.map(mapRow);
+    },
+  };
+}

--- a/apps/sdp-api/src/db/repositories/helius-rings-key-ref.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-key-ref.repository.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import type { HeliusRingsKeyRefRepository } from "./helius-rings-key-ref.repository";
+import { createPostgresHeliusRingsKeyRefRepository } from "./helius-rings-key-ref.repository.postgres";
+import { createPostgresHeliusRingsWalletRepository } from "./helius-rings-wallet.repository.postgres";
+import type { HeliusRingsZoneRepository } from "./helius-rings-zone.repository";
+import { mapHeliusRingsZoneRow } from "./helius-rings-zone.repository";
+import { createPostgresHeliusRingsZoneRepository } from "./helius-rings-zone.repository.postgres";
+
+const TEST_PROJECT_ID = "prj_hrk_repo_test";
+const scope = { organizationId: TEST_ORG.id, projectId: TEST_PROJECT_ID };
+
+let keyRefRepo: HeliusRingsKeyRefRepository;
+let zoneRepo: HeliusRingsZoneRepository;
+let walletId: string;
+let otherWalletId: string;
+
+describe("HeliusRingsKeyRefRepository / HeliusRingsZoneRepository (postgres)", () => {
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    const db = getDb(env);
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
+      )
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
+      .run();
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')"
+      )
+      .bind(TEST_USER.id, TEST_USER.email)
+      .run();
+
+    await db
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, 'Test Project', ?, 'sandbox', 'active', ?)`
+      )
+      .bind(TEST_PROJECT_ID, TEST_ORG.id, TEST_PROJECT_ID, TEST_USER.id)
+      .run();
+
+    const walletRepo = createPostgresHeliusRingsWalletRepository(db);
+    const wallet = await walletRepo.createWallet({
+      ...scope,
+      sdpWalletId: "wal_hrk_repo_test",
+      name: "Treasury",
+      materialTag: "simulated",
+    });
+    const other = await walletRepo.createWallet({
+      ...scope,
+      sdpWalletId: "wal_hrk_repo_other",
+      name: "Operations",
+      materialTag: "simulated",
+    });
+    if (!wallet || !other) throw new Error("wallet fixtures were not created");
+    walletId = wallet.id;
+    otherWalletId = other.id;
+
+    keyRefRepo = createPostgresHeliusRingsKeyRefRepository(db);
+    zoneRepo = createPostgresHeliusRingsZoneRepository(db);
+  });
+
+  describe("key refs", () => {
+    it("stores a sealed blob without interpreting it", async () => {
+      const keyRef = await keyRefRepo.createKeyRef({
+        walletId,
+        kind: "viewing",
+        ciphertext: "sealed-blob",
+        keyVersion: "v1",
+        materialTag: "simulated",
+      });
+
+      expect(keyRef).toMatchObject({
+        wallet_id: walletId,
+        kind: "viewing",
+        ciphertext: "sealed-blob",
+        key_version: "v1",
+      });
+    });
+
+    it("does not re-seal on a replay, because the first blob owns the identity", async () => {
+      const first = await keyRefRepo.createKeyRef({
+        walletId,
+        kind: "viewing",
+        ciphertext: "sealed-first",
+        keyVersion: "v1",
+        materialTag: "simulated",
+      });
+      const replay = await keyRefRepo.createKeyRef({
+        walletId,
+        kind: "viewing",
+        ciphertext: "sealed-second",
+        keyVersion: "v2",
+        materialTag: "simulated",
+      });
+
+      expect(replay?.id).toBe(first?.id);
+      // Overwriting would strand the blob the shielded identity was derived
+      // from and make the wallet unreachable.
+      expect(replay?.ciphertext).toBe("sealed-first");
+      expect(replay?.key_version).toBe("v1");
+    });
+
+    it("keeps one blob per kind per wallet", async () => {
+      await keyRefRepo.createKeyRef({
+        walletId,
+        kind: "viewing",
+        ciphertext: "sealed-viewing",
+        keyVersion: "v1",
+        materialTag: "simulated",
+      });
+      await keyRefRepo.createKeyRef({
+        walletId,
+        kind: "nullifier",
+        ciphertext: "sealed-nullifier",
+        keyVersion: "v1",
+        materialTag: "simulated",
+      });
+
+      const listed = await keyRefRepo.listKeyRefsByWallet({ walletId });
+      expect(listed.map((keyRef) => keyRef.kind)).toEqual(["nullifier", "viewing"]);
+      expect(await keyRefRepo.getKeyRef({ walletId, kind: "viewing" })).toMatchObject({
+        ciphertext: "sealed-viewing",
+      });
+    });
+
+    it("does not leak another wallet's blobs", async () => {
+      await keyRefRepo.createKeyRef({
+        walletId,
+        kind: "viewing",
+        ciphertext: "sealed-viewing",
+        keyVersion: "v1",
+        materialTag: "simulated",
+      });
+
+      expect(await keyRefRepo.getKeyRef({ walletId: otherWalletId, kind: "viewing" })).toBeNull();
+      expect(await keyRefRepo.listKeyRefsByWallet({ walletId: otherWalletId })).toEqual([]);
+    });
+  });
+
+  describe("zones", () => {
+    it("creates a zone", async () => {
+      const zone = await zoneRepo.createZone({ walletId, name: "Payroll", kind: "treasury" });
+
+      expect(zone).toMatchObject({ wallet_id: walletId, name: "Payroll", kind: "treasury" });
+    });
+
+    it("returns the existing zone on a replay without moving its kind", async () => {
+      const first = await zoneRepo.createZone({ walletId, name: "Payroll", kind: "treasury" });
+      const replay = await zoneRepo.createZone({ walletId, name: "Payroll", kind: "public" });
+
+      expect(replay?.id).toBe(first?.id);
+      // Changing the kind under a live operation would move its destination.
+      expect(replay?.kind).toBe("treasury");
+      expect(await zoneRepo.listZonesByWallet({ walletId })).toHaveLength(1);
+    });
+
+    it("lets two wallets each hold a zone of the same name", async () => {
+      await zoneRepo.createZone({ walletId, name: "Payroll", kind: "treasury" });
+      const other = await zoneRepo.createZone({
+        walletId: otherWalletId,
+        name: "Payroll",
+        kind: "treasury",
+      });
+
+      expect(other?.wallet_id).toBe(otherWalletId);
+    });
+
+    it("scopes a zone read to its wallet", async () => {
+      const zone = await zoneRepo.createZone({ walletId, name: "Payroll", kind: "treasury" });
+      if (!zone) throw new Error("zone was not created");
+
+      expect(await zoneRepo.getZoneById({ id: zone.id, walletId: otherWalletId })).toBeNull();
+      expect(await zoneRepo.getZoneById({ id: zone.id, walletId })).toMatchObject({ id: zone.id });
+    });
+
+    it("maps a row onto the domain zone", async () => {
+      const zone = await zoneRepo.createZone({ walletId, name: "Payroll", kind: "treasury" });
+      if (!zone) throw new Error("zone was not created");
+
+      expect(mapHeliusRingsZoneRow(zone)).toEqual({
+        id: zone.id,
+        name: "Payroll",
+        kind: "treasury",
+      });
+    });
+  });
+});

--- a/apps/sdp-api/src/db/repositories/helius-rings-key-ref.repository.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-key-ref.repository.ts
@@ -1,0 +1,46 @@
+import type { KeyKind, MaterialTag } from "@sdp/helius-rings";
+import type { RepositoryDbClient } from "./base";
+
+export function generateHeliusRingsKeyRefId(): string {
+  return `hrk_${crypto.randomUUID()}`;
+}
+
+/**
+ * A sealed key blob as stored. `ciphertext` is whatever custody-cipher produced
+ * and is never interpreted here — ciphertext in, ciphertext out. This repository
+ * must never call `SecretRef.reveal`, and there is deliberately no method that
+ * decrypts.
+ */
+export interface HeliusRingsKeyRefRow {
+  id: string;
+  wallet_id: string;
+  kind: KeyKind;
+  ciphertext: string;
+  /** Cipher key generation that sealed this blob, for rotation. */
+  key_version: string;
+  material_tag: MaterialTag;
+  created_at: string;
+}
+
+export interface CreateHeliusRingsKeyRefInput {
+  walletId: string;
+  kind: KeyKind;
+  ciphertext: string;
+  keyVersion: string;
+  materialTag: MaterialTag;
+}
+
+export interface HeliusRingsKeyRefRepositoryContext {
+  db: RepositoryDbClient;
+}
+
+export interface HeliusRingsKeyRefRepository {
+  /**
+   * Stores one key blob. A wallet holds at most one key per kind, so a replay of
+   * provisioning returns the blob already sealed rather than writing a second
+   * one — re-sealing would strand the first and make the identity unreachable.
+   */
+  createKeyRef(input: CreateHeliusRingsKeyRefInput): Promise<HeliusRingsKeyRefRow | null>;
+  getKeyRef(input: { walletId: string; kind: KeyKind }): Promise<HeliusRingsKeyRefRow | null>;
+  listKeyRefsByWallet(input: { walletId: string }): Promise<HeliusRingsKeyRefRow[]>;
+}

--- a/apps/sdp-api/src/db/repositories/helius-rings-operation.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-operation.repository.postgres.ts
@@ -1,0 +1,361 @@
+import type { AppDb } from "@/db";
+import {
+  DEFAULT_RINGS_IN_FLIGHT_SWEEP_LIMIT,
+  DEFAULT_RINGS_OPERATION_LIST_LIMIT,
+  type FailHeliusRingsOperationInput,
+  generateHeliusRingsOperationId,
+  type HeliusRingsOperationRepository,
+  type HeliusRingsOperationRow,
+  type HeliusRingsTimelockRow,
+  type ListHeliusRingsInFlightOperationsInput,
+  type ListHeliusRingsOperationsByProjectInput,
+  type ListHeliusRingsOperationsByWalletInput,
+  type ReleaseHeliusRingsTimelockInput,
+  type ReserveHeliusRingsIntentInput,
+  type TransitionHeliusRingsOperationInput,
+} from "./helius-rings-operation.repository";
+import type { HeliusRingsProjectScope } from "./helius-rings-wallet.repository";
+
+/** The states the resume sweep considers live, matching the partial index. */
+const IN_FLIGHT_STATES = [
+  "preparing",
+  "approval_required",
+  "proving",
+  "ready_to_sign",
+  "submitted",
+  "indexing",
+] as const;
+
+function mapRow(row: Record<string, unknown>): HeliusRingsOperationRow {
+  return {
+    id: row.id as string,
+    organization_id: row.organization_id as string,
+    project_id: row.project_id as string,
+    wallet_id: row.wallet_id as string,
+    op_type: row.op_type as HeliusRingsOperationRow["op_type"],
+    state: row.state as HeliusRingsOperationRow["state"],
+    asset_mint: (row.asset_mint ?? null) as string | null,
+    amount_raw: (row.amount_raw ?? null) as string | null,
+    from_addr: (row.from_addr ?? null) as string | null,
+    to_addr: (row.to_addr ?? null) as string | null,
+    zone_id: (row.zone_id ?? null) as string | null,
+    transfer_mode: (row.transfer_mode ?? null) as HeliusRingsOperationRow["transfer_mode"],
+    intent_key: row.intent_key as string,
+    approval_request_id: (row.approval_request_id ?? null) as string | null,
+    policy_evaluation_id: (row.policy_evaluation_id ?? null) as string | null,
+    proof_source: (row.proof_source ?? null) as HeliusRingsOperationRow["proof_source"],
+    proof_ref: (row.proof_ref ?? null) as string | null,
+    outer_tx_signature: (row.outer_tx_signature ?? null) as string | null,
+    photon_indexed_at: (row.photon_indexed_at ?? null) as string | null,
+    failure_code: (row.failure_code ?? null) as HeliusRingsOperationRow["failure_code"],
+    failure_message: (row.failure_message ?? null) as string | null,
+    retryable: (row.retryable ?? null) as boolean | null,
+    retry_of_operation_id: (row.retry_of_operation_id ?? null) as string | null,
+    timelock_unlock_at: (row.timelock_unlock_at ?? null) as string | null,
+    created_at: row.created_at as string,
+    updated_at: row.updated_at as string,
+  };
+}
+
+function mapTimelockRow(row: Record<string, unknown>): HeliusRingsTimelockRow {
+  return {
+    operation_id: row.operation_id as string,
+    unlock_at: row.unlock_at as string,
+    released_at: (row.released_at ?? null) as string | null,
+    beneficiary_addr: row.beneficiary_addr as string,
+  };
+}
+
+export function createPostgresHeliusRingsOperationRepository(
+  db: AppDb
+): HeliusRingsOperationRepository {
+  return {
+    async reserveIntent(input: ReserveHeliusRingsIntentInput) {
+      const id = generateHeliusRingsOperationId();
+
+      return db.transaction(async (tx) => {
+        const row = await tx
+          .prepare(
+            `INSERT INTO helius_rings_operations (
+               id,
+               organization_id,
+               project_id,
+               wallet_id,
+               op_type,
+               intent_key,
+               asset_mint,
+               amount_raw,
+               from_addr,
+               to_addr,
+               zone_id,
+               transfer_mode,
+               retry_of_operation_id,
+               timelock_unlock_at
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT (intent_key)
+             -- Self-assignment rather than DO NOTHING: DO NOTHING returns zero
+             -- rows on a replay, which is indistinguishable from a failed
+             -- insert. Assigning updated_at to itself makes RETURNING emit the
+             -- row that is already there without altering it.
+             DO UPDATE SET updated_at = helius_rings_operations.updated_at
+             RETURNING *`
+          )
+          .bind(
+            id,
+            input.organizationId,
+            input.projectId,
+            input.walletId,
+            input.opType,
+            input.intentKey,
+            input.assetMint ?? null,
+            input.amountRaw ?? null,
+            input.fromAddr ?? null,
+            input.toAddr ?? null,
+            input.zoneId ?? null,
+            input.transferMode ?? null,
+            input.retryOfOperationId ?? null,
+            input.timelock?.unlockAt ?? null
+          )
+          .first<Record<string, unknown>>();
+
+        if (!row) {
+          // The upsert always returns a row; a null here means the statement
+          // matched nothing at all, which is not a state this table can reach.
+          throw new Error("helius rings reserveIntent returned no row");
+        }
+
+        const operation = mapRow(row);
+        // The id we generated only survives if this call is the one that
+        // inserted. On a replay the row carries the original id, which is a
+        // cheaper and clearer signal than inspecting xmax.
+        const reserved = operation.id === id;
+
+        if (reserved && input.timelock) {
+          await tx
+            .prepare(
+              `INSERT INTO helius_rings_timelocks (operation_id, unlock_at, beneficiary_addr)
+               VALUES (?, ?, ?)
+               ON CONFLICT (operation_id) DO NOTHING`
+            )
+            .bind(operation.id, input.timelock.unlockAt, input.timelock.beneficiaryAddr)
+            .run();
+        }
+
+        return { operation, reserved };
+      });
+    },
+
+    async getOperationById(input: HeliusRingsProjectScope & { id: string }) {
+      const row = await db
+        .prepare(
+          `SELECT * FROM helius_rings_operations
+            WHERE id = ? AND organization_id = ? AND project_id = ?`
+        )
+        .bind(input.id, input.organizationId, input.projectId)
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+
+    async getOperationByIntentKey(input: HeliusRingsProjectScope & { intentKey: string }) {
+      const row = await db
+        .prepare(
+          `SELECT * FROM helius_rings_operations
+            WHERE intent_key = ? AND organization_id = ? AND project_id = ?`
+        )
+        .bind(input.intentKey, input.organizationId, input.projectId)
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+
+    async listOperationsByWallet(input: ListHeliusRingsOperationsByWalletInput) {
+      const result = await db
+        .prepare(
+          `SELECT * FROM helius_rings_operations
+            WHERE wallet_id = ? AND organization_id = ? AND project_id = ?
+            ORDER BY created_at DESC, id DESC
+            LIMIT ?`
+        )
+        .bind(
+          input.walletId,
+          input.organizationId,
+          input.projectId,
+          input.limit ?? DEFAULT_RINGS_OPERATION_LIST_LIMIT
+        )
+        .all<Record<string, unknown>>();
+      return result.results.map(mapRow);
+    },
+
+    async listOperationsByProject(input: ListHeliusRingsOperationsByProjectInput) {
+      const result = await db
+        .prepare(
+          `SELECT * FROM helius_rings_operations
+            WHERE organization_id = ? AND project_id = ?
+            ORDER BY created_at DESC, id DESC
+            LIMIT ?`
+        )
+        .bind(
+          input.organizationId,
+          input.projectId,
+          input.limit ?? DEFAULT_RINGS_OPERATION_LIST_LIMIT
+        )
+        .all<Record<string, unknown>>();
+      return result.results.map(mapRow);
+    },
+
+    async transitionState(input: TransitionHeliusRingsOperationInput) {
+      return db.transaction(async (tx) => {
+        // Lock first. Two workers resuming the same operation would otherwise
+        // both read `submitted`, both write `indexing`, and both go on to do the
+        // follow-up work once each.
+        const locked = await tx
+          .prepare(
+            `SELECT state FROM helius_rings_operations
+              WHERE id = ? AND organization_id = ? AND project_id = ?
+              FOR UPDATE`
+          )
+          .bind(input.id, input.organizationId, input.projectId)
+          .first<{ state: string }>();
+
+        if (!locked || locked.state !== input.expectedState) return null;
+
+        const patch = input.patch ?? {};
+        const assignments: string[] = ["state = ?", "updated_at = sdp_iso_now()"];
+        const values: unknown[] = [input.nextState];
+
+        // Only columns the caller named are written, so a later step cannot
+        // blank the approval id an earlier one recorded.
+        if (patch.approvalRequestId !== undefined) {
+          assignments.push("approval_request_id = ?");
+          values.push(patch.approvalRequestId);
+        }
+        if (patch.policyEvaluationId !== undefined) {
+          assignments.push("policy_evaluation_id = ?");
+          values.push(patch.policyEvaluationId);
+        }
+        if (patch.proofSource !== undefined) {
+          assignments.push("proof_source = ?");
+          values.push(patch.proofSource);
+        }
+        if (patch.proofRef !== undefined) {
+          assignments.push("proof_ref = ?");
+          values.push(patch.proofRef);
+        }
+        if (patch.outerTxSignature !== undefined) {
+          assignments.push("outer_tx_signature = ?");
+          values.push(patch.outerTxSignature);
+        }
+        if (patch.photonIndexedAt !== undefined) {
+          assignments.push("photon_indexed_at = ?");
+          values.push(patch.photonIndexedAt);
+        }
+
+        const row = await tx
+          .prepare(
+            `UPDATE helius_rings_operations
+                SET ${assignments.join(", ")}
+              WHERE id = ? AND organization_id = ? AND project_id = ?
+            RETURNING *`
+          )
+          .bind(...values, input.id, input.organizationId, input.projectId)
+          .first<Record<string, unknown>>();
+
+        return row ? mapRow(row) : null;
+      });
+    },
+
+    async failOperation(input: FailHeliusRingsOperationInput) {
+      return db.transaction(async (tx) => {
+        const locked = await tx
+          .prepare(
+            `SELECT state FROM helius_rings_operations
+              WHERE id = ? AND organization_id = ? AND project_id = ?
+              FOR UPDATE`
+          )
+          .bind(input.id, input.organizationId, input.projectId)
+          .first<{ state: string }>();
+
+        if (!locked || locked.state !== input.expectedState) return null;
+
+        // The failure triple moves together because the DB CHECK requires it:
+        // a `failed` row without a code is unactionable in the recovery UI.
+        const row = await tx
+          .prepare(
+            `UPDATE helius_rings_operations
+                SET state = 'failed',
+                    failure_code = ?,
+                    failure_message = ?,
+                    retryable = ?,
+                    updated_at = sdp_iso_now()
+              WHERE id = ? AND organization_id = ? AND project_id = ?
+            RETURNING *`
+          )
+          .bind(
+            input.code,
+            input.message,
+            input.retryable,
+            input.id,
+            input.organizationId,
+            input.projectId
+          )
+          .first<Record<string, unknown>>();
+
+        return row ? mapRow(row) : null;
+      });
+    },
+
+    async listInFlightOperations(input: ListHeliusRingsInFlightOperationsInput) {
+      const placeholders = IN_FLIGHT_STATES.map(() => "?").join(", ");
+      const result = await db
+        .prepare(
+          `SELECT * FROM helius_rings_operations
+            WHERE state IN (${placeholders})
+              AND updated_at < ?
+            ORDER BY updated_at ASC, id ASC
+            LIMIT ?`
+        )
+        .bind(
+          ...IN_FLIGHT_STATES,
+          input.staleBefore,
+          input.limit ?? DEFAULT_RINGS_IN_FLIGHT_SWEEP_LIMIT
+        )
+        .all<Record<string, unknown>>();
+      return result.results.map(mapRow);
+    },
+
+    async getTimelock(input: { operationId: string }) {
+      const row = await db
+        .prepare(`SELECT * FROM helius_rings_timelocks WHERE operation_id = ?`)
+        .bind(input.operationId)
+        .first<Record<string, unknown>>();
+      return row ? mapTimelockRow(row) : null;
+    },
+
+    async listReleasableTimelocks(input: { asOf: string; limit?: number }) {
+      const result = await db
+        .prepare(
+          `SELECT * FROM helius_rings_timelocks
+            WHERE released_at IS NULL AND unlock_at <= ?
+            ORDER BY unlock_at ASC, operation_id ASC
+            LIMIT ?`
+        )
+        .bind(input.asOf, input.limit ?? DEFAULT_RINGS_IN_FLIGHT_SWEEP_LIMIT)
+        .all<Record<string, unknown>>();
+      return result.results.map(mapTimelockRow);
+    },
+
+    async releaseTimelock(input: ReleaseHeliusRingsTimelockInput) {
+      // `released_at IS NULL` is the whole guard: it makes the release
+      // single-shot, so two sweeps racing produce one payout and one null.
+      const row = await db
+        .prepare(
+          `UPDATE helius_rings_timelocks
+              SET released_at = ?
+            WHERE operation_id = ? AND released_at IS NULL
+          RETURNING *`
+        )
+        .bind(input.releasedAt, input.operationId)
+        .first<Record<string, unknown>>();
+      return row ? mapTimelockRow(row) : null;
+    },
+  };
+}

--- a/apps/sdp-api/src/db/repositories/helius-rings-operation.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-operation.repository.test.ts
@@ -10,6 +10,7 @@ import type {
 import { createPostgresHeliusRingsOperationRepository } from "./helius-rings-operation.repository.postgres";
 import type { HeliusRingsWalletRepository } from "./helius-rings-wallet.repository";
 import { createPostgresHeliusRingsWalletRepository } from "./helius-rings-wallet.repository.postgres";
+import { createPostgresHeliusRingsZoneRepository } from "./helius-rings-zone.repository.postgres";
 
 const TEST_PROJECT_ID = "prj_hro_repo_test";
 const OTHER_PROJECT_ID = "prj_hro_repo_other";
@@ -313,6 +314,29 @@ describe("HeliusRingsOperationRepository (postgres)", () => {
       });
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe("zone destinations", () => {
+    it("rejects a zone owned by another wallet", async () => {
+      const other = await walletRepo.createWallet({
+        ...scope,
+        sdpWalletId: "wal_hro_zone_other",
+        name: "Operations",
+        materialTag: "simulated",
+      });
+      if (!other) throw new Error("wallet fixture was not created");
+      const zone = await createPostgresHeliusRingsZoneRepository(getDb(env)).createZone({
+        walletId: other.id,
+        name: "Payroll",
+        kind: "treasury",
+      });
+      if (!zone) throw new Error("zone fixture was not created");
+
+      // The composite (zone_id, wallet_id) FK refuses the cross-wallet reference.
+      await expect(
+        repo.reserveIntent(shieldIntent({ intentKey: "sha256:cross-zone", zoneId: zone.id }))
+      ).rejects.toMatchObject({ message: expect.stringContaining("zone") });
     });
   });
 

--- a/apps/sdp-api/src/db/repositories/helius-rings-operation.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-operation.repository.test.ts
@@ -1,0 +1,458 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import type {
+  HeliusRingsOperationRepository,
+  ReserveHeliusRingsIntentInput,
+} from "./helius-rings-operation.repository";
+import { createPostgresHeliusRingsOperationRepository } from "./helius-rings-operation.repository.postgres";
+import type { HeliusRingsWalletRepository } from "./helius-rings-wallet.repository";
+import { createPostgresHeliusRingsWalletRepository } from "./helius-rings-wallet.repository.postgres";
+
+const TEST_PROJECT_ID = "prj_hro_repo_test";
+const OTHER_PROJECT_ID = "prj_hro_repo_other";
+
+let repo: HeliusRingsOperationRepository;
+let walletRepo: HeliusRingsWalletRepository;
+let walletId: string;
+
+const scope = {
+  organizationId: TEST_ORG.id,
+  projectId: TEST_PROJECT_ID,
+};
+
+function shieldIntent(
+  overrides: Partial<ReserveHeliusRingsIntentInput> = {}
+): ReserveHeliusRingsIntentInput {
+  return {
+    ...scope,
+    walletId,
+    opType: "shield",
+    intentKey: "sha256:shield-1",
+    assetMint: "So11111111111111111111111111111111111111112",
+    amountRaw: "1000000",
+    ...overrides,
+  };
+}
+
+/** Pins created_at so ordering assertions do not depend on clock resolution. */
+async function setCreatedAt(id: string, createdAt: string): Promise<void> {
+  await getDb(env)
+    .prepare("UPDATE helius_rings_operations SET created_at = ? WHERE id = ?")
+    .bind(createdAt, id)
+    .run();
+}
+
+/** Pins updated_at so the sweep's staleness window is deterministic. */
+async function setUpdatedAt(id: string, updatedAt: string): Promise<void> {
+  await getDb(env)
+    .prepare("UPDATE helius_rings_operations SET updated_at = ? WHERE id = ?")
+    .bind(updatedAt, id)
+    .run();
+}
+
+describe("HeliusRingsOperationRepository (postgres)", () => {
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    const db = getDb(env);
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
+      )
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
+      .run();
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')"
+      )
+      .bind(TEST_USER.id, TEST_USER.email)
+      .run();
+
+    for (const projectId of [TEST_PROJECT_ID, OTHER_PROJECT_ID]) {
+      await db
+        .prepare(
+          `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+           VALUES (?, ?, 'Test Project', ?, 'sandbox', 'active', ?)`
+        )
+        .bind(projectId, TEST_ORG.id, projectId, TEST_USER.id)
+        .run();
+    }
+
+    walletRepo = createPostgresHeliusRingsWalletRepository(db);
+    repo = createPostgresHeliusRingsOperationRepository(db);
+
+    const wallet = await walletRepo.createWallet({
+      ...scope,
+      sdpWalletId: "wal_hro_repo_test",
+      name: "Treasury",
+      materialTag: "simulated",
+    });
+    if (!wallet) throw new Error("wallet fixture was not created");
+    walletId = wallet.id;
+  });
+
+  describe("reserveIntent", () => {
+    it("inserts a draft operation and reports it as reserved", async () => {
+      const result = await repo.reserveIntent(shieldIntent());
+
+      expect(result.reserved).toBe(true);
+      expect(result.operation).toMatchObject({
+        wallet_id: walletId,
+        op_type: "shield",
+        state: "draft",
+        intent_key: "sha256:shield-1",
+        amount_raw: "1000000",
+        failure_code: null,
+      });
+    });
+
+    it("returns the existing operation on a replay instead of opening a second one", async () => {
+      const first = await repo.reserveIntent(shieldIntent());
+      // Same intent key, different everything else: a replay must be decided by
+      // the key alone, or a retried request with a jittered payload would slip
+      // through and move funds twice.
+      const replay = await repo.reserveIntent(
+        shieldIntent({ amountRaw: "999", toAddr: "somewhere-else" })
+      );
+
+      expect(replay.reserved).toBe(false);
+      expect(replay.operation.id).toBe(first.operation.id);
+      expect(replay.operation.amount_raw).toBe("1000000");
+      expect(replay.operation.to_addr).toBeNull();
+
+      const all = await repo.listOperationsByWallet({ ...scope, walletId });
+      expect(all).toHaveLength(1);
+    });
+
+    it("does not let a replay overwrite work the first attempt already recorded", async () => {
+      const first = await repo.reserveIntent(shieldIntent());
+      await repo.transitionState({
+        ...scope,
+        id: first.operation.id,
+        expectedState: "draft",
+        nextState: "preparing",
+        patch: { policyEvaluationId: "pev_1" },
+      });
+
+      const replay = await repo.reserveIntent(shieldIntent());
+
+      expect(replay.operation.state).toBe("preparing");
+      expect(replay.operation.policy_evaluation_id).toBe("pev_1");
+    });
+
+    it("keeps distinct intent keys as distinct operations", async () => {
+      await repo.reserveIntent(shieldIntent({ intentKey: "sha256:shield-1" }));
+      const second = await repo.reserveIntent(shieldIntent({ intentKey: "sha256:shield-2" }));
+
+      expect(second.reserved).toBe(true);
+      const all = await repo.listOperationsByWallet({ ...scope, walletId });
+      expect(all).toHaveLength(2);
+    });
+
+    it("writes the escrow row and the denormalized unlock time for a timelock", async () => {
+      const result = await repo.reserveIntent(
+        shieldIntent({
+          opType: "timelock_create",
+          intentKey: "sha256:timelock-1",
+          timelock: { unlockAt: "2026-12-01T00:00:00.000Z", beneficiaryAddr: "beneficiary-1" },
+        })
+      );
+
+      expect(result.operation.timelock_unlock_at).toBe("2026-12-01T00:00:00.000Z");
+      const timelock = await repo.getTimelock({ operationId: result.operation.id });
+      expect(timelock).toMatchObject({
+        unlock_at: "2026-12-01T00:00:00.000Z",
+        beneficiary_addr: "beneficiary-1",
+        released_at: null,
+      });
+    });
+
+    it("pins transfer_mode to the op type", async () => {
+      const result = await repo.reserveIntent(
+        shieldIntent({
+          opType: "transfer_anonymous",
+          intentKey: "sha256:transfer-1",
+          transferMode: "anonymous",
+          toAddr: "recipient-1",
+        })
+      );
+
+      expect(result.operation.transfer_mode).toBe("anonymous");
+
+      // The DB refuses the pairing that would misreport disclosure.
+      await expect(
+        repo.reserveIntent(
+          shieldIntent({
+            opType: "transfer_anonymous",
+            intentKey: "sha256:transfer-2",
+            transferMode: "registered",
+          })
+        )
+      ).rejects.toMatchObject({ message: expect.stringContaining("transfer_mode") });
+    });
+  });
+
+  describe("transitionState", () => {
+    it("advances when the expected state still holds", async () => {
+      const { operation } = await repo.reserveIntent(shieldIntent());
+
+      const moved = await repo.transitionState({
+        ...scope,
+        id: operation.id,
+        expectedState: "draft",
+        nextState: "preparing",
+      });
+
+      expect(moved?.state).toBe("preparing");
+    });
+
+    it("refuses and leaves the row alone when the expectation is stale", async () => {
+      const { operation } = await repo.reserveIntent(shieldIntent());
+      await repo.transitionState({
+        ...scope,
+        id: operation.id,
+        expectedState: "draft",
+        nextState: "preparing",
+      });
+
+      // The second worker still believes the operation is a draft.
+      const loser = await repo.transitionState({
+        ...scope,
+        id: operation.id,
+        expectedState: "draft",
+        nextState: "preparing",
+      });
+
+      expect(loser).toBeNull();
+      const current = await repo.getOperationById({ ...scope, id: operation.id });
+      expect(current?.state).toBe("preparing");
+    });
+
+    it("writes only the patched columns and preserves the rest", async () => {
+      const { operation } = await repo.reserveIntent(shieldIntent());
+
+      await repo.transitionState({
+        ...scope,
+        id: operation.id,
+        expectedState: "draft",
+        nextState: "approval_required",
+        patch: { approvalRequestId: "apr_1", policyEvaluationId: "pev_1" },
+      });
+      const later = await repo.transitionState({
+        ...scope,
+        id: operation.id,
+        expectedState: "approval_required",
+        nextState: "proving",
+        patch: { proofSource: "simulated" },
+      });
+
+      expect(later).toMatchObject({
+        state: "proving",
+        approval_request_id: "apr_1",
+        policy_evaluation_id: "pev_1",
+        proof_source: "simulated",
+      });
+    });
+
+    it("will not transition an operation belonging to another project", async () => {
+      const { operation } = await repo.reserveIntent(shieldIntent());
+
+      const crossTenant = await repo.transitionState({
+        organizationId: TEST_ORG.id,
+        projectId: OTHER_PROJECT_ID,
+        id: operation.id,
+        expectedState: "draft",
+        nextState: "preparing",
+      });
+
+      expect(crossTenant).toBeNull();
+    });
+  });
+
+  describe("failOperation", () => {
+    it("records the whole failure triple", async () => {
+      const { operation } = await repo.reserveIntent(shieldIntent());
+      await repo.transitionState({
+        ...scope,
+        id: operation.id,
+        expectedState: "draft",
+        nextState: "preparing",
+      });
+
+      const failed = await repo.failOperation({
+        ...scope,
+        id: operation.id,
+        expectedState: "preparing",
+        code: "gateway_unavailable",
+        message: "rings gateway is not implemented",
+        retryable: true,
+      });
+
+      expect(failed).toMatchObject({
+        state: "failed",
+        failure_code: "gateway_unavailable",
+        failure_message: "rings gateway is not implemented",
+        retryable: true,
+      });
+    });
+
+    it("refuses when the expected state is stale", async () => {
+      const { operation } = await repo.reserveIntent(shieldIntent());
+
+      const result = await repo.failOperation({
+        ...scope,
+        id: operation.id,
+        expectedState: "submitted",
+        code: "submit_failed",
+        message: "nope",
+        retryable: false,
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("retry lineage", () => {
+    it("links a retry to the operation it replaces", async () => {
+      const first = await repo.reserveIntent(shieldIntent());
+      const retry = await repo.reserveIntent(
+        shieldIntent({ intentKey: "sha256:shield-retry", retryOfOperationId: first.operation.id })
+      );
+
+      expect(retry.operation.retry_of_operation_id).toBe(first.operation.id);
+    });
+  });
+
+  describe("reads", () => {
+    it("scopes lookups to the tenant that owns the operation", async () => {
+      const { operation } = await repo.reserveIntent(shieldIntent());
+
+      expect(
+        await repo.getOperationById({
+          organizationId: TEST_ORG.id,
+          projectId: OTHER_PROJECT_ID,
+          id: operation.id,
+        })
+      ).toBeNull();
+      expect(
+        await repo.getOperationByIntentKey({
+          organizationId: TEST_ORG.id,
+          projectId: OTHER_PROJECT_ID,
+          intentKey: "sha256:shield-1",
+        })
+      ).toBeNull();
+      expect(
+        await repo.getOperationByIntentKey({ ...scope, intentKey: "sha256:shield-1" })
+      ).toMatchObject({ id: operation.id });
+    });
+
+    it("lists newest first", async () => {
+      const older = await repo.reserveIntent(shieldIntent({ intentKey: "sha256:older" }));
+      const newer = await repo.reserveIntent(shieldIntent({ intentKey: "sha256:newer" }));
+      await setCreatedAt(older.operation.id, "2026-01-01T00:00:00.000Z");
+      await setCreatedAt(newer.operation.id, "2026-02-01T00:00:00.000Z");
+
+      const listed = await repo.listOperationsByProject(scope);
+      expect(listed.map((row) => row.id)).toEqual([newer.operation.id, older.operation.id]);
+    });
+
+    it("honours the list limit", async () => {
+      await repo.reserveIntent(shieldIntent({ intentKey: "sha256:a" }));
+      await repo.reserveIntent(shieldIntent({ intentKey: "sha256:b" }));
+
+      expect(await repo.listOperationsByWallet({ ...scope, walletId, limit: 1 })).toHaveLength(1);
+    });
+  });
+
+  describe("listInFlightOperations", () => {
+    it("returns only non-terminal operations older than the staleness cutoff", async () => {
+      const inFlight = await repo.reserveIntent(shieldIntent({ intentKey: "sha256:in-flight" }));
+      const draft = await repo.reserveIntent(shieldIntent({ intentKey: "sha256:draft" }));
+      const done = await repo.reserveIntent(shieldIntent({ intentKey: "sha256:done" }));
+      const fresh = await repo.reserveIntent(shieldIntent({ intentKey: "sha256:fresh" }));
+
+      for (const id of [inFlight.operation.id, done.operation.id, fresh.operation.id]) {
+        await repo.transitionState({
+          ...scope,
+          id,
+          expectedState: "draft",
+          nextState: "submitted",
+        });
+      }
+      await repo.transitionState({
+        ...scope,
+        id: done.operation.id,
+        expectedState: "submitted",
+        nextState: "completed",
+      });
+
+      await setUpdatedAt(inFlight.operation.id, "2026-01-01T00:00:00.000Z");
+      await setUpdatedAt(draft.operation.id, "2026-01-01T00:00:00.000Z");
+      await setUpdatedAt(done.operation.id, "2026-01-01T00:00:00.000Z");
+
+      const swept = await repo.listInFlightOperations({ staleBefore: "2026-06-01T00:00:00.000Z" });
+
+      // `draft` is excluded because nothing is in flight yet, `completed`
+      // because it is terminal, and the fresh row because it was just touched.
+      expect(swept.map((row) => row.id)).toEqual([inFlight.operation.id]);
+    });
+  });
+
+  describe("timelocks", () => {
+    async function reserveTimelock(key: string, unlockAt: string): Promise<string> {
+      const result = await repo.reserveIntent(
+        shieldIntent({
+          opType: "timelock_create",
+          intentKey: key,
+          timelock: { unlockAt, beneficiaryAddr: "beneficiary-1" },
+        })
+      );
+      return result.operation.id;
+    }
+
+    it("lists only escrows whose unlock time has passed and that are still held", async () => {
+      const due = await reserveTimelock("sha256:due", "2026-01-01T00:00:00.000Z");
+      const notDue = await reserveTimelock("sha256:not-due", "2027-01-01T00:00:00.000Z");
+      const released = await reserveTimelock("sha256:released", "2026-01-01T00:00:00.000Z");
+      await repo.releaseTimelock({
+        operationId: released,
+        releasedAt: "2026-02-01T00:00:00.000Z",
+      });
+
+      const releasable = await repo.listReleasableTimelocks({ asOf: "2026-06-01T00:00:00.000Z" });
+
+      expect(releasable.map((row) => row.operation_id)).toEqual([due]);
+      expect(releasable.map((row) => row.operation_id)).not.toContain(notDue);
+    });
+
+    it("releases once, so a double sweep cannot pay a beneficiary twice", async () => {
+      const operationId = await reserveTimelock("sha256:once", "2026-01-01T00:00:00.000Z");
+
+      const first = await repo.releaseTimelock({
+        operationId,
+        releasedAt: "2026-02-01T00:00:00.000Z",
+      });
+      const second = await repo.releaseTimelock({
+        operationId,
+        releasedAt: "2026-03-01T00:00:00.000Z",
+      });
+
+      expect(first?.released_at).toBe("2026-02-01T00:00:00.000Z");
+      expect(second).toBeNull();
+      const stored = await repo.getTimelock({ operationId });
+      expect(stored?.released_at).toBe("2026-02-01T00:00:00.000Z");
+    });
+
+    it("refuses a release dated before the unlock time", async () => {
+      const operationId = await reserveTimelock("sha256:early", "2026-06-01T00:00:00.000Z");
+
+      await expect(
+        repo.releaseTimelock({ operationId, releasedAt: "2026-01-01T00:00:00.000Z" })
+      ).rejects.toMatchObject({ message: expect.stringContaining("released_after_unlock") });
+    });
+  });
+});

--- a/apps/sdp-api/src/db/repositories/helius-rings-operation.repository.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-operation.repository.ts
@@ -1,0 +1,210 @@
+import type {
+  FailureCode,
+  OperationState,
+  OpType,
+  PrivateOperationSummary,
+  TransferMode,
+} from "@sdp/helius-rings";
+import type { RepositoryDbClient } from "./base";
+import type { HeliusRingsProjectScope } from "./helius-rings-wallet.repository";
+
+export function generateHeliusRingsOperationId(): string {
+  return `hro_${crypto.randomUUID()}`;
+}
+
+/** Upper bound on an unpaginated activity read. */
+export const DEFAULT_RINGS_OPERATION_LIST_LIMIT = 50;
+
+/** Upper bound on one pass of the resume sweep. */
+export const DEFAULT_RINGS_IN_FLIGHT_SWEEP_LIMIT = 100;
+
+export interface HeliusRingsOperationRow {
+  id: string;
+  organization_id: string;
+  project_id: string;
+  wallet_id: string;
+  op_type: OpType;
+  state: OperationState;
+  asset_mint: string | null;
+  amount_raw: string | null;
+  from_addr: string | null;
+  to_addr: string | null;
+  zone_id: string | null;
+  transfer_mode: TransferMode | null;
+  intent_key: string;
+  approval_request_id: string | null;
+  policy_evaluation_id: string | null;
+  proof_source: "simulated" | "live" | null;
+  proof_ref: string | null;
+  outer_tx_signature: string | null;
+  photon_indexed_at: string | null;
+  failure_code: FailureCode | null;
+  failure_message: string | null;
+  retryable: boolean | null;
+  retry_of_operation_id: string | null;
+  /** Denormalized from `helius_rings_timelocks`; that table stays the authority. */
+  timelock_unlock_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface HeliusRingsTimelockRow {
+  operation_id: string;
+  unlock_at: string;
+  released_at: string | null;
+  beneficiary_addr: string;
+}
+
+export interface HeliusRingsTimelockInput {
+  unlockAt: string;
+  beneficiaryAddr: string;
+}
+
+/**
+ * The intent as the caller described it. `intentKey` is computed upstream — the
+ * repository takes it as given rather than deriving it, so the hashing rule
+ * lives in one place (the service) instead of being duplicated behind a column.
+ */
+export interface ReserveHeliusRingsIntentInput extends HeliusRingsProjectScope {
+  walletId: string;
+  opType: OpType;
+  intentKey: string;
+  assetMint?: string | null;
+  amountRaw?: string | null;
+  fromAddr?: string | null;
+  toAddr?: string | null;
+  zoneId?: string | null;
+  transferMode?: TransferMode | null;
+  retryOfOperationId?: string | null;
+  /** Required for `timelock_create`; writes the escrow row and the denormalized column. */
+  timelock?: HeliusRingsTimelockInput | null;
+}
+
+export interface ReserveHeliusRingsIntentResult {
+  operation: HeliusRingsOperationRow;
+  /**
+   * False when the intent key was already taken and `operation` is the row that
+   * was there. Callers use this to skip re-doing side effects on a replay — the
+   * whole point of the idempotency contract.
+   */
+  reserved: boolean;
+}
+
+/**
+ * Optional columns a transition may set on its way through. Each is written only
+ * when present, so a transition never blanks a field an earlier step recorded.
+ */
+export interface HeliusRingsOperationTransitionPatch {
+  approvalRequestId?: string | null;
+  policyEvaluationId?: string | null;
+  proofSource?: "simulated" | "live" | null;
+  proofRef?: string | null;
+  outerTxSignature?: string | null;
+  photonIndexedAt?: string | null;
+}
+
+export interface TransitionHeliusRingsOperationInput extends HeliusRingsProjectScope {
+  id: string;
+  /** Compare-and-swap guard; the update is skipped unless the locked row still reads this. */
+  expectedState: OperationState;
+  nextState: OperationState;
+  patch?: HeliusRingsOperationTransitionPatch;
+}
+
+export interface FailHeliusRingsOperationInput extends HeliusRingsProjectScope {
+  id: string;
+  expectedState: OperationState;
+  code: FailureCode;
+  message: string;
+  retryable: boolean;
+}
+
+export interface ListHeliusRingsOperationsByWalletInput extends HeliusRingsProjectScope {
+  walletId: string;
+  limit?: number;
+}
+
+export interface ListHeliusRingsOperationsByProjectInput extends HeliusRingsProjectScope {
+  limit?: number;
+}
+
+export interface ListHeliusRingsInFlightOperationsInput {
+  /** Only operations untouched since this ISO-8601 instant, so a fresh write is not swept mid-flight. */
+  staleBefore: string;
+  limit?: number;
+}
+
+export interface ReleaseHeliusRingsTimelockInput {
+  operationId: string;
+  releasedAt: string;
+}
+
+export interface HeliusRingsOperationRepositoryContext {
+  db: RepositoryDbClient;
+}
+
+export interface HeliusRingsOperationRepository {
+  /**
+   * The idempotency entry point. Inserts the operation, or returns the one the
+   * intent key already names — a retried request must never open a second
+   * shielded operation, because the caller has no way to tell the duplicate
+   * apart afterwards and both would move funds.
+   */
+  reserveIntent(input: ReserveHeliusRingsIntentInput): Promise<ReserveHeliusRingsIntentResult>;
+  getOperationById(
+    input: HeliusRingsProjectScope & { id: string }
+  ): Promise<HeliusRingsOperationRow | null>;
+  getOperationByIntentKey(
+    input: HeliusRingsProjectScope & { intentKey: string }
+  ): Promise<HeliusRingsOperationRow | null>;
+  listOperationsByWallet(
+    input: ListHeliusRingsOperationsByWalletInput
+  ): Promise<HeliusRingsOperationRow[]>;
+  listOperationsByProject(
+    input: ListHeliusRingsOperationsByProjectInput
+  ): Promise<HeliusRingsOperationRow[]>;
+  /**
+   * Advances one operation under `SELECT ... FOR UPDATE`. Returns null when the
+   * guard loses — either the row moved on already or it is not in this tenant —
+   * leaving the row untouched.
+   */
+  transitionState(
+    input: TransitionHeliusRingsOperationInput
+  ): Promise<HeliusRingsOperationRow | null>;
+  /** Terminal failure. Writes the full failure triple the DB CHECK requires. */
+  failOperation(input: FailHeliusRingsOperationInput): Promise<HeliusRingsOperationRow | null>;
+  /** Resume sweep feed: non-terminal operations, oldest touched first. */
+  listInFlightOperations(
+    input: ListHeliusRingsInFlightOperationsInput
+  ): Promise<HeliusRingsOperationRow[]>;
+  getTimelock(input: { operationId: string }): Promise<HeliusRingsTimelockRow | null>;
+  /** Escrows whose unlock time has passed and that are still held. */
+  listReleasableTimelocks(input: {
+    asOf: string;
+    limit?: number;
+  }): Promise<HeliusRingsTimelockRow[]>;
+  /**
+   * Marks one escrow released. Returns null if it was already released, so a
+   * double sweep cannot pay a beneficiary twice.
+   */
+  releaseTimelock(input: ReleaseHeliusRingsTimelockInput): Promise<HeliusRingsTimelockRow | null>;
+}
+
+/**
+ * Row to the list-shaped domain projection. The activity table renders this;
+ * the full `PrivateOperation` needs the event feed joined in, which the service
+ * assembles.
+ */
+export function mapHeliusRingsOperationSummaryRow(
+  row: HeliusRingsOperationRow
+): PrivateOperationSummary {
+  return {
+    id: row.id,
+    opType: row.op_type,
+    state: row.state,
+    assetMint: row.asset_mint ?? null,
+    amountRaw: row.amount_raw ?? null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}

--- a/apps/sdp-api/src/db/repositories/helius-rings-wallet.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-wallet.repository.postgres.ts
@@ -1,0 +1,152 @@
+import type { AppDb } from "@/db";
+import {
+  type CreateHeliusRingsWalletInput,
+  DEFAULT_RINGS_WALLET_LIST_LIMIT,
+  generateHeliusRingsWalletId,
+  type HeliusRingsProjectScope,
+  type HeliusRingsWalletRepository,
+  type HeliusRingsWalletRow,
+  type ListHeliusRingsWalletsInput,
+  type MarkHeliusRingsWalletProvisionedInput,
+  type UpdateHeliusRingsWalletStatusInput,
+  type UpdateHeliusRingsWalletSyncCursorInput,
+} from "./helius-rings-wallet.repository";
+
+function mapRow(row: Record<string, unknown>): HeliusRingsWalletRow {
+  return {
+    id: row.id as string,
+    organization_id: row.organization_id as string,
+    project_id: row.project_id as string,
+    sdp_wallet_id: row.sdp_wallet_id as string,
+    name: row.name as string,
+    network: row.network as string,
+    status: row.status as HeliusRingsWalletRow["status"],
+    shielded_address: (row.shielded_address ?? null) as string | null,
+    sync_cursor: (row.sync_cursor ?? null) as string | null,
+    material_tag: row.material_tag as HeliusRingsWalletRow["material_tag"],
+    created_at: row.created_at as string,
+    updated_at: row.updated_at as string,
+  };
+}
+
+export function createPostgresHeliusRingsWalletRepository(db: AppDb): HeliusRingsWalletRepository {
+  return {
+    async createWallet(input: CreateHeliusRingsWalletInput) {
+      const id = generateHeliusRingsWalletId();
+      const row = await db
+        .prepare(
+          `INSERT INTO helius_rings_wallets (
+             id,
+             organization_id,
+             project_id,
+             sdp_wallet_id,
+             name,
+             material_tag
+           ) VALUES (?, ?, ?, ?, ?, ?)
+           ON CONFLICT (project_id, sdp_wallet_id)
+           -- Self-assignment so RETURNING * emits the row that already exists.
+           -- DO NOTHING would return zero rows and make a retried provision
+           -- look like a failure.
+           DO UPDATE SET updated_at = helius_rings_wallets.updated_at
+           RETURNING *`
+        )
+        .bind(
+          id,
+          input.organizationId,
+          input.projectId,
+          input.sdpWalletId,
+          input.name,
+          input.materialTag
+        )
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+
+    async getWalletById(scope: HeliusRingsProjectScope & { id: string }) {
+      const row = await db
+        .prepare(
+          `SELECT * FROM helius_rings_wallets
+            WHERE id = ? AND organization_id = ? AND project_id = ?`
+        )
+        .bind(scope.id, scope.organizationId, scope.projectId)
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+
+    async getWalletBySdpWalletId(scope: HeliusRingsProjectScope & { sdpWalletId: string }) {
+      const row = await db
+        .prepare(
+          `SELECT * FROM helius_rings_wallets
+            WHERE sdp_wallet_id = ? AND organization_id = ? AND project_id = ?`
+        )
+        .bind(scope.sdpWalletId, scope.organizationId, scope.projectId)
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+
+    async listWallets(input: ListHeliusRingsWalletsInput) {
+      const result = await db
+        .prepare(
+          `SELECT * FROM helius_rings_wallets
+            WHERE organization_id = ? AND project_id = ?
+            ORDER BY created_at DESC, id DESC
+            LIMIT ?`
+        )
+        .bind(input.organizationId, input.projectId, input.limit ?? DEFAULT_RINGS_WALLET_LIST_LIMIT)
+        .all<Record<string, unknown>>();
+      return result.results.map(mapRow);
+    },
+
+    async markProvisioned(input: MarkHeliusRingsWalletProvisionedInput) {
+      const row = await db
+        .prepare(
+          `UPDATE helius_rings_wallets
+              SET status = 'ready',
+                  shielded_address = ?,
+                  material_tag = ?,
+                  updated_at = sdp_iso_now()
+            WHERE id = ?
+              AND organization_id = ?
+              AND project_id = ?
+              AND status = ?
+          RETURNING *`
+        )
+        .bind(
+          input.shieldedAddress,
+          input.materialTag,
+          input.id,
+          input.organizationId,
+          input.projectId,
+          input.expectedStatus
+        )
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+
+    async updateStatus(input: UpdateHeliusRingsWalletStatusInput) {
+      const row = await db
+        .prepare(
+          `UPDATE helius_rings_wallets
+              SET status = ?, updated_at = sdp_iso_now()
+            WHERE id = ? AND organization_id = ? AND project_id = ?
+          RETURNING *`
+        )
+        .bind(input.status, input.id, input.organizationId, input.projectId)
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+
+    async updateSyncCursor(input: UpdateHeliusRingsWalletSyncCursorInput) {
+      const row = await db
+        .prepare(
+          `UPDATE helius_rings_wallets
+              SET sync_cursor = ?, updated_at = sdp_iso_now()
+            WHERE id = ? AND organization_id = ? AND project_id = ?
+          RETURNING *`
+        )
+        .bind(input.syncCursor, input.id, input.organizationId, input.projectId)
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+  };
+}

--- a/apps/sdp-api/src/db/repositories/helius-rings-wallet.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-wallet.repository.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import type { HeliusRingsWalletRepository } from "./helius-rings-wallet.repository";
+import { mapHeliusRingsWalletRow } from "./helius-rings-wallet.repository";
+import { createPostgresHeliusRingsWalletRepository } from "./helius-rings-wallet.repository.postgres";
+
+const TEST_PROJECT_ID = "prj_hrw_repo_test";
+const OTHER_PROJECT_ID = "prj_hrw_repo_other";
+
+const scope = { organizationId: TEST_ORG.id, projectId: TEST_PROJECT_ID };
+
+let repo: HeliusRingsWalletRepository;
+
+async function createWallet(sdpWalletId: string, name = "Treasury") {
+  const wallet = await repo.createWallet({ ...scope, sdpWalletId, name, materialTag: "simulated" });
+  if (!wallet) throw new Error("wallet fixture was not created");
+  return wallet;
+}
+
+describe("HeliusRingsWalletRepository (postgres)", () => {
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    const db = getDb(env);
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
+      )
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
+      .run();
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')"
+      )
+      .bind(TEST_USER.id, TEST_USER.email)
+      .run();
+
+    for (const projectId of [TEST_PROJECT_ID, OTHER_PROJECT_ID]) {
+      await db
+        .prepare(
+          `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+           VALUES (?, ?, 'Test Project', ?, 'sandbox', 'active', ?)`
+        )
+        .bind(projectId, TEST_ORG.id, projectId, TEST_USER.id)
+        .run();
+    }
+
+    repo = createPostgresHeliusRingsWalletRepository(db);
+  });
+
+  it("creates a wallet pending with no shielded address", async () => {
+    const wallet = await createWallet("wal_1");
+
+    expect(wallet).toMatchObject({
+      status: "pending",
+      network: "devnet",
+      shielded_address: null,
+      sync_cursor: null,
+      material_tag: "simulated",
+    });
+  });
+
+  it("returns the existing wallet when provisioning is retried", async () => {
+    const first = await createWallet("wal_1", "Treasury");
+    // A second shielded identity over one custody wallet would split its
+    // balance across two identities that cannot see each other.
+    const replay = await createWallet("wal_1", "Renamed");
+
+    expect(replay.id).toBe(first.id);
+    expect(replay.name).toBe("Treasury");
+    expect(await repo.listWallets(scope)).toHaveLength(1);
+  });
+
+  it("allows the same sdp wallet id under a different project", async () => {
+    await createWallet("wal_shared");
+    const other = await repo.createWallet({
+      organizationId: TEST_ORG.id,
+      projectId: OTHER_PROJECT_ID,
+      sdpWalletId: "wal_shared",
+      name: "Treasury",
+      materialTag: "simulated",
+    });
+
+    expect(other?.project_id).toBe(OTHER_PROJECT_ID);
+  });
+
+  describe("markProvisioned", () => {
+    it("attaches the shielded address and flips the wallet ready", async () => {
+      const wallet = await createWallet("wal_1");
+
+      const provisioned = await repo.markProvisioned({
+        ...scope,
+        id: wallet.id,
+        shieldedAddress: "shielded-1",
+        materialTag: "live",
+        expectedStatus: "pending",
+      });
+
+      expect(provisioned).toMatchObject({
+        status: "ready",
+        shielded_address: "shielded-1",
+        material_tag: "live",
+      });
+    });
+
+    it("loses the compare-and-swap against a paused wallet", async () => {
+      const wallet = await createWallet("wal_1");
+      await repo.updateStatus({ ...scope, id: wallet.id, status: "paused" });
+
+      // A late provisioning callback must not resurrect a wallet an operator
+      // deliberately paused.
+      const late = await repo.markProvisioned({
+        ...scope,
+        id: wallet.id,
+        shieldedAddress: "shielded-1",
+        materialTag: "live",
+        expectedStatus: "pending",
+      });
+
+      expect(late).toBeNull();
+      const current = await repo.getWalletById({ ...scope, id: wallet.id });
+      expect(current).toMatchObject({ status: "paused", shielded_address: null });
+    });
+  });
+
+  it("advances the sync cursor", async () => {
+    const wallet = await createWallet("wal_1");
+
+    const updated = await repo.updateSyncCursor({ ...scope, id: wallet.id, syncCursor: "slot:42" });
+
+    expect(updated?.sync_cursor).toBe("slot:42");
+  });
+
+  it("scopes reads and writes to the owning tenant", async () => {
+    const wallet = await createWallet("wal_1");
+    const crossTenant = {
+      organizationId: TEST_ORG.id,
+      projectId: OTHER_PROJECT_ID,
+    };
+
+    expect(await repo.getWalletById({ ...crossTenant, id: wallet.id })).toBeNull();
+    expect(await repo.getWalletBySdpWalletId({ ...crossTenant, sdpWalletId: "wal_1" })).toBeNull();
+    expect(await repo.updateStatus({ ...crossTenant, id: wallet.id, status: "paused" })).toBeNull();
+    expect(await repo.getWalletBySdpWalletId({ ...scope, sdpWalletId: "wal_1" })).toMatchObject({
+      id: wallet.id,
+    });
+  });
+
+  it("honours the list limit", async () => {
+    await createWallet("wal_1");
+    await createWallet("wal_2");
+
+    expect(await repo.listWallets({ ...scope, limit: 1 })).toHaveLength(1);
+  });
+
+  describe("mapHeliusRingsWalletRow", () => {
+    it("projects the row onto the domain wallet without tenant columns", async () => {
+      const wallet = await createWallet("wal_1");
+      const provisioned = await repo.markProvisioned({
+        ...scope,
+        id: wallet.id,
+        shieldedAddress: "shielded-1",
+        materialTag: "live",
+        expectedStatus: "pending",
+      });
+      if (!provisioned) throw new Error("wallet was not provisioned");
+
+      expect(mapHeliusRingsWalletRow(provisioned)).toEqual({
+        id: wallet.id,
+        sdpWalletId: "wal_1",
+        name: "Treasury",
+        shieldedAddress: "shielded-1",
+        status: "ready",
+        network: "devnet",
+        syncCursor: null,
+        materialTag: "live",
+      });
+    });
+  });
+});

--- a/apps/sdp-api/src/db/repositories/helius-rings-wallet.repository.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-wallet.repository.ts
@@ -1,0 +1,115 @@
+import type { MaterialTag, PrivateWallet, WalletStatus } from "@sdp/helius-rings";
+import type { RepositoryDbClient } from "./base";
+
+export function generateHeliusRingsWalletId(): string {
+  return `hrw_${crypto.randomUUID()}`;
+}
+
+/** Upper bound on an unpaginated wallet list. */
+export const DEFAULT_RINGS_WALLET_LIST_LIMIT = 100;
+
+export interface HeliusRingsWalletRow {
+  id: string;
+  organization_id: string;
+  project_id: string;
+  sdp_wallet_id: string;
+  name: string;
+  /** Always 'devnet' for this scope; the DB CHECK enforces it. */
+  network: string;
+  status: WalletStatus;
+  /** Null until the gateway provisions the shielded identity. */
+  shielded_address: string | null;
+  /** Photon sync cursor; null before the first successful sync. */
+  sync_cursor: string | null;
+  material_tag: MaterialTag;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface HeliusRingsProjectScope {
+  organizationId: string;
+  projectId: string;
+}
+
+/**
+ * Wallets are always inserted as `pending` with no shielded address — those
+ * arrive from the gateway via `markProvisioned`.
+ */
+export interface CreateHeliusRingsWalletInput extends HeliusRingsProjectScope {
+  sdpWalletId: string;
+  name: string;
+  materialTag: MaterialTag;
+}
+
+export interface MarkHeliusRingsWalletProvisionedInput extends HeliusRingsProjectScope {
+  id: string;
+  shieldedAddress: string;
+  materialTag: MaterialTag;
+  /**
+   * Compare-and-swap guard: only applies while the wallet is still in this
+   * status, so a late provisioning callback cannot resurrect a paused wallet.
+   */
+  expectedStatus: WalletStatus;
+}
+
+export interface UpdateHeliusRingsWalletStatusInput extends HeliusRingsProjectScope {
+  id: string;
+  status: WalletStatus;
+}
+
+export interface UpdateHeliusRingsWalletSyncCursorInput extends HeliusRingsProjectScope {
+  id: string;
+  syncCursor: string;
+}
+
+export interface ListHeliusRingsWalletsInput extends HeliusRingsProjectScope {
+  limit?: number;
+}
+
+export interface HeliusRingsWalletRepositoryContext {
+  db: RepositoryDbClient;
+}
+
+export interface HeliusRingsWalletRepository {
+  /**
+   * Reserves the one wallet allowed per (project, sdpWalletId). On a replay it
+   * returns the wallet already there rather than a second one, so provisioning
+   * is safe to retry.
+   */
+  createWallet(input: CreateHeliusRingsWalletInput): Promise<HeliusRingsWalletRow | null>;
+  getWalletById(
+    scope: HeliusRingsProjectScope & { id: string }
+  ): Promise<HeliusRingsWalletRow | null>;
+  getWalletBySdpWalletId(
+    scope: HeliusRingsProjectScope & { sdpWalletId: string }
+  ): Promise<HeliusRingsWalletRow | null>;
+  listWallets(input: ListHeliusRingsWalletsInput): Promise<HeliusRingsWalletRow[]>;
+  /** Returns null when the CAS guard loses, leaving the row untouched. */
+  markProvisioned(
+    input: MarkHeliusRingsWalletProvisionedInput
+  ): Promise<HeliusRingsWalletRow | null>;
+  updateStatus(input: UpdateHeliusRingsWalletStatusInput): Promise<HeliusRingsWalletRow | null>;
+  updateSyncCursor(
+    input: UpdateHeliusRingsWalletSyncCursorInput
+  ): Promise<HeliusRingsWalletRow | null>;
+}
+
+/**
+ * Row to domain object. `organization_id`/`project_id` are dropped: the domain
+ * `PrivateWallet` is what the API returns, and the caller already knows the
+ * scope it queried by.
+ */
+export function mapHeliusRingsWalletRow(row: HeliusRingsWalletRow): PrivateWallet {
+  return {
+    id: row.id,
+    sdpWalletId: row.sdp_wallet_id,
+    name: row.name,
+    shieldedAddress: row.shielded_address ?? null,
+    status: row.status,
+    // The DB CHECK pins this column to 'devnet', which is what makes the cast
+    // to the domain literal honest rather than hopeful.
+    network: "devnet",
+    syncCursor: row.sync_cursor ?? null,
+    materialTag: row.material_tag,
+  };
+}

--- a/apps/sdp-api/src/db/repositories/helius-rings-zone.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-zone.repository.postgres.ts
@@ -1,0 +1,59 @@
+import type { AppDb } from "@/db";
+import {
+  type CreateHeliusRingsZoneInput,
+  generateHeliusRingsZoneId,
+  type HeliusRingsZoneRepository,
+  type HeliusRingsZoneRow,
+} from "./helius-rings-zone.repository";
+
+function mapRow(row: Record<string, unknown>): HeliusRingsZoneRow {
+  return {
+    id: row.id as string,
+    wallet_id: row.wallet_id as string,
+    name: row.name as string,
+    kind: row.kind as HeliusRingsZoneRow["kind"],
+    created_at: row.created_at as string,
+  };
+}
+
+export function createPostgresHeliusRingsZoneRepository(db: AppDb): HeliusRingsZoneRepository {
+  return {
+    async createZone(input: CreateHeliusRingsZoneInput) {
+      const id = generateHeliusRingsZoneId();
+      const row = await db
+        .prepare(
+          `INSERT INTO helius_rings_zones (id, wallet_id, name, kind)
+           VALUES (?, ?, ?, ?)
+           ON CONFLICT (wallet_id, name)
+           -- Self-assignment so a replayed zone_create returns the existing zone
+           -- rather than zero rows. The kind is not overwritten: renaming a
+           -- zone's kind under a live operation would move its destination.
+           DO UPDATE SET created_at = helius_rings_zones.created_at
+           RETURNING *`
+        )
+        .bind(id, input.walletId, input.name, input.kind)
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+
+    async getZoneById(input: { id: string; walletId: string }) {
+      const row = await db
+        .prepare(`SELECT * FROM helius_rings_zones WHERE id = ? AND wallet_id = ?`)
+        .bind(input.id, input.walletId)
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+
+    async listZonesByWallet(input: { walletId: string }) {
+      const result = await db
+        .prepare(
+          `SELECT * FROM helius_rings_zones
+            WHERE wallet_id = ?
+            ORDER BY created_at DESC, id DESC`
+        )
+        .bind(input.walletId)
+        .all<Record<string, unknown>>();
+      return result.results.map(mapRow);
+    },
+  };
+}

--- a/apps/sdp-api/src/db/repositories/helius-rings-zone.repository.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-zone.repository.ts
@@ -1,0 +1,35 @@
+import type { Zone, ZoneKind } from "@sdp/helius-rings";
+import type { RepositoryDbClient } from "./base";
+
+export function generateHeliusRingsZoneId(): string {
+  return `hrz_${crypto.randomUUID()}`;
+}
+
+export interface HeliusRingsZoneRow {
+  id: string;
+  wallet_id: string;
+  name: string;
+  kind: ZoneKind;
+  created_at: string;
+}
+
+export interface CreateHeliusRingsZoneInput {
+  walletId: string;
+  name: string;
+  kind: ZoneKind;
+}
+
+export interface HeliusRingsZoneRepositoryContext {
+  db: RepositoryDbClient;
+}
+
+export interface HeliusRingsZoneRepository {
+  /** Zone names are unique per wallet; a replay returns the existing zone. */
+  createZone(input: CreateHeliusRingsZoneInput): Promise<HeliusRingsZoneRow | null>;
+  getZoneById(input: { id: string; walletId: string }): Promise<HeliusRingsZoneRow | null>;
+  listZonesByWallet(input: { walletId: string }): Promise<HeliusRingsZoneRow[]>;
+}
+
+export function mapHeliusRingsZoneRow(row: HeliusRingsZoneRow): Zone {
+  return { id: row.id, name: row.name, kind: row.kind };
+}

--- a/apps/sdp-api/src/db/repositories/index.ts
+++ b/apps/sdp-api/src/db/repositories/index.ts
@@ -55,6 +55,87 @@ export type {
 export { generateEarnStrategyId } from "./earn.repository";
 export { createPostgresEarnRepository } from "./earn.repository.postgres";
 export type {
+  AppendHeliusRingsEventInput,
+  HeliusRingsEventRepository,
+  HeliusRingsEventRepositoryContext,
+  HeliusRingsEventRow,
+  ListHeliusRingsEventsInput,
+} from "./helius-rings-event.repository";
+export {
+  DEFAULT_RINGS_EVENT_LIST_LIMIT,
+  generateHeliusRingsEventId,
+  mapHeliusRingsEventRow,
+  redactHeliusRingsEventPayload,
+} from "./helius-rings-event.repository";
+export { createPostgresHeliusRingsEventRepository } from "./helius-rings-event.repository.postgres";
+export type {
+  HeliusRingsHealthRepository,
+  HeliusRingsHealthRepositoryContext,
+  HeliusRingsRuntimeHealthRow,
+  RecordHeliusRingsHealthInput,
+} from "./helius-rings-health.repository";
+export { mapHeliusRingsHealthRows } from "./helius-rings-health.repository";
+export { createPostgresHeliusRingsHealthRepository } from "./helius-rings-health.repository.postgres";
+export type {
+  CreateHeliusRingsKeyRefInput,
+  HeliusRingsKeyRefRepository,
+  HeliusRingsKeyRefRepositoryContext,
+  HeliusRingsKeyRefRow,
+} from "./helius-rings-key-ref.repository";
+export { generateHeliusRingsKeyRefId } from "./helius-rings-key-ref.repository";
+export { createPostgresHeliusRingsKeyRefRepository } from "./helius-rings-key-ref.repository.postgres";
+export type {
+  FailHeliusRingsOperationInput,
+  HeliusRingsOperationRepository,
+  HeliusRingsOperationRepositoryContext,
+  HeliusRingsOperationRow,
+  HeliusRingsOperationTransitionPatch,
+  HeliusRingsTimelockInput,
+  HeliusRingsTimelockRow,
+  ListHeliusRingsInFlightOperationsInput,
+  ListHeliusRingsOperationsByProjectInput,
+  ListHeliusRingsOperationsByWalletInput,
+  ReleaseHeliusRingsTimelockInput,
+  ReserveHeliusRingsIntentInput,
+  ReserveHeliusRingsIntentResult,
+  TransitionHeliusRingsOperationInput,
+} from "./helius-rings-operation.repository";
+export {
+  DEFAULT_RINGS_IN_FLIGHT_SWEEP_LIMIT,
+  DEFAULT_RINGS_OPERATION_LIST_LIMIT,
+  generateHeliusRingsOperationId,
+  mapHeliusRingsOperationSummaryRow,
+} from "./helius-rings-operation.repository";
+export { createPostgresHeliusRingsOperationRepository } from "./helius-rings-operation.repository.postgres";
+export type {
+  CreateHeliusRingsWalletInput,
+  HeliusRingsProjectScope,
+  HeliusRingsWalletRepository,
+  HeliusRingsWalletRepositoryContext,
+  HeliusRingsWalletRow,
+  ListHeliusRingsWalletsInput,
+  MarkHeliusRingsWalletProvisionedInput,
+  UpdateHeliusRingsWalletStatusInput,
+  UpdateHeliusRingsWalletSyncCursorInput,
+} from "./helius-rings-wallet.repository";
+export {
+  DEFAULT_RINGS_WALLET_LIST_LIMIT,
+  generateHeliusRingsWalletId,
+  mapHeliusRingsWalletRow,
+} from "./helius-rings-wallet.repository";
+export { createPostgresHeliusRingsWalletRepository } from "./helius-rings-wallet.repository.postgres";
+export type {
+  CreateHeliusRingsZoneInput,
+  HeliusRingsZoneRepository,
+  HeliusRingsZoneRepositoryContext,
+  HeliusRingsZoneRow,
+} from "./helius-rings-zone.repository";
+export {
+  generateHeliusRingsZoneId,
+  mapHeliusRingsZoneRow,
+} from "./helius-rings-zone.repository";
+export { createPostgresHeliusRingsZoneRepository } from "./helius-rings-zone.repository.postgres";
+export type {
   KycWalletRow,
   KycWalletsRepository,
   SetKycStatusByCounterpartyInput,
@@ -331,6 +412,12 @@ export {
   createCounterpartiesRepository,
   createCounterpartyAccountsRepository,
   createEarnRepository,
+  createHeliusRingsEventRepository,
+  createHeliusRingsHealthRepository,
+  createHeliusRingsKeyRefRepository,
+  createHeliusRingsOperationRepository,
+  createHeliusRingsWalletRepository,
+  createHeliusRingsZoneRepository,
   createKycWalletsRepository,
   createNotificationsRepository,
   createPaymentRecurringPaymentsRepository,

--- a/apps/sdp-api/src/db/repositories/repository-factory.ts
+++ b/apps/sdp-api/src/db/repositories/repository-factory.ts
@@ -13,6 +13,18 @@ import type { CounterpartyAccountsRepository } from "./counterparty-account.repo
 import { createPostgresCounterpartyAccountsRepository } from "./counterparty-account.repository.postgres";
 import type { EarnRepository } from "./earn.repository";
 import { createPostgresEarnRepository } from "./earn.repository.postgres";
+import type { HeliusRingsEventRepository } from "./helius-rings-event.repository";
+import { createPostgresHeliusRingsEventRepository } from "./helius-rings-event.repository.postgres";
+import type { HeliusRingsHealthRepository } from "./helius-rings-health.repository";
+import { createPostgresHeliusRingsHealthRepository } from "./helius-rings-health.repository.postgres";
+import type { HeliusRingsKeyRefRepository } from "./helius-rings-key-ref.repository";
+import { createPostgresHeliusRingsKeyRefRepository } from "./helius-rings-key-ref.repository.postgres";
+import type { HeliusRingsOperationRepository } from "./helius-rings-operation.repository";
+import { createPostgresHeliusRingsOperationRepository } from "./helius-rings-operation.repository.postgres";
+import type { HeliusRingsWalletRepository } from "./helius-rings-wallet.repository";
+import { createPostgresHeliusRingsWalletRepository } from "./helius-rings-wallet.repository.postgres";
+import type { HeliusRingsZoneRepository } from "./helius-rings-zone.repository";
+import { createPostgresHeliusRingsZoneRepository } from "./helius-rings-zone.repository.postgres";
 import type { KycWalletsRepository } from "./kyc-wallet.repository";
 import { createPostgresKycWalletsRepository } from "./kyc-wallet.repository.postgres";
 import type { NotificationsRepository } from "./notification.repository";
@@ -216,6 +228,30 @@ export function createNotificationsRepository(env: Env): NotificationsRepository
 
 export function createEarnRepository(env: Env): EarnRepository {
   return createPostgresEarnRepository(getDb(env));
+}
+
+export function createHeliusRingsWalletRepository(env: Env): HeliusRingsWalletRepository {
+  return createPostgresHeliusRingsWalletRepository(getDb(env));
+}
+
+export function createHeliusRingsOperationRepository(env: Env): HeliusRingsOperationRepository {
+  return createPostgresHeliusRingsOperationRepository(getDb(env));
+}
+
+export function createHeliusRingsKeyRefRepository(env: Env): HeliusRingsKeyRefRepository {
+  return createPostgresHeliusRingsKeyRefRepository(getDb(env));
+}
+
+export function createHeliusRingsZoneRepository(env: Env): HeliusRingsZoneRepository {
+  return createPostgresHeliusRingsZoneRepository(getDb(env));
+}
+
+export function createHeliusRingsEventRepository(env: Env): HeliusRingsEventRepository {
+  return createPostgresHeliusRingsEventRepository(getDb(env));
+}
+
+export function createHeliusRingsHealthRepository(env: Env): HeliusRingsHealthRepository {
+  return createPostgresHeliusRingsHealthRepository(getDb(env));
 }
 
 export function createPrivateChannelInstanceRepository(env: Env): PrivateChannelInstanceRepository {

--- a/apps/sdp-api/src/job.node.test.ts
+++ b/apps/sdp-api/src/job.node.test.ts
@@ -9,6 +9,7 @@ import { closeAllRedisClients } from "@/runtime/kv-redis";
 import { isSentryEnabled } from "@/runtime/observability";
 import { nodeObservability } from "@/runtime/observability-node";
 import { collectDueRecurringPayments } from "@/services/jobs/collect-recurring-payments";
+import { pollRingsIndexing } from "@/services/jobs/poll-rings-indexing";
 import { reconcileEarnVaultMovements } from "@/services/jobs/reconcile-earn-vault-movements";
 import { reconcileSponsorshipBudgets } from "@/services/jobs/reconcile-sponsorship-budgets";
 import { retireOrphanedActionSecrets } from "@/services/jobs/retire-workflow-secrets";
@@ -61,6 +62,10 @@ vi.mock("@/cron/recurring-payments", () => ({
   RECURRING_PAYMENTS_COLLECTION_MONITOR: "sdp-api-collect-recurring-payments",
 }));
 
+vi.mock("@/cron/rings-indexing", () => ({
+  RINGS_INDEXING_MONITOR: "sdp-api-poll-rings-indexing",
+}));
+
 vi.mock("@/cron/workflow-executions", () => ({
   WORKFLOW_EXECUTIONS_MONITOR: "sdp-api-run-workflow-executions",
 }));
@@ -108,6 +113,10 @@ vi.mock("@/services/jobs/run-workflow-executions", () => ({
 
 vi.mock("@/services/jobs/collect-recurring-payments", () => ({
   collectDueRecurringPayments: vi.fn(async () => {}),
+}));
+
+vi.mock("@/services/jobs/poll-rings-indexing", () => ({
+  pollRingsIndexing: vi.fn(async () => {}),
 }));
 
 vi.mock("@/services/jobs/track-pending-deposits", () => ({
@@ -158,6 +167,7 @@ describe("runCronJob", () => {
     vi.mocked(collectDueRecurringPayments)
       .mockReset()
       .mockResolvedValue({ recovered: 0, collected: 0, failed: 0, skipped: 0 });
+    vi.mocked(pollRingsIndexing).mockReset().mockResolvedValue(undefined);
     vi.mocked(trackPendingDeposits).mockReset().mockResolvedValue(undefined);
     vi.mocked(trackPendingWithdrawals).mockReset().mockResolvedValue(undefined);
     vi.mocked(reconcileEarnVaultMovements).mockReset().mockResolvedValue(undefined);
@@ -198,6 +208,9 @@ describe("runCronJob", () => {
     // Recurring payments are an always-on product surface: the collection tick
     // is deliberately behind no flag.
     expect(collectDueRecurringPayments).toHaveBeenCalledExactlyOnceWith(env);
+    // The rings poll gates itself on the flag plus the http adapter, so the job
+    // hands it every tick — this is its only tick on a managed deployment.
+    expect(pollRingsIndexing).toHaveBeenCalledExactlyOnceWith(env);
     expect(reconcileEarnVaultMovements).toHaveBeenCalledTimes(1);
     // Managed deployments always have asset profiles on, so the workflow tick runs.
     expect(runDueWorkflowExecutions).toHaveBeenCalledTimes(1);
@@ -216,6 +229,16 @@ describe("runCronJob", () => {
 
     expect(closeDatabasePools).toHaveBeenCalledTimes(1);
     expect(closeAllRedisClients).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails the job on a rings-poll error but still runs the ticks after it", async () => {
+    vi.mocked(pollRingsIndexing).mockRejectedValue(new Error("photon down"));
+
+    await expect(runCronJob()).rejects.toThrow("photon down");
+
+    expect(reconcileEarnVaultMovements).toHaveBeenCalledTimes(1);
+    expect(runDueWorkflowExecutions).toHaveBeenCalledTimes(1);
+    expect(closeDatabasePools).toHaveBeenCalledTimes(1);
   });
 
   it("runs both private-channel reconcilers behind the flag", async () => {
@@ -373,7 +396,14 @@ describe("runCronJob", () => {
 
     // The pair keeps the transfers monitor; the workflow tick and the retirement sweep
     // each report to their own, so neither masquerades as a reconciliation failure.
-    expect(nodeObservability.withMonitor).toHaveBeenCalledTimes(5);
+    expect(nodeObservability.withMonitor).toHaveBeenCalledTimes(6);
+    // The rings poll declares this job's cadence, not its per-minute crontab,
+    // so Sentry does not alert on four "missed" check-ins between executions.
+    expect(nodeObservability.withMonitor).toHaveBeenCalledWith(
+      "sdp-api-poll-rings-indexing",
+      expect.any(Function),
+      { schedule: { type: "crontab", value: "*/5 * * * *" } }
+    );
     expect(nodeObservability.withMonitor).toHaveBeenCalledWith(
       EARN_VAULT_MOVEMENTS_MONITOR,
       expect.any(Function),

--- a/apps/sdp-api/src/job.ts
+++ b/apps/sdp-api/src/job.ts
@@ -8,6 +8,7 @@ import { PENDING_DEPOSITS_MONITOR } from "@/cron/pending-deposits";
 import { PENDING_TRANSFERS_MONITOR } from "@/cron/pending-transfers";
 import { PENDING_WITHDRAWALS_MONITOR } from "@/cron/pending-withdrawals";
 import { RECURRING_PAYMENTS_COLLECTION_MONITOR } from "@/cron/recurring-payments";
+import { RINGS_INDEXING_MONITOR } from "@/cron/rings-indexing";
 import { WORKFLOW_EXECUTIONS_MONITOR } from "@/cron/workflow-executions";
 import { WORKFLOW_SECRET_RETIREMENTS_MONITOR } from "@/cron/workflow-secret-retirements";
 import { closeDatabasePools } from "@/db/client";
@@ -22,6 +23,7 @@ import { getLogger } from "@/runtime/logger";
 import { getSentryOptions, isSentryEnabled } from "@/runtime/observability";
 import { initNodeSentry, nodeObservability } from "@/runtime/observability-node";
 import { collectDueRecurringPayments } from "@/services/jobs/collect-recurring-payments";
+import { pollRingsIndexing } from "@/services/jobs/poll-rings-indexing";
 import { reconcileEarnVaultMovements } from "@/services/jobs/reconcile-earn-vault-movements";
 import { reconcileSponsorshipBudgets } from "@/services/jobs/reconcile-sponsorship-budgets";
 import { retireOrphanedActionSecrets } from "@/services/jobs/retire-workflow-secrets";
@@ -72,20 +74,28 @@ const MANAGED_JOB_CRON = "*/5 * * * *";
  *    their own monitors so a failing leg never skips the other. The job's
  *    five-minute schedule is the effective cadence, the same degradation from
  *    the per-minute crontab that pending-transfers accepts. Fatal.
- * 4. **Earn vault-movement reconciliation** — deliberately outside the Earn
+ * 4. **Rings indexing poll** — behind no gate here, because the job itself
+ *    early-returns unless the rings flag is on AND `HELIUS_RINGS_ADAPTER` is
+ *    `http`, which is why the in-process runner also schedules it
+ *    unconditionally. This job is the poll's only tick on managed deployments;
+ *    without it an operation that reached `indexing` would neither complete nor
+ *    ever time out. The five-minute schedule sits well inside the 30-minute
+ *    indexing budget, so the degradation from the per-minute crontab costs
+ *    nothing. Fatal.
+ * 5. **Earn vault-movement reconciliation** — deliberately outside the Earn
  *    gate: signed vault intents are an outbox, not feature state, so disabling
  *    new deposits cannot strand old ones. Fatal.
- * 5. **Workflow executions** (gated on asset profiles) — this job is the
+ * 6. **Workflow executions** (gated on asset profiles) — this job is the
  *    workflow engine's only tick on managed deployments; without it, enqueued
  *    executions would sit `pending` forever. Fatal.
- * 6. **Workflow secret retirements** — behind no flag, because the queue holds
+ * 7. **Workflow secret retirements** — behind no flag, because the queue holds
  *    credentials that are ALREADY orphaned, so cleanup must outlive the
  *    feature that filled it — and managed Cloud Run is where GCP Secret
  *    Manager is the default backend, so it is precisely where retirements are
  *    queued. Non-fatal: a queued row is never abandoned, the next run picks it
  *    up, and a failing sweep must not sink the reconciliation this job exists
  *    for.
- * 7. **Earn metrics refresh, then catalogue sync** (both gated on the two Earn
+ * 8. **Earn metrics refresh, then catalogue sync** (both gated on the two Earn
  *    flags). Refresh first — unslotted, this job's schedule IS its cadence —
  *    so a slow catalogue pass cannot eat the tick and leave rates stale;
  *    non-fatal because rates going one tick stale must not stop the sync.
@@ -155,6 +165,7 @@ export async function runCronJob(): Promise<void> {
       ]);
       failures.push(...rejectionReasons(outcomes));
     }
+    await collect(monitored(RINGS_INDEXING_MONITOR, () => pollRingsIndexing(env)));
     await collect(monitored(EARN_VAULT_MOVEMENTS_MONITOR, () => reconcileEarnVaultMovements(env)));
     if (isAssetProfilesEnabled(env)) {
       await collect(monitored(WORKFLOW_EXECUTIONS_MONITOR, () => runDueWorkflowExecutions(env)));

--- a/apps/sdp-api/src/lib/feature-flags.ts
+++ b/apps/sdp-api/src/lib/feature-flags.ts
@@ -25,6 +25,10 @@ export function isPrivateChannelsEnabled(env: Pick<Env, "PRIVATE_CHANNELS_ENABLE
   return isTruthyFlag(env.PRIVATE_CHANNELS_ENABLED);
 }
 
+export function isHeliusRingsEnabled(env: Pick<Env, "HELIUS_RINGS_ENABLED">): boolean {
+  return isTruthyFlag(env.HELIUS_RINGS_ENABLED);
+}
+
 export function isPrivyByokEnabled(env: Pick<Env, "PRIVY_BYOK_ENABLED">): boolean {
   return isTruthyFlag(env.PRIVY_BYOK_ENABLED);
 }

--- a/apps/sdp-api/src/routes/helius-rings.test.ts
+++ b/apps/sdp-api/src/routes/helius-rings.test.ts
@@ -1,0 +1,283 @@
+import { hashString } from "@sdp/payments/hash";
+import type { CachedApiKey } from "@sdp/types";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import { createHeliusRingsWalletRepository } from "@/db/repositories";
+import app from "@/index";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import { clearKVStores, seedCachedApiKey } from "@/test/mocks/kv";
+
+const TEST_ORG = { id: "org_hr_route", name: "Rings Route Org", slug: "rings-route-org" };
+const TEST_PROJECT = { id: "prj_hr_route", slug: "rings-route-project" };
+const TEST_USER = { id: "usr_hr_route", email: "rings-route@example.com" };
+const TEST_API_KEY = { id: "key_hr_route", raw: "sk_test_helius_rings", prefix: "sk_test_hr" };
+
+const TEST_CACHED_API_KEY: CachedApiKey = {
+  id: TEST_API_KEY.id,
+  organizationId: TEST_ORG.id,
+  projectId: TEST_PROJECT.id,
+  role: "api_admin",
+  permissions: ["*"],
+  environment: "sandbox",
+  rateLimitTier: "standard",
+  allowedIps: null,
+  signingWalletId: null,
+  status: "active",
+  expiresAt: null,
+};
+
+let originalFlag: string | undefined;
+let ringsWalletId: string;
+
+async function seedAuth(): Promise<void> {
+  const keyHash = await hashString(TEST_API_KEY.raw, env.API_KEY_PEPPER);
+  await seedCachedApiKey(env, keyHash, TEST_CACHED_API_KEY);
+  const db = getDb(env);
+  await db.batch([
+    db
+      .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, "enterprise", "active"),
+    db
+      .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, ?, ?)")
+      .bind(TEST_USER.id, TEST_USER.email, 1, "active"),
+    db
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        TEST_PROJECT.id,
+        TEST_ORG.id,
+        "Rings Route Project",
+        TEST_PROJECT.slug,
+        "sandbox",
+        "active",
+        TEST_USER.id
+      ),
+    db
+      .prepare(
+        `INSERT INTO api_keys
+           (id, organization_id, project_id, created_by, name, key_prefix, key_hash, role, permissions, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        TEST_API_KEY.id,
+        TEST_ORG.id,
+        TEST_PROJECT.id,
+        TEST_USER.id,
+        "Rings Route Key",
+        TEST_API_KEY.prefix,
+        keyHash,
+        "api_admin",
+        JSON.stringify(["*"]),
+        "active"
+      ),
+  ]);
+
+  // Policy enforcement requires the operation's wallet to be an active
+  // custody wallet owned by the tenant.
+  await db.batch([
+    db
+      .prepare(
+        `INSERT INTO custody_configs (id, organization_id, project_id, provider, config_encrypted, status)
+         VALUES ('cfg_hr_route', ?, ?, 'privy', 'test-encrypted', 'active')`
+      )
+      .bind(TEST_ORG.id, TEST_PROJECT.id),
+    db
+      .prepare(
+        `INSERT INTO custody_wallets (id, custody_config_id, wallet_id, public_key, status)
+         VALUES ('cw_hr_route', 'cfg_hr_route', 'wal_hr_route', 'HrRouteTestPublicKey111111111111111111111111', 'active')`
+      )
+      .bind(),
+  ]);
+
+  const wallet = await createHeliusRingsWalletRepository(env).createWallet({
+    organizationId: TEST_ORG.id,
+    projectId: TEST_PROJECT.id,
+    sdpWalletId: "wal_hr_route",
+    name: "Treasury",
+    materialTag: "simulated",
+  });
+  if (!wallet) throw new Error("rings wallet fixture was not created");
+  ringsWalletId = wallet.id;
+}
+
+function authHeaders() {
+  return {
+    Authorization: `Bearer ${TEST_API_KEY.raw}`,
+    "Content-Type": "application/json",
+  };
+}
+
+function post(path: string, body: unknown) {
+  return app.request(
+    path,
+    { method: "POST", headers: authHeaders(), body: JSON.stringify(body) },
+    env
+  );
+}
+
+describe("Helius Rings routes", () => {
+  beforeEach(async () => {
+    originalFlag = env.HELIUS_RINGS_ENABLED;
+    env.HELIUS_RINGS_ENABLED = "true";
+    await seedTestDatabase(env);
+    await seedAuth();
+  });
+
+  afterEach(async () => {
+    env.HELIUS_RINGS_ENABLED = originalFlag;
+    await clearKVStores(env);
+  });
+
+  it("returns 403 when the feature flag is off", async () => {
+    env.HELIUS_RINGS_ENABLED = undefined;
+    const res = await app.request("/v1/helius-rings/wallets", { headers: authHeaders() }, env);
+    expect(res.status).toBe(403);
+  });
+
+  it("GET /health reports the unimplemented gateway red", async () => {
+    const res = await app.request("/v1/helius-rings/health", { headers: authHeaders() }, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { health: Record<string, string> } };
+    expect(body.data.health.gateway).toBe("red");
+  });
+
+  it("GET /wallets lists the project's rings wallets", async () => {
+    const res = await app.request("/v1/helius-rings/wallets", { headers: authHeaders() }, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { wallets: Array<{ id: string; status: string }> } };
+    expect(body.data.wallets).toHaveLength(1);
+    expect(body.data.wallets[0]).toMatchObject({ id: ringsWalletId, status: "pending" });
+  });
+
+  it("POST /wallets 404s for an unknown custody wallet", async () => {
+    const res = await post("/v1/helius-rings/wallets", { walletId: "wal_missing", name: "Ops" });
+    expect(res.status).toBe(404);
+  });
+
+  it("zone create and list round-trips, idempotently", async () => {
+    const created = await post(`/v1/helius-rings/wallets/${ringsWalletId}/zones`, {
+      name: "Payroll",
+      kind: "treasury",
+    });
+    expect(created.status).toBe(201);
+    const replay = await post(`/v1/helius-rings/wallets/${ringsWalletId}/zones`, {
+      name: "Payroll",
+      kind: "treasury",
+    });
+    expect(replay.status).toBe(201);
+
+    const listed = await app.request(
+      `/v1/helius-rings/wallets/${ringsWalletId}/zones`,
+      { headers: authHeaders() },
+      env
+    );
+    const body = (await listed.json()) as { data: { zones: Array<{ name: string }> } };
+    expect(body.data.zones).toHaveLength(1);
+    expect(body.data.zones[0]?.name).toBe("Payroll");
+  });
+
+  it("prepares an operation through real policy and fails honestly at the port", async () => {
+    const res = await post("/v1/helius-rings/operations", {
+      walletId: ringsWalletId,
+      opType: "shield",
+      asset: { mint: "So11111111111111111111111111111111111111112", amountRaw: "1000000" },
+      clientNonce: "route-nonce-1",
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      data: {
+        operation: {
+          id: string;
+          state: string;
+          failure: { code: string; message: string } | null;
+        };
+      };
+    };
+
+    // Default policy is implicit allow, so the operation advances until the
+    // port call — which the NotImplemented gateway refuses.
+    expect(body.data.operation.state).toBe("failed");
+    expect(body.data.operation.failure, body.data.operation.failure?.message).toMatchObject({
+      code: "gateway_unavailable",
+    });
+  });
+
+  it("replays a prepare idempotently and serves detail with the timeline", async () => {
+    const input = {
+      walletId: ringsWalletId,
+      opType: "shield",
+      clientNonce: "route-nonce-2",
+    };
+    const first = (await (await post("/v1/helius-rings/operations", input)).json()) as {
+      data: { operation: { id: string } };
+    };
+    const replay = (await (await post("/v1/helius-rings/operations", input)).json()) as {
+      data: { operation: { id: string } };
+    };
+    expect(replay.data.operation.id).toBe(first.data.operation.id);
+
+    const detail = await app.request(
+      `/v1/helius-rings/operations/${first.data.operation.id}`,
+      { headers: authHeaders() },
+      env
+    );
+    expect(detail.status).toBe(200);
+    const detailBody = (await detail.json()) as {
+      data: { operation: { events: Array<{ kind: string }> } };
+    };
+    const kinds = detailBody.data.operation.events.map((event) => event.kind);
+    expect(kinds).toContain("operation.created");
+    expect(kinds).toContain("operation.failed");
+  });
+
+  it("retries a failed operation with lineage and lists the activity feed", async () => {
+    const failed = (await (
+      await post("/v1/helius-rings/operations", {
+        walletId: ringsWalletId,
+        opType: "shield",
+        clientNonce: "route-nonce-3",
+      })
+    ).json()) as { data: { operation: { id: string } } };
+
+    const retried = await post(`/v1/helius-rings/operations/${failed.data.operation.id}/retry`, {
+      clientNonce: "route-nonce-3-retry",
+    });
+    expect(retried.status).toBe(201);
+    const retryBody = (await retried.json()) as { data: { operation: { id: string } } };
+    expect(retryBody.data.operation.id).not.toBe(failed.data.operation.id);
+
+    const list = await app.request("/v1/helius-rings/operations", { headers: authHeaders() }, env);
+    const listBody = (await list.json()) as { data: { operations: Array<{ id: string }> } };
+    expect(listBody.data.operations.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("execute is a no-op on a terminal operation", async () => {
+    const failed = (await (
+      await post("/v1/helius-rings/operations", {
+        walletId: ringsWalletId,
+        opType: "shield",
+        clientNonce: "route-nonce-4",
+      })
+    ).json()) as { data: { operation: { id: string; state: string } } };
+
+    const executed = await post(
+      `/v1/helius-rings/operations/${failed.data.operation.id}/execute`,
+      {}
+    );
+    expect(executed.status).toBe(200);
+    const body = (await executed.json()) as { data: { operation: { state: string } } };
+    expect(body.data.operation.state).toBe("failed");
+  });
+
+  it("rejects an invalid operation body", async () => {
+    const res = await post("/v1/helius-rings/operations", {
+      walletId: ringsWalletId,
+      opType: "not-a-real-op",
+      clientNonce: "route-nonce-5",
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/sdp-api/src/routes/helius-rings/context.ts
+++ b/apps/sdp-api/src/routes/helius-rings/context.ts
@@ -1,0 +1,61 @@
+import { HeliusRingsError } from "@sdp/helius-rings";
+import type { Context } from "hono";
+import {
+  createHeliusRingsOperationRepository,
+  createHeliusRingsWalletRepository,
+  createHeliusRingsZoneRepository,
+} from "@/db/repositories";
+import { AppError, type ErrorCode } from "@/lib/errors";
+import { createHeliusRingsService } from "@/services/helius-rings";
+import type { Env } from "@/types/env";
+
+/** Hono request context bound to the app `Env`. */
+export type AppContext = Context<{ Bindings: Env }>;
+
+export function getHeliusRingsService(
+  c: AppContext,
+  tenant: { organizationId: string; projectId: string }
+) {
+  return createHeliusRingsService(c.env, tenant);
+}
+
+export function getHeliusRingsWalletRepository(c: AppContext) {
+  return createHeliusRingsWalletRepository(c.env);
+}
+
+export function getHeliusRingsOperationRepository(c: AppContext) {
+  return createHeliusRingsOperationRepository(c.env);
+}
+
+export function getHeliusRingsZoneRepository(c: AppContext) {
+  return createHeliusRingsZoneRepository(c.env);
+}
+
+const RINGS_ERROR_CODES: Record<HeliusRingsError["code"], ErrorCode> = {
+  invalid_input: "BAD_REQUEST",
+  not_found: "NOT_FOUND",
+  conflict: "CONFLICT",
+  // 503 with the seam-marker message: the wizard renders "external
+  // integration pending" from exactly this response.
+  gateway_unavailable: "SERVICE_UNAVAILABLE",
+  config_error: "SERVICE_UNAVAILABLE",
+};
+
+/** Path param, typed as present — the router only matches when it is. */
+export function requireParam(c: AppContext, name: string): string {
+  const value = c.req.param(name);
+  if (!value) throw new AppError("BAD_REQUEST", `missing ${name}`);
+  return value;
+}
+
+/** Runs a handler body, translating domain errors to API errors. */
+export async function withRingsErrors<T>(work: () => Promise<T>): Promise<T> {
+  try {
+    return await work();
+  } catch (error) {
+    if (error instanceof HeliusRingsError) {
+      throw new AppError(RINGS_ERROR_CODES[error.code], error.message);
+    }
+    throw error;
+  }
+}

--- a/apps/sdp-api/src/routes/helius-rings/handlers.ts
+++ b/apps/sdp-api/src/routes/helius-rings/handlers.ts
@@ -200,11 +200,13 @@ export async function retryRingsOperation(c: AppContext) {
   });
   if (!failed) throw notFound("rings operation");
 
-  const ringsWallet = await getHeliusRingsWalletRepository(c).getWalletById({
-    ...tenant,
-    id: failed.wallet_id,
-  });
-  const scope = await resolveScope(c);
+  const [ringsWallet, scope] = await Promise.all([
+    getHeliusRingsWalletRepository(c).getWalletById({
+      ...tenant,
+      id: failed.wallet_id,
+    }),
+    resolveScope(c),
+  ]);
   const custodyWallet = ringsWallet
     ? scope.wallets.find((entry) => entry.walletId === ringsWallet.sdp_wallet_id)
     : undefined;

--- a/apps/sdp-api/src/routes/helius-rings/handlers.ts
+++ b/apps/sdp-api/src/routes/helius-rings/handlers.ts
@@ -20,7 +20,6 @@ import {
 import {
   createRingsWalletSchema,
   createRingsZoneSchema,
-  executeRingsOperationSchema,
   listLimitSchema,
   prepareRingsOperationSchema,
   retryRingsOperationSchema,
@@ -170,28 +169,53 @@ export async function getRingsOperation(c: AppContext) {
   return success(c, { operation });
 }
 
-/** POST /operations/:operationId/execute — advance a waiting operation. */
+/**
+ * POST /operations/:operationId/execute — advance a waiting operation. The
+ * approval verdict is read server-side from the approval request; the request
+ * carries no body worth trusting.
+ */
 export async function executeRingsOperation(c: AppContext) {
-  const parsed = executeRingsOperationSchema.safeParse(await c.req.json().catch(() => ({})));
-  if (!parsed.success) throw badRequest(parsed.error.issues[0]?.message ?? "invalid body");
-
   const { tenant } = tenantOf(c);
   const service = getHeliusRingsService(c, tenant);
   const operation = await withRingsErrors(() =>
-    service.executeOperation(requireParam(c, "operationId"), parsed.data)
+    service.executeOperation(requireParam(c, "operationId"))
   );
   return success(c, { operation });
 }
 
-/** POST /operations/:operationId/retry — file a linked retry of a failed op. */
+/**
+ * POST /operations/:operationId/retry — file a linked retry of a failed op.
+ * The retry runs the full prepare-through-policy path, so it re-earns its
+ * policy verdict under the current caller's context.
+ */
 export async function retryRingsOperation(c: AppContext) {
   const parsed = retryRingsOperationSchema.safeParse(await c.req.json());
   if (!parsed.success) throw badRequest(parsed.error.issues[0]?.message ?? "invalid body");
 
-  const { tenant } = tenantOf(c);
+  const { auth, tenant } = tenantOf(c);
+  const failedId = requireParam(c, "operationId");
+  const failed = await getHeliusRingsOperationRepository(c).getOperationById({
+    ...tenant,
+    id: failedId,
+  });
+  if (!failed) throw notFound("rings operation");
+
+  const ringsWallet = await getHeliusRingsWalletRepository(c).getWalletById({
+    ...tenant,
+    id: failed.wallet_id,
+  });
+  const scope = await resolveScope(c);
+  const custodyWallet = ringsWallet
+    ? scope.wallets.find((entry) => entry.walletId === ringsWallet.sdp_wallet_id)
+    : undefined;
+
   const service = getHeliusRingsService(c, tenant);
   const operation = await withRingsErrors(() =>
-    service.retryOperation(requireParam(c, "operationId"), parsed.data.clientNonce)
+    service.retryOperation(failedId, parsed.data.clientNonce, {
+      apiKeyId: auth.apiKeyId,
+      actor: walletOperationActorFromAuth(auth),
+      custodyWalletId: custodyWallet?.id ?? null,
+    })
   );
   return success(c, { operation }, 201);
 }

--- a/apps/sdp-api/src/routes/helius-rings/handlers.ts
+++ b/apps/sdp-api/src/routes/helius-rings/handlers.ts
@@ -1,0 +1,197 @@
+import {
+  mapHeliusRingsOperationSummaryRow,
+  mapHeliusRingsWalletRow,
+  mapHeliusRingsZoneRow,
+} from "@/db/repositories";
+import { getAuth, requireProjectId } from "@/lib/auth";
+import { badRequest, notFound } from "@/lib/errors";
+import { success } from "@/lib/response";
+import { resolveScope, resolveWallet } from "@/routes/payments/wallets";
+import { walletOperationActorFromAuth } from "@/services/policy/enforcement.service";
+import {
+  type AppContext,
+  getHeliusRingsOperationRepository,
+  getHeliusRingsService,
+  getHeliusRingsWalletRepository,
+  getHeliusRingsZoneRepository,
+  requireParam,
+  withRingsErrors,
+} from "./context";
+import {
+  createRingsWalletSchema,
+  createRingsZoneSchema,
+  executeRingsOperationSchema,
+  listLimitSchema,
+  prepareRingsOperationSchema,
+  retryRingsOperationSchema,
+} from "./schemas";
+
+function tenantOf(c: AppContext) {
+  const auth = getAuth(c);
+  return {
+    auth,
+    tenant: { organizationId: auth.organizationId, projectId: requireProjectId(c) },
+  };
+}
+
+// --- health -----------------------------------------------------------------
+
+/** GET /health — probe the gateway and return the per-component status board. */
+export async function getRingsHealth(c: AppContext) {
+  const { tenant } = tenantOf(c);
+  const service = getHeliusRingsService(c, tenant);
+  return success(c, { health: await service.probeHealth() });
+}
+
+// --- wallets ----------------------------------------------------------------
+
+/**
+ * POST /wallets — bind a rings wallet to an SDP custody wallet and provision
+ * its shielded identity. Until the live gateway lands this responds 503 with a
+ * seam-marker message and the wallet stays `pending` — the wizard renders that.
+ */
+export async function createRingsWallet(c: AppContext) {
+  const parsed = createRingsWalletSchema.safeParse(await c.req.json());
+  if (!parsed.success) throw badRequest(parsed.error.issues[0]?.message ?? "invalid body");
+
+  const { tenant } = tenantOf(c);
+  const scope = await resolveScope(c);
+  const custodyWallet = resolveWallet(scope.wallets, parsed.data.walletId);
+
+  const service = getHeliusRingsService(c, tenant);
+  const wallet = await withRingsErrors(() =>
+    service.provisionPrivateWallet({
+      sdpWalletId: custodyWallet.walletId,
+      sdpAddress: custodyWallet.publicKey,
+      name: parsed.data.name,
+    })
+  );
+  return success(c, { wallet }, 201);
+}
+
+/** GET /wallets — the project's rings wallets, newest first. */
+export async function listRingsWallets(c: AppContext) {
+  const { tenant } = tenantOf(c);
+  const limit = listLimitSchema.parse(c.req.query("limit"));
+  const rows = await getHeliusRingsWalletRepository(c).listWallets({ ...tenant, limit });
+  return success(c, { wallets: rows.map(mapHeliusRingsWalletRow) });
+}
+
+/** GET /wallets/:walletId */
+export async function getRingsWallet(c: AppContext) {
+  const { tenant } = tenantOf(c);
+  const row = await getHeliusRingsWalletRepository(c).getWalletById({
+    ...tenant,
+    id: requireParam(c, "walletId"),
+  });
+  if (!row) throw notFound("rings wallet");
+  return success(c, { wallet: mapHeliusRingsWalletRow(row) });
+}
+
+// --- zones ------------------------------------------------------------------
+
+/** GET /wallets/:walletId/zones — SDP-owned metadata; fully functional today. */
+export async function listRingsZones(c: AppContext) {
+  const { tenant } = tenantOf(c);
+  const walletId = requireParam(c, "walletId");
+  const wallet = await getHeliusRingsWalletRepository(c).getWalletById({ ...tenant, id: walletId });
+  if (!wallet) throw notFound("rings wallet");
+  const zones = await getHeliusRingsZoneRepository(c).listZonesByWallet({ walletId });
+  return success(c, { zones: zones.map(mapHeliusRingsZoneRow) });
+}
+
+/** POST /wallets/:walletId/zones — idempotent per (wallet, name). */
+export async function createRingsZone(c: AppContext) {
+  const parsed = createRingsZoneSchema.safeParse(await c.req.json());
+  if (!parsed.success) throw badRequest(parsed.error.issues[0]?.message ?? "invalid body");
+
+  const { tenant } = tenantOf(c);
+  const walletId = requireParam(c, "walletId");
+  const wallet = await getHeliusRingsWalletRepository(c).getWalletById({ ...tenant, id: walletId });
+  if (!wallet) throw notFound("rings wallet");
+
+  const zone = await getHeliusRingsZoneRepository(c).createZone({
+    walletId,
+    name: parsed.data.name,
+    kind: parsed.data.kind,
+  });
+  if (!zone) throw badRequest("zone could not be created");
+  return success(c, { zone: mapHeliusRingsZoneRow(zone) }, 201);
+}
+
+// --- operations ---------------------------------------------------------------
+
+/** POST /operations — reserve the intent and advance through policy. */
+export async function prepareRingsOperation(c: AppContext) {
+  const parsed = prepareRingsOperationSchema.safeParse(await c.req.json());
+  if (!parsed.success) throw badRequest(parsed.error.issues[0]?.message ?? "invalid body");
+
+  const { auth, tenant } = tenantOf(c);
+  const ringsWallet = await getHeliusRingsWalletRepository(c).getWalletById({
+    ...tenant,
+    id: parsed.data.walletId,
+  });
+  if (!ringsWallet) throw notFound("rings wallet");
+
+  // The policy envelope wants the custody wallet backing the rings wallet;
+  // absence is tolerated (the envelope's wallet id still scopes the policy).
+  const scope = await resolveScope(c);
+  const custodyWallet = scope.wallets.find((entry) => entry.walletId === ringsWallet.sdp_wallet_id);
+
+  const service = getHeliusRingsService(c, tenant);
+  const operation = await withRingsErrors(() =>
+    service.prepareOperation(parsed.data, {
+      apiKeyId: auth.apiKeyId,
+      actor: walletOperationActorFromAuth(auth),
+      custodyWalletId: custodyWallet?.id ?? null,
+    })
+  );
+  return success(c, { operation }, 201);
+}
+
+/** GET /operations — the project's activity feed, newest first. */
+export async function listRingsOperations(c: AppContext) {
+  const { tenant } = tenantOf(c);
+  const limit = listLimitSchema.parse(c.req.query("limit"));
+  const rows = await getHeliusRingsOperationRepository(c).listOperationsByProject({
+    ...tenant,
+    limit,
+  });
+  return success(c, { operations: rows.map(mapHeliusRingsOperationSummaryRow) });
+}
+
+/** GET /operations/:operationId — full detail with the event timeline. */
+export async function getRingsOperation(c: AppContext) {
+  const { tenant } = tenantOf(c);
+  const service = getHeliusRingsService(c, tenant);
+  const operation = await withRingsErrors(() =>
+    service.getOperationWithEvents(requireParam(c, "operationId"))
+  );
+  return success(c, { operation });
+}
+
+/** POST /operations/:operationId/execute — advance a waiting operation. */
+export async function executeRingsOperation(c: AppContext) {
+  const parsed = executeRingsOperationSchema.safeParse(await c.req.json().catch(() => ({})));
+  if (!parsed.success) throw badRequest(parsed.error.issues[0]?.message ?? "invalid body");
+
+  const { tenant } = tenantOf(c);
+  const service = getHeliusRingsService(c, tenant);
+  const operation = await withRingsErrors(() =>
+    service.executeOperation(requireParam(c, "operationId"), parsed.data)
+  );
+  return success(c, { operation });
+}
+
+/** POST /operations/:operationId/retry — file a linked retry of a failed op. */
+export async function retryRingsOperation(c: AppContext) {
+  const parsed = retryRingsOperationSchema.safeParse(await c.req.json());
+  if (!parsed.success) throw badRequest(parsed.error.issues[0]?.message ?? "invalid body");
+
+  const { tenant } = tenantOf(c);
+  const service = getHeliusRingsService(c, tenant);
+  const operation = await withRingsErrors(() =>
+    service.retryOperation(requireParam(c, "operationId"), parsed.data.clientNonce)
+  );
+  return success(c, { operation }, 201);
+}

--- a/apps/sdp-api/src/routes/helius-rings/index.ts
+++ b/apps/sdp-api/src/routes/helius-rings/index.ts
@@ -1,0 +1,61 @@
+import { type Context, Hono, type Next } from "hono";
+import { AppError } from "@/lib/errors";
+import { isHeliusRingsEnabled } from "@/lib/feature-flags";
+import { requirePermissions, unifiedAuthMiddleware } from "@/middleware/auth";
+import { projectContextMiddleware } from "@/middleware/project-context";
+import type { Env } from "@/types/env";
+import {
+  createRingsWallet,
+  createRingsZone,
+  executeRingsOperation,
+  getRingsHealth,
+  getRingsOperation,
+  getRingsWallet,
+  listRingsOperations,
+  listRingsWallets,
+  listRingsZones,
+  prepareRingsOperation,
+  retryRingsOperation,
+} from "./handlers";
+
+const heliusRings = new Hono<{ Bindings: Env }>();
+
+/**
+ * Router-wide gate: 403 unless the feature flag is on. The flag stays off in
+ * every deployed environment until Track B lands the live gateway; the
+ * devnet-only guard inside HeliusRingsService is the second lock.
+ */
+async function requireHeliusRingsFeature(c: Context<{ Bindings: Env }>, next: Next) {
+  if (!isHeliusRingsEnabled(c.env)) {
+    throw new AppError("FORBIDDEN", "Helius Rings is not enabled for this environment.");
+  }
+  await next();
+}
+
+heliusRings.use("*", requireHeliusRingsFeature);
+heliusRings.use("*", unifiedAuthMiddleware({ allowClerk: true, allowSession: true }));
+heliusRings.use("*", projectContextMiddleware());
+
+heliusRings.get("/health", requirePermissions("payments:read"), getRingsHealth);
+
+heliusRings.get("/wallets", requirePermissions("payments:read"), listRingsWallets);
+heliusRings.post("/wallets", requirePermissions("payments:write"), createRingsWallet);
+heliusRings.get("/wallets/:walletId", requirePermissions("payments:read"), getRingsWallet);
+heliusRings.get("/wallets/:walletId/zones", requirePermissions("payments:read"), listRingsZones);
+heliusRings.post("/wallets/:walletId/zones", requirePermissions("payments:write"), createRingsZone);
+
+heliusRings.get("/operations", requirePermissions("payments:read"), listRingsOperations);
+heliusRings.post("/operations", requirePermissions("payments:write"), prepareRingsOperation);
+heliusRings.get("/operations/:operationId", requirePermissions("payments:read"), getRingsOperation);
+heliusRings.post(
+  "/operations/:operationId/execute",
+  requirePermissions("payments:write"),
+  executeRingsOperation
+);
+heliusRings.post(
+  "/operations/:operationId/retry",
+  requirePermissions("payments:write"),
+  retryRingsOperation
+);
+
+export default heliusRings;

--- a/apps/sdp-api/src/routes/helius-rings/schemas.ts
+++ b/apps/sdp-api/src/routes/helius-rings/schemas.ts
@@ -22,7 +22,7 @@ export const prepareRingsOperationSchema = z.object({
   transferMode: z.enum(TRANSFER_MODES).optional(),
   timelock: z
     .object({
-      unlockAt: z.string().datetime(),
+      unlockAt: z.iso.datetime(),
       beneficiary: z.string().min(1),
     })
     .optional(),

--- a/apps/sdp-api/src/routes/helius-rings/schemas.ts
+++ b/apps/sdp-api/src/routes/helius-rings/schemas.ts
@@ -30,10 +30,6 @@ export const prepareRingsOperationSchema = z.object({
   clientNonce: z.string().min(1).max(128),
 });
 
-export const executeRingsOperationSchema = z.object({
-  approvalStatus: z.enum(["approved", "rejected", "pending"]).optional(),
-});
-
 export const retryRingsOperationSchema = z.object({
   clientNonce: z.string().min(1).max(128),
 });

--- a/apps/sdp-api/src/routes/helius-rings/schemas.ts
+++ b/apps/sdp-api/src/routes/helius-rings/schemas.ts
@@ -1,0 +1,46 @@
+import { OP_TYPES, TRANSFER_MODES, ZONE_KINDS } from "@sdp/helius-rings";
+import { z } from "zod";
+
+export const createRingsWalletSchema = z.object({
+  /** SDP custody wallet id (`walletId` from GET /v1/wallets). */
+  walletId: z.string().min(1),
+  name: z.string().min(1).max(120),
+});
+
+export const prepareRingsOperationSchema = z.object({
+  walletId: z.string().min(1),
+  opType: z.enum(OP_TYPES),
+  asset: z
+    .object({
+      mint: z.string().min(1),
+      amountRaw: z.string().regex(/^\d+$/, "amountRaw must be a base-unit integer string"),
+    })
+    .optional(),
+  from: z.string().min(1).optional(),
+  to: z.string().min(1).optional(),
+  zoneId: z.string().min(1).optional(),
+  transferMode: z.enum(TRANSFER_MODES).optional(),
+  timelock: z
+    .object({
+      unlockAt: z.string().datetime(),
+      beneficiary: z.string().min(1),
+    })
+    .optional(),
+  /** Caller-supplied; contributes to the intent key so retries are explicit. */
+  clientNonce: z.string().min(1).max(128),
+});
+
+export const executeRingsOperationSchema = z.object({
+  approvalStatus: z.enum(["approved", "rejected", "pending"]).optional(),
+});
+
+export const retryRingsOperationSchema = z.object({
+  clientNonce: z.string().min(1).max(128),
+});
+
+export const createRingsZoneSchema = z.object({
+  name: z.string().min(1).max(120),
+  kind: z.enum(ZONE_KINDS),
+});
+
+export const listLimitSchema = z.coerce.number().int().min(1).max(200).optional();

--- a/apps/sdp-api/src/runtime/log-redaction.test.ts
+++ b/apps/sdp-api/src/runtime/log-redaction.test.ts
@@ -1,0 +1,132 @@
+import pino from "pino";
+import { describe, expect, it } from "vitest";
+import {
+  LOG_REDACTION_PATHS,
+  REDACTED_LEAF_FIELDS,
+  REDACTED_NESTED_PATHS,
+  REDACTION_CENSOR,
+} from "./log-redaction";
+import { baseLoggerOptions } from "./logger";
+
+/**
+ * Stands in for `SecretRef` from `@sdp/helius-rings`, which sdp-api does not yet
+ * depend on — A5 adds that dependency when the repositories need the domain
+ * types. What matters here is the contract pino relies on, `toJSON()` returning
+ * the censor; that `SecretRef` honours it is asserted in
+ * packages/sdp-helius-rings/src/secrets.test.ts.
+ */
+class WrappedSecret {
+  readonly #value: string;
+  constructor(value: string) {
+    this.#value = value;
+  }
+  reveal(): string {
+    return this.#value;
+  }
+  toJSON(): string {
+    return REDACTION_CENSOR;
+  }
+}
+
+/** Captures what the real logger options would actually emit to a sink. */
+function captureLogs(write: (logger: pino.Logger) => void): string {
+  const lines: string[] = [];
+  const logger = pino(
+    { ...baseLoggerOptions(), transport: undefined, timestamp: false },
+    { write: (line: string) => lines.push(line) }
+  );
+  write(logger);
+  return lines.join("\n");
+}
+
+describe("log redaction registry", () => {
+  it("expands every registered field to the root and one level deep", () => {
+    for (const field of [...REDACTED_LEAF_FIELDS, ...REDACTED_NESTED_PATHS]) {
+      expect(LOG_REDACTION_PATHS).toContain(field);
+      expect(LOG_REDACTION_PATHS).toContain(`*.${field}`);
+    }
+  });
+
+  it("is accepted by pino — an unsupported path shape throws at construction", () => {
+    expect(() => captureLogs((logger) => logger.info("ok"))).not.toThrow();
+  });
+
+  it("censors the Rings key domain at the root of a log object", () => {
+    const output = captureLogs((logger) => {
+      logger.info({ viewingKey: "vk-plaintext", nullifierKey: "nk-plaintext" }, "provisioned");
+    });
+
+    expect(output).not.toContain("vk-plaintext");
+    expect(output).not.toContain("nk-plaintext");
+    expect(output).toContain(REDACTION_CENSOR);
+  });
+
+  it("censors the Rings key domain one level deep, where callers actually put it", () => {
+    const output = captureLogs((logger) => {
+      logger.info({ wallet: { id: "hrw_1", viewingKey: "vk-plaintext" } }, "wallet ready");
+    });
+
+    expect(output).not.toContain("vk-plaintext");
+    expect(output).toContain("hrw_1");
+  });
+
+  it("censors proof internals and key ref material", () => {
+    const output = captureLogs((logger) => {
+      logger.info(
+        {
+          operation: {
+            id: "hro_1",
+            proof: { ref: "proof-handle", internal: "witness-bytes" },
+          },
+          keyRefs: [{ material: "blob-a" }, { material: "blob-b" }],
+        },
+        "proof received"
+      );
+    });
+
+    expect(output).not.toContain("proof-handle");
+    expect(output).not.toContain("witness-bytes");
+    expect(output).not.toContain("blob-a");
+    expect(output).not.toContain("blob-b");
+    expect(output).toContain("hro_1");
+  });
+
+  it("censors the gateway metadata envelope", () => {
+    const output = captureLogs((logger) => {
+      logger.info({ ringsMetadata: { anything: "opaque-upstream-detail" } }, "gateway replied");
+    });
+
+    expect(output).not.toContain("opaque-upstream-detail");
+  });
+
+  it("leaves a wrapped secret redacted by the wrapper, at any depth", () => {
+    // This is why the one-level limit on the registry is tolerable: a wrapped
+    // secret redacts itself through toJSON(), so depth does not matter for
+    // wrapped material. The registry only has to cover plaintext that escaped
+    // wrapping.
+    const output = captureLogs((logger) => {
+      logger.info(
+        { a: { b: { c: { secret: new WrappedSecret("hunter2"), note: "deeply nested" } } } },
+        "deep"
+      );
+    });
+
+    expect(output).not.toContain("hunter2");
+    expect(output).toContain(REDACTION_CENSOR);
+    expect(output).toContain("deeply nested");
+  });
+
+  it("keeps ordinary operational fields readable", () => {
+    const output = captureLogs((logger) => {
+      logger.info(
+        { operation: { id: "hro_2", state: "proving", opType: "transfer_anonymous" } },
+        "advanced"
+      );
+    });
+
+    expect(output).toContain("hro_2");
+    expect(output).toContain("proving");
+    expect(output).toContain("transfer_anonymous");
+    expect(output).not.toContain(REDACTION_CENSOR);
+  });
+});

--- a/apps/sdp-api/src/runtime/log-redaction.ts
+++ b/apps/sdp-api/src/runtime/log-redaction.ts
@@ -1,0 +1,73 @@
+/**
+ * The log redaction registry: field paths pino censors before anything reaches
+ * a log sink.
+ *
+ * This is the belt, not the braces. The primary defence against secret material
+ * in logs is the type layer — `SecretRef<T>` in `@sdp/helius-rings` overrides
+ * `toJSON()`/`toString()` to `"[REDACTED]"`, so a wrapped secret is already safe
+ * wherever it is serialized. This registry catches the case the type layer
+ * cannot: a *plaintext* value that reached a log object without ever being
+ * wrapped, because someone called `reveal()` upstream, read a column straight
+ * out of the database, or destructured a gateway response.
+ *
+ * A known limit, verified against pino 10: the `*.` prefix matches exactly one
+ * intermediate key, not arbitrary depth. `{ wallet: { viewingKey } }` is
+ * censored; `{ a: { b: { viewingKey } } }` is not. fast-redact has no
+ * recursive-descent wildcard, so the alternative would be a hand-rolled deep
+ * walk on every log call — a cost paid on every log line in production to cover
+ * a shape that only appears if secret material is being passed around
+ * unwrapped, which is the thing `SecretRef` and
+ * `scripts/check-secretref-serialization.mjs` exist to prevent. Keep log objects
+ * shallow, and keep secrets wrapped.
+ *
+ * To register a field: add the key to `REDACTED_LEAF_FIELDS` if it can appear
+ * anywhere under its own name, or the full path to `REDACTED_NESTED_PATHS` if it
+ * is only meaningful inside a parent object. Both forms are expanded to cover
+ * the top level and one nesting level.
+ */
+
+/** What a censored value is replaced with. */
+export const REDACTION_CENSOR = "[REDACTED]";
+
+/**
+ * Keys that are sensitive wherever they appear, regardless of parent.
+ *
+ * `viewingKey` and `nullifierKey` are the Helius Rings key domain: a viewing key
+ * deanonymizes every transfer a shielded wallet has ever received, and a
+ * nullifier key can spend from it. `ringsMetadata` is the catch-all envelope the
+ * gateway attaches to operations, whose contents are not ours to audit.
+ */
+export const REDACTED_LEAF_FIELDS: readonly string[] = [
+  "viewingKey",
+  "nullifierKey",
+  "ringsMetadata",
+];
+
+/**
+ * Paths that are only sensitive in context.
+ *
+ * `proof.ref` is the gateway's opaque handle to a proof and `proof.internal` its
+ * witness data — neither is a secret about SDP, but both are a secret about the
+ * customer's transfer graph. `keyRefs[*].material` is the encrypted key blob as
+ * it travels in memory between the key authority and the signer.
+ */
+export const REDACTED_NESTED_PATHS: readonly string[] = [
+  "proof.ref",
+  "proof.internal",
+  "keyRefs[*].material",
+];
+
+/**
+ * Expands a registered field into the shapes pino can actually match: the path
+ * at the root of the log object, and the same path one key deeper (the common
+ * case, where the caller logs `{ operation: {...} }` or `{ wallet: {...} }`).
+ */
+function withOneLevelOfNesting(path: string): string[] {
+  return [path, `*.${path}`];
+}
+
+/** Paths handed to pino's `redact` option. */
+export const LOG_REDACTION_PATHS: readonly string[] = [
+  ...REDACTED_LEAF_FIELDS.flatMap(withOneLevelOfNesting),
+  ...REDACTED_NESTED_PATHS.flatMap(withOneLevelOfNesting),
+];

--- a/apps/sdp-api/src/runtime/logger.ts
+++ b/apps/sdp-api/src/runtime/logger.ts
@@ -1,5 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import pino, { type Logger, type LoggerOptions } from "pino";
+import { LOG_REDACTION_PATHS, REDACTION_CENSOR } from "./log-redaction";
 
 export interface LogContext {
   request_id?: string;
@@ -43,6 +44,7 @@ export function baseLoggerOptions(): LoggerOptions {
       },
     },
     serializers: { error: serializeError, err: serializeError },
+    redact: { paths: [...LOG_REDACTION_PATHS], censor: REDACTION_CENSOR },
     mixin: () => ({ ...getLogContext() }),
     ...(process.env.LOG_FORMAT === "pretty" ? { transport: { target: "pino-pretty" } } : {}),
   };

--- a/apps/sdp-api/src/services/helius-rings/adapter-error.ts
+++ b/apps/sdp-api/src/services/helius-rings/adapter-error.ts
@@ -1,0 +1,22 @@
+import type { FailureCode } from "@sdp/helius-rings";
+
+/**
+ * Failure from the signer or RPC adapter, carrying exactly what the service
+ * needs to take the state machine's fail edge: the operation-level failure
+ * code and whether a retry can succeed.
+ */
+export class RingsAdapterError extends Error {
+  readonly failureCode: Extract<FailureCode, "signer_failed" | "submit_failed">;
+  readonly retryable: boolean;
+
+  constructor(
+    failureCode: Extract<FailureCode, "signer_failed" | "submit_failed">,
+    message: string,
+    options: { retryable: boolean; cause?: unknown }
+  ) {
+    super(message, { cause: options.cause });
+    this.name = "RingsAdapterError";
+    this.failureCode = failureCode;
+    this.retryable = options.retryable;
+  }
+}

--- a/apps/sdp-api/src/services/helius-rings/index.ts
+++ b/apps/sdp-api/src/services/helius-rings/index.ts
@@ -1,0 +1,19 @@
+export { RingsAdapterError } from "./adapter-error";
+export {
+  buildRingsWalletOperationInput,
+  RINGS_ENVELOPE_KINDS,
+  type RingsEnvelopeKind,
+  ringsEnvelopeKind,
+} from "./policy-envelope";
+export { submitRingsOuterTransaction } from "./rpc-adapter";
+export {
+  computeIntentKey,
+  createHeliusRingsService,
+  type HeliusRingsActor,
+  HeliusRingsService,
+  type HeliusRingsServiceDependencies,
+  type HeliusRingsTenant,
+  type PrepareOperationContext,
+  type ProvisionPrivateWalletInput,
+} from "./service";
+export { signRingsOuterTransaction } from "./signer-adapter";

--- a/apps/sdp-api/src/services/helius-rings/policy-envelope.test.ts
+++ b/apps/sdp-api/src/services/helius-rings/policy-envelope.test.ts
@@ -1,0 +1,163 @@
+import { OP_TYPES } from "@sdp/helius-rings";
+import { evaluateCandidatePolicies } from "@sdp/policy";
+import type { EffectiveWalletPolicy, PolicyCandidate, PolicyRule } from "@sdp/types";
+import { describe, expect, it } from "vitest";
+import {
+  buildRingsWalletOperationInput,
+  RINGS_ENVELOPE_KINDS,
+  ringsEnvelopeKind,
+} from "./policy-envelope";
+
+function ringsCandidate(opType: (typeof OP_TYPES)[number]): PolicyCandidate {
+  return {
+    organizationId: "org_1",
+    projectId: "prj_1",
+    custodyWalletId: "cw_1",
+    walletId: "wal_1",
+    apiKeyId: null,
+    actor: null,
+    source: "api",
+    operationFamily: "transfer",
+    operationType: ringsEnvelopeKind(opType),
+    asset: null,
+    amount: null,
+    destination: null,
+    context: {},
+    providerExtensions: {},
+  };
+}
+
+function activeWalletPolicy(rules: PolicyRule[]): EffectiveWalletPolicy {
+  const now = "2026-08-17T00:00:00.000Z";
+  return {
+    source: "customer_profile",
+    profile: {
+      id: "wcp_1",
+      organizationId: "org_1",
+      projectId: "prj_1",
+      custodyWalletId: "cw_1",
+      name: "Wallet controls",
+      status: "active",
+      activeRevisionId: "wcpr_1",
+      createdBy: "usr_1",
+      createdAt: now,
+      updatedAt: now,
+      activatedAt: now,
+      archivedAt: null,
+    },
+    revision: {
+      id: "wcpr_1",
+      profileId: "wcp_1",
+      revisionNumber: 1,
+      rules,
+      defaultAction: "allow",
+      commitMessage: null,
+      createdBy: "usr_1",
+      createdAt: now,
+      activatedAt: now,
+    },
+    defaultAction: "allow",
+  };
+}
+
+describe("ringsEnvelopeKind", () => {
+  it("covers every op type with a rings_ prefix", () => {
+    expect(RINGS_ENVELOPE_KINDS).toEqual(OP_TYPES.map((opType) => `rings_${opType}`));
+  });
+});
+
+describe("rings operations under wallet policy", () => {
+  it("a policy denying transfers denies every rings op type — no bypass", () => {
+    const denyTransfers = activeWalletPolicy([
+      { kind: "operation_family", family: "transfer", action: "deny" },
+    ]);
+
+    for (const opType of OP_TYPES) {
+      const evaluation = evaluateCandidatePolicies({
+        candidate: ringsCandidate(opType),
+        legs: [],
+        walletPolicy: denyTransfers,
+        apiKeyPolicy: null,
+      });
+      expect(evaluation.decision, `rings_${opType} escaped the transfer deny`).toBe("deny");
+    }
+  });
+
+  it("a rule can target one rings op type without touching the rest", () => {
+    const approveAnonymous = activeWalletPolicy([
+      {
+        kind: "operation_type",
+        operationType: "rings_transfer_anonymous",
+        action: "approval_required",
+      },
+    ]);
+
+    expect(
+      evaluateCandidatePolicies({
+        candidate: ringsCandidate("transfer_anonymous"),
+        legs: [],
+        walletPolicy: approveAnonymous,
+        apiKeyPolicy: null,
+      }).decision
+    ).toBe("approval_required");
+    expect(
+      evaluateCandidatePolicies({
+        candidate: ringsCandidate("shield"),
+        legs: [],
+        walletPolicy: approveAnonymous,
+        apiKeyPolicy: null,
+      }).decision
+    ).toBe("allow");
+  });
+});
+
+describe("buildRingsWalletOperationInput", () => {
+  const base = {
+    organizationId: "org_1",
+    projectId: "prj_1",
+    custodyWalletId: "cw_1",
+    sdpWalletId: "wal_1",
+    apiKeyId: "key_1",
+    actor: null,
+    operationId: "hro_1",
+    intentKey: "sha256:abc",
+  };
+
+  it("maps a transfer onto the transfer family with a rings operation type", () => {
+    const input = buildRingsWalletOperationInput({
+      ...base,
+      operation: {
+        walletId: "hrw_1",
+        opType: "transfer_anonymous",
+        asset: { mint: "mint_1", amountRaw: "1000" },
+        to: "recipient",
+        transferMode: "anonymous",
+        clientNonce: "n1",
+      },
+    });
+
+    expect(input).toMatchObject({
+      operationFamily: "transfer",
+      operationType: "rings_transfer_anonymous",
+      asset: "mint_1",
+      amount: "1000",
+      destination: "recipient",
+      idempotencyKey: "sha256:abc",
+      source: "api",
+    });
+    expect(input.context).toMatchObject({ transferMode: "anonymous", ringsOperationId: "hro_1" });
+  });
+
+  it("marks a system-originated operation as system-sourced", () => {
+    const input = buildRingsWalletOperationInput({
+      ...base,
+      apiKeyId: null,
+      actor: null,
+      operation: { walletId: "hrw_1", opType: "shield", clientNonce: "n1" },
+    });
+
+    expect(input.source).toBe("system");
+    expect(input.asset).toBeNull();
+    expect(input.destination).toBeNull();
+  });
+});

--- a/apps/sdp-api/src/services/helius-rings/policy-envelope.ts
+++ b/apps/sdp-api/src/services/helius-rings/policy-envelope.ts
@@ -1,0 +1,70 @@
+import type { OpType, PrivateOperationInput } from "@sdp/helius-rings";
+import { OP_TYPES } from "@sdp/helius-rings";
+import type { CreateWalletOperationInput } from "@sdp/policy";
+import type { WalletOperationActor } from "@sdp/types";
+
+/**
+ * Maps a Rings operation onto the wallet-operation policy machinery. Every
+ * Rings op evaluates as `operationFamily: "transfer"` with a `rings_*`
+ * operation type: a policy that gates transfers on a wallet therefore gates
+ * every Rings op rooted in it, so Rings can never be an approval bypass.
+ * Finer-grained rules target the individual `rings_*` types.
+ */
+
+export type RingsEnvelopeKind = `rings_${OpType}`;
+
+export const RINGS_ENVELOPE_KINDS = OP_TYPES.map((opType): RingsEnvelopeKind => `rings_${opType}`);
+
+export function ringsEnvelopeKind(opType: OpType): RingsEnvelopeKind {
+  return `rings_${opType}`;
+}
+
+export interface BuildRingsWalletOperationInput {
+  organizationId: string;
+  projectId: string;
+  /** The SDP custody wallet the Rings wallet is bound to. */
+  custodyWalletId: string | null;
+  sdpWalletId: string;
+  apiKeyId: string | null;
+  actor: WalletOperationActor | null;
+  operation: PrivateOperationInput;
+  /** The reserved operation id, kept with the raw payload for audit. */
+  operationId: string;
+  intentKey: string;
+}
+
+export function buildRingsWalletOperationInput(
+  input: BuildRingsWalletOperationInput
+): CreateWalletOperationInput {
+  const { operation } = input;
+  return {
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    custodyWalletId: input.custodyWalletId,
+    walletId: input.sdpWalletId,
+    apiKeyId: input.apiKeyId,
+    actor: input.actor,
+    source: input.apiKeyId === null && input.actor === null ? "system" : "api",
+    operationFamily: "transfer",
+    operationType: ringsEnvelopeKind(operation.opType),
+    asset: operation.asset?.mint ?? null,
+    amount: operation.asset?.amountRaw ?? null,
+    destination: operation.to ?? null,
+    legs: [],
+    context: {
+      ringsOperationId: input.operationId,
+      ringsWalletId: operation.walletId,
+      // Anonymous transfers are not lower-risk than registered ones — the
+      // counterparty is undisclosed, so reviewers see the mode explicitly.
+      transferMode: operation.transferMode ?? null,
+      zoneId: operation.zoneId ?? null,
+    },
+    providerExtensions: {},
+    rawPayload: {
+      opType: operation.opType,
+      intentKey: input.intentKey,
+      timelock: operation.timelock ?? null,
+    },
+    idempotencyKey: input.intentKey,
+  };
+}

--- a/apps/sdp-api/src/services/helius-rings/rpc-adapter.ts
+++ b/apps/sdp-api/src/services/helius-rings/rpc-adapter.ts
@@ -1,0 +1,32 @@
+import { createRpc, type SolanaRpc, sendTransaction } from "@sdp/rpc/solana";
+import { getBase64Codec } from "@solana/codecs";
+import type { Env } from "@/types/env";
+import { RingsAdapterError } from "./adapter-error";
+
+/**
+ * Broadcasts the signed outer transaction over the existing SDP RPC path.
+ * Submission failures are always retryable: the service's intent key makes a
+ * resubmission safe, and the RPC cannot tell a dropped transaction from a
+ * transient outage.
+ */
+
+export interface SubmitRingsOuterTransactionInput {
+  env: Env;
+  signedTxBase64: string;
+  /** Test seam; production resolves the env RPC. */
+  rpc?: SolanaRpc;
+}
+
+export async function submitRingsOuterTransaction(
+  input: SubmitRingsOuterTransactionInput
+): Promise<string> {
+  const rpc = input.rpc ?? createRpc(input.env);
+  const signedBytes = getBase64Codec().encode(input.signedTxBase64);
+
+  try {
+    return await sendTransaction(rpc, new Uint8Array(signedBytes));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "transaction submission failed";
+    throw new RingsAdapterError("submit_failed", message, { retryable: true, cause: error });
+  }
+}

--- a/apps/sdp-api/src/services/helius-rings/service.test.ts
+++ b/apps/sdp-api/src/services/helius-rings/service.test.ts
@@ -1,0 +1,367 @@
+import type { PrivateOperationInput } from "@sdp/helius-rings";
+import { InMemoryRingsGateway } from "@sdp/helius-rings/testing";
+import type { WalletOperationPolicyEnforcement } from "@sdp/policy";
+import type { PolicyDecision } from "@sdp/types";
+import { beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import { createHeliusRingsWalletRepository } from "@/db/repositories";
+import { AppError } from "@/lib/errors";
+import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import { RingsAdapterError } from "./adapter-error";
+import {
+  computeIntentKey,
+  createHeliusRingsService,
+  type HeliusRingsServiceDependencies,
+} from "./service";
+
+const TEST_PROJECT_ID = "prj_hrs_service_test";
+const tenant = { organizationId: TEST_ORG.id, projectId: TEST_PROJECT_ID };
+
+let walletId: string;
+
+function policyStub(
+  decision: PolicyDecision,
+  overrides: { requiresApproval?: boolean; approvalRequestId?: string | null } = {}
+): HeliusRingsServiceDependencies["enforcePolicy"] {
+  return async () =>
+    ({
+      operation: { id: "wop_1" },
+      evaluation: {
+        id: "pev_1",
+        decision,
+        reason: decision === "deny" ? "denied by wallet policy" : null,
+        requiresApproval: overrides.requiresApproval ?? false,
+        approvalRequestId: overrides.approvalRequestId ?? null,
+      },
+    }) as unknown as WalletOperationPolicyEnforcement;
+}
+
+function operationInput(overrides: Partial<PrivateOperationInput> = {}): PrivateOperationInput {
+  return {
+    walletId,
+    opType: "shield",
+    asset: { mint: "So11111111111111111111111111111111111111112", amountRaw: "1000000" },
+    clientNonce: "nonce-1",
+    ...overrides,
+  };
+}
+
+const actorContext = { apiKeyId: "key_1", actor: null, custodyWalletId: "cw_1" };
+
+function service(deps: HeliusRingsServiceDependencies = {}) {
+  return createHeliusRingsService(env, tenant, {
+    enforcePolicy: policyStub("allow"),
+    ...deps,
+  });
+}
+
+/** A service whose gateway succeeds and whose sign/submit adapters are stubbed. */
+function liveishService(deps: HeliusRingsServiceDependencies = {}) {
+  return service({
+    gateway: new InMemoryRingsGateway(),
+    signOuterTransaction: async () => "c2lnbmVk",
+    submitOuterTransaction: async () => "sig_outer_1",
+    ...deps,
+  });
+}
+
+describe("HeliusRingsService", () => {
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    const db = getDb(env);
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
+      )
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
+      .run();
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')"
+      )
+      .bind(TEST_USER.id, TEST_USER.email)
+      .run();
+    await db
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, 'Test Project', ?, 'sandbox', 'active', ?)`
+      )
+      .bind(TEST_PROJECT_ID, TEST_ORG.id, TEST_PROJECT_ID, TEST_USER.id)
+      .run();
+
+    const wallet = await createHeliusRingsWalletRepository(env).createWallet({
+      ...tenant,
+      sdpWalletId: "wal_hrs_service_test",
+      name: "Treasury",
+      materialTag: "simulated",
+    });
+    if (!wallet) throw new Error("wallet fixture was not created");
+    walletId = wallet.id;
+  });
+
+  describe("devnet guard", () => {
+    it("refuses to construct outside devnet", () => {
+      expect(() =>
+        createHeliusRingsService({ ...env, SOLANA_NETWORK: "mainnet-beta" }, tenant)
+      ).toThrow(AppError);
+    });
+  });
+
+  describe("provisionPrivateWallet", () => {
+    it("provisions through the gateway and marks the wallet ready", async () => {
+      const wallet = await service({ gateway: new InMemoryRingsGateway() }).provisionPrivateWallet({
+        sdpWalletId: "wal_prov_1",
+        sdpAddress: "addr1",
+        name: "Ops",
+      });
+
+      expect(wallet.status).toBe("ready");
+      expect(wallet.shieldedAddress).toMatch(/^rings1/);
+    });
+
+    it("leaves the wallet pending when the gateway is not implemented", async () => {
+      const result = await service()
+        .provisionPrivateWallet({ sdpWalletId: "wal_prov_2", sdpAddress: "addr2", name: "Ops" })
+        .then(
+          () => null,
+          (error: unknown) => error
+        );
+
+      // The route maps this to a 503; the wizard renders the pending state.
+      expect(result).toMatchObject({ code: "gateway_unavailable" });
+      const rows = await createHeliusRingsWalletRepository(env).getWalletBySdpWalletId({
+        ...tenant,
+        sdpWalletId: "wal_prov_2",
+      });
+      expect(rows?.status).toBe("pending");
+    });
+  });
+
+  describe("prepareOperation", () => {
+    it("is idempotent: the same client nonce returns the same operation", async () => {
+      const svc = service();
+      const first = await svc.prepareOperation(operationInput(), actorContext);
+      const replay = await svc.prepareOperation(operationInput(), actorContext);
+
+      expect(replay.id).toBe(first.id);
+      expect(replay.intentKey).toBe(computeIntentKey(operationInput()));
+    });
+
+    it("ends in failed:policy_denied when the policy denies", async () => {
+      const operation = await service({ enforcePolicy: policyStub("deny") }).prepareOperation(
+        operationInput({ clientNonce: "nonce-deny" }),
+        actorContext
+      );
+
+      expect(operation.state).toBe("failed");
+      expect(operation.failure).toMatchObject({ code: "policy_denied", retryable: false });
+    });
+
+    it("pauses at approval_required and records the approval request", async () => {
+      const operation = await service({
+        enforcePolicy: policyStub("approval_required", {
+          requiresApproval: true,
+          approvalRequestId: "apr_1",
+        }),
+      }).prepareOperation(operationInput({ clientNonce: "nonce-approval" }), actorContext);
+
+      expect(operation.state).toBe("approval_required");
+      expect(operation.approvalRequestId).toBe("apr_1");
+      expect(operation.policyEvaluationId).toBe("pev_1");
+    });
+
+    it("fails honestly at the port when the gateway is not implemented", async () => {
+      const operation = await service().prepareOperation(
+        operationInput({ clientNonce: "nonce-notimpl" }),
+        actorContext
+      );
+
+      expect(operation.state).toBe("failed");
+      expect(operation.failure).toMatchObject({ code: "gateway_unavailable", retryable: true });
+    });
+
+    it("drives an allowed operation through sign and submit to indexing", async () => {
+      const operation = await liveishService().prepareOperation(
+        operationInput({ clientNonce: "nonce-live" }),
+        actorContext
+      );
+
+      expect(operation.state).toBe("indexing");
+      expect(operation.outerTxSignature).toBe("sig_outer_1");
+    });
+
+    it("takes the signer's fail edge when custody signing fails", async () => {
+      const operation = await liveishService({
+        signOuterTransaction: async () => {
+          throw new RingsAdapterError("signer_failed", "signer down", { retryable: true });
+        },
+      }).prepareOperation(operationInput({ clientNonce: "nonce-signer" }), actorContext);
+
+      expect(operation.state).toBe("failed");
+      expect(operation.failure).toMatchObject({ code: "signer_failed", retryable: true });
+    });
+  });
+
+  describe("executeOperation", () => {
+    it("advances an approved operation and is inert while approval is pending", async () => {
+      const svc = liveishService({
+        enforcePolicy: policyStub("approval_required", {
+          requiresApproval: true,
+          approvalRequestId: "apr_1",
+        }),
+      });
+      const paused = await svc.prepareOperation(
+        operationInput({ clientNonce: "nonce-exec" }),
+        actorContext
+      );
+      expect(paused.state).toBe("approval_required");
+
+      const stillPaused = await svc.executeOperation(paused.id, { approvalStatus: "pending" });
+      expect(stillPaused.state).toBe("approval_required");
+
+      const advanced = await svc.executeOperation(paused.id, { approvalStatus: "approved" });
+      expect(advanced.state).toBe("indexing");
+    });
+
+    it("fails a rejected approval as non-retryable", async () => {
+      const svc = liveishService({
+        enforcePolicy: policyStub("approval_required", {
+          requiresApproval: true,
+          approvalRequestId: "apr_1",
+        }),
+      });
+      const paused = await svc.prepareOperation(
+        operationInput({ clientNonce: "nonce-reject" }),
+        actorContext
+      );
+
+      const rejected = await svc.executeOperation(paused.id, { approvalStatus: "rejected" });
+      expect(rejected.state).toBe("failed");
+      expect(rejected.failure).toMatchObject({ code: "approval_rejected", retryable: false });
+    });
+
+    it("polls indexing idempotently and completes on the Photon hit", async () => {
+      let now = "2026-08-18T00:00:00.000Z";
+      const gateway = new InMemoryRingsGateway({ now: () => now, indexingDelayMs: 1000 });
+      const svc = liveishService({ gateway });
+      const operation = await svc.prepareOperation(
+        operationInput({ clientNonce: "nonce-index" }),
+        actorContext
+      );
+      expect(operation.state).toBe("indexing");
+
+      gateway.recordSubmission("sig_outer_1");
+      // Photon has not indexed yet: repeated polls change nothing.
+      expect((await svc.executeOperation(operation.id)).state).toBe("indexing");
+      expect((await svc.executeOperation(operation.id)).state).toBe("indexing");
+
+      now = "2026-08-18T00:00:02.000Z";
+      const completed = await svc.executeOperation(operation.id);
+      expect(completed.state).toBe("completed");
+      expect(completed.photonIndexedAt).toBe(now);
+
+      // Executing a terminal operation is a no-op.
+      expect((await svc.executeOperation(operation.id)).state).toBe("completed");
+    });
+  });
+
+  describe("retryOperation", () => {
+    it("files a linked retry and leaves the failed original untouched", async () => {
+      const svc = service();
+      const failed = await svc.prepareOperation(
+        operationInput({ clientNonce: "nonce-retry" }),
+        actorContext
+      );
+      expect(failed.state).toBe("failed");
+
+      const retry = await svc.retryOperation(failed.id, "nonce-retry-2");
+
+      expect(retry.id).not.toBe(failed.id);
+      expect(retry.intentKey).not.toBe(failed.intentKey);
+      const original = await svc.getOperation(failed.id);
+      expect(original.state).toBe("failed");
+
+      const detail = await svc.getOperationWithEvents(retry.id);
+      expect(detail.events.map((event) => event.kind)).toContain("operation.retried");
+    });
+
+    it("refuses to retry a non-retryable failure", async () => {
+      const svc = service({ enforcePolicy: policyStub("deny") });
+      const denied = await svc.prepareOperation(
+        operationInput({ clientNonce: "nonce-noretry" }),
+        actorContext
+      );
+
+      await expect(svc.retryOperation(denied.id, "nonce-noretry-2")).rejects.toMatchObject({
+        code: "CONFLICT",
+      });
+    });
+
+    it("refuses to retry an operation that has not failed", async () => {
+      const svc = liveishService();
+      const inFlight = await svc.prepareOperation(
+        operationInput({ clientNonce: "nonce-inflight" }),
+        actorContext
+      );
+      expect(inFlight.state).toBe("indexing");
+
+      await expect(svc.retryOperation(inFlight.id, "again")).rejects.toMatchObject({
+        code: "CONFLICT",
+      });
+    });
+  });
+
+  describe("probeHealth", () => {
+    it("records gateway red when the port is not implemented", async () => {
+      const health = await service().probeHealth();
+
+      expect(health.gateway).toBe("red");
+      // Unobserved components read red, not green.
+      expect(health.prover).toBe("red");
+    });
+
+    it("records the gateway's component statuses when reachable", async () => {
+      const health = await service({
+        gateway: new InMemoryRingsGateway({
+          health: { rpc: "green", prover: "amber", photon: "green", gateway: "green" },
+        }),
+      }).probeHealth();
+
+      expect(health).toMatchObject({ rpc: "green", prover: "amber", gateway: "green" });
+    });
+  });
+
+  describe("event feed", () => {
+    it("records the full lifecycle on the timeline", async () => {
+      const svc = liveishService();
+      const operation = await svc.prepareOperation(
+        operationInput({ clientNonce: "nonce-events" }),
+        actorContext
+      );
+
+      const detail = await svc.getOperationWithEvents(operation.id);
+      const kinds = detail.events.map((event) => event.kind);
+      expect(kinds).toContain("operation.created");
+      expect(kinds).toContain("policy.evaluated");
+      expect(kinds).toContain("proof.received");
+      expect(kinds).toContain("transaction.submitted");
+    });
+  });
+});
+
+describe("computeIntentKey", () => {
+  it("is deterministic and nonce-sensitive", () => {
+    const base: PrivateOperationInput = {
+      walletId: "hrw_1",
+      opType: "shield",
+      clientNonce: "n1",
+    };
+
+    expect(computeIntentKey(base)).toBe(computeIntentKey({ ...base }));
+    expect(computeIntentKey(base)).not.toBe(computeIntentKey({ ...base, clientNonce: "n2" }));
+    expect(computeIntentKey(base)).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+});

--- a/apps/sdp-api/src/services/helius-rings/service.test.ts
+++ b/apps/sdp-api/src/services/helius-rings/service.test.ts
@@ -206,12 +206,14 @@ describe("HeliusRingsService", () => {
   });
 
   describe("executeOperation", () => {
-    it("advances an approved operation and is inert while approval is pending", async () => {
+    it("advances only once the stored approval reads approved", async () => {
+      let approvalStatus: "pending" | "approved" = "pending";
       const svc = liveishService({
         enforcePolicy: policyStub("approval_required", {
           requiresApproval: true,
           approvalRequestId: "apr_1",
         }),
+        getApprovalStatus: async () => approvalStatus,
       });
       const paused = await svc.prepareOperation(
         operationInput({ clientNonce: "nonce-exec" }),
@@ -219,10 +221,13 @@ describe("HeliusRingsService", () => {
       );
       expect(paused.state).toBe("approval_required");
 
-      const stillPaused = await svc.executeOperation(paused.id, { approvalStatus: "pending" });
+      // The verdict comes from the approval request, never the caller: while
+      // it reads pending, execute is inert no matter how often it is called.
+      const stillPaused = await svc.executeOperation(paused.id);
       expect(stillPaused.state).toBe("approval_required");
 
-      const advanced = await svc.executeOperation(paused.id, { approvalStatus: "approved" });
+      approvalStatus = "approved";
+      const advanced = await svc.executeOperation(paused.id);
       expect(advanced.state).toBe("indexing");
     });
 
@@ -232,13 +237,14 @@ describe("HeliusRingsService", () => {
           requiresApproval: true,
           approvalRequestId: "apr_1",
         }),
+        getApprovalStatus: async () => "rejected",
       });
       const paused = await svc.prepareOperation(
         operationInput({ clientNonce: "nonce-reject" }),
         actorContext
       );
 
-      const rejected = await svc.executeOperation(paused.id, { approvalStatus: "rejected" });
+      const rejected = await svc.executeOperation(paused.id);
       expect(rejected.state).toBe("failed");
       expect(rejected.failure).toMatchObject({ code: "approval_rejected", retryable: false });
     });
@@ -277,7 +283,7 @@ describe("HeliusRingsService", () => {
       );
       expect(failed.state).toBe("failed");
 
-      const retry = await svc.retryOperation(failed.id, "nonce-retry-2");
+      const retry = await svc.retryOperation(failed.id, "nonce-retry-2", actorContext);
 
       expect(retry.id).not.toBe(failed.id);
       expect(retry.intentKey).not.toBe(failed.intentKey);
@@ -295,8 +301,32 @@ describe("HeliusRingsService", () => {
         actorContext
       );
 
-      await expect(svc.retryOperation(denied.id, "nonce-noretry-2")).rejects.toMatchObject({
+      await expect(
+        svc.retryOperation(denied.id, "nonce-noretry-2", actorContext)
+      ).rejects.toMatchObject({
         code: "CONFLICT",
+      });
+    });
+
+    it("caps the retry lineage depth", async () => {
+      const svc = service();
+      let current = await svc.prepareOperation(
+        operationInput({ clientNonce: "nonce-depth-0" }),
+        actorContext
+      );
+      expect(current.state).toBe("failed");
+
+      // Depth 1 is the original; four retries reach the cap of five.
+      for (let attempt = 1; attempt < 5; attempt++) {
+        current = await svc.retryOperation(current.id, `nonce-depth-${attempt}`, actorContext);
+        expect(current.state).toBe("failed");
+      }
+
+      await expect(
+        svc.retryOperation(current.id, "nonce-depth-5", actorContext)
+      ).rejects.toMatchObject({
+        code: "CONFLICT",
+        message: expect.stringContaining("retry limit"),
       });
     });
 
@@ -308,7 +338,7 @@ describe("HeliusRingsService", () => {
       );
       expect(inFlight.state).toBe("indexing");
 
-      await expect(svc.retryOperation(inFlight.id, "again")).rejects.toMatchObject({
+      await expect(svc.retryOperation(inFlight.id, "again", actorContext)).rejects.toMatchObject({
         code: "CONFLICT",
       });
     });

--- a/apps/sdp-api/src/services/helius-rings/service.test.ts
+++ b/apps/sdp-api/src/services/helius-rings/service.test.ts
@@ -7,6 +7,7 @@ import { getDb } from "@/db";
 import { createHeliusRingsWalletRepository } from "@/db/repositories";
 import { AppError } from "@/lib/errors";
 import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
+import { signedRingsTransaction } from "@/test/fixtures/rings-transactions";
 import { env } from "@/test/helpers/env";
 import { seedTestDatabase } from "@/test/mocks/db";
 import { RingsAdapterError } from "./adapter-error";
@@ -57,12 +58,18 @@ function service(deps: HeliusRingsServiceDependencies = {}) {
   });
 }
 
-/** A service whose gateway succeeds and whose sign/submit adapters are stubbed. */
+const OUTER_TX = signedRingsTransaction(7);
+
+/**
+ * A service whose gateway succeeds and whose sign/submit adapters are stubbed.
+ * The signer returns real wire bytes because the service derives the outer
+ * signature from them before it broadcasts.
+ */
 function liveishService(deps: HeliusRingsServiceDependencies = {}) {
   return service({
     gateway: new InMemoryRingsGateway(),
-    signOuterTransaction: async () => "c2lnbmVk",
-    submitOuterTransaction: async () => "sig_outer_1",
+    signOuterTransaction: async () => OUTER_TX.signedTxBase64,
+    submitOuterTransaction: async () => OUTER_TX.signature,
     ...deps,
   });
 }
@@ -190,7 +197,30 @@ describe("HeliusRingsService", () => {
       );
 
       expect(operation.state).toBe("indexing");
-      expect(operation.outerTxSignature).toBe("sig_outer_1");
+      expect(operation.outerTxSignature).toBe(OUTER_TX.signature);
+    });
+
+    it("persists the outer signature before broadcasting", async () => {
+      const operation = await liveishService({
+        submitOuterTransaction: async () => {
+          throw new RingsAdapterError("submit_failed", "rpc down", { retryable: true });
+        },
+      }).prepareOperation(operationInput({ clientNonce: "nonce-submit" }), actorContext);
+
+      expect(operation.state).toBe("failed");
+      expect(operation.failure).toMatchObject({ code: "submit_failed", retryable: true });
+      // The signature was durable before the RPC call, so a transaction that
+      // landed anyway is still recoverable from the row.
+      expect(operation.outerTxSignature).toBe(OUTER_TX.signature);
+    });
+
+    it("fails as signer_failed when the signer returns undecodable bytes", async () => {
+      const operation = await liveishService({
+        signOuterTransaction: async () => "c2lnbmVk",
+      }).prepareOperation(operationInput({ clientNonce: "nonce-garbage" }), actorContext);
+
+      expect(operation.state).toBe("failed");
+      expect(operation.failure).toMatchObject({ code: "signer_failed", retryable: false });
     });
 
     it("takes the signer's fail edge when custody signing fails", async () => {
@@ -259,7 +289,7 @@ describe("HeliusRingsService", () => {
       );
       expect(operation.state).toBe("indexing");
 
-      gateway.recordSubmission("sig_outer_1");
+      gateway.recordSubmission(OUTER_TX.signature);
       // Photon has not indexed yet: repeated polls change nothing.
       expect((await svc.executeOperation(operation.id)).state).toBe("indexing");
       expect((await svc.executeOperation(operation.id)).state).toBe("indexing");

--- a/apps/sdp-api/src/services/helius-rings/service.test.ts
+++ b/apps/sdp-api/src/services/helius-rings/service.test.ts
@@ -302,6 +302,30 @@ describe("HeliusRingsService", () => {
       // Executing a terminal operation is a no-op.
       expect((await svc.executeOperation(operation.id)).state).toBe("completed");
     });
+
+    it("resumes a broadcast stranded in submitted", async () => {
+      const gateway = new InMemoryRingsGateway({ indexingDelayMs: 0 });
+      const svc = liveishService({ gateway });
+      const operation = await svc.prepareOperation(
+        operationInput({ clientNonce: "nonce-stranded" }),
+        actorContext
+      );
+      expect(operation.state).toBe("indexing");
+
+      // Exactly the row a process that died between the RPC broadcast and the
+      // submitted → indexing commit leaves behind: the signature is durable,
+      // the state never moved on.
+      await getDb(env)
+        .prepare("UPDATE helius_rings_operations SET state = 'submitted' WHERE id = ?")
+        .bind(operation.id)
+        .run();
+      gateway.recordSubmission(OUTER_TX.signature);
+
+      // One execute both advances it out of `submitted` and polls Photon, so a
+      // stranded broadcast lands in reconciliation instead of sitting forever.
+      const resumed = await svc.executeOperation(operation.id);
+      expect(resumed.state).toBe("completed");
+    });
   });
 
   describe("retryOperation", () => {

--- a/apps/sdp-api/src/services/helius-rings/service.ts
+++ b/apps/sdp-api/src/services/helius-rings/service.ts
@@ -16,6 +16,7 @@ import {
 } from "@sdp/helius-rings";
 import type { WalletOperationPolicyEnforcement } from "@sdp/policy";
 import type { ApprovalRequestStatus, WalletOperationActor } from "@sdp/types";
+import { getBase64Codec, getSignatureFromTransaction, getTransactionDecoder } from "@solana/kit";
 import {
   createHeliusRingsEventRepository,
   createHeliusRingsHealthRepository,
@@ -486,40 +487,43 @@ export class HeliusRingsService {
         payload: { source: proof.source },
       });
 
-      // ready_to_sign → submitted: sign with custody, then broadcast.
-      //
-      // This ordering must be inverted before the live gateway ships. It is
-      // unreachable today — the port above is always NotImplementedRingsGateway,
-      // which fails at `proving` — which is the only reason it is still here:
-      //   1. The broadcast runs while the operation is still `ready_to_sign`.
-      //      Lose the process after `sendTransaction` succeeds and the
-      //      transaction is live on chain with its signature recorded nowhere,
-      //      and nothing sweeps `ready_to_sign`, so the operation strands.
-      //   2. `failEdgeFor("ready_to_sign")` is `signer_failed`, so an RPC
-      //      failure is filed as a signing failure and the state machine's own
-      //      `submitted → indexing` edge (`submit_failed`) is dead code.
-      // Both close the same way: derive the signature from the signed bytes
-      // (`getSignatureFromTransaction`, as sponsorship-budget.service.ts does),
-      // persist it through the `signed` guard, then broadcast — putting the
-      // broadcast inside `submitted`, where `submit_failed` applies. That needs
-      // real transaction fixtures first: every sign/submit test double here
-      // returns a placeholder base64 string, not a decodable transaction.
+      // ready_to_sign → submitted: sign with custody, then persist the signature
+      // *before* broadcasting. The signature is a property of the signed
+      // transaction, so it is knowable without the network — which is what makes
+      // `submitted` durable ahead of the RPC call. Broadcasting first would leave
+      // a live on-chain transaction whose signature was never recorded if the
+      // process died in between, and nothing sweeps `ready_to_sign` to find it.
       const signed = await this.signOuterTransaction({
         env: this.env,
         organizationId: this.tenant.organizationId,
         projectId: this.tenant.projectId,
         unsignedTxBase64: built.outerUnsignedTxBase64,
       });
-      const signature = await this.submitOuterTransaction({
-        env: this.env,
-        signedTxBase64: signed,
-      });
+      let signature: string;
+      try {
+        signature = getSignatureFromTransaction(
+          getTransactionDecoder().decode(getBase64Codec().encode(signed))
+        );
+      } catch (cause) {
+        // The signer returned something that is not a transaction. Retrying the
+        // same inputs cannot change that, so this is the signer's failure.
+        throw new RingsAdapterError("signer_failed", "signer returned undecodable bytes", {
+          retryable: false,
+          cause,
+        });
+      }
 
       const submitted = await this.transition(current.id, "ready_to_sign", "signed", {
         outerTxSignature: signature,
       });
       if (!submitted) return this.requireOperation(current.id);
       current = submitted;
+
+      // Broadcast from inside `submitted`, so an RPC failure records
+      // `submit_failed` against the state the state machine declares it for. The
+      // intent key makes a resubmission safe.
+      await this.submitOuterTransaction({ env: this.env, signedTxBase64: signed });
+
       await this.events.append({
         operationId: current.id,
         kind: "transaction.submitted",

--- a/apps/sdp-api/src/services/helius-rings/service.ts
+++ b/apps/sdp-api/src/services/helius-rings/service.ts
@@ -487,6 +487,23 @@ export class HeliusRingsService {
       });
 
       // ready_to_sign → submitted: sign with custody, then broadcast.
+      //
+      // This ordering must be inverted before the live gateway ships. It is
+      // unreachable today — the port above is always NotImplementedRingsGateway,
+      // which fails at `proving` — which is the only reason it is still here:
+      //   1. The broadcast runs while the operation is still `ready_to_sign`.
+      //      Lose the process after `sendTransaction` succeeds and the
+      //      transaction is live on chain with its signature recorded nowhere,
+      //      and nothing sweeps `ready_to_sign`, so the operation strands.
+      //   2. `failEdgeFor("ready_to_sign")` is `signer_failed`, so an RPC
+      //      failure is filed as a signing failure and the state machine's own
+      //      `submitted → indexing` edge (`submit_failed`) is dead code.
+      // Both close the same way: derive the signature from the signed bytes
+      // (`getSignatureFromTransaction`, as sponsorship-budget.service.ts does),
+      // persist it through the `signed` guard, then broadcast — putting the
+      // broadcast inside `submitted`, where `submit_failed` applies. That needs
+      // real transaction fixtures first: every sign/submit test double here
+      // returns a placeholder base64 string, not a decodable transaction.
       const signed = await this.signOuterTransaction({
         env: this.env,
         organizationId: this.tenant.organizationId,

--- a/apps/sdp-api/src/services/helius-rings/service.ts
+++ b/apps/sdp-api/src/services/helius-rings/service.ts
@@ -1,0 +1,647 @@
+import { createHash } from "node:crypto";
+import type {
+  OperationEvent,
+  OperationState,
+  PrivateOperation,
+  PrivateOperationInput,
+  PrivateWallet,
+  RuntimeHealth,
+  TransitionGuard,
+} from "@sdp/helius-rings";
+import {
+  HeliusRingsError,
+  NotImplementedRingsGateway,
+  nextState,
+  type RingsGatewayPort,
+} from "@sdp/helius-rings";
+import type { WalletOperationPolicyEnforcement } from "@sdp/policy";
+import type { WalletOperationActor } from "@sdp/types";
+import {
+  createHeliusRingsEventRepository,
+  createHeliusRingsHealthRepository,
+  createHeliusRingsOperationRepository,
+  createHeliusRingsWalletRepository,
+  type HeliusRingsEventRepository,
+  type HeliusRingsHealthRepository,
+  type HeliusRingsOperationRepository,
+  type HeliusRingsOperationRow,
+  type HeliusRingsWalletRepository,
+  mapHeliusRingsEventRow,
+  mapHeliusRingsHealthRows,
+  mapHeliusRingsWalletRow,
+} from "@/db/repositories";
+import { AppError } from "@/lib/errors";
+import { createTenantScope } from "@/lib/tenant-scope";
+import { enforceWalletOperationPolicy } from "@/services/policy/enforcement.service";
+import type { Env } from "@/types/env";
+import { RingsAdapterError } from "./adapter-error";
+import { buildRingsWalletOperationInput } from "./policy-envelope";
+import { submitRingsOuterTransaction } from "./rpc-adapter";
+import { signRingsOuterTransaction } from "./signer-adapter";
+
+/**
+ * Orchestrates every Rings action: provisioning, prepare-through-policy,
+ * execution, retry lineage. State transitions run through the persisted state
+ * machine with compare-and-swap guards, and every hop is recorded on the
+ * operation's event feed.
+ *
+ * Until Track B lands the live gateway, any path that reaches the port ends in
+ * `failed:gateway_unavailable` (retryable) — the UI reports the pending
+ * integration honestly instead of simulating it.
+ */
+
+export interface HeliusRingsTenant {
+  organizationId: string;
+  projectId: string;
+}
+
+export interface HeliusRingsActor {
+  apiKeyId: string | null;
+  actor: WalletOperationActor | null;
+}
+
+export interface HeliusRingsServiceDependencies {
+  gateway?: RingsGatewayPort;
+  wallets?: HeliusRingsWalletRepository;
+  operations?: HeliusRingsOperationRepository;
+  events?: HeliusRingsEventRepository;
+  health?: HeliusRingsHealthRepository;
+  enforcePolicy?: typeof enforceWalletOperationPolicy;
+  signOuterTransaction?: typeof signRingsOuterTransaction;
+  submitOuterTransaction?: typeof submitRingsOuterTransaction;
+  now?: () => string;
+}
+
+export interface ProvisionPrivateWalletInput {
+  sdpWalletId: string;
+  /** The custody wallet's public address, handed to the gateway. */
+  sdpAddress: string;
+  name: string;
+}
+
+export interface PrepareOperationContext extends HeliusRingsActor {
+  /** The SDP custody wallet id backing the rings wallet, for the policy envelope. */
+  custodyWalletId: string | null;
+}
+
+/** States `executeOperation` acts on; the rest return unchanged. */
+const EXECUTABLE_STATES: ReadonlySet<OperationState> = new Set(["approval_required", "indexing"]);
+
+export function createHeliusRingsService(
+  env: Env,
+  tenant: HeliusRingsTenant,
+  dependencies: HeliusRingsServiceDependencies = {}
+): HeliusRingsService {
+  return new HeliusRingsService(env, tenant, dependencies);
+}
+
+export class HeliusRingsService {
+  private readonly gateway: RingsGatewayPort;
+  private readonly wallets: HeliusRingsWalletRepository;
+  private readonly operations: HeliusRingsOperationRepository;
+  private readonly events: HeliusRingsEventRepository;
+  private readonly health: HeliusRingsHealthRepository;
+  private readonly enforcePolicy: typeof enforceWalletOperationPolicy;
+  private readonly signOuterTransaction: typeof signRingsOuterTransaction;
+  private readonly submitOuterTransaction: typeof submitRingsOuterTransaction;
+  private readonly now: () => string;
+
+  constructor(
+    private readonly env: Env,
+    private readonly tenant: HeliusRingsTenant,
+    dependencies: HeliusRingsServiceDependencies = {}
+  ) {
+    // The schema's network CHECK is the second half of this guard. Going to
+    // mainnet is a deliberate migration, not a config flip.
+    if ((env.SOLANA_NETWORK ?? "devnet") !== "devnet") {
+      throw new AppError("SERVICE_UNAVAILABLE", "Helius Rings is devnet-only");
+    }
+    this.gateway = dependencies.gateway ?? new NotImplementedRingsGateway();
+    this.wallets = dependencies.wallets ?? createHeliusRingsWalletRepository(env);
+    this.operations = dependencies.operations ?? createHeliusRingsOperationRepository(env);
+    this.events = dependencies.events ?? createHeliusRingsEventRepository(env);
+    this.health = dependencies.health ?? createHeliusRingsHealthRepository(env);
+    this.enforcePolicy = dependencies.enforcePolicy ?? enforceWalletOperationPolicy;
+    this.signOuterTransaction = dependencies.signOuterTransaction ?? signRingsOuterTransaction;
+    this.submitOuterTransaction =
+      dependencies.submitOuterTransaction ?? submitRingsOuterTransaction;
+    this.now = dependencies.now ?? (() => new Date().toISOString());
+  }
+
+  /**
+   * Creates (or returns) the rings wallet bound to one custody wallet, then
+   * asks the gateway for a shielded identity. Until Track B lands, the port
+   * throws and the wallet stays `pending` — the wizard renders that state.
+   *
+   * Key material is deliberately not persisted here: sealing it through
+   * custody-cipher into `helius_rings_key_refs` is the key-authority work
+   * (Track B4), and holding it unsealed anywhere is not an option.
+   */
+  async provisionPrivateWallet(input: ProvisionPrivateWalletInput): Promise<PrivateWallet> {
+    const wallet = await this.wallets.createWallet({
+      ...this.tenant,
+      sdpWalletId: input.sdpWalletId,
+      name: input.name,
+      materialTag: "simulated",
+    });
+    if (!wallet) {
+      throw new AppError("INTERNAL_ERROR", "rings wallet reservation returned no row");
+    }
+    if (wallet.status !== "pending") {
+      return mapHeliusRingsWalletRow(wallet);
+    }
+
+    const identity = await this.gateway.provisionIdentity({
+      walletId: wallet.id,
+      sdpAddress: input.sdpAddress,
+    });
+
+    const materialTag = identity.keyRefs.every((keyRef) => keyRef.materialTag === "live")
+      ? "live"
+      : "simulated";
+    const provisioned = await this.wallets.markProvisioned({
+      ...this.tenant,
+      id: wallet.id,
+      shieldedAddress: identity.shieldedAddress,
+      materialTag,
+      expectedStatus: "pending",
+    });
+    // A lost CAS means an operator paused the wallet mid-provision; honour it.
+    return mapHeliusRingsWalletRow(provisioned ?? (await this.requireWallet(wallet.id)));
+  }
+
+  /**
+   * Reserves the intent, then advances draft → preparing → policy. Idempotent:
+   * a replayed request returns the operation already reserved, at whatever
+   * state it has reached, without re-running policy.
+   */
+  async prepareOperation(
+    input: PrivateOperationInput,
+    context: PrepareOperationContext
+  ): Promise<PrivateOperation> {
+    const wallet = await this.requireWallet(input.walletId);
+    const intentKey = computeIntentKey(input);
+
+    const { operation, reserved } = await this.operations.reserveIntent({
+      ...this.tenant,
+      walletId: wallet.id,
+      opType: input.opType,
+      intentKey,
+      assetMint: input.asset?.mint ?? null,
+      amountRaw: input.asset?.amountRaw ?? null,
+      fromAddr: input.from ?? null,
+      toAddr: input.to ?? null,
+      zoneId: input.zoneId ?? null,
+      transferMode: input.transferMode ?? null,
+      timelock: input.timelock
+        ? { unlockAt: input.timelock.unlockAt, beneficiaryAddr: input.timelock.beneficiary }
+        : null,
+    });
+    if (!reserved) {
+      return this.toPrivateOperation(operation);
+    }
+
+    await this.events.append({ operationId: operation.id, kind: "operation.created" });
+    const preparing = await this.transition(operation.id, "draft", undefined);
+    if (!preparing) return this.toPrivateOperation(await this.requireOperation(operation.id));
+
+    let enforcement: WalletOperationPolicyEnforcement;
+    try {
+      enforcement = await this.enforcePolicy(
+        this.env,
+        createTenantScope({
+          organizationId: this.tenant.organizationId,
+          projectId: this.tenant.projectId,
+        }),
+        buildRingsWalletOperationInput({
+          organizationId: this.tenant.organizationId,
+          projectId: this.tenant.projectId,
+          custodyWalletId: context.custodyWalletId,
+          sdpWalletId: wallet.sdp_wallet_id,
+          apiKeyId: context.apiKeyId,
+          actor: context.actor,
+          operation: input,
+          operationId: operation.id,
+          intentKey,
+        })
+      );
+    } catch (error) {
+      const failed = await this.fail(operation.id, "preparing", {
+        code: "invalid_input",
+        message: error instanceof Error ? error.message : "policy evaluation failed",
+        retryable: true,
+      });
+      return this.toPrivateOperation(failed ?? (await this.requireOperation(operation.id)));
+    }
+
+    const { evaluation } = enforcement;
+    await this.events.append({
+      operationId: operation.id,
+      kind: "policy.evaluated",
+      payload: { decision: evaluation.decision, policyEvaluationId: evaluation.id },
+    });
+
+    if (evaluation.decision === "deny") {
+      const failed = await this.fail(operation.id, "preparing", {
+        code: "policy_denied",
+        message: evaluation.reason ?? "denied by wallet policy",
+        retryable: false,
+      });
+      return this.toPrivateOperation(failed ?? (await this.requireOperation(operation.id)));
+    }
+
+    // The machine has no preparing → proving shortcut: an allowed operation
+    // passes through approval_required with the `approved` guard immediately
+    // satisfied, so the row's history reads the same either way.
+    const paused = await this.transition(operation.id, "preparing", "policy_ok", {
+      policyEvaluationId: evaluation.id,
+      approvalRequestId: evaluation.approvalRequestId,
+    });
+    if (!paused) return this.toPrivateOperation(await this.requireOperation(operation.id));
+
+    if (evaluation.requiresApproval) {
+      await this.events.append({
+        operationId: operation.id,
+        kind: "approval.requested",
+        payload: { approvalRequestId: evaluation.approvalRequestId },
+      });
+      return this.toPrivateOperation(paused);
+    }
+
+    const proving = await this.transition(operation.id, "approval_required", "approved");
+    if (!proving) return this.toPrivateOperation(await this.requireOperation(operation.id));
+    return this.toPrivateOperation(await this.runPipeline(proving));
+  }
+
+  /**
+   * Advances an operation that is waiting on an external condition. Idempotent
+   * per state: an approval still pending or a signature not yet indexed leaves
+   * the row untouched.
+   */
+  async executeOperation(
+    operationId: string,
+    options: { approvalStatus?: "approved" | "rejected" | "pending" } = {}
+  ): Promise<PrivateOperation> {
+    const operation = await this.requireOperation(operationId);
+    if (!EXECUTABLE_STATES.has(operation.state)) {
+      return this.toPrivateOperation(operation);
+    }
+
+    if (operation.state === "approval_required") {
+      const status = options.approvalStatus ?? "pending";
+      if (status === "rejected") {
+        const failed = await this.fail(operation.id, "approval_required", {
+          code: "approval_rejected",
+          message: "approval request was rejected",
+          retryable: false,
+        });
+        return this.toPrivateOperation(failed ?? (await this.requireOperation(operation.id)));
+      }
+      if (status !== "approved") {
+        return this.toPrivateOperation(operation);
+      }
+      await this.events.append({ operationId: operation.id, kind: "approval.granted" });
+      const proving = await this.transition(operation.id, "approval_required", "approved");
+      if (!proving) return this.toPrivateOperation(await this.requireOperation(operation.id));
+      return this.toPrivateOperation(await this.runPipeline(proving));
+    }
+
+    // indexing: poll Photon through the port.
+    if (!operation.outer_tx_signature) {
+      const failed = await this.fail(operation.id, "indexing", {
+        code: "invalid_input",
+        message: "indexing without a submitted signature",
+        retryable: false,
+      });
+      return this.toPrivateOperation(failed ?? (await this.requireOperation(operation.id)));
+    }
+    try {
+      const indexed = await this.gateway.verifyIndexed(operation.outer_tx_signature);
+      if (!indexed) return this.toPrivateOperation(operation);
+      const completed = await this.transition(operation.id, "indexing", "indexed", {
+        photonIndexedAt: indexed.indexedAt,
+      });
+      if (completed) {
+        await this.events.append({
+          operationId: operation.id,
+          kind: "operation.completed",
+          payload: { photonRef: indexed.photonRef },
+        });
+      }
+      return this.toPrivateOperation(completed ?? (await this.requireOperation(operation.id)));
+    } catch (error) {
+      return this.toPrivateOperation(await this.failFromPortError(operation, error));
+    }
+  }
+
+  /**
+   * Files a fresh operation linked to a failed, retryable one. The retry gets
+   * its own intent key (new client nonce), so the original row stays exactly
+   * as it failed — the lineage is audit evidence.
+   */
+  async retryOperation(operationId: string, clientNonce: string): Promise<PrivateOperation> {
+    const failed = await this.requireOperation(operationId);
+    if (failed.state !== "failed") {
+      throw new AppError("CONFLICT", "only a failed operation can be retried");
+    }
+    if (!failed.retryable) {
+      throw new AppError("CONFLICT", "operation failure is not retryable");
+    }
+
+    const timelock = failed.timelock_unlock_at
+      ? await this.operations.getTimelock({ operationId: failed.id })
+      : null;
+
+    const input: PrivateOperationInput = {
+      walletId: failed.wallet_id,
+      opType: failed.op_type,
+      asset:
+        failed.asset_mint && failed.amount_raw
+          ? { mint: failed.asset_mint, amountRaw: failed.amount_raw }
+          : undefined,
+      from: failed.from_addr ?? undefined,
+      to: failed.to_addr ?? undefined,
+      zoneId: failed.zone_id ?? undefined,
+      transferMode: failed.transfer_mode ?? undefined,
+      timelock: timelock
+        ? { unlockAt: timelock.unlock_at, beneficiary: timelock.beneficiary_addr }
+        : undefined,
+      clientNonce,
+    };
+
+    const intentKey = computeIntentKey(input);
+    const { operation, reserved } = await this.operations.reserveIntent({
+      ...this.tenant,
+      walletId: failed.wallet_id,
+      opType: failed.op_type,
+      intentKey,
+      assetMint: failed.asset_mint,
+      amountRaw: failed.amount_raw,
+      fromAddr: failed.from_addr,
+      toAddr: failed.to_addr,
+      zoneId: failed.zone_id,
+      transferMode: failed.transfer_mode,
+      retryOfOperationId: failed.id,
+      timelock: timelock
+        ? { unlockAt: timelock.unlock_at, beneficiaryAddr: timelock.beneficiary_addr }
+        : null,
+    });
+    if (reserved) {
+      await this.events.append({
+        operationId: operation.id,
+        kind: "operation.retried",
+        payload: { retryOfOperationId: failed.id },
+      });
+    }
+    return this.toPrivateOperation(operation);
+  }
+
+  async getOperation(operationId: string): Promise<PrivateOperation> {
+    return this.toPrivateOperation(await this.requireOperation(operationId));
+  }
+
+  /**
+   * Probes the gateway and records the observation per component. A gateway
+   * that cannot be reached records itself red — never having observed an
+   * upstream is not evidence that it is healthy.
+   */
+  async probeHealth(): Promise<RuntimeHealth> {
+    try {
+      const health = await this.gateway.probeHealth();
+      for (const component of ["rpc", "prover", "photon", "gateway"] as const) {
+        await this.health.recordHealth({
+          projectId: this.tenant.projectId,
+          component,
+          status: health[component],
+        });
+      }
+    } catch (error) {
+      await this.health.recordHealth({
+        projectId: this.tenant.projectId,
+        component: "gateway",
+        status: "red",
+        detail: {
+          reason: error instanceof HeliusRingsError ? error.message : "gateway probe failed",
+        },
+      });
+    }
+    return mapHeliusRingsHealthRows(
+      await this.health.listHealthByProject({ projectId: this.tenant.projectId })
+    );
+  }
+
+  /**
+   * Drives an operation from `proving` as far as the port allows:
+   * build → proof → sign → submit → indexing. The first port failure takes the
+   * state's fail edge; adapter failures carry their own codes.
+   */
+  private async runPipeline(operation: HeliusRingsOperationRow): Promise<HeliusRingsOperationRow> {
+    let current = operation;
+
+    // proving: build the outer tx and request the proof.
+    try {
+      const built = await this.gateway.buildOperation({
+        // The port receives the domain view; key refs arrive with Track B4.
+        operation: this.toPrivateOperation(current),
+        keyRefs: [],
+      });
+      const proof = await this.gateway.requestProof({
+        operationId: current.id,
+        ringsMetadata: built.ringsMetadata,
+      });
+      const ready = await this.transition(current.id, "proving", "proof_received", {
+        proofSource: proof.source,
+        proofRef: proof.ref.reveal("adapter"),
+      });
+      if (!ready) return this.requireOperation(current.id);
+      current = ready;
+
+      await this.events.append({
+        operationId: current.id,
+        kind: "proof.received",
+        payload: { source: proof.source },
+      });
+
+      // ready_to_sign → submitted: sign with custody, then broadcast.
+      const signed = await this.signOuterTransaction({
+        env: this.env,
+        organizationId: this.tenant.organizationId,
+        projectId: this.tenant.projectId,
+        unsignedTxBase64: built.outerUnsignedTxBase64,
+      });
+      const signature = await this.submitOuterTransaction({
+        env: this.env,
+        signedTxBase64: signed,
+      });
+
+      const submitted = await this.transition(current.id, "ready_to_sign", "signed", {
+        outerTxSignature: signature,
+      });
+      if (!submitted) return this.requireOperation(current.id);
+      current = submitted;
+      await this.events.append({
+        operationId: current.id,
+        kind: "transaction.submitted",
+        payload: { signature },
+      });
+
+      const indexing = await this.transition(current.id, "submitted", "submitted");
+      return indexing ?? (await this.requireOperation(current.id));
+    } catch (error) {
+      return this.failFromPortError(current, error);
+    }
+  }
+
+  /** Maps a port or adapter failure onto the operation's fail edge. */
+  private async failFromPortError(
+    operation: HeliusRingsOperationRow,
+    error: unknown
+  ): Promise<HeliusRingsOperationRow> {
+    const failure =
+      error instanceof RingsAdapterError
+        ? { code: error.failureCode, message: error.message, retryable: error.retryable }
+        : error instanceof HeliusRingsError && error.code === "gateway_unavailable"
+          ? { code: "gateway_unavailable" as const, message: error.message, retryable: true }
+          : {
+              code: "gateway_unavailable" as const,
+              message: error instanceof Error ? error.message : "rings gateway failed",
+              retryable: true,
+            };
+
+    const failed = await this.fail(operation.id, operation.state, failure);
+    return failed ?? (await this.requireOperation(operation.id));
+  }
+
+  private async transition(
+    operationId: string,
+    expectedState: OperationState,
+    guard: TransitionGuard | undefined,
+    patch?: Parameters<HeliusRingsOperationRepository["transitionState"]>[0]["patch"]
+  ): Promise<HeliusRingsOperationRow | null> {
+    const to = nextState(expectedState, guard);
+    if (!to) return null;
+    const row = await this.operations.transitionState({
+      ...this.tenant,
+      id: operationId,
+      expectedState,
+      nextState: to,
+      patch,
+    });
+    if (row) {
+      await this.events.append({
+        operationId,
+        kind: "state.transitioned",
+        payload: { from: expectedState, to },
+      });
+    }
+    return row;
+  }
+
+  private async fail(
+    operationId: string,
+    expectedState: OperationState,
+    failure: { code: HeliusRingsOperationRow["failure_code"]; message: string; retryable: boolean }
+  ): Promise<HeliusRingsOperationRow | null> {
+    if (!failure.code) return null;
+    const row = await this.operations.failOperation({
+      ...this.tenant,
+      id: operationId,
+      expectedState,
+      code: failure.code,
+      message: failure.message,
+      retryable: failure.retryable,
+    });
+    if (row) {
+      await this.events.append({
+        operationId,
+        kind: "operation.failed",
+        payload: { code: failure.code, retryable: failure.retryable },
+      });
+    }
+    return row;
+  }
+
+  private async requireWallet(walletId: string) {
+    const wallet = await this.wallets.getWalletById({ ...this.tenant, id: walletId });
+    if (!wallet) throw new AppError("NOT_FOUND", "rings wallet not found");
+    return wallet;
+  }
+
+  private async requireOperation(operationId: string): Promise<HeliusRingsOperationRow> {
+    const operation = await this.operations.getOperationById({
+      ...this.tenant,
+      id: operationId,
+    });
+    if (!operation) throw new AppError("NOT_FOUND", "rings operation not found");
+    return operation;
+  }
+
+  private toPrivateOperation(
+    row: HeliusRingsOperationRow,
+    events: OperationEvent[] = []
+  ): PrivateOperation {
+    return {
+      id: row.id,
+      walletId: row.wallet_id,
+      opType: row.op_type,
+      state: row.state,
+      approvalRequestId: row.approval_request_id,
+      policyEvaluationId: row.policy_evaluation_id,
+      proof: null,
+      outerTxSignature: row.outer_tx_signature,
+      photonIndexedAt: row.photon_indexed_at,
+      failure:
+        row.failure_code && row.failure_message !== null && row.retryable !== null
+          ? { code: row.failure_code, message: row.failure_message, retryable: row.retryable }
+          : null,
+      input: {
+        walletId: row.wallet_id,
+        opType: row.op_type,
+        asset:
+          row.asset_mint && row.amount_raw
+            ? { mint: row.asset_mint, amountRaw: row.amount_raw }
+            : undefined,
+        from: row.from_addr ?? undefined,
+        to: row.to_addr ?? undefined,
+        zoneId: row.zone_id ?? undefined,
+        transferMode: row.transfer_mode ?? undefined,
+        timelock: undefined,
+        // Consumed by the intent key at reservation; not retained.
+        clientNonce: "",
+      },
+      intentKey: row.intent_key,
+      events,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  /** The operation with its event feed joined in, for the detail panel. */
+  async getOperationWithEvents(operationId: string): Promise<PrivateOperation> {
+    const row = await this.requireOperation(operationId);
+    const events = await this.events.listByOperation({ operationId: row.id });
+    return this.toPrivateOperation(row, events.map(mapHeliusRingsEventRow));
+  }
+}
+
+/**
+ * The idempotency contract: one deterministic key per (wallet, op, canonical
+ * input, client nonce). Field order is pinned here — object spread order is
+ * not part of the contract.
+ */
+export function computeIntentKey(input: PrivateOperationInput): string {
+  const canonical = JSON.stringify({
+    walletId: input.walletId,
+    opType: input.opType,
+    asset: input.asset ? { mint: input.asset.mint, amountRaw: input.asset.amountRaw } : null,
+    from: input.from ?? null,
+    to: input.to ?? null,
+    zoneId: input.zoneId ?? null,
+    transferMode: input.transferMode ?? null,
+    timelock: input.timelock
+      ? { unlockAt: input.timelock.unlockAt, beneficiary: input.timelock.beneficiary }
+      : null,
+    clientNonce: input.clientNonce,
+  });
+  return `sha256:${createHash("sha256").update(canonical).digest("hex")}`;
+}

--- a/apps/sdp-api/src/services/helius-rings/service.ts
+++ b/apps/sdp-api/src/services/helius-rings/service.ts
@@ -15,12 +15,13 @@ import {
   type RingsGatewayPort,
 } from "@sdp/helius-rings";
 import type { WalletOperationPolicyEnforcement } from "@sdp/policy";
-import type { WalletOperationActor } from "@sdp/types";
+import type { ApprovalRequestStatus, WalletOperationActor } from "@sdp/types";
 import {
   createHeliusRingsEventRepository,
   createHeliusRingsHealthRepository,
   createHeliusRingsOperationRepository,
   createHeliusRingsWalletRepository,
+  createPolicyRepository,
   type HeliusRingsEventRepository,
   type HeliusRingsHealthRepository,
   type HeliusRingsOperationRepository,
@@ -69,8 +70,16 @@ export interface HeliusRingsServiceDependencies {
   enforcePolicy?: typeof enforceWalletOperationPolicy;
   signOuterTransaction?: typeof signRingsOuterTransaction;
   submitOuterTransaction?: typeof submitRingsOuterTransaction;
+  /** Reads the approval verdict; defaults to the policy repository. */
+  getApprovalStatus?: (approvalRequestId: string) => Promise<ApprovalRequestStatus | null>;
   now?: () => string;
 }
+
+/**
+ * How deep a retry chain may grow. Retrying the same failure past this depth
+ * is churn, not recovery, and the operator should look at the failure code.
+ */
+export const RINGS_MAX_RETRY_DEPTH = 5;
 
 export interface ProvisionPrivateWalletInput {
   sdpWalletId: string;
@@ -104,6 +113,9 @@ export class HeliusRingsService {
   private readonly enforcePolicy: typeof enforceWalletOperationPolicy;
   private readonly signOuterTransaction: typeof signRingsOuterTransaction;
   private readonly submitOuterTransaction: typeof submitRingsOuterTransaction;
+  private readonly getApprovalStatus: (
+    approvalRequestId: string
+  ) => Promise<ApprovalRequestStatus | null>;
   private readonly now: () => string;
 
   constructor(
@@ -125,6 +137,20 @@ export class HeliusRingsService {
     this.signOuterTransaction = dependencies.signOuterTransaction ?? signRingsOuterTransaction;
     this.submitOuterTransaction =
       dependencies.submitOuterTransaction ?? submitRingsOuterTransaction;
+    this.getApprovalStatus =
+      dependencies.getApprovalStatus ??
+      (async (approvalRequestId) => {
+        const scope = createTenantScope({
+          organizationId: tenant.organizationId,
+          projectId: tenant.projectId,
+        });
+        const detail = await createPolicyRepository(env, scope).getApprovalRequestDetail({
+          organizationId: tenant.organizationId,
+          projectId: tenant.projectId,
+          approvalRequestId,
+        });
+        return detail?.approval_status ?? null;
+      });
     this.now = dependencies.now ?? (() => new Date().toISOString());
   }
 
@@ -177,7 +203,8 @@ export class HeliusRingsService {
    */
   async prepareOperation(
     input: PrivateOperationInput,
-    context: PrepareOperationContext
+    context: PrepareOperationContext,
+    retryOfOperationId: string | null = null
   ): Promise<PrivateOperation> {
     const wallet = await this.requireWallet(input.walletId);
     const intentKey = computeIntentKey(input);
@@ -193,6 +220,7 @@ export class HeliusRingsService {
       toAddr: input.to ?? null,
       zoneId: input.zoneId ?? null,
       transferMode: input.transferMode ?? null,
+      retryOfOperationId,
       timelock: input.timelock
         ? { unlockAt: input.timelock.unlockAt, beneficiaryAddr: input.timelock.beneficiary }
         : null,
@@ -201,7 +229,11 @@ export class HeliusRingsService {
       return this.toPrivateOperation(operation);
     }
 
-    await this.events.append({ operationId: operation.id, kind: "operation.created" });
+    await this.events.append({
+      operationId: operation.id,
+      kind: retryOfOperationId ? "operation.retried" : "operation.created",
+      payload: retryOfOperationId ? { retryOfOperationId } : undefined,
+    });
     const preparing = await this.transition(operation.id, "draft", undefined);
     if (!preparing) return this.toPrivateOperation(await this.requireOperation(operation.id));
 
@@ -278,21 +310,29 @@ export class HeliusRingsService {
    * per state: an approval still pending or a signature not yet indexed leaves
    * the row untouched.
    */
-  async executeOperation(
-    operationId: string,
-    options: { approvalStatus?: "approved" | "rejected" | "pending" } = {}
-  ): Promise<PrivateOperation> {
+  async executeOperation(operationId: string): Promise<PrivateOperation> {
     const operation = await this.requireOperation(operationId);
     if (!EXECUTABLE_STATES.has(operation.state)) {
       return this.toPrivateOperation(operation);
     }
 
     if (operation.state === "approval_required") {
-      const status = options.approvalStatus ?? "pending";
-      if (status === "rejected") {
+      // The approval verdict is read from the approval request itself — never
+      // from the caller. Trusting the request body here would let anyone with
+      // write access skip a reviewer.
+      if (!operation.approval_request_id) {
+        const failed = await this.fail(operation.id, "approval_required", {
+          code: "invalid_input",
+          message: "approval_required without an approval request",
+          retryable: false,
+        });
+        return this.toPrivateOperation(failed ?? (await this.requireOperation(operation.id)));
+      }
+      const status = await this.getApprovalStatus(operation.approval_request_id);
+      if (status === "rejected" || status === "canceled" || status === "expired") {
         const failed = await this.fail(operation.id, "approval_required", {
           code: "approval_rejected",
-          message: "approval request was rejected",
+          message: `approval request was ${status}`,
           retryable: false,
         });
         return this.toPrivateOperation(failed ?? (await this.requireOperation(operation.id)));
@@ -335,11 +375,16 @@ export class HeliusRingsService {
   }
 
   /**
-   * Files a fresh operation linked to a failed, retryable one. The retry gets
-   * its own intent key (new client nonce), so the original row stays exactly
-   * as it failed — the lineage is audit evidence.
+   * Files a fresh operation linked to a failed, retryable one and runs it
+   * through the same prepare-through-policy path — a retry re-earns its policy
+   * verdict, never inherits one. The original row stays exactly as it failed;
+   * the lineage is audit evidence, capped at RINGS_MAX_RETRY_DEPTH.
    */
-  async retryOperation(operationId: string, clientNonce: string): Promise<PrivateOperation> {
+  async retryOperation(
+    operationId: string,
+    clientNonce: string,
+    context: PrepareOperationContext
+  ): Promise<PrivateOperation> {
     const failed = await this.requireOperation(operationId);
     if (failed.state !== "failed") {
       throw new AppError("CONFLICT", "only a failed operation can be retried");
@@ -347,6 +392,7 @@ export class HeliusRingsService {
     if (!failed.retryable) {
       throw new AppError("CONFLICT", "operation failure is not retryable");
     }
+    await this.assertRetryDepth(failed);
 
     const timelock = failed.timelock_unlock_at
       ? await this.operations.getTimelock({ operationId: failed.id })
@@ -369,31 +415,7 @@ export class HeliusRingsService {
       clientNonce,
     };
 
-    const intentKey = computeIntentKey(input);
-    const { operation, reserved } = await this.operations.reserveIntent({
-      ...this.tenant,
-      walletId: failed.wallet_id,
-      opType: failed.op_type,
-      intentKey,
-      assetMint: failed.asset_mint,
-      amountRaw: failed.amount_raw,
-      fromAddr: failed.from_addr,
-      toAddr: failed.to_addr,
-      zoneId: failed.zone_id,
-      transferMode: failed.transfer_mode,
-      retryOfOperationId: failed.id,
-      timelock: timelock
-        ? { unlockAt: timelock.unlock_at, beneficiaryAddr: timelock.beneficiary_addr }
-        : null,
-    });
-    if (reserved) {
-      await this.events.append({
-        operationId: operation.id,
-        kind: "operation.retried",
-        payload: { retryOfOperationId: failed.id },
-      });
-    }
-    return this.toPrivateOperation(operation);
+    return this.prepareOperation(input, context, failed.id);
   }
 
   async getOperation(operationId: string): Promise<PrivateOperation> {
@@ -559,6 +581,31 @@ export class HeliusRingsService {
       });
     }
     return row;
+  }
+
+  /**
+   * Walks the retry lineage toward the original operation and refuses once the
+   * chain reaches RINGS_MAX_RETRY_DEPTH. The DB's retry_not_self CHECK rules
+   * out a self-loop; the walk is still bounded in case of a longer cycle.
+   */
+  private async assertRetryDepth(operation: HeliusRingsOperationRow): Promise<void> {
+    let depth = 1;
+    let ancestorId = operation.retry_of_operation_id;
+    while (ancestorId && depth < RINGS_MAX_RETRY_DEPTH + 1) {
+      depth += 1;
+      const ancestor = await this.operations.getOperationById({
+        ...this.tenant,
+        id: ancestorId,
+      });
+      ancestorId = ancestor?.retry_of_operation_id ?? null;
+    }
+    // The retry being filed would sit at depth + 1.
+    if (depth + 1 > RINGS_MAX_RETRY_DEPTH) {
+      throw new AppError(
+        "CONFLICT",
+        `retry limit reached (${RINGS_MAX_RETRY_DEPTH}); inspect the failure instead of retrying`
+      );
+    }
   }
 
   private async requireWallet(walletId: string) {

--- a/apps/sdp-api/src/services/helius-rings/service.ts
+++ b/apps/sdp-api/src/services/helius-rings/service.ts
@@ -430,13 +430,15 @@ export class HeliusRingsService {
   async probeHealth(): Promise<RuntimeHealth> {
     try {
       const health = await this.gateway.probeHealth();
-      for (const component of ["rpc", "prover", "photon", "gateway"] as const) {
-        await this.health.recordHealth({
-          projectId: this.tenant.projectId,
-          component,
-          status: health[component],
-        });
-      }
+      await Promise.all(
+        (["rpc", "prover", "photon", "gateway"] as const).map((component) =>
+          this.health.recordHealth({
+            projectId: this.tenant.projectId,
+            component,
+            status: health[component],
+          })
+        )
+      );
     } catch (error) {
       await this.health.recordHealth({
         projectId: this.tenant.projectId,

--- a/apps/sdp-api/src/services/helius-rings/service.ts
+++ b/apps/sdp-api/src/services/helius-rings/service.ts
@@ -95,7 +95,11 @@ export interface PrepareOperationContext extends HeliusRingsActor {
 }
 
 /** States `executeOperation` acts on; the rest return unchanged. */
-const EXECUTABLE_STATES: ReadonlySet<OperationState> = new Set(["approval_required", "indexing"]);
+const EXECUTABLE_STATES: ReadonlySet<OperationState> = new Set([
+  "approval_required",
+  "submitted",
+  "indexing",
+]);
 
 export function createHeliusRingsService(
   env: Env,
@@ -309,10 +313,11 @@ export class HeliusRingsService {
   /**
    * Advances an operation that is waiting on an external condition. Idempotent
    * per state: an approval still pending or a signature not yet indexed leaves
-   * the row untouched.
+   * the row untouched. `submitted` is executable too, so a broadcast whose
+   * indexing transition never committed is resumed rather than stranded.
    */
   async executeOperation(operationId: string): Promise<PrivateOperation> {
-    const operation = await this.requireOperation(operationId);
+    let operation = await this.requireOperation(operationId);
     if (!EXECUTABLE_STATES.has(operation.state)) {
       return this.toPrivateOperation(operation);
     }
@@ -345,6 +350,21 @@ export class HeliusRingsService {
       const proving = await this.transition(operation.id, "approval_required", "approved");
       if (!proving) return this.toPrivateOperation(await this.requireOperation(operation.id));
       return this.toPrivateOperation(await this.runPipeline(proving));
+    }
+
+    // submitted: the broadcast either landed or never left the process, and
+    // nothing here can tell the two apart — only the signature is persisted, not
+    // the signed bytes, so there is nothing to resubmit. Both readings resolve
+    // the same way: hand the signature to Photon and let the indexing budget
+    // settle it. A hit completes the operation; a miss times out as
+    // `indexing_timeout` (retryable). Without this, a crash between the RPC
+    // call and the submitted → indexing transition left a live transaction
+    // outside reconciliation forever — the poll skips non-`indexing` rows,
+    // execute ignored `submitted`, and retry requires `failed`.
+    if (operation.state === "submitted") {
+      const resumed = await this.transition(operation.id, "submitted", "submitted");
+      if (!resumed) return this.toPrivateOperation(await this.requireOperation(operation.id));
+      operation = resumed;
     }
 
     // indexing: poll Photon through the port.

--- a/apps/sdp-api/src/services/helius-rings/signer-adapter.test.ts
+++ b/apps/sdp-api/src/services/helius-rings/signer-adapter.test.ts
@@ -1,0 +1,142 @@
+import { SigningError } from "@sdp/custody/signing";
+import type { SolanaRpc } from "@sdp/rpc/solana";
+import {
+  type Address,
+  type Blockhash,
+  compileTransaction,
+  createTransactionMessage,
+  getBase58Codec,
+  getBase64Codec,
+  getTransactionDecoder,
+  getTransactionEncoder,
+  pipe,
+  type SignatureBytes,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
+} from "@solana/kit";
+import type { TransactionPartialSigner } from "@solana/signers";
+import { describe, expect, it } from "vitest";
+import type { Env } from "@/types/env";
+import { RingsAdapterError } from "./adapter-error";
+import { submitRingsOuterTransaction } from "./rpc-adapter";
+import { signRingsOuterTransaction } from "./signer-adapter";
+
+const FEE_PAYER = "11111111111111111111111111111111" as Address;
+const BLOCKHASH = getBase58Codec().decode(new Uint8Array(32).fill(7)) as Blockhash;
+
+const base64 = getBase64Codec();
+const env = {} as Env;
+
+function unsignedTxBase64(): string {
+  const message = pipe(
+    createTransactionMessage({ version: 0 }),
+    (current) => setTransactionMessageFeePayer(FEE_PAYER, current),
+    (current) =>
+      setTransactionMessageLifetimeUsingBlockhash(
+        { blockhash: BLOCKHASH, lastValidBlockHeight: 100n },
+        current
+      )
+  );
+  return base64.decode(getTransactionEncoder().encode(compileTransaction(message)));
+}
+
+function partialSigner(
+  sign: () => Promise<Array<Record<Address, SignatureBytes>>>
+): TransactionPartialSigner {
+  return { address: FEE_PAYER, signTransactions: sign };
+}
+
+describe("signRingsOuterTransaction", () => {
+  it("attaches the custody signature and returns base64 wire bytes", async () => {
+    const signature = new Uint8Array(64).fill(7) as SignatureBytes;
+    const signer = partialSigner(async () => [{ [FEE_PAYER]: signature }]);
+
+    const signed = await signRingsOuterTransaction({
+      env,
+      organizationId: "org_1",
+      projectId: "prj_1",
+      unsignedTxBase64: unsignedTxBase64(),
+      signer,
+    });
+
+    const decoded = getTransactionDecoder().decode(base64.encode(signed));
+    expect(decoded.signatures[FEE_PAYER]).toEqual(signature);
+  });
+
+  it("maps a transient signer error to a retryable signer_failed", async () => {
+    const signer = partialSigner(async () => {
+      throw new SigningError("provider timeout", "NETWORK_ERROR");
+    });
+
+    const error = await signRingsOuterTransaction({
+      env,
+      organizationId: "org_1",
+      projectId: "prj_1",
+      unsignedTxBase64: unsignedTxBase64(),
+      signer,
+    }).then(
+      () => null,
+      (thrown: unknown) => thrown
+    );
+
+    expect(error).toBeInstanceOf(RingsAdapterError);
+    expect(error).toMatchObject({ failureCode: "signer_failed", retryable: true });
+  });
+
+  it("marks a missing wallet as non-retryable", async () => {
+    const signer = partialSigner(async () => {
+      throw new SigningError("no such wallet", "WALLET_NOT_FOUND");
+    });
+
+    const error = await signRingsOuterTransaction({
+      env,
+      organizationId: "org_1",
+      projectId: "prj_1",
+      unsignedTxBase64: unsignedTxBase64(),
+      signer,
+    }).then(
+      () => null,
+      (thrown: unknown) => thrown
+    );
+
+    expect(error).toMatchObject({ failureCode: "signer_failed", retryable: false });
+  });
+});
+
+describe("submitRingsOuterTransaction", () => {
+  it("broadcasts and returns the signature", async () => {
+    const rpc = {
+      sendTransaction: () => ({ send: async () => "sig_abc" }),
+    } as unknown as SolanaRpc;
+
+    await expect(
+      submitRingsOuterTransaction({ env, signedTxBase64: unsignedTxBase64(), rpc })
+    ).resolves.toBe("sig_abc");
+  });
+
+  it("maps a broadcast failure to a retryable submit_failed", async () => {
+    const rpc = {
+      sendTransaction: () => ({
+        send: async () => {
+          throw new Error("blockhash not found");
+        },
+      }),
+    } as unknown as SolanaRpc;
+
+    const error = await submitRingsOuterTransaction({
+      env,
+      signedTxBase64: unsignedTxBase64(),
+      rpc,
+    }).then(
+      () => null,
+      (thrown: unknown) => thrown
+    );
+
+    expect(error).toBeInstanceOf(RingsAdapterError);
+    expect(error).toMatchObject({
+      failureCode: "submit_failed",
+      retryable: true,
+      message: "blockhash not found",
+    });
+  });
+});

--- a/apps/sdp-api/src/services/helius-rings/signer-adapter.ts
+++ b/apps/sdp-api/src/services/helius-rings/signer-adapter.ts
@@ -1,0 +1,96 @@
+import { SigningError } from "@sdp/custody/signing";
+import { getBase64Codec } from "@solana/codecs";
+import {
+  getTransactionDecoder,
+  getTransactionEncoder,
+  type Transaction,
+  type TransactionWithinSizeLimit,
+  type TransactionWithLifetime,
+} from "@solana/kit";
+import {
+  isTransactionModifyingSigner,
+  isTransactionPartialSigner,
+  type TransactionSigner,
+} from "@solana/signers";
+import { createOrgSigner } from "@/services/solana/signer";
+import type { Env } from "@/types/env";
+import { RingsAdapterError } from "./adapter-error";
+
+/**
+ * Signs the gateway-built outer transaction with the SDP custody signer.
+ * Base64 bytes in, base64 bytes out — no SecretRef crosses this boundary, and
+ * the transaction bytes are never logged here (they can carry routing
+ * metadata the redaction registry does not model).
+ */
+
+/** Signer errors that a retry cannot fix. */
+const NON_RETRYABLE_SIGNING_CODES = new Set([
+  "PROVIDER_NOT_CONFIGURED",
+  "WALLET_NOT_FOUND",
+  "NOT_FOUND",
+  "INVALID_REQUEST",
+  "APPROVAL_REJECTED",
+]);
+
+export interface SignRingsOuterTransactionInput {
+  env: Env;
+  organizationId: string;
+  projectId: string;
+  unsignedTxBase64: string;
+  /** Test seam; production resolves the org signer. */
+  signer?: TransactionSigner;
+}
+
+export async function signRingsOuterTransaction(
+  input: SignRingsOuterTransactionInput
+): Promise<string> {
+  const base64 = getBase64Codec();
+
+  let signer: TransactionSigner;
+  let signed: Transaction;
+  try {
+    signer =
+      input.signer ?? (await createOrgSigner(input.env, input.organizationId, input.projectId));
+  } catch (error) {
+    throw toSignerFailure(error);
+  }
+
+  // The decoder returns an unbranded Transaction; the gateway built these
+  // bytes as a complete compiled tx, which is what the signer brands assert.
+  const transaction = getTransactionDecoder().decode(
+    base64.encode(input.unsignedTxBase64)
+  ) as Transaction & TransactionWithinSizeLimit & TransactionWithLifetime;
+
+  try {
+    if (isTransactionModifyingSigner(signer)) {
+      [signed] = await signer.modifyAndSignTransactions([transaction]);
+    } else if (isTransactionPartialSigner(signer)) {
+      const [signatures] = await signer.signTransactions([transaction]);
+      signed = { ...transaction, signatures: { ...transaction.signatures, ...signatures } };
+    } else {
+      throw new RingsAdapterError(
+        "signer_failed",
+        "custody signer cannot sign compiled transactions",
+        { retryable: false }
+      );
+    }
+  } catch (error) {
+    throw toSignerFailure(error);
+  }
+
+  return base64.decode(getTransactionEncoder().encode(signed));
+}
+
+function toSignerFailure(error: unknown): RingsAdapterError {
+  if (error instanceof RingsAdapterError) return error;
+  if (error instanceof SigningError) {
+    return new RingsAdapterError("signer_failed", error.message, {
+      retryable: !NON_RETRYABLE_SIGNING_CODES.has(error.code),
+      cause: error,
+    });
+  }
+  return new RingsAdapterError("signer_failed", "custody signing failed", {
+    retryable: true,
+    cause: error,
+  });
+}

--- a/apps/sdp-api/src/services/jobs/poll-rings-indexing.test.ts
+++ b/apps/sdp-api/src/services/jobs/poll-rings-indexing.test.ts
@@ -140,4 +140,30 @@ describe("pollRingsIndexing", () => {
     expect(row?.failure_code).toBe("indexing_timeout");
     expect(row?.retryable).toBe(true);
   });
+
+  it("sweeps a broadcast stranded in submitted into reconciliation", async () => {
+    const gateway = new InMemoryRingsGateway({ indexingDelayMs: 0 });
+    const operation = await serviceWith(gateway).prepareOperation(
+      { walletId, opType: "shield", clientNonce: "job-stranded" },
+      { apiKeyId: null, actor: null, custodyWalletId: null }
+    );
+    expect(operation.state).toBe("indexing");
+    gateway.recordSubmission(OUTER_TX.signature);
+
+    // Exactly the row a process that died between the RPC broadcast and the
+    // submitted → indexing commit leaves behind. Before the sweep covered
+    // `submitted`, nothing in the system would ever look at this row again.
+    await getDb(env)
+      .prepare("UPDATE helius_rings_operations SET state = 'submitted' WHERE id = ?")
+      .bind(operation.id)
+      .run();
+
+    await pollRingsIndexing(jobEnv, { createService: () => serviceWith(gateway) });
+
+    const row = await createHeliusRingsOperationRepository(env).getOperationById({
+      ...tenant,
+      id: operation.id,
+    });
+    expect(row?.state).toBe("completed");
+  });
 });

--- a/apps/sdp-api/src/services/jobs/poll-rings-indexing.test.ts
+++ b/apps/sdp-api/src/services/jobs/poll-rings-indexing.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@/db/repositories";
 import { createHeliusRingsService } from "@/services/helius-rings";
 import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
+import { signedRingsTransaction } from "@/test/fixtures/rings-transactions";
 import { env } from "@/test/helpers/env";
 import { seedTestDatabase } from "@/test/mocks/db";
 import { pollRingsIndexing, RINGS_INDEXING_TIMEOUT_MS } from "./poll-rings-indexing";
@@ -27,6 +28,8 @@ const allowPolicy = async () =>
     },
   }) as unknown as WalletOperationPolicyEnforcement;
 
+const OUTER_TX = signedRingsTransaction(9);
+
 let walletId: string;
 let jobEnv: typeof env;
 
@@ -34,8 +37,8 @@ function serviceWith(gateway: InMemoryRingsGateway) {
   return createHeliusRingsService(env, tenant, {
     gateway,
     enforcePolicy: allowPolicy,
-    signOuterTransaction: async () => "c2lnbmVk",
-    submitOuterTransaction: async () => "sig_job_1",
+    signOuterTransaction: async () => OUTER_TX.signedTxBase64,
+    submitOuterTransaction: async () => OUTER_TX.signature,
   });
 }
 
@@ -82,7 +85,7 @@ describe("pollRingsIndexing", () => {
       { apiKeyId: null, actor: null, custodyWalletId: null }
     );
     expect(operation.state).toBe("indexing");
-    gateway.recordSubmission("sig_job_1");
+    gateway.recordSubmission(OUTER_TX.signature);
 
     await pollRingsIndexing(
       { ...env, HELIUS_RINGS_ENABLED: "true" },
@@ -103,7 +106,7 @@ describe("pollRingsIndexing", () => {
       { apiKeyId: null, actor: null, custodyWalletId: null }
     );
     expect(operation.state).toBe("indexing");
-    gateway.recordSubmission("sig_job_1");
+    gateway.recordSubmission(OUTER_TX.signature);
 
     await pollRingsIndexing(jobEnv, { createService: () => serviceWith(gateway) });
 

--- a/apps/sdp-api/src/services/jobs/poll-rings-indexing.test.ts
+++ b/apps/sdp-api/src/services/jobs/poll-rings-indexing.test.ts
@@ -1,0 +1,140 @@
+import { InMemoryRingsGateway } from "@sdp/helius-rings/testing";
+import type { WalletOperationPolicyEnforcement } from "@sdp/policy";
+import { beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import {
+  createHeliusRingsOperationRepository,
+  createHeliusRingsWalletRepository,
+} from "@/db/repositories";
+import { createHeliusRingsService } from "@/services/helius-rings";
+import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import { pollRingsIndexing, RINGS_INDEXING_TIMEOUT_MS } from "./poll-rings-indexing";
+
+const TEST_PROJECT_ID = "prj_hr_job_test";
+const tenant = { organizationId: TEST_ORG.id, projectId: TEST_PROJECT_ID };
+
+const allowPolicy = async () =>
+  ({
+    operation: { id: "wop_1" },
+    evaluation: {
+      id: "pev_1",
+      decision: "allow",
+      reason: null,
+      requiresApproval: false,
+      approvalRequestId: null,
+    },
+  }) as unknown as WalletOperationPolicyEnforcement;
+
+let walletId: string;
+let jobEnv: typeof env;
+
+function serviceWith(gateway: InMemoryRingsGateway) {
+  return createHeliusRingsService(env, tenant, {
+    gateway,
+    enforcePolicy: allowPolicy,
+    signOuterTransaction: async () => "c2lnbmVk",
+    submitOuterTransaction: async () => "sig_job_1",
+  });
+}
+
+describe("pollRingsIndexing", () => {
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    jobEnv = { ...env, HELIUS_RINGS_ENABLED: "true", HELIUS_RINGS_ADAPTER: "http" };
+    const db = getDb(env);
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
+      )
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
+      .run();
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')"
+      )
+      .bind(TEST_USER.id, TEST_USER.email)
+      .run();
+    await db
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, 'Test Project', ?, 'sandbox', 'active', ?)`
+      )
+      .bind(TEST_PROJECT_ID, TEST_ORG.id, TEST_PROJECT_ID, TEST_USER.id)
+      .run();
+
+    const wallet = await createHeliusRingsWalletRepository(env).createWallet({
+      ...tenant,
+      sdpWalletId: "wal_hr_job_test",
+      name: "Treasury",
+      materialTag: "simulated",
+    });
+    if (!wallet) throw new Error("wallet fixture was not created");
+    walletId = wallet.id;
+  });
+
+  it("stays dormant unless the flag and the http adapter are both set", async () => {
+    const gateway = new InMemoryRingsGateway({ indexingDelayMs: 0 });
+    const operation = await serviceWith(gateway).prepareOperation(
+      { walletId, opType: "shield", clientNonce: "job-dormant" },
+      { apiKeyId: null, actor: null, custodyWalletId: null }
+    );
+    expect(operation.state).toBe("indexing");
+    gateway.recordSubmission("sig_job_1");
+
+    await pollRingsIndexing(
+      { ...env, HELIUS_RINGS_ENABLED: "true" },
+      { createService: () => serviceWith(gateway) }
+    );
+
+    const row = await createHeliusRingsOperationRepository(env).getOperationById({
+      ...tenant,
+      id: operation.id,
+    });
+    expect(row?.state).toBe("indexing");
+  });
+
+  it("completes an indexing operation once Photon reports it", async () => {
+    const gateway = new InMemoryRingsGateway({ indexingDelayMs: 0 });
+    const operation = await serviceWith(gateway).prepareOperation(
+      { walletId, opType: "shield", clientNonce: "job-complete" },
+      { apiKeyId: null, actor: null, custodyWalletId: null }
+    );
+    expect(operation.state).toBe("indexing");
+    gateway.recordSubmission("sig_job_1");
+
+    await pollRingsIndexing(jobEnv, { createService: () => serviceWith(gateway) });
+
+    const row = await createHeliusRingsOperationRepository(env).getOperationById({
+      ...tenant,
+      id: operation.id,
+    });
+    expect(row?.state).toBe("completed");
+  });
+
+  it("times out an operation stuck in indexing past the budget", async () => {
+    const gateway = new InMemoryRingsGateway({ indexingDelayMs: 60 * 60 * 1000 });
+    const operation = await serviceWith(gateway).prepareOperation(
+      { walletId, opType: "shield", clientNonce: "job-timeout" },
+      { apiKeyId: null, actor: null, custodyWalletId: null }
+    );
+    expect(operation.state).toBe("indexing");
+
+    // Sweep from a clock beyond the budget: the poll fails it rather than
+    // leaving it in limbo.
+    await pollRingsIndexing(jobEnv, {
+      createService: () => serviceWith(gateway),
+      now: () => new Date(Date.now() + RINGS_INDEXING_TIMEOUT_MS + 60_000),
+    });
+
+    const row = await createHeliusRingsOperationRepository(env).getOperationById({
+      ...tenant,
+      id: operation.id,
+    });
+    expect(row?.state).toBe("failed");
+    expect(row?.failure_code).toBe("indexing_timeout");
+    expect(row?.retryable).toBe(true);
+  });
+});

--- a/apps/sdp-api/src/services/jobs/poll-rings-indexing.ts
+++ b/apps/sdp-api/src/services/jobs/poll-rings-indexing.ts
@@ -1,10 +1,15 @@
 /**
- * Background job: poll Photon for rings operations stuck in `indexing`.
+ * Background job: reconcile rings operations that have already been broadcast.
  *
  * Each tick sweeps in-flight operations:
- *  1. `indexing` → `executeOperation` polls `verifyIndexed` through the port;
+ *  1. `submitted` → `executeOperation` advances it to `indexing` and polls in
+ *     the same call. This is the crash-recovery path: the broadcast happens
+ *     inside `submitted`, so a process that dies before the indexing
+ *     transition commits leaves a live transaction here, and nothing else
+ *     would ever look at it again.
+ *  2. `indexing` → `executeOperation` polls `verifyIndexed` through the port;
  *     a hit completes the operation, a miss leaves it untouched (idempotent).
- *  2. `indexing` older than the timeout budget → `failed:indexing_timeout`
+ *  3. `indexing` older than the timeout budget → `failed:indexing_timeout`
  *     (retryable) — the sweep never leaves an operation in limbo forever.
  *
  * Ships dormant: the job early-returns unless the feature flag is on AND
@@ -63,15 +68,26 @@ export async function pollRingsIndexing(
   const logger = getLogger();
   const timeoutCutoff = now().getTime() - RINGS_INDEXING_TIMEOUT_MS;
 
-  // Deliberately sequential. Each iteration builds a per-tenant service and runs
-  // a transactional state transition, so fanning the batch out concurrently
-  // would put up to MAX_PER_RUN pipelines on the shared pool in one tick — and
-  // the per-operation catch below would no longer isolate a single failure.
-  // The 30-minute indexing budget leaves ample room for a serial sweep.
+  // Deliberately sequential. executeOperation makes one Photon call per
+  // operation, so fanning MAX_PER_RUN out would put 100 unthrottled requests at
+  // the indexer every tick. It would not even buy much: the pool caps at 10
+  // connections with a 5s acquire timeout, so the batch serializes there anyway
+  // and any operation that waits longer is logged as a failure that never
+  // happened. Serial also keeps listInFlightOperations' oldest-first ordering
+  // meaningful when there is a backlog. The 60s tick against the 30-minute
+  // indexing budget leaves ample headroom.
+  //
+  // Note this is not about error isolation: the catch below is per-operation and
+  // would survive a Promise.all over the same body unchanged.
   for (const operation of inFlight) {
-    if (operation.state !== "indexing") continue;
+    // `submitted` rides along with `indexing`: executeOperation advances it and
+    // polls in one call, which is the only thing that rescues a broadcast whose
+    // indexing transition never committed. The timeout is deliberately not
+    // applied to it — the budget measures how long Photon has been asked, and a
+    // resumed operation has not been asked yet.
+    if (operation.state !== "indexing" && operation.state !== "submitted") continue;
     try {
-      if (Date.parse(operation.updated_at) < timeoutCutoff) {
+      if (operation.state === "indexing" && Date.parse(operation.updated_at) < timeoutCutoff) {
         await failIndexingTimeout(repository, operation);
         continue;
       }

--- a/apps/sdp-api/src/services/jobs/poll-rings-indexing.ts
+++ b/apps/sdp-api/src/services/jobs/poll-rings-indexing.ts
@@ -63,6 +63,11 @@ export async function pollRingsIndexing(
   const logger = getLogger();
   const timeoutCutoff = now().getTime() - RINGS_INDEXING_TIMEOUT_MS;
 
+  // Deliberately sequential. Each iteration builds a per-tenant service and runs
+  // a transactional state transition, so fanning the batch out concurrently
+  // would put up to MAX_PER_RUN pipelines on the shared pool in one tick — and
+  // the per-operation catch below would no longer isolate a single failure.
+  // The 30-minute indexing budget leaves ample room for a serial sweep.
   for (const operation of inFlight) {
     if (operation.state !== "indexing") continue;
     try {

--- a/apps/sdp-api/src/services/jobs/poll-rings-indexing.ts
+++ b/apps/sdp-api/src/services/jobs/poll-rings-indexing.ts
@@ -1,0 +1,101 @@
+/**
+ * Background job: poll Photon for rings operations stuck in `indexing`.
+ *
+ * Each tick sweeps in-flight operations:
+ *  1. `indexing` → `executeOperation` polls `verifyIndexed` through the port;
+ *     a hit completes the operation, a miss leaves it untouched (idempotent).
+ *  2. `indexing` older than the timeout budget → `failed:indexing_timeout`
+ *     (retryable) — the sweep never leaves an operation in limbo forever.
+ *
+ * Ships dormant: the job early-returns unless the feature flag is on AND
+ * HELIUS_RINGS_ADAPTER is "http" — the live gateway selector Track B flips.
+ * Until then no operation can reach `indexing` in production anyway (the
+ * NotImplemented gateway fails the pipeline at `proving`).
+ */
+
+import {
+  createHeliusRingsOperationRepository,
+  type HeliusRingsOperationRow,
+} from "@/db/repositories";
+import { isHeliusRingsEnabled } from "@/lib/feature-flags";
+import { getLogger } from "@/runtime/logger";
+import { createHeliusRingsService, type HeliusRingsService } from "@/services/helius-rings";
+import type { Env } from "@/types/env";
+
+/** An operation may sit in `indexing` this long before it times out. */
+export const RINGS_INDEXING_TIMEOUT_MS = 30 * 60 * 1000;
+
+const MAX_PER_RUN = 100;
+
+export interface PollRingsIndexingDependencies {
+  /** Test seam: service per tenant; production builds the real one. */
+  createService?: (tenant: { organizationId: string; projectId: string }) => HeliusRingsService;
+  now?: () => Date;
+}
+
+export function isRingsIndexingPollEnabled(
+  env: Pick<Env, "HELIUS_RINGS_ENABLED" | "HELIUS_RINGS_ADAPTER">
+): boolean {
+  return isHeliusRingsEnabled(env) && env.HELIUS_RINGS_ADAPTER === "http";
+}
+
+export async function pollRingsIndexing(
+  env: Env,
+  dependencies: PollRingsIndexingDependencies = {}
+): Promise<void> {
+  if (!isRingsIndexingPollEnabled(env)) {
+    return;
+  }
+
+  const now = dependencies.now ?? (() => new Date());
+  const createService =
+    dependencies.createService ??
+    ((tenant: { organizationId: string; projectId: string }) =>
+      createHeliusRingsService(env, tenant));
+
+  const repository = createHeliusRingsOperationRepository(env);
+  // Everything in flight as of this tick; the poll itself decides per state.
+  const inFlight = await repository.listInFlightOperations({
+    staleBefore: now().toISOString(),
+    limit: MAX_PER_RUN,
+  });
+
+  const logger = getLogger();
+  const timeoutCutoff = now().getTime() - RINGS_INDEXING_TIMEOUT_MS;
+
+  for (const operation of inFlight) {
+    if (operation.state !== "indexing") continue;
+    try {
+      if (Date.parse(operation.updated_at) < timeoutCutoff) {
+        await failIndexingTimeout(repository, operation);
+        continue;
+      }
+      const service = createService({
+        organizationId: operation.organization_id,
+        projectId: operation.project_id,
+      });
+      await service.executeOperation(operation.id);
+    } catch (error) {
+      // One stuck operation must not starve the rest of the sweep.
+      logger.warn(
+        { operationId: operation.id, err: error },
+        "rings indexing poll failed for operation"
+      );
+    }
+  }
+}
+
+async function failIndexingTimeout(
+  repository: ReturnType<typeof createHeliusRingsOperationRepository>,
+  operation: HeliusRingsOperationRow
+): Promise<void> {
+  await repository.failOperation({
+    organizationId: operation.organization_id,
+    projectId: operation.project_id,
+    id: operation.id,
+    expectedState: "indexing",
+    code: "indexing_timeout",
+    message: "Photon did not index the transaction within the budget",
+    retryable: true,
+  });
+}

--- a/apps/sdp-api/src/test/fixtures/rings-transactions.ts
+++ b/apps/sdp-api/src/test/fixtures/rings-transactions.ts
@@ -1,0 +1,52 @@
+import {
+  type Address,
+  type Blockhash,
+  compileTransaction,
+  createTransactionMessage,
+  getBase58Codec,
+  getBase64Codec,
+  getSignatureFromTransaction,
+  getTransactionEncoder,
+  pipe,
+  type SignatureBytes,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
+} from "@solana/kit";
+
+const FEE_PAYER = "11111111111111111111111111111111" as Address;
+const BLOCKHASH = getBase58Codec().decode(new Uint8Array(32).fill(7)) as Blockhash;
+
+/**
+ * A signed outer transaction as base64 wire bytes, plus the signature the
+ * service derives from them.
+ *
+ * `HeliusRingsService` persists the outer signature before broadcasting, which
+ * means it decodes what the signer returned — so a sign/submit test double has
+ * to hand back a real transaction, not a placeholder string. `fill` byte-fills
+ * the signature so two fixtures in one test are distinguishable.
+ */
+export function signedRingsTransaction(fill: number): {
+  signedTxBase64: string;
+  signature: string;
+} {
+  const compiled = compileTransaction(
+    pipe(
+      createTransactionMessage({ version: 0 }),
+      (message) => setTransactionMessageFeePayer(FEE_PAYER, message),
+      (message) =>
+        setTransactionMessageLifetimeUsingBlockhash(
+          { blockhash: BLOCKHASH, lastValidBlockHeight: 100n },
+          message
+        )
+    )
+  );
+  const signed = {
+    ...compiled,
+    signatures: { [FEE_PAYER]: new Uint8Array(64).fill(fill) as SignatureBytes },
+  };
+
+  return {
+    signedTxBase64: getBase64Codec().decode(getTransactionEncoder().encode(signed)),
+    signature: getSignatureFromTransaction(signed),
+  };
+}

--- a/apps/sdp-api/src/test/mocks/db.ts
+++ b/apps/sdp-api/src/test/mocks/db.ts
@@ -78,6 +78,16 @@ const POSTGRES_TEST_TABLES = [
   "private_channel_deposits",
   "private_channels",
   "private_channel_instances",
+  "helius_rings_events",
+  "helius_rings_timelocks",
+  "helius_rings_operations",
+  "helius_rings_zones",
+  "helius_rings_key_refs",
+  "helius_rings_wallets",
+  "helius_rings_runtime_health",
+  // helius_rings_asset_allowlist is deliberately absent: it is platform
+  // reference data seeded by migration 0057, not per-test state. Truncating it
+  // would empty it for the rest of the run, and nothing re-seeds it.
   "magic_links",
   "sessions",
   "project_members",

--- a/apps/sdp-api/src/types/env.d.ts
+++ b/apps/sdp-api/src/types/env.d.ts
@@ -225,6 +225,10 @@ export interface Env {
   // Helius Rings feature gate — devnet-only shielded wallet API routes.
   HELIUS_RINGS_ENABLED?: string;
 
+  // Rings gateway selector. Only "http" activates the live adapter and the
+  // indexing-poll job; anything else keeps NotImplementedRingsGateway.
+  HELIUS_RINGS_ADAPTER?: string;
+
   // Compliance providers
   RANGE_API_KEY?: string;
   RANGE_API_BASE_URL?: string;

--- a/apps/sdp-api/src/types/env.d.ts
+++ b/apps/sdp-api/src/types/env.d.ts
@@ -222,6 +222,9 @@ export interface Env {
   // Private Channels (SPC) feature gate — API routes + deposit/withdrawal cron.
   PRIVATE_CHANNELS_ENABLED?: string;
 
+  // Helius Rings feature gate — devnet-only shielded wallet API routes.
+  HELIUS_RINGS_ENABLED?: string;
+
   // Compliance providers
   RANGE_API_KEY?: string;
   RANGE_API_BASE_URL?: string;

--- a/apps/sdp-web/messages/en/dashboard-helius-rings.json
+++ b/apps/sdp-web/messages/en/dashboard-helius-rings.json
@@ -118,11 +118,13 @@
       "notRetryable": "Not retryable."
     },
     "recovery": {
-      "title": "Recovery",
-      "description": "Failed operations. A retry files a fresh operation linked to the original and re-runs policy; retry chains are capped server-side.",
-      "empty": "Nothing to recover.",
+      "title": "Needs attention",
+      "description": "Operations resting on a human decision. Approved operations execute against the verdict already stored server-side; a retry files a fresh operation linked to the original and re-runs policy, and retry chains are capped server-side.",
+      "empty": "Nothing waiting.",
       "retry": "Retry",
-      "retrying": "Retrying…"
+      "retrying": "Retrying…",
+      "execute": "Execute",
+      "executing": "Executing…"
     }
   }
 }

--- a/apps/sdp-web/messages/en/dashboard-helius-rings.json
+++ b/apps/sdp-web/messages/en/dashboard-helius-rings.json
@@ -95,7 +95,8 @@
       "summaryZone": "Zone",
       "summaryUnlockAt": "Unlocks at",
       "summaryBeneficiary": "Beneficiary",
-      "anonymousWarning": "I understand the counterparty is not disclosed on-chain. Anonymous transfers are subject to the same wallet policy and approval rules as any other transfer — they are not lower-risk."
+      "anonymousWarning": "I understand the counterparty is not disclosed on-chain. Anonymous transfers are subject to the same wallet policy and approval rules as any other transfer — they are not lower-risk.",
+      "gatewayRedNotice": "The Rings gateway is unavailable. You can still compose and confirm — the operation will run through policy and record an honest gateway failure."
     },
     "zones": {
       "title": "Zones",
@@ -115,6 +116,13 @@
       "timelineEmpty": "No events recorded.",
       "retryable": "A retry can succeed.",
       "notRetryable": "Not retryable."
+    },
+    "recovery": {
+      "title": "Recovery",
+      "description": "Failed operations. A retry files a fresh operation linked to the original and re-runs policy; retry chains are capped server-side.",
+      "empty": "Nothing to recover.",
+      "retry": "Retry",
+      "retrying": "Retrying…"
     }
   }
 }

--- a/apps/sdp-web/messages/en/dashboard-helius-rings.json
+++ b/apps/sdp-web/messages/en/dashboard-helius-rings.json
@@ -107,6 +107,14 @@
       "kind_treasury": "Treasury",
       "kind_public": "Public",
       "create": "Create zone"
+    },
+    "detail": {
+      "title": "Operation detail",
+      "operationId": "Operation",
+      "timeline": "Timeline",
+      "timelineEmpty": "No events recorded.",
+      "retryable": "A retry can succeed.",
+      "notRetryable": "Not retryable."
     }
   }
 }

--- a/apps/sdp-web/messages/en/dashboard-helius-rings.json
+++ b/apps/sdp-web/messages/en/dashboard-helius-rings.json
@@ -34,9 +34,7 @@
       "creating": "Provisioning…",
       "createPendingNotice": "The wallet was reserved but its shielded identity is awaiting the external gateway integration. It will stay Pending until that lands.",
       "createFailed": "The wallet could not be created. Check the details and try again.",
-      "noCustodyWallets": "No custody wallets available. Create a wallet under Wallets first.",
-      "testOperation": "Prepare test operation",
-      "testOperationHint": "Files a shield operation through policy; it fails at the gateway seam until the integration lands."
+      "noCustodyWallets": "No custody wallets available. Create a wallet under Wallets first."
     },
     "activity": {
       "title": "Activity",
@@ -67,6 +65,48 @@
     "errors": {
       "loadFailed": "Could not load Helius Rings data. Retry shortly.",
       "gatewayUnavailable": "External integration pending"
+    },
+    "composer": {
+      "title": "New operation",
+      "description": "Compose a shielded operation, review it, then confirm. Until the live gateway lands, operations advance through policy and fail honestly at the integration seam.",
+      "wallet": "Private wallet",
+      "walletPlaceholder": "Select a private wallet",
+      "operation": "Operation",
+      "asset": "Asset",
+      "amount": "Amount (base units)",
+      "baseUnits": "base units",
+      "recipient": "Recipient address",
+      "recipientAnonymous": "Recipient address (undisclosed on-chain)",
+      "recipientPlaceholder": "Solana address",
+      "zone": "Destination zone",
+      "zonePlaceholder": "Optional",
+      "unlockAt": "Unlocks at",
+      "beneficiary": "Beneficiary address",
+      "review": "Review",
+      "back": "Back",
+      "confirm": "Confirm",
+      "preparing": "Preparing…",
+      "newOperation": "New operation",
+      "prepareFailed": "The operation could not be prepared. Check the details and try again.",
+      "summaryWallet": "Wallet",
+      "summaryOperation": "Operation",
+      "summaryAmount": "Amount",
+      "summaryRecipient": "Recipient",
+      "summaryZone": "Zone",
+      "summaryUnlockAt": "Unlocks at",
+      "summaryBeneficiary": "Beneficiary",
+      "anonymousWarning": "I understand the counterparty is not disclosed on-chain. Anonymous transfers are subject to the same wallet policy and approval rules as any other transfer — they are not lower-risk."
+    },
+    "zones": {
+      "title": "Zones",
+      "description": "Named destinations inside a wallet. Zone metadata is SDP-owned and works today; on-chain effects wait on the gateway.",
+      "empty": "No zones yet.",
+      "nameLabel": "Zone name",
+      "namePlaceholder": "Payroll",
+      "kindLabel": "Kind",
+      "kind_treasury": "Treasury",
+      "kind_public": "Public",
+      "create": "Create zone"
     }
   }
 }

--- a/apps/sdp-web/messages/en/dashboard-helius-rings.json
+++ b/apps/sdp-web/messages/en/dashboard-helius-rings.json
@@ -1,0 +1,72 @@
+{
+  "DashboardHeliusRings": {
+    "title": "Helius Rings",
+    "subtitle": "Shielded wallets and private transfers on Solana devnet.",
+    "devnetBanner": "Devnet only — Helius Rings runs exclusively on Solana devnet. Nothing here touches mainnet funds.",
+    "health": {
+      "title": "Runtime health",
+      "description": "Live status of the Rings upstreams. Actions stay disabled while a component is red.",
+      "component_rpc": "RPC",
+      "component_prover": "Prover",
+      "component_photon": "Photon indexer",
+      "component_gateway": "Gateway",
+      "status_green": "Operational",
+      "status_amber": "Degraded",
+      "status_red": "Unavailable",
+      "pendingIntegration": "The Rings gateway is awaiting external integration. Wallet provisioning and shielded operations will fail honestly until it comes online."
+    },
+    "wallets": {
+      "title": "Private wallets",
+      "description": "Each private wallet is bound to one SDP custody wallet and holds its own shielded identity.",
+      "empty": "No private wallets yet. Create one from a custody wallet below.",
+      "name": "Name",
+      "backingWallet": "Custody wallet",
+      "shieldedAddress": "Shielded address",
+      "shieldedAddressPending": "Not provisioned",
+      "status_pending": "Pending",
+      "status_ready": "Ready",
+      "status_paused": "Paused",
+      "create": "Create private wallet",
+      "createNameLabel": "Wallet name",
+      "createNamePlaceholder": "Treasury",
+      "createWalletLabel": "Custody wallet",
+      "createWalletPlaceholder": "Select a custody wallet",
+      "creating": "Provisioning…",
+      "createPendingNotice": "The wallet was reserved but its shielded identity is awaiting the external gateway integration. It will stay Pending until that lands.",
+      "createFailed": "The wallet could not be created. Check the details and try again.",
+      "noCustodyWallets": "No custody wallets available. Create a wallet under Wallets first.",
+      "testOperation": "Prepare test operation",
+      "testOperationHint": "Files a shield operation through policy; it fails at the gateway seam until the integration lands."
+    },
+    "activity": {
+      "title": "Activity",
+      "description": "Every shielded operation, newest first. Failed operations carry their failure code.",
+      "empty": "No operations yet.",
+      "operation": "Operation",
+      "state": "State",
+      "amount": "Amount (base units)",
+      "created": "Created",
+      "opType_shield": "Shield",
+      "opType_transfer_registered": "Send (registered)",
+      "opType_transfer_anonymous": "Send (anonymous)",
+      "opType_withdraw": "Withdraw",
+      "opType_merge": "Merge",
+      "opType_timelock_create": "Timelock",
+      "opType_timelock_settle": "Timelock settle",
+      "opType_zone_create": "Zone create",
+      "state_draft": "Draft",
+      "state_preparing": "Preparing",
+      "state_approval_required": "Approval required",
+      "state_proving": "Proving",
+      "state_ready_to_sign": "Ready to sign",
+      "state_submitted": "Submitted",
+      "state_indexing": "Indexing",
+      "state_completed": "Completed",
+      "state_failed": "Failed"
+    },
+    "errors": {
+      "loadFailed": "Could not load Helius Rings data. Retry shortly.",
+      "gatewayUnavailable": "External integration pending"
+    }
+  }
+}

--- a/apps/sdp-web/src/app/api/dashboard/helius-rings/health/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/helius-rings/health/route.ts
@@ -1,0 +1,9 @@
+import { proxyToSdpApi } from "@/lib/sdp-api";
+
+export async function GET(request: Request) {
+  return proxyToSdpApi({
+    request,
+    traceSource: "route.dashboard.helius-rings.health",
+    path: "/v1/helius-rings/health",
+  });
+}

--- a/apps/sdp-web/src/app/api/dashboard/helius-rings/operations/[operationId]/execute/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/helius-rings/operations/[operationId]/execute/route.ts
@@ -1,0 +1,13 @@
+import { proxyToSdpApi } from "@/lib/sdp-api";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ operationId: string }> }
+) {
+  const { operationId } = await params;
+  return proxyToSdpApi({
+    request,
+    traceSource: "route.dashboard.helius-rings.execute",
+    path: `/v1/helius-rings/operations/${encodeURIComponent(operationId)}/execute`,
+  });
+}

--- a/apps/sdp-web/src/app/api/dashboard/helius-rings/operations/[operationId]/retry/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/helius-rings/operations/[operationId]/retry/route.ts
@@ -1,0 +1,13 @@
+import { proxyToSdpApi } from "@/lib/sdp-api";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ operationId: string }> }
+) {
+  const { operationId } = await params;
+  return proxyToSdpApi({
+    request,
+    traceSource: "route.dashboard.helius-rings.retry",
+    path: `/v1/helius-rings/operations/${encodeURIComponent(operationId)}/retry`,
+  });
+}

--- a/apps/sdp-web/src/app/api/dashboard/helius-rings/operations/[operationId]/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/helius-rings/operations/[operationId]/route.ts
@@ -1,0 +1,13 @@
+import { proxyToSdpApi } from "@/lib/sdp-api";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ operationId: string }> }
+) {
+  const { operationId } = await params;
+  return proxyToSdpApi({
+    request,
+    traceSource: "route.dashboard.helius-rings.operation",
+    path: `/v1/helius-rings/operations/${encodeURIComponent(operationId)}`,
+  });
+}

--- a/apps/sdp-web/src/app/api/dashboard/helius-rings/operations/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/helius-rings/operations/route.ts
@@ -1,0 +1,17 @@
+import { proxyToSdpApi } from "@/lib/sdp-api";
+
+export async function GET(request: Request) {
+  return proxyToSdpApi({
+    request,
+    traceSource: "route.dashboard.helius-rings.operations",
+    path: "/v1/helius-rings/operations",
+  });
+}
+
+export async function POST(request: Request) {
+  return proxyToSdpApi({
+    request,
+    traceSource: "route.dashboard.helius-rings.operations",
+    path: "/v1/helius-rings/operations",
+  });
+}

--- a/apps/sdp-web/src/app/api/dashboard/helius-rings/wallets/[walletId]/zones/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/helius-rings/wallets/[walletId]/zones/route.ts
@@ -1,0 +1,22 @@
+import { proxyToSdpApi } from "@/lib/sdp-api";
+
+export async function GET(request: Request, { params }: { params: Promise<{ walletId: string }> }) {
+  const { walletId } = await params;
+  return proxyToSdpApi({
+    request,
+    traceSource: "route.dashboard.helius-rings.zones",
+    path: `/v1/helius-rings/wallets/${encodeURIComponent(walletId)}/zones`,
+  });
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ walletId: string }> }
+) {
+  const { walletId } = await params;
+  return proxyToSdpApi({
+    request,
+    traceSource: "route.dashboard.helius-rings.zones",
+    path: `/v1/helius-rings/wallets/${encodeURIComponent(walletId)}/zones`,
+  });
+}

--- a/apps/sdp-web/src/app/api/dashboard/helius-rings/wallets/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/helius-rings/wallets/route.ts
@@ -1,0 +1,17 @@
+import { proxyToSdpApi } from "@/lib/sdp-api";
+
+export async function GET(request: Request) {
+  return proxyToSdpApi({
+    request,
+    traceSource: "route.dashboard.helius-rings.wallets",
+    path: "/v1/helius-rings/wallets",
+  });
+}
+
+export async function POST(request: Request) {
+  return proxyToSdpApi({
+    request,
+    traceSource: "route.dashboard.helius-rings.wallets",
+    path: "/v1/helius-rings/wallets",
+  });
+}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Callout } from "@/components/ui/callout";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectItem } from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useTranslations } from "@/i18n/provider";
+import {
+  createRingsWallet,
+  fetchRingsHealth,
+  fetchRingsOperations,
+  fetchRingsWallets,
+  prepareRingsTestOperation,
+  type RingsHealth,
+  type RingsHealthStatus,
+  type RingsOperationState,
+  type RingsOperationSummary,
+  type RingsWallet,
+} from "./helius-rings.data";
+
+interface CustodyWalletOption {
+  walletId: string;
+  label: string | null;
+  publicKey: string;
+}
+
+const HEALTH_COMPONENTS = ["rpc", "prover", "photon", "gateway"] as const;
+
+const HEALTH_BADGE: Record<RingsHealthStatus, "success" | "warning" | "danger"> = {
+  green: "success",
+  amber: "warning",
+  red: "danger",
+};
+
+const WALLET_BADGE: Record<RingsWallet["status"], "warning" | "success" | "default"> = {
+  pending: "warning",
+  ready: "success",
+  paused: "default",
+};
+
+const STATE_BADGE: Record<RingsOperationState, "default" | "success" | "warning" | "danger"> = {
+  draft: "default",
+  preparing: "default",
+  approval_required: "warning",
+  proving: "default",
+  ready_to_sign: "default",
+  submitted: "default",
+  indexing: "default",
+  completed: "success",
+  failed: "danger",
+};
+
+export function HeliusRingsWorkspace({
+  custodyWallets,
+}: {
+  custodyWallets: CustodyWalletOption[];
+}) {
+  const t = useTranslations();
+
+  const [health, setHealth] = useState<RingsHealth | null>(null);
+  const [wallets, setWallets] = useState<RingsWallet[]>([]);
+  const [operations, setOperations] = useState<RingsOperationSummary[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [walletName, setWalletName] = useState("");
+  const [selectedCustodyWallet, setSelectedCustodyWallet] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [createNotice, setCreateNotice] = useState<"pending" | "failed" | null>(null);
+
+  const loadFailedCopy = t("DashboardHeliusRings.errors.loadFailed");
+
+  const refresh = useCallback(async () => {
+    try {
+      const [healthResult, walletsResult, operationsResult] = await Promise.all([
+        fetchRingsHealth(loadFailedCopy),
+        fetchRingsWallets(loadFailedCopy),
+        fetchRingsOperations(loadFailedCopy),
+      ]);
+      setHealth(healthResult.health);
+      setWallets(walletsResult.wallets);
+      setOperations(operationsResult.operations);
+      setLoadError(null);
+    } catch (error) {
+      setLoadError(error instanceof Error ? error.message : loadFailedCopy);
+    }
+  }, [loadFailedCopy]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const gatewayPending = health !== null && health.gateway !== "green";
+
+  const handleCreate = useCallback(async () => {
+    if (!selectedCustodyWallet || !walletName.trim()) return;
+    setCreating(true);
+    setCreateNotice(null);
+    const result = await createRingsWallet({
+      walletId: selectedCustodyWallet,
+      name: walletName.trim(),
+    });
+    setCreating(false);
+    if (result.pendingIntegration) {
+      setCreateNotice("pending");
+    } else if (result.error) {
+      setCreateNotice("failed");
+    }
+    setWalletName("");
+    await refresh();
+  }, [selectedCustodyWallet, walletName, refresh]);
+
+  const handleTestOperation = useCallback(
+    async (walletId: string) => {
+      await prepareRingsTestOperation({ walletId });
+      await refresh();
+    },
+    [refresh]
+  );
+
+  const custodyLabel = useMemo(() => {
+    const byId = new Map(custodyWallets.map((wallet) => [wallet.walletId, wallet]));
+    return (sdpWalletId: string) => {
+      const wallet = byId.get(sdpWalletId);
+      return wallet?.label ?? sdpWalletId;
+    };
+  }, [custodyWallets]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Callout variant="warning">{t("DashboardHeliusRings.devnetBanner")}</Callout>
+
+      {loadError ? <Callout variant="danger">{loadError}</Callout> : null}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("DashboardHeliusRings.health.title")}</CardTitle>
+          <CardDescription>{t("DashboardHeliusRings.health.description")}</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3">
+          <div className="flex flex-wrap gap-4">
+            {HEALTH_COMPONENTS.map((component) => {
+              const status = health?.[component] ?? "red";
+              return (
+                <div key={component} className="flex items-center gap-2">
+                  <span className="text-sm text-secondary">
+                    {t(`DashboardHeliusRings.health.component_${component}`)}
+                  </span>
+                  <Badge variant={HEALTH_BADGE[status]}>
+                    {t(`DashboardHeliusRings.health.status_${status}`)}
+                  </Badge>
+                </div>
+              );
+            })}
+          </div>
+          {gatewayPending ? (
+            <p className="text-sm text-secondary">
+              {t("DashboardHeliusRings.health.pendingIntegration")}
+            </p>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("DashboardHeliusRings.wallets.title")}</CardTitle>
+          <CardDescription>{t("DashboardHeliusRings.wallets.description")}</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          {wallets.length === 0 ? (
+            <p className="text-sm text-secondary">{t("DashboardHeliusRings.wallets.empty")}</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("DashboardHeliusRings.wallets.name")}</TableHead>
+                  <TableHead>{t("DashboardHeliusRings.wallets.backingWallet")}</TableHead>
+                  <TableHead>{t("DashboardHeliusRings.wallets.shieldedAddress")}</TableHead>
+                  <TableHead>{t("DashboardHeliusRings.activity.state")}</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {wallets.map((wallet) => (
+                  <TableRow key={wallet.id}>
+                    <TableCell>{wallet.name}</TableCell>
+                    <TableCell>{custodyLabel(wallet.sdpWalletId)}</TableCell>
+                    <TableCell>
+                      {wallet.shieldedAddress ??
+                        t("DashboardHeliusRings.wallets.shieldedAddressPending")}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={WALLET_BADGE[wallet.status]}>
+                        {t(`DashboardHeliusRings.wallets.status_${wallet.status}`)}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        title={t("DashboardHeliusRings.wallets.testOperationHint")}
+                        onClick={() => void handleTestOperation(wallet.id)}
+                      >
+                        {t("DashboardHeliusRings.wallets.testOperation")}
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+
+          {createNotice === "pending" ? (
+            <Callout variant="info">
+              {t("DashboardHeliusRings.wallets.createPendingNotice")}
+            </Callout>
+          ) : null}
+          {createNotice === "failed" ? (
+            <Callout variant="danger">{t("DashboardHeliusRings.wallets.createFailed")}</Callout>
+          ) : null}
+
+          {custodyWallets.length === 0 ? (
+            <p className="text-sm text-secondary">
+              {t("DashboardHeliusRings.wallets.noCustodyWallets")}
+            </p>
+          ) : (
+            <div className="flex flex-wrap items-end gap-3">
+              <div className="flex min-w-56 flex-col gap-1.5">
+                <span className="text-sm font-medium text-primary">
+                  {t("DashboardHeliusRings.wallets.createWalletLabel")}
+                </span>
+                <Select
+                  ariaLabel={t("DashboardHeliusRings.wallets.createWalletLabel")}
+                  value={selectedCustodyWallet}
+                  onValueChange={setSelectedCustodyWallet}
+                  placeholder={t("DashboardHeliusRings.wallets.createWalletPlaceholder")}
+                >
+                  {custodyWallets.map((wallet) => (
+                    <SelectItem key={wallet.walletId} value={wallet.walletId}>
+                      {wallet.label ?? wallet.walletId}
+                    </SelectItem>
+                  ))}
+                </Select>
+              </div>
+              <div className="flex min-w-48 flex-col gap-1.5">
+                <Label htmlFor="rings-wallet-name">
+                  {t("DashboardHeliusRings.wallets.createNameLabel")}
+                </Label>
+                <Input
+                  id="rings-wallet-name"
+                  value={walletName}
+                  placeholder={t("DashboardHeliusRings.wallets.createNamePlaceholder")}
+                  onChange={(event) => setWalletName(event.target.value)}
+                />
+              </div>
+              <Button
+                disabled={creating || !selectedCustodyWallet || !walletName.trim()}
+                onClick={() => void handleCreate()}
+              >
+                {creating
+                  ? t("DashboardHeliusRings.wallets.creating")
+                  : t("DashboardHeliusRings.wallets.create")}
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("DashboardHeliusRings.activity.title")}</CardTitle>
+          <CardDescription>{t("DashboardHeliusRings.activity.description")}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {operations.length === 0 ? (
+            <p className="text-sm text-secondary">{t("DashboardHeliusRings.activity.empty")}</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("DashboardHeliusRings.activity.operation")}</TableHead>
+                  <TableHead>{t("DashboardHeliusRings.activity.state")}</TableHead>
+                  <TableHead>{t("DashboardHeliusRings.activity.amount")}</TableHead>
+                  <TableHead>{t("DashboardHeliusRings.activity.created")}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {operations.map((operation) => (
+                  <TableRow key={operation.id}>
+                    <TableCell>
+                      {t(`DashboardHeliusRings.activity.opType_${operation.opType}`)}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={STATE_BADGE[operation.state]}>
+                        {t(`DashboardHeliusRings.activity.state_${operation.state}`)}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>{operation.amountRaw ?? "—"}</TableCell>
+                    <TableCell>{new Date(operation.createdAt).toLocaleString()}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
@@ -27,7 +27,6 @@ import {
   type RingsOperationState,
   type RingsOperationSummary,
   type RingsWallet,
-  type RingsZone,
 } from "./helius-rings.data";
 import { formatWhen } from "./helius-rings.utils";
 import { OperationComposer } from "./operation-composer";
@@ -78,7 +77,6 @@ export function HeliusRingsWorkspace({
   const [health, setHealth] = useState<RingsHealth | null>(null);
   const [wallets, setWallets] = useState<RingsWallet[]>([]);
   const [operations, setOperations] = useState<RingsOperationSummary[]>([]);
-  const [zones, setZones] = useState<RingsZone[]>([]);
   const [detailOperationId, setDetailOperationId] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -266,14 +264,9 @@ export function HeliusRingsWorkspace({
         </CardContent>
       </Card>
 
-      <OperationComposer
-        wallets={wallets}
-        zones={zones}
-        gatewayRed={gatewayPending}
-        onPrepared={refresh}
-      />
+      <OperationComposer wallets={wallets} gatewayRed={gatewayPending} onPrepared={refresh} />
 
-      <ZonesCard wallets={wallets} onZonesChanged={setZones} />
+      <ZonesCard wallets={wallets} />
 
       <RecoveryCard operations={operations} onRetried={refresh} />
 

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
@@ -29,6 +29,7 @@ import {
   type RingsWallet,
   type RingsZone,
 } from "./helius-rings.data";
+import { formatWhen } from "./helius-rings.utils";
 import { OperationComposer } from "./operation-composer";
 import { OperationDetailDrawer } from "./operation-detail-drawer";
 import { RecoveryCard } from "./recovery-card";
@@ -310,12 +311,7 @@ export function HeliusRingsWorkspace({
                       </Badge>
                     </TableCell>
                     <TableCell>{operation.amountRaw ?? "—"}</TableCell>
-                    <TableCell>
-                      {new Date(operation.createdAt).toLocaleString(locale, {
-                        dateStyle: "medium",
-                        timeStyle: "short",
-                      })}
-                    </TableCell>
+                    <TableCell>{formatWhen(operation.createdAt, locale)}</TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
@@ -268,7 +268,7 @@ export function HeliusRingsWorkspace({
 
       <ZonesCard wallets={wallets} />
 
-      <RecoveryCard operations={operations} onRetried={refresh} />
+      <RecoveryCard operations={operations} onChanged={refresh} />
 
       <Card>
         <CardHeader>

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
@@ -31,6 +31,7 @@ import {
 } from "./helius-rings.data";
 import { OperationComposer } from "./operation-composer";
 import { OperationDetailDrawer } from "./operation-detail-drawer";
+import { RecoveryCard } from "./recovery-card";
 import { ZonesCard } from "./zones-card";
 
 interface CustodyWalletOption {
@@ -263,9 +264,16 @@ export function HeliusRingsWorkspace({
         </CardContent>
       </Card>
 
-      <OperationComposer wallets={wallets} zones={zones} onPrepared={refresh} />
+      <OperationComposer
+        wallets={wallets}
+        zones={zones}
+        gatewayRed={gatewayPending}
+        onPrepared={refresh}
+      />
 
       <ZonesCard wallets={wallets} onZonesChanged={setZones} />
+
+      <RecoveryCard operations={operations} onRetried={refresh} />
 
       <Card>
         <CardHeader>

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
@@ -22,13 +22,15 @@ import {
   fetchRingsHealth,
   fetchRingsOperations,
   fetchRingsWallets,
-  prepareRingsTestOperation,
   type RingsHealth,
   type RingsHealthStatus,
   type RingsOperationState,
   type RingsOperationSummary,
   type RingsWallet,
+  type RingsZone,
 } from "./helius-rings.data";
+import { OperationComposer } from "./operation-composer";
+import { ZonesCard } from "./zones-card";
 
 interface CustodyWalletOption {
   walletId: string;
@@ -72,6 +74,7 @@ export function HeliusRingsWorkspace({
   const [health, setHealth] = useState<RingsHealth | null>(null);
   const [wallets, setWallets] = useState<RingsWallet[]>([]);
   const [operations, setOperations] = useState<RingsOperationSummary[]>([]);
+  const [zones, setZones] = useState<RingsZone[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
 
   const [walletName, setWalletName] = useState("");
@@ -120,14 +123,6 @@ export function HeliusRingsWorkspace({
     setWalletName("");
     await refresh();
   }, [selectedCustodyWallet, walletName, refresh]);
-
-  const handleTestOperation = useCallback(
-    async (walletId: string) => {
-      await prepareRingsTestOperation({ walletId });
-      await refresh();
-    },
-    [refresh]
-  );
 
   const custodyLabel = useMemo(() => {
     const byId = new Map(custodyWallets.map((wallet) => [wallet.walletId, wallet]));
@@ -188,7 +183,6 @@ export function HeliusRingsWorkspace({
                   <TableHead>{t("DashboardHeliusRings.wallets.backingWallet")}</TableHead>
                   <TableHead>{t("DashboardHeliusRings.wallets.shieldedAddress")}</TableHead>
                   <TableHead>{t("DashboardHeliusRings.activity.state")}</TableHead>
-                  <TableHead />
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -204,16 +198,6 @@ export function HeliusRingsWorkspace({
                       <Badge variant={WALLET_BADGE[wallet.status]}>
                         {t(`DashboardHeliusRings.wallets.status_${wallet.status}`)}
                       </Badge>
-                    </TableCell>
-                    <TableCell>
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        title={t("DashboardHeliusRings.wallets.testOperationHint")}
-                        onClick={() => void handleTestOperation(wallet.id)}
-                      >
-                        {t("DashboardHeliusRings.wallets.testOperation")}
-                      </Button>
                     </TableCell>
                   </TableRow>
                 ))}
@@ -276,6 +260,10 @@ export function HeliusRingsWorkspace({
           )}
         </CardContent>
       </Card>
+
+      <OperationComposer wallets={wallets} zones={zones} onPrepared={refresh} />
+
+      <ZonesCard wallets={wallets} onZonesChanged={setZones} />
 
       <Card>
         <CardHeader>

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
@@ -30,6 +30,7 @@ import {
   type RingsZone,
 } from "./helius-rings.data";
 import { OperationComposer } from "./operation-composer";
+import { OperationDetailDrawer } from "./operation-detail-drawer";
 import { ZonesCard } from "./zones-card";
 
 interface CustodyWalletOption {
@@ -75,6 +76,7 @@ export function HeliusRingsWorkspace({
   const [wallets, setWallets] = useState<RingsWallet[]>([]);
   const [operations, setOperations] = useState<RingsOperationSummary[]>([]);
   const [zones, setZones] = useState<RingsZone[]>([]);
+  const [detailOperationId, setDetailOperationId] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
   const [walletName, setWalletName] = useState("");
@@ -285,7 +287,11 @@ export function HeliusRingsWorkspace({
               </TableHeader>
               <TableBody>
                 {operations.map((operation) => (
-                  <TableRow key={operation.id}>
+                  <TableRow
+                    key={operation.id}
+                    className="cursor-pointer"
+                    onClick={() => setDetailOperationId(operation.id)}
+                  >
                     <TableCell>
                       {t(`DashboardHeliusRings.activity.opType_${operation.opType}`)}
                     </TableCell>
@@ -303,6 +309,11 @@ export function HeliusRingsWorkspace({
           )}
         </CardContent>
       </Card>
+
+      <OperationDetailDrawer
+        operationId={detailOperationId}
+        onClose={() => setDetailOperationId(null)}
+      />
     </div>
   );
 }

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
@@ -16,7 +16,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { useTranslations } from "@/i18n/provider";
+import { useLocale, useTranslations } from "@/i18n/provider";
 import {
   createRingsWallet,
   fetchRingsHealth,
@@ -72,6 +72,7 @@ export function HeliusRingsWorkspace({
   custodyWallets: CustodyWalletOption[];
 }) {
   const t = useTranslations();
+  const locale = useLocale();
 
   const [health, setHealth] = useState<RingsHealth | null>(null);
   const [wallets, setWallets] = useState<RingsWallet[]>([]);
@@ -309,7 +310,12 @@ export function HeliusRingsWorkspace({
                       </Badge>
                     </TableCell>
                     <TableCell>{operation.amountRaw ?? "—"}</TableCell>
-                    <TableCell>{new Date(operation.createdAt).toLocaleString()}</TableCell>
+                    <TableCell>
+                      {new Date(operation.createdAt).toLocaleString(locale, {
+                        dateStyle: "medium",
+                        timeStyle: "short",
+                      })}
+                    </TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
@@ -109,22 +109,31 @@ export async function createRingsWallet(input: {
   return { wallet: body.data.wallet, pendingIntegration: false };
 }
 
-export async function prepareRingsTestOperation(input: {
+export type RingsOpType =
+  | "shield"
+  | "transfer_registered"
+  | "transfer_anonymous"
+  | "withdraw"
+  | "merge"
+  | "timelock_create";
+
+export interface PrepareRingsOperationInput {
   walletId: string;
-}): Promise<{ operation?: RingsOperationDetail; error?: string }> {
+  opType: RingsOpType;
+  asset?: { mint: string; amountRaw: string };
+  to?: string;
+  zoneId?: string;
+  transferMode?: "registered" | "anonymous";
+  timelock?: { unlockAt: string; beneficiary: string };
+}
+
+export async function prepareRingsOperation(
+  input: PrepareRingsOperationInput
+): Promise<{ operation?: RingsOperationDetail; error?: string }> {
   const response = await fetch("/api/dashboard/helius-rings/operations", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      walletId: input.walletId,
-      opType: "shield",
-      asset: {
-        // Wrapped SOL on devnet; seeded in the rings asset allowlist.
-        mint: "So11111111111111111111111111111111111111112",
-        amountRaw: "1000000",
-      },
-      clientNonce: crypto.randomUUID(),
-    }),
+    body: JSON.stringify({ ...input, clientNonce: crypto.randomUUID() }),
     cache: "no-store",
   });
   const body = (await response.json().catch(() => ({}))) as Envelope<{
@@ -135,3 +144,48 @@ export async function prepareRingsTestOperation(input: {
   }
   return { operation: body.data.operation };
 }
+
+export interface RingsZone {
+  id: string;
+  name: string;
+  kind: "treasury" | "public";
+}
+
+export function fetchRingsZones(
+  walletId: string,
+  fallbackError: string
+): Promise<{ zones: RingsZone[] }> {
+  return getJson(
+    `/api/dashboard/helius-rings/wallets/${encodeURIComponent(walletId)}/zones`,
+    fallbackError
+  );
+}
+
+export async function createRingsZone(input: {
+  walletId: string;
+  name: string;
+  kind: RingsZone["kind"];
+}): Promise<{ zone?: RingsZone; error?: string }> {
+  const response = await fetch(
+    `/api/dashboard/helius-rings/wallets/${encodeURIComponent(input.walletId)}/zones`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: input.name, kind: input.kind }),
+      cache: "no-store",
+    }
+  );
+  const body = (await response.json().catch(() => ({}))) as Envelope<{ zone: RingsZone }>;
+  if (!response.ok || !body.data) {
+    return { error: body.error?.message };
+  }
+  return { zone: body.data.zone };
+}
+
+/** Devnet assets seeded in the rings allowlist. */
+export const RINGS_ALLOWLISTED_ASSETS = [
+  // biome-ignore lint/security/noSecrets: wrapped SOL mint address, not a secret.
+  { mint: "So11111111111111111111111111111111111111112", symbol: "SOL", decimals: 9 },
+  // biome-ignore lint/security/noSecrets: devnet USDC mint address, not a secret.
+  { mint: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU", symbol: "USDC", decimals: 6 },
+] as const;

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
@@ -50,8 +50,14 @@ export interface RingsOperationSummary {
   createdAt: string;
 }
 
+export interface RingsOperationEvent {
+  kind: string;
+  createdAt: string;
+}
+
 export interface RingsOperationDetail extends RingsOperationSummary {
   failure: { code: string; message: string; retryable: boolean } | null;
+  events: RingsOperationEvent[];
 }
 
 interface Envelope<T> {
@@ -74,6 +80,16 @@ export function fetchRingsHealth(fallbackError: string): Promise<{ health: Rings
 
 export function fetchRingsWallets(fallbackError: string): Promise<{ wallets: RingsWallet[] }> {
   return getJson("/api/dashboard/helius-rings/wallets", fallbackError);
+}
+
+export function fetchRingsOperationDetail(
+  operationId: string,
+  fallbackError: string
+): Promise<{ operation: RingsOperationDetail }> {
+  return getJson(
+    `/api/dashboard/helius-rings/operations/${encodeURIComponent(operationId)}`,
+    fallbackError
+  );
 }
 
 export function fetchRingsOperations(

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
@@ -29,9 +29,21 @@ export type RingsOperationState =
   | "completed"
   | "failed";
 
+/** Mirrors OP_TYPES in @sdp/helius-rings; a literal union so the typed i18n
+ * keys (`activity.opType_*`) resolve. */
+export type RingsOperationOpType =
+  | "shield"
+  | "transfer_registered"
+  | "transfer_anonymous"
+  | "withdraw"
+  | "merge"
+  | "timelock_create"
+  | "timelock_settle"
+  | "zone_create";
+
 export interface RingsOperationSummary {
   id: string;
-  opType: string;
+  opType: RingsOperationOpType;
   state: RingsOperationState;
   assetMint: string | null;
   amountRaw: string | null;

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
@@ -184,8 +184,6 @@ export async function createRingsZone(input: {
 
 /** Devnet assets seeded in the rings allowlist. */
 export const RINGS_ALLOWLISTED_ASSETS = [
-  // biome-ignore lint/security/noSecrets: wrapped SOL mint address, not a secret.
   { mint: "So11111111111111111111111111111111111111112", symbol: "SOL", decimals: 9 },
-  // biome-ignore lint/security/noSecrets: devnet USDC mint address, not a secret.
   { mint: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU", symbol: "USDC", decimals: 6 },
 ] as const;

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
@@ -65,13 +65,29 @@ interface Envelope<T> {
   error?: { message?: string };
 }
 
-async function getJson<T>(path: string, fallbackError: string): Promise<T> {
-  const response = await fetch(path, { cache: "no-store" });
+type EnvelopeResult<T> = { ok: true; data: T } | { ok: false; status: number; error?: string };
+
+/**
+ * Single reader for every `{ data } | { error }` response on this surface. The
+ * body is parsed even on failure so the server's own `error.message` reaches
+ * the caller rather than a generic string, and `.catch` absorbs a non-JSON
+ * error page.
+ */
+async function readEnvelope<T>(response: Response): Promise<EnvelopeResult<T>> {
   const body = (await response.json().catch(() => ({}))) as Envelope<T>;
   if (!response.ok || !body.data) {
-    throw new Error(body.error?.message ?? fallbackError);
+    return { ok: false, status: response.status, error: body.error?.message };
   }
-  return body.data;
+  return { ok: true, data: body.data };
+}
+
+async function getJson<T>(path: string, fallbackError: string): Promise<T> {
+  const response = await fetch(path, { cache: "no-store" });
+  const result = await readEnvelope<T>(response);
+  if (!result.ok) {
+    throw new Error(result.error ?? fallbackError);
+  }
+  return result.data;
 }
 
 export function fetchRingsHealth(fallbackError: string): Promise<{ health: RingsHealth }> {
@@ -115,14 +131,14 @@ export async function createRingsWallet(input: {
     body: JSON.stringify(input),
     cache: "no-store",
   });
-  const body = (await response.json().catch(() => ({}))) as Envelope<{ wallet: RingsWallet }>;
-  if (response.status === 503) {
-    return { pendingIntegration: true };
+  const result = await readEnvelope<{ wallet: RingsWallet }>(response);
+  if (!result.ok) {
+    if (result.status === 503) {
+      return { pendingIntegration: true };
+    }
+    return { pendingIntegration: false, error: result.error };
   }
-  if (!response.ok || !body.data) {
-    return { pendingIntegration: false, error: body.error?.message };
-  }
-  return { wallet: body.data.wallet, pendingIntegration: false };
+  return { wallet: result.data.wallet, pendingIntegration: false };
 }
 
 export type RingsOpType =
@@ -152,13 +168,11 @@ export async function prepareRingsOperation(
     body: JSON.stringify({ ...input, clientNonce: crypto.randomUUID() }),
     cache: "no-store",
   });
-  const body = (await response.json().catch(() => ({}))) as Envelope<{
-    operation: RingsOperationDetail;
-  }>;
-  if (!response.ok || !body.data) {
-    return { error: body.error?.message };
+  const result = await readEnvelope<{ operation: RingsOperationDetail }>(response);
+  if (!result.ok) {
+    return { error: result.error };
   }
-  return { operation: body.data.operation };
+  return { operation: result.data.operation };
 }
 
 export async function retryRingsOperation(
@@ -173,13 +187,11 @@ export async function retryRingsOperation(
       cache: "no-store",
     }
   );
-  const body = (await response.json().catch(() => ({}))) as Envelope<{
-    operation: RingsOperationDetail;
-  }>;
-  if (!response.ok || !body.data) {
-    return { error: body.error?.message };
+  const result = await readEnvelope<{ operation: RingsOperationDetail }>(response);
+  if (!result.ok) {
+    return { error: result.error };
   }
-  return { operation: body.data.operation };
+  return { operation: result.data.operation };
 }
 
 export interface RingsZone {
@@ -212,11 +224,11 @@ export async function createRingsZone(input: {
       cache: "no-store",
     }
   );
-  const body = (await response.json().catch(() => ({}))) as Envelope<{ zone: RingsZone }>;
-  if (!response.ok || !body.data) {
-    return { error: body.error?.message };
+  const result = await readEnvelope<{ zone: RingsZone }>(response);
+  if (!result.ok) {
+    return { error: result.error };
   }
-  return { zone: body.data.zone };
+  return { zone: result.data.zone };
 }
 
 /** Devnet assets seeded in the rings allowlist. */

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
@@ -175,6 +175,24 @@ export async function prepareRingsOperation(
   return { operation: result.data.operation };
 }
 
+/**
+ * Advances an operation the server has already cleared. The verdict is read
+ * from the stored approval request server-side, so this carries no body.
+ */
+export async function executeRingsOperation(
+  operationId: string
+): Promise<{ operation?: RingsOperationDetail; error?: string }> {
+  const response = await fetch(
+    `/api/dashboard/helius-rings/operations/${encodeURIComponent(operationId)}/execute`,
+    { method: "POST", cache: "no-store" }
+  );
+  const result = await readEnvelope<{ operation: RingsOperationDetail }>(response);
+  if (!result.ok) {
+    return { error: result.error };
+  }
+  return { operation: result.data.operation };
+}
+
 export async function retryRingsOperation(
   operationId: string
 ): Promise<{ operation?: RingsOperationDetail; error?: string }> {

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
@@ -161,6 +161,27 @@ export async function prepareRingsOperation(
   return { operation: body.data.operation };
 }
 
+export async function retryRingsOperation(
+  operationId: string
+): Promise<{ operation?: RingsOperationDetail; error?: string }> {
+  const response = await fetch(
+    `/api/dashboard/helius-rings/operations/${encodeURIComponent(operationId)}/retry`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ clientNonce: crypto.randomUUID() }),
+      cache: "no-store",
+    }
+  );
+  const body = (await response.json().catch(() => ({}))) as Envelope<{
+    operation: RingsOperationDetail;
+  }>;
+  if (!response.ok || !body.data) {
+    return { error: body.error?.message };
+  }
+  return { operation: body.data.operation };
+}
+
 export interface RingsZone {
   id: string;
   name: string;

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
@@ -1,0 +1,125 @@
+/**
+ * Client seam for the Helius Rings workspace. Fetches go through the
+ * /api/dashboard/helius-rings BFF proxies; view-model types mirror the API
+ * DTOs without importing server packages.
+ */
+
+export type RingsHealthStatus = "green" | "amber" | "red";
+export type RingsHealth = Record<"rpc" | "prover" | "photon" | "gateway", RingsHealthStatus>;
+
+export type RingsWalletStatus = "pending" | "ready" | "paused";
+
+export interface RingsWallet {
+  id: string;
+  sdpWalletId: string;
+  name: string;
+  shieldedAddress: string | null;
+  status: RingsWalletStatus;
+  network: "devnet";
+}
+
+export type RingsOperationState =
+  | "draft"
+  | "preparing"
+  | "approval_required"
+  | "proving"
+  | "ready_to_sign"
+  | "submitted"
+  | "indexing"
+  | "completed"
+  | "failed";
+
+export interface RingsOperationSummary {
+  id: string;
+  opType: string;
+  state: RingsOperationState;
+  assetMint: string | null;
+  amountRaw: string | null;
+  createdAt: string;
+}
+
+export interface RingsOperationDetail extends RingsOperationSummary {
+  failure: { code: string; message: string; retryable: boolean } | null;
+}
+
+interface Envelope<T> {
+  data?: T;
+  error?: { message?: string };
+}
+
+async function getJson<T>(path: string, fallbackError: string): Promise<T> {
+  const response = await fetch(path, { cache: "no-store" });
+  const body = (await response.json().catch(() => ({}))) as Envelope<T>;
+  if (!response.ok || !body.data) {
+    throw new Error(body.error?.message ?? fallbackError);
+  }
+  return body.data;
+}
+
+export function fetchRingsHealth(fallbackError: string): Promise<{ health: RingsHealth }> {
+  return getJson("/api/dashboard/helius-rings/health", fallbackError);
+}
+
+export function fetchRingsWallets(fallbackError: string): Promise<{ wallets: RingsWallet[] }> {
+  return getJson("/api/dashboard/helius-rings/wallets", fallbackError);
+}
+
+export function fetchRingsOperations(
+  fallbackError: string
+): Promise<{ operations: RingsOperationSummary[] }> {
+  return getJson("/api/dashboard/helius-rings/operations", fallbackError);
+}
+
+export interface CreateRingsWalletResult {
+  wallet?: RingsWallet;
+  /** Set when the gateway seam refused (503): the wallet stays pending. */
+  pendingIntegration: boolean;
+  error?: string;
+}
+
+export async function createRingsWallet(input: {
+  walletId: string;
+  name: string;
+}): Promise<CreateRingsWalletResult> {
+  const response = await fetch("/api/dashboard/helius-rings/wallets", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+    cache: "no-store",
+  });
+  const body = (await response.json().catch(() => ({}))) as Envelope<{ wallet: RingsWallet }>;
+  if (response.status === 503) {
+    return { pendingIntegration: true };
+  }
+  if (!response.ok || !body.data) {
+    return { pendingIntegration: false, error: body.error?.message };
+  }
+  return { wallet: body.data.wallet, pendingIntegration: false };
+}
+
+export async function prepareRingsTestOperation(input: {
+  walletId: string;
+}): Promise<{ operation?: RingsOperationDetail; error?: string }> {
+  const response = await fetch("/api/dashboard/helius-rings/operations", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      walletId: input.walletId,
+      opType: "shield",
+      asset: {
+        // Wrapped SOL on devnet; seeded in the rings asset allowlist.
+        mint: "So11111111111111111111111111111111111111112",
+        amountRaw: "1000000",
+      },
+      clientNonce: crypto.randomUUID(),
+    }),
+    cache: "no-store",
+  });
+  const body = (await response.json().catch(() => ({}))) as Envelope<{
+    operation: RingsOperationDetail;
+  }>;
+  if (!response.ok || !body.data) {
+    return { error: body.error?.message };
+  }
+  return { operation: body.data.operation };
+}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.utils.ts
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Presentation helpers for the Helius Rings workspace.
+ *
+ * Timestamps are formatted with the locale the i18n provider resolved rather
+ * than the runtime's default, so a server render and its hydration agree.
+ * Mirrors `formatWhen` in the private-channels events list.
+ */
+
+export function formatWhen(iso: string, locale: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(locale, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+export function formatTimeOfDay(iso: string, locale: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleTimeString(locale, { timeStyle: "medium" });
+}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/operation-composer.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/operation-composer.tsx
@@ -17,6 +17,8 @@ import {
   type RingsZone,
 } from "./helius-rings.data";
 
+type Translate = ReturnType<typeof useTranslations>;
+
 const OP_TYPES: RingsOpType[] = [
   "shield",
   "transfer_registered",
@@ -40,6 +42,87 @@ const NEEDS_RECIPIENT: ReadonlySet<RingsOpType> = new Set([
 
 type Step = "compose" | "review" | "result";
 
+/** Everything the compose form has collected. */
+interface ComposerDraft {
+  walletId: string | null;
+  opType: RingsOpType;
+  assetMint: string;
+  amountRaw: string;
+  recipient: string;
+  zoneId: string | null;
+  unlockAt: string;
+  beneficiary: string;
+}
+
+const EMPTY_DRAFT: ComposerDraft = {
+  walletId: null,
+  opType: "shield",
+  assetMint: RINGS_ALLOWLISTED_ASSETS[0].mint,
+  amountRaw: "",
+  recipient: "",
+  zoneId: null,
+  unlockAt: "",
+  beneficiary: "",
+};
+
+function transferModeFor(opType: RingsOpType): "registered" | "anonymous" | undefined {
+  if (opType === "transfer_registered") return "registered";
+  if (opType === "transfer_anonymous") return "anonymous";
+  return undefined;
+}
+
+function isDraftComplete(draft: ComposerDraft): boolean {
+  if (draft.walletId === null) return false;
+  if (NEEDS_ASSET.has(draft.opType) && !/^\d+$/.test(draft.amountRaw)) return false;
+  if (NEEDS_RECIPIENT.has(draft.opType) && draft.recipient.trim().length === 0) return false;
+  if (
+    draft.opType === "timelock_create" &&
+    (draft.unlockAt.length === 0 || draft.beneficiary.trim().length === 0)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function buildSummaryRows(
+  t: Translate,
+  draft: ComposerDraft,
+  wallets: RingsWallet[],
+  zones: RingsZone[]
+): Array<[string, string]> {
+  const asset = RINGS_ALLOWLISTED_ASSETS.find((entry) => entry.mint === draft.assetMint);
+  const rows: Array<[string, string]> = [
+    [
+      t("DashboardHeliusRings.composer.summaryWallet"),
+      wallets.find((wallet) => wallet.id === draft.walletId)?.name ?? "—",
+    ],
+    [
+      t("DashboardHeliusRings.composer.summaryOperation"),
+      t(`DashboardHeliusRings.activity.opType_${draft.opType}`),
+    ],
+  ];
+  if (NEEDS_ASSET.has(draft.opType)) {
+    rows.push([
+      t("DashboardHeliusRings.composer.summaryAmount"),
+      `${draft.amountRaw} (${asset?.symbol ?? "?"} ${t("DashboardHeliusRings.composer.baseUnits")})`,
+    ]);
+  }
+  if (NEEDS_RECIPIENT.has(draft.opType)) {
+    rows.push([t("DashboardHeliusRings.composer.summaryRecipient"), draft.recipient]);
+  }
+  if (draft.opType === "merge" && draft.zoneId) {
+    rows.push([
+      t("DashboardHeliusRings.composer.summaryZone"),
+      zones.find((zone) => zone.id === draft.zoneId)?.name ?? draft.zoneId,
+    ]);
+  }
+  if (draft.opType === "timelock_create") {
+    rows.push([t("DashboardHeliusRings.composer.summaryUnlockAt"), draft.unlockAt]);
+    rows.push([t("DashboardHeliusRings.composer.summaryBeneficiary"), draft.beneficiary]);
+  }
+  return rows;
+}
+
 /**
  * One composer for every shielded operation kind. A `review` step sits between
  * the form and the POST; anonymous transfers additionally require an explicit
@@ -57,66 +140,46 @@ export function OperationComposer({
   const t = useTranslations();
 
   const [step, setStep] = useState<Step>("compose");
-  const [walletId, setWalletId] = useState<string | null>(null);
-  const [opType, setOpType] = useState<RingsOpType>("shield");
-  const [assetMint, setAssetMint] = useState<string>(RINGS_ALLOWLISTED_ASSETS[0].mint);
-  const [amountRaw, setAmountRaw] = useState("");
-  const [recipient, setRecipient] = useState("");
-  const [zoneId, setZoneId] = useState<string | null>(null);
-  const [unlockAt, setUnlockAt] = useState("");
-  const [beneficiary, setBeneficiary] = useState("");
+  const [draft, setDraft] = useState<ComposerDraft>(EMPTY_DRAFT);
   const [anonymousAcknowledged, setAnonymousAcknowledged] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState<RingsOperationDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const needsAsset = NEEDS_ASSET.has(opType);
-  const needsRecipient = NEEDS_RECIPIENT.has(opType);
-  const isTimelock = opType === "timelock_create";
-  const isAnonymous = opType === "transfer_anonymous";
-  const isMerge = opType === "merge";
-
-  const asset = useMemo(
-    () => RINGS_ALLOWLISTED_ASSETS.find((entry) => entry.mint === assetMint),
-    [assetMint]
-  );
-
-  const composeComplete =
-    walletId !== null &&
-    (!needsAsset || /^\d+$/.test(amountRaw)) &&
-    (!needsRecipient || recipient.trim().length > 0) &&
-    (!isTimelock || (unlockAt.length > 0 && beneficiary.trim().length > 0));
+  const patchDraft = useCallback((patch: Partial<ComposerDraft>) => {
+    setDraft((current) => ({ ...current, ...patch }));
+  }, []);
 
   const reset = useCallback(() => {
     setStep("compose");
-    setAmountRaw("");
-    setRecipient("");
-    setUnlockAt("");
-    setBeneficiary("");
-    setZoneId(null);
+    setDraft((current) => ({ ...EMPTY_DRAFT, walletId: current.walletId }));
     setAnonymousAcknowledged(false);
     setResult(null);
     setError(null);
   }, []);
 
   const handleConfirm = useCallback(async () => {
-    if (!walletId) return;
+    if (!draft.walletId) return;
     setSubmitting(true);
     setError(null);
+    const asset = RINGS_ALLOWLISTED_ASSETS.find((entry) => entry.mint === draft.assetMint);
     const prepared = await prepareRingsOperation({
-      walletId,
-      opType,
-      asset: needsAsset && asset ? { mint: asset.mint, amountRaw } : undefined,
-      to: needsRecipient ? recipient.trim() : undefined,
-      zoneId: isMerge && zoneId ? zoneId : undefined,
-      transferMode: isAnonymous
-        ? "anonymous"
-        : opType === "transfer_registered"
-          ? "registered"
+      walletId: draft.walletId,
+      opType: draft.opType,
+      asset:
+        NEEDS_ASSET.has(draft.opType) && asset
+          ? { mint: asset.mint, amountRaw: draft.amountRaw }
           : undefined,
-      timelock: isTimelock
-        ? { unlockAt: new Date(unlockAt).toISOString(), beneficiary: beneficiary.trim() }
-        : undefined,
+      to: NEEDS_RECIPIENT.has(draft.opType) ? draft.recipient.trim() : undefined,
+      zoneId: draft.opType === "merge" && draft.zoneId ? draft.zoneId : undefined,
+      transferMode: transferModeFor(draft.opType),
+      timelock:
+        draft.opType === "timelock_create"
+          ? {
+              unlockAt: new Date(draft.unlockAt).toISOString(),
+              beneficiary: draft.beneficiary.trim(),
+            }
+          : undefined,
     });
     setSubmitting(false);
     if (prepared.error || !prepared.operation) {
@@ -126,61 +189,12 @@ export function OperationComposer({
     setResult(prepared.operation);
     setStep("result");
     await onPrepared();
-  }, [
-    walletId,
-    opType,
-    needsAsset,
-    asset,
-    amountRaw,
-    needsRecipient,
-    recipient,
-    isMerge,
-    zoneId,
-    isAnonymous,
-    isTimelock,
-    unlockAt,
-    beneficiary,
-    onPrepared,
-    t,
-  ]);
+  }, [draft, onPrepared, t]);
 
-  const summaryRows: Array<[string, string]> = [
-    [
-      t("DashboardHeliusRings.composer.summaryWallet"),
-      wallets.find((wallet) => wallet.id === walletId)?.name ?? "—",
-    ],
-    [
-      t("DashboardHeliusRings.composer.summaryOperation"),
-      t(`DashboardHeliusRings.activity.opType_${opType}`),
-    ],
-    ...(needsAsset
-      ? ([
-          [
-            t("DashboardHeliusRings.composer.summaryAmount"),
-            `${amountRaw} (${asset?.symbol ?? "?"} ${t("DashboardHeliusRings.composer.baseUnits")})`,
-          ],
-        ] as Array<[string, string]>)
-      : []),
-    ...(needsRecipient
-      ? ([[t("DashboardHeliusRings.composer.summaryRecipient"), recipient]] as Array<
-          [string, string]
-        >)
-      : []),
-    ...(isMerge && zoneId
-      ? ([
-          [
-            t("DashboardHeliusRings.composer.summaryZone"),
-            zones.find((zone) => zone.id === zoneId)?.name ?? zoneId,
-          ],
-        ] as Array<[string, string]>)
-      : []),
-    ...(isTimelock
-      ? ([
-          [t("DashboardHeliusRings.composer.summaryUnlockAt"), unlockAt],
-          [t("DashboardHeliusRings.composer.summaryBeneficiary"), beneficiary],
-        ] as Array<[string, string]>)
-      : []),
-  ];
+  const summaryRows = useMemo(
+    () => buildSummaryRows(t, draft, wallets, zones),
+    [t, draft, wallets, zones]
+  );
 
   return (
     <Card>
@@ -190,212 +204,263 @@ export function OperationComposer({
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         {step === "compose" ? (
-          <>
-            <div className="flex flex-wrap gap-3">
-              <div className="flex min-w-52 flex-col gap-1.5">
-                <span className="text-sm font-medium text-primary">
-                  {t("DashboardHeliusRings.composer.wallet")}
-                </span>
-                <Select
-                  ariaLabel={t("DashboardHeliusRings.composer.wallet")}
-                  value={walletId}
-                  onValueChange={setWalletId}
-                  placeholder={t("DashboardHeliusRings.composer.walletPlaceholder")}
-                >
-                  {wallets.map((wallet) => (
-                    <SelectItem key={wallet.id} value={wallet.id}>
-                      {wallet.name}
-                    </SelectItem>
-                  ))}
-                </Select>
-              </div>
-              <div className="flex min-w-52 flex-col gap-1.5">
-                <span className="text-sm font-medium text-primary">
-                  {t("DashboardHeliusRings.composer.operation")}
-                </span>
-                <Select
-                  ariaLabel={t("DashboardHeliusRings.composer.operation")}
-                  value={opType}
-                  onValueChange={(value) => {
-                    if (value) setOpType(value as RingsOpType);
-                  }}
-                >
-                  {OP_TYPES.map((type) => (
-                    <SelectItem key={type} value={type}>
-                      {t(`DashboardHeliusRings.activity.opType_${type}`)}
-                    </SelectItem>
-                  ))}
-                </Select>
-              </div>
-            </div>
-
-            {needsAsset ? (
-              <div className="flex flex-wrap gap-3">
-                <div className="flex min-w-40 flex-col gap-1.5">
-                  <span className="text-sm font-medium text-primary">
-                    {t("DashboardHeliusRings.composer.asset")}
-                  </span>
-                  <Select
-                    ariaLabel={t("DashboardHeliusRings.composer.asset")}
-                    value={assetMint}
-                    onValueChange={(value) => {
-                      if (value) setAssetMint(value);
-                    }}
-                  >
-                    {RINGS_ALLOWLISTED_ASSETS.map((entry) => (
-                      <SelectItem key={entry.mint} value={entry.mint}>
-                        {entry.symbol}
-                      </SelectItem>
-                    ))}
-                  </Select>
-                </div>
-                <div className="flex min-w-48 flex-col gap-1.5">
-                  <span className="text-sm font-medium text-primary">
-                    {t("DashboardHeliusRings.composer.amount")}
-                  </span>
-                  <Input
-                    inputMode="numeric"
-                    value={amountRaw}
-                    placeholder="1000000"
-                    onChange={(event) => setAmountRaw(event.target.value.replace(/\D/g, ""))}
-                  />
-                </div>
-              </div>
-            ) : null}
-
-            {needsRecipient ? (
-              <div className="flex flex-col gap-1.5">
-                <span className="text-sm font-medium text-primary">
-                  {isAnonymous
-                    ? t("DashboardHeliusRings.composer.recipientAnonymous")
-                    : t("DashboardHeliusRings.composer.recipient")}
-                </span>
-                <Input
-                  value={recipient}
-                  placeholder={t("DashboardHeliusRings.composer.recipientPlaceholder")}
-                  onChange={(event) => setRecipient(event.target.value)}
-                />
-              </div>
-            ) : null}
-
-            {isMerge && zones.length > 0 ? (
-              <div className="flex min-w-52 flex-col gap-1.5">
-                <span className="text-sm font-medium text-primary">
-                  {t("DashboardHeliusRings.composer.zone")}
-                </span>
-                <Select
-                  ariaLabel={t("DashboardHeliusRings.composer.zone")}
-                  value={zoneId}
-                  onValueChange={setZoneId}
-                  placeholder={t("DashboardHeliusRings.composer.zonePlaceholder")}
-                >
-                  {zones.map((zone) => (
-                    <SelectItem key={zone.id} value={zone.id}>
-                      {zone.name}
-                    </SelectItem>
-                  ))}
-                </Select>
-              </div>
-            ) : null}
-
-            {isTimelock ? (
-              <div className="flex flex-wrap gap-3">
-                <div className="flex min-w-52 flex-col gap-1.5">
-                  <span className="text-sm font-medium text-primary">
-                    {t("DashboardHeliusRings.composer.unlockAt")}
-                  </span>
-                  <Input
-                    type="datetime-local"
-                    value={unlockAt}
-                    onChange={(event) => setUnlockAt(event.target.value)}
-                  />
-                </div>
-                <div className="flex min-w-52 flex-col gap-1.5">
-                  <span className="text-sm font-medium text-primary">
-                    {t("DashboardHeliusRings.composer.beneficiary")}
-                  </span>
-                  <Input
-                    value={beneficiary}
-                    placeholder={t("DashboardHeliusRings.composer.recipientPlaceholder")}
-                    onChange={(event) => setBeneficiary(event.target.value)}
-                  />
-                </div>
-              </div>
-            ) : null}
-
-            <div>
-              <Button disabled={!composeComplete} onClick={() => setStep("review")}>
-                {t("DashboardHeliusRings.composer.review")}
-              </Button>
-            </div>
-          </>
+          <ComposeStep
+            draft={draft}
+            wallets={wallets}
+            zones={zones}
+            onPatch={patchDraft}
+            onReview={() => setStep("review")}
+          />
         ) : null}
-
         {step === "review" ? (
-          <>
-            <dl className="flex flex-col gap-2">
-              {summaryRows.map(([label, value]) => (
-                <div key={label} className="flex items-baseline justify-between gap-4">
-                  <dt className="text-sm text-secondary">{label}</dt>
-                  <dd className="text-sm text-primary">{value}</dd>
-                </div>
-              ))}
-            </dl>
-
-            {isAnonymous ? (
-              <Callout variant="warning">
-                <label className="flex items-start gap-2">
-                  <input
-                    type="checkbox"
-                    className="mt-0.5"
-                    checked={anonymousAcknowledged}
-                    onChange={(event) => setAnonymousAcknowledged(event.target.checked)}
-                  />
-                  <span>{t("DashboardHeliusRings.composer.anonymousWarning")}</span>
-                </label>
-              </Callout>
-            ) : null}
-
-            {error ? <Callout variant="danger">{error}</Callout> : null}
-
-            <div className="flex gap-2">
-              <Button variant="secondary" onClick={() => setStep("compose")}>
-                {t("DashboardHeliusRings.composer.back")}
-              </Button>
-              <Button
-                disabled={submitting || (isAnonymous && !anonymousAcknowledged)}
-                onClick={() => void handleConfirm()}
-              >
-                {submitting
-                  ? t("DashboardHeliusRings.composer.preparing")
-                  : t("DashboardHeliusRings.composer.confirm")}
-              </Button>
-            </div>
-          </>
+          <ReviewStep
+            rows={summaryRows}
+            isAnonymous={draft.opType === "transfer_anonymous"}
+            acknowledged={anonymousAcknowledged}
+            onAcknowledge={setAnonymousAcknowledged}
+            error={error}
+            submitting={submitting}
+            onBack={() => setStep("compose")}
+            onConfirm={() => void handleConfirm()}
+          />
         ) : null}
-
-        {step === "result" && result ? (
-          <>
-            <div className="flex items-center gap-2">
-              <Badge variant={result.state === "failed" ? "danger" : "default"}>
-                {t(`DashboardHeliusRings.activity.state_${result.state}`)}
-              </Badge>
-              {result.failure ? (
-                <span className="text-sm text-secondary">
-                  {result.failure.code === "gateway_unavailable"
-                    ? t("DashboardHeliusRings.errors.gatewayUnavailable")
-                    : result.failure.message}
-                </span>
-              ) : null}
-            </div>
-            <div>
-              <Button variant="secondary" onClick={reset}>
-                {t("DashboardHeliusRings.composer.newOperation")}
-              </Button>
-            </div>
-          </>
-        ) : null}
+        {step === "result" && result ? <ResultStep result={result} onReset={reset} /> : null}
       </CardContent>
     </Card>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex min-w-48 flex-col gap-1.5">
+      <span className="text-sm font-medium text-primary">{label}</span>
+      {children}
+    </div>
+  );
+}
+
+function ComposeStep({
+  draft,
+  wallets,
+  zones,
+  onPatch,
+  onReview,
+}: {
+  draft: ComposerDraft;
+  wallets: RingsWallet[];
+  zones: RingsZone[];
+  onPatch: (patch: Partial<ComposerDraft>) => void;
+  onReview: () => void;
+}) {
+  const t = useTranslations();
+  const needsAsset = NEEDS_ASSET.has(draft.opType);
+  const needsRecipient = NEEDS_RECIPIENT.has(draft.opType);
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-3">
+        <Field label={t("DashboardHeliusRings.composer.wallet")}>
+          <Select
+            ariaLabel={t("DashboardHeliusRings.composer.wallet")}
+            value={draft.walletId}
+            onValueChange={(walletId) => onPatch({ walletId })}
+            placeholder={t("DashboardHeliusRings.composer.walletPlaceholder")}
+          >
+            {wallets.map((wallet) => (
+              <SelectItem key={wallet.id} value={wallet.id}>
+                {wallet.name}
+              </SelectItem>
+            ))}
+          </Select>
+        </Field>
+        <Field label={t("DashboardHeliusRings.composer.operation")}>
+          <Select
+            ariaLabel={t("DashboardHeliusRings.composer.operation")}
+            value={draft.opType}
+            onValueChange={(value) => {
+              if (value) onPatch({ opType: value as RingsOpType });
+            }}
+          >
+            {OP_TYPES.map((type) => (
+              <SelectItem key={type} value={type}>
+                {t(`DashboardHeliusRings.activity.opType_${type}`)}
+              </SelectItem>
+            ))}
+          </Select>
+        </Field>
+      </div>
+
+      {needsAsset ? (
+        <div className="flex flex-wrap gap-3">
+          <Field label={t("DashboardHeliusRings.composer.asset")}>
+            <Select
+              ariaLabel={t("DashboardHeliusRings.composer.asset")}
+              value={draft.assetMint}
+              onValueChange={(value) => {
+                if (value) onPatch({ assetMint: value });
+              }}
+            >
+              {RINGS_ALLOWLISTED_ASSETS.map((entry) => (
+                <SelectItem key={entry.mint} value={entry.mint}>
+                  {entry.symbol}
+                </SelectItem>
+              ))}
+            </Select>
+          </Field>
+          <Field label={t("DashboardHeliusRings.composer.amount")}>
+            <Input
+              inputMode="numeric"
+              value={draft.amountRaw}
+              placeholder="1000000"
+              onChange={(event) => onPatch({ amountRaw: event.target.value.replace(/\D/g, "") })}
+            />
+          </Field>
+        </div>
+      ) : null}
+
+      {needsRecipient ? (
+        <Field
+          label={
+            draft.opType === "transfer_anonymous"
+              ? t("DashboardHeliusRings.composer.recipientAnonymous")
+              : t("DashboardHeliusRings.composer.recipient")
+          }
+        >
+          <Input
+            value={draft.recipient}
+            placeholder={t("DashboardHeliusRings.composer.recipientPlaceholder")}
+            onChange={(event) => onPatch({ recipient: event.target.value })}
+          />
+        </Field>
+      ) : null}
+
+      {draft.opType === "merge" && zones.length > 0 ? (
+        <Field label={t("DashboardHeliusRings.composer.zone")}>
+          <Select
+            ariaLabel={t("DashboardHeliusRings.composer.zone")}
+            value={draft.zoneId}
+            onValueChange={(zoneId) => onPatch({ zoneId })}
+            placeholder={t("DashboardHeliusRings.composer.zonePlaceholder")}
+          >
+            {zones.map((zone) => (
+              <SelectItem key={zone.id} value={zone.id}>
+                {zone.name}
+              </SelectItem>
+            ))}
+          </Select>
+        </Field>
+      ) : null}
+
+      {draft.opType === "timelock_create" ? (
+        <div className="flex flex-wrap gap-3">
+          <Field label={t("DashboardHeliusRings.composer.unlockAt")}>
+            <Input
+              type="datetime-local"
+              value={draft.unlockAt}
+              onChange={(event) => onPatch({ unlockAt: event.target.value })}
+            />
+          </Field>
+          <Field label={t("DashboardHeliusRings.composer.beneficiary")}>
+            <Input
+              value={draft.beneficiary}
+              placeholder={t("DashboardHeliusRings.composer.recipientPlaceholder")}
+              onChange={(event) => onPatch({ beneficiary: event.target.value })}
+            />
+          </Field>
+        </div>
+      ) : null}
+
+      <div>
+        <Button disabled={!isDraftComplete(draft)} onClick={onReview}>
+          {t("DashboardHeliusRings.composer.review")}
+        </Button>
+      </div>
+    </>
+  );
+}
+
+function ReviewStep({
+  rows,
+  isAnonymous,
+  acknowledged,
+  onAcknowledge,
+  error,
+  submitting,
+  onBack,
+  onConfirm,
+}: {
+  rows: Array<[string, string]>;
+  isAnonymous: boolean;
+  acknowledged: boolean;
+  onAcknowledge: (acknowledged: boolean) => void;
+  error: string | null;
+  submitting: boolean;
+  onBack: () => void;
+  onConfirm: () => void;
+}) {
+  const t = useTranslations();
+  return (
+    <>
+      <dl className="flex flex-col gap-2">
+        {rows.map(([label, value]) => (
+          <div key={label} className="flex items-baseline justify-between gap-4">
+            <dt className="text-sm text-secondary">{label}</dt>
+            <dd className="text-sm text-primary">{value}</dd>
+          </div>
+        ))}
+      </dl>
+
+      {isAnonymous ? (
+        <Callout variant="warning">
+          <label className="flex items-start gap-2">
+            <input
+              type="checkbox"
+              className="mt-0.5"
+              checked={acknowledged}
+              onChange={(event) => onAcknowledge(event.target.checked)}
+            />
+            <span>{t("DashboardHeliusRings.composer.anonymousWarning")}</span>
+          </label>
+        </Callout>
+      ) : null}
+
+      {error ? <Callout variant="danger">{error}</Callout> : null}
+
+      <div className="flex gap-2">
+        <Button variant="secondary" onClick={onBack}>
+          {t("DashboardHeliusRings.composer.back")}
+        </Button>
+        <Button disabled={submitting || (isAnonymous && !acknowledged)} onClick={onConfirm}>
+          {submitting
+            ? t("DashboardHeliusRings.composer.preparing")
+            : t("DashboardHeliusRings.composer.confirm")}
+        </Button>
+      </div>
+    </>
+  );
+}
+
+function ResultStep({ result, onReset }: { result: RingsOperationDetail; onReset: () => void }) {
+  const t = useTranslations();
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        <Badge variant={result.state === "failed" ? "danger" : "default"}>
+          {t(`DashboardHeliusRings.activity.state_${result.state}`)}
+        </Badge>
+        {result.failure ? (
+          <span className="text-sm text-secondary">
+            {result.failure.code === "gateway_unavailable"
+              ? t("DashboardHeliusRings.errors.gatewayUnavailable")
+              : result.failure.message}
+          </span>
+        ) : null}
+      </div>
+      <div>
+        <Button variant="secondary" onClick={onReset}>
+          {t("DashboardHeliusRings.composer.newOperation")}
+        </Button>
+      </div>
+    </>
   );
 }

--- a/apps/sdp-web/src/app/dashboard/helius-rings/operation-composer.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/operation-composer.tsx
@@ -165,25 +165,29 @@ export function OperationComposer({
     setSubmitting(true);
     setError(null);
     const asset = RINGS_ALLOWLISTED_ASSETS.find((entry) => entry.mint === draft.assetMint);
-    const prepared = await prepareRingsOperation({
-      walletId: draft.walletId,
-      opType: draft.opType,
-      asset:
-        NEEDS_ASSET.has(draft.opType) && asset
-          ? { mint: asset.mint, amountRaw: draft.amountRaw }
-          : undefined,
-      to: NEEDS_RECIPIENT.has(draft.opType) ? draft.recipient.trim() : undefined,
-      zoneId: draft.opType === "merge" && draft.zoneId ? draft.zoneId : undefined,
-      transferMode: transferModeFor(draft.opType),
-      timelock:
-        draft.opType === "timelock_create"
-          ? {
-              unlockAt: new Date(draft.unlockAt).toISOString(),
-              beneficiary: draft.beneficiary.trim(),
-            }
-          : undefined,
-    });
-    setSubmitting(false);
+    let prepared: Awaited<ReturnType<typeof prepareRingsOperation>>;
+    try {
+      prepared = await prepareRingsOperation({
+        walletId: draft.walletId,
+        opType: draft.opType,
+        asset:
+          NEEDS_ASSET.has(draft.opType) && asset
+            ? { mint: asset.mint, amountRaw: draft.amountRaw }
+            : undefined,
+        to: NEEDS_RECIPIENT.has(draft.opType) ? draft.recipient.trim() : undefined,
+        zoneId: draft.opType === "merge" && draft.zoneId ? draft.zoneId : undefined,
+        transferMode: transferModeFor(draft.opType),
+        timelock:
+          draft.opType === "timelock_create"
+            ? {
+                unlockAt: new Date(draft.unlockAt).toISOString(),
+                beneficiary: draft.beneficiary.trim(),
+              }
+            : undefined,
+      });
+    } finally {
+      setSubmitting(false);
+    }
     if (prepared.error || !prepared.operation) {
       setError(prepared.error ?? t("DashboardHeliusRings.composer.prepareFailed"));
       return;

--- a/apps/sdp-web/src/app/dashboard/helius-rings/operation-composer.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/operation-composer.tsx
@@ -1,0 +1,401 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Callout } from "@/components/ui/callout";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Select, SelectItem } from "@/components/ui/select";
+import { useTranslations } from "@/i18n/provider";
+import {
+  prepareRingsOperation,
+  RINGS_ALLOWLISTED_ASSETS,
+  type RingsOperationDetail,
+  type RingsOpType,
+  type RingsWallet,
+  type RingsZone,
+} from "./helius-rings.data";
+
+const OP_TYPES: RingsOpType[] = [
+  "shield",
+  "transfer_registered",
+  "transfer_anonymous",
+  "withdraw",
+  "merge",
+  "timelock_create",
+];
+
+const NEEDS_ASSET: ReadonlySet<RingsOpType> = new Set([
+  "shield",
+  "transfer_registered",
+  "transfer_anonymous",
+  "withdraw",
+]);
+const NEEDS_RECIPIENT: ReadonlySet<RingsOpType> = new Set([
+  "transfer_registered",
+  "transfer_anonymous",
+  "withdraw",
+]);
+
+type Step = "compose" | "review" | "result";
+
+/**
+ * One composer for every shielded operation kind. A `review` step sits between
+ * the form and the POST; anonymous transfers additionally require an explicit
+ * acknowledgement on that step before Confirm unlocks.
+ */
+export function OperationComposer({
+  wallets,
+  zones,
+  onPrepared,
+}: {
+  wallets: RingsWallet[];
+  zones: RingsZone[];
+  onPrepared: () => Promise<void>;
+}) {
+  const t = useTranslations();
+
+  const [step, setStep] = useState<Step>("compose");
+  const [walletId, setWalletId] = useState<string | null>(null);
+  const [opType, setOpType] = useState<RingsOpType>("shield");
+  const [assetMint, setAssetMint] = useState<string>(RINGS_ALLOWLISTED_ASSETS[0].mint);
+  const [amountRaw, setAmountRaw] = useState("");
+  const [recipient, setRecipient] = useState("");
+  const [zoneId, setZoneId] = useState<string | null>(null);
+  const [unlockAt, setUnlockAt] = useState("");
+  const [beneficiary, setBeneficiary] = useState("");
+  const [anonymousAcknowledged, setAnonymousAcknowledged] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<RingsOperationDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const needsAsset = NEEDS_ASSET.has(opType);
+  const needsRecipient = NEEDS_RECIPIENT.has(opType);
+  const isTimelock = opType === "timelock_create";
+  const isAnonymous = opType === "transfer_anonymous";
+  const isMerge = opType === "merge";
+
+  const asset = useMemo(
+    () => RINGS_ALLOWLISTED_ASSETS.find((entry) => entry.mint === assetMint),
+    [assetMint]
+  );
+
+  const composeComplete =
+    walletId !== null &&
+    (!needsAsset || /^\d+$/.test(amountRaw)) &&
+    (!needsRecipient || recipient.trim().length > 0) &&
+    (!isTimelock || (unlockAt.length > 0 && beneficiary.trim().length > 0));
+
+  const reset = useCallback(() => {
+    setStep("compose");
+    setAmountRaw("");
+    setRecipient("");
+    setUnlockAt("");
+    setBeneficiary("");
+    setZoneId(null);
+    setAnonymousAcknowledged(false);
+    setResult(null);
+    setError(null);
+  }, []);
+
+  const handleConfirm = useCallback(async () => {
+    if (!walletId) return;
+    setSubmitting(true);
+    setError(null);
+    const prepared = await prepareRingsOperation({
+      walletId,
+      opType,
+      asset: needsAsset && asset ? { mint: asset.mint, amountRaw } : undefined,
+      to: needsRecipient ? recipient.trim() : undefined,
+      zoneId: isMerge && zoneId ? zoneId : undefined,
+      transferMode: isAnonymous
+        ? "anonymous"
+        : opType === "transfer_registered"
+          ? "registered"
+          : undefined,
+      timelock: isTimelock
+        ? { unlockAt: new Date(unlockAt).toISOString(), beneficiary: beneficiary.trim() }
+        : undefined,
+    });
+    setSubmitting(false);
+    if (prepared.error || !prepared.operation) {
+      setError(prepared.error ?? t("DashboardHeliusRings.composer.prepareFailed"));
+      return;
+    }
+    setResult(prepared.operation);
+    setStep("result");
+    await onPrepared();
+  }, [
+    walletId,
+    opType,
+    needsAsset,
+    asset,
+    amountRaw,
+    needsRecipient,
+    recipient,
+    isMerge,
+    zoneId,
+    isAnonymous,
+    isTimelock,
+    unlockAt,
+    beneficiary,
+    onPrepared,
+    t,
+  ]);
+
+  const summaryRows: Array<[string, string]> = [
+    [
+      t("DashboardHeliusRings.composer.summaryWallet"),
+      wallets.find((wallet) => wallet.id === walletId)?.name ?? "—",
+    ],
+    [
+      t("DashboardHeliusRings.composer.summaryOperation"),
+      t(`DashboardHeliusRings.activity.opType_${opType}`),
+    ],
+    ...(needsAsset
+      ? ([
+          [
+            t("DashboardHeliusRings.composer.summaryAmount"),
+            `${amountRaw} (${asset?.symbol ?? "?"} ${t("DashboardHeliusRings.composer.baseUnits")})`,
+          ],
+        ] as Array<[string, string]>)
+      : []),
+    ...(needsRecipient
+      ? ([[t("DashboardHeliusRings.composer.summaryRecipient"), recipient]] as Array<
+          [string, string]
+        >)
+      : []),
+    ...(isMerge && zoneId
+      ? ([
+          [
+            t("DashboardHeliusRings.composer.summaryZone"),
+            zones.find((zone) => zone.id === zoneId)?.name ?? zoneId,
+          ],
+        ] as Array<[string, string]>)
+      : []),
+    ...(isTimelock
+      ? ([
+          [t("DashboardHeliusRings.composer.summaryUnlockAt"), unlockAt],
+          [t("DashboardHeliusRings.composer.summaryBeneficiary"), beneficiary],
+        ] as Array<[string, string]>)
+      : []),
+  ];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("DashboardHeliusRings.composer.title")}</CardTitle>
+        <CardDescription>{t("DashboardHeliusRings.composer.description")}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {step === "compose" ? (
+          <>
+            <div className="flex flex-wrap gap-3">
+              <div className="flex min-w-52 flex-col gap-1.5">
+                <span className="text-sm font-medium text-primary">
+                  {t("DashboardHeliusRings.composer.wallet")}
+                </span>
+                <Select
+                  ariaLabel={t("DashboardHeliusRings.composer.wallet")}
+                  value={walletId}
+                  onValueChange={setWalletId}
+                  placeholder={t("DashboardHeliusRings.composer.walletPlaceholder")}
+                >
+                  {wallets.map((wallet) => (
+                    <SelectItem key={wallet.id} value={wallet.id}>
+                      {wallet.name}
+                    </SelectItem>
+                  ))}
+                </Select>
+              </div>
+              <div className="flex min-w-52 flex-col gap-1.5">
+                <span className="text-sm font-medium text-primary">
+                  {t("DashboardHeliusRings.composer.operation")}
+                </span>
+                <Select
+                  ariaLabel={t("DashboardHeliusRings.composer.operation")}
+                  value={opType}
+                  onValueChange={(value) => {
+                    if (value) setOpType(value as RingsOpType);
+                  }}
+                >
+                  {OP_TYPES.map((type) => (
+                    <SelectItem key={type} value={type}>
+                      {t(`DashboardHeliusRings.activity.opType_${type}`)}
+                    </SelectItem>
+                  ))}
+                </Select>
+              </div>
+            </div>
+
+            {needsAsset ? (
+              <div className="flex flex-wrap gap-3">
+                <div className="flex min-w-40 flex-col gap-1.5">
+                  <span className="text-sm font-medium text-primary">
+                    {t("DashboardHeliusRings.composer.asset")}
+                  </span>
+                  <Select
+                    ariaLabel={t("DashboardHeliusRings.composer.asset")}
+                    value={assetMint}
+                    onValueChange={(value) => {
+                      if (value) setAssetMint(value);
+                    }}
+                  >
+                    {RINGS_ALLOWLISTED_ASSETS.map((entry) => (
+                      <SelectItem key={entry.mint} value={entry.mint}>
+                        {entry.symbol}
+                      </SelectItem>
+                    ))}
+                  </Select>
+                </div>
+                <div className="flex min-w-48 flex-col gap-1.5">
+                  <span className="text-sm font-medium text-primary">
+                    {t("DashboardHeliusRings.composer.amount")}
+                  </span>
+                  <Input
+                    inputMode="numeric"
+                    value={amountRaw}
+                    placeholder="1000000"
+                    onChange={(event) => setAmountRaw(event.target.value.replace(/\D/g, ""))}
+                  />
+                </div>
+              </div>
+            ) : null}
+
+            {needsRecipient ? (
+              <div className="flex flex-col gap-1.5">
+                <span className="text-sm font-medium text-primary">
+                  {isAnonymous
+                    ? t("DashboardHeliusRings.composer.recipientAnonymous")
+                    : t("DashboardHeliusRings.composer.recipient")}
+                </span>
+                <Input
+                  value={recipient}
+                  placeholder={t("DashboardHeliusRings.composer.recipientPlaceholder")}
+                  onChange={(event) => setRecipient(event.target.value)}
+                />
+              </div>
+            ) : null}
+
+            {isMerge && zones.length > 0 ? (
+              <div className="flex min-w-52 flex-col gap-1.5">
+                <span className="text-sm font-medium text-primary">
+                  {t("DashboardHeliusRings.composer.zone")}
+                </span>
+                <Select
+                  ariaLabel={t("DashboardHeliusRings.composer.zone")}
+                  value={zoneId}
+                  onValueChange={setZoneId}
+                  placeholder={t("DashboardHeliusRings.composer.zonePlaceholder")}
+                >
+                  {zones.map((zone) => (
+                    <SelectItem key={zone.id} value={zone.id}>
+                      {zone.name}
+                    </SelectItem>
+                  ))}
+                </Select>
+              </div>
+            ) : null}
+
+            {isTimelock ? (
+              <div className="flex flex-wrap gap-3">
+                <div className="flex min-w-52 flex-col gap-1.5">
+                  <span className="text-sm font-medium text-primary">
+                    {t("DashboardHeliusRings.composer.unlockAt")}
+                  </span>
+                  <Input
+                    type="datetime-local"
+                    value={unlockAt}
+                    onChange={(event) => setUnlockAt(event.target.value)}
+                  />
+                </div>
+                <div className="flex min-w-52 flex-col gap-1.5">
+                  <span className="text-sm font-medium text-primary">
+                    {t("DashboardHeliusRings.composer.beneficiary")}
+                  </span>
+                  <Input
+                    value={beneficiary}
+                    placeholder={t("DashboardHeliusRings.composer.recipientPlaceholder")}
+                    onChange={(event) => setBeneficiary(event.target.value)}
+                  />
+                </div>
+              </div>
+            ) : null}
+
+            <div>
+              <Button disabled={!composeComplete} onClick={() => setStep("review")}>
+                {t("DashboardHeliusRings.composer.review")}
+              </Button>
+            </div>
+          </>
+        ) : null}
+
+        {step === "review" ? (
+          <>
+            <dl className="flex flex-col gap-2">
+              {summaryRows.map(([label, value]) => (
+                <div key={label} className="flex items-baseline justify-between gap-4">
+                  <dt className="text-sm text-secondary">{label}</dt>
+                  <dd className="text-sm text-primary">{value}</dd>
+                </div>
+              ))}
+            </dl>
+
+            {isAnonymous ? (
+              <Callout variant="warning">
+                <label className="flex items-start gap-2">
+                  <input
+                    type="checkbox"
+                    className="mt-0.5"
+                    checked={anonymousAcknowledged}
+                    onChange={(event) => setAnonymousAcknowledged(event.target.checked)}
+                  />
+                  <span>{t("DashboardHeliusRings.composer.anonymousWarning")}</span>
+                </label>
+              </Callout>
+            ) : null}
+
+            {error ? <Callout variant="danger">{error}</Callout> : null}
+
+            <div className="flex gap-2">
+              <Button variant="secondary" onClick={() => setStep("compose")}>
+                {t("DashboardHeliusRings.composer.back")}
+              </Button>
+              <Button
+                disabled={submitting || (isAnonymous && !anonymousAcknowledged)}
+                onClick={() => void handleConfirm()}
+              >
+                {submitting
+                  ? t("DashboardHeliusRings.composer.preparing")
+                  : t("DashboardHeliusRings.composer.confirm")}
+              </Button>
+            </div>
+          </>
+        ) : null}
+
+        {step === "result" && result ? (
+          <>
+            <div className="flex items-center gap-2">
+              <Badge variant={result.state === "failed" ? "danger" : "default"}>
+                {t(`DashboardHeliusRings.activity.state_${result.state}`)}
+              </Badge>
+              {result.failure ? (
+                <span className="text-sm text-secondary">
+                  {result.failure.code === "gateway_unavailable"
+                    ? t("DashboardHeliusRings.errors.gatewayUnavailable")
+                    : result.failure.message}
+                </span>
+              ) : null}
+            </div>
+            <div>
+              <Button variant="secondary" onClick={reset}>
+                {t("DashboardHeliusRings.composer.newOperation")}
+              </Button>
+            </div>
+          </>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/operation-composer.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/operation-composer.tsx
@@ -16,6 +16,7 @@ import {
   type RingsWallet,
   type RingsZone,
 } from "./helius-rings.data";
+import { useRingsZones } from "./use-rings-zones";
 
 type Translate = ReturnType<typeof useTranslations>;
 
@@ -130,12 +131,10 @@ function buildSummaryRows(
  */
 export function OperationComposer({
   wallets,
-  zones,
   gatewayRed,
   onPrepared,
 }: {
   wallets: RingsWallet[];
-  zones: RingsZone[];
   gatewayRed: boolean;
   onPrepared: () => Promise<void>;
 }) {
@@ -147,6 +146,8 @@ export function OperationComposer({
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState<RingsOperationDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  const { zones } = useRingsZones(draft.walletId, t("DashboardHeliusRings.errors.loadFailed"));
 
   const patchDraft = useCallback((patch: Partial<ComposerDraft>) => {
     setDraft((current) => ({ ...current, ...patch }));

--- a/apps/sdp-web/src/app/dashboard/helius-rings/operation-composer.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/operation-composer.tsx
@@ -131,10 +131,12 @@ function buildSummaryRows(
 export function OperationComposer({
   wallets,
   zones,
+  gatewayRed,
   onPrepared,
 }: {
   wallets: RingsWallet[];
   zones: RingsZone[];
+  gatewayRed: boolean;
   onPrepared: () => Promise<void>;
 }) {
   const t = useTranslations();
@@ -218,6 +220,7 @@ export function OperationComposer({
             isAnonymous={draft.opType === "transfer_anonymous"}
             acknowledged={anonymousAcknowledged}
             onAcknowledge={setAnonymousAcknowledged}
+            gatewayRed={gatewayRed}
             error={error}
             submitting={submitting}
             onBack={() => setStep("compose")}
@@ -384,6 +387,7 @@ function ReviewStep({
   isAnonymous,
   acknowledged,
   onAcknowledge,
+  gatewayRed,
   error,
   submitting,
   onBack,
@@ -393,6 +397,7 @@ function ReviewStep({
   isAnonymous: boolean;
   acknowledged: boolean;
   onAcknowledge: (acknowledged: boolean) => void;
+  gatewayRed: boolean;
   error: string | null;
   submitting: boolean;
   onBack: () => void;
@@ -401,6 +406,9 @@ function ReviewStep({
   const t = useTranslations();
   return (
     <>
+      {gatewayRed ? (
+        <Callout variant="info">{t("DashboardHeliusRings.composer.gatewayRedNotice")}</Callout>
+      ) : null}
       <dl className="flex flex-col gap-2">
         {rows.map(([label, value]) => (
           <div key={label} className="flex items-baseline justify-between gap-4">

--- a/apps/sdp-web/src/app/dashboard/helius-rings/operation-composer.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/operation-composer.tsx
@@ -41,7 +41,15 @@ const NEEDS_RECIPIENT: ReadonlySet<RingsOpType> = new Set([
   "withdraw",
 ]);
 
-type Step = "compose" | "review" | "result";
+/**
+ * Where the wizard is, and the only data valid at that point. A union rather
+ * than parallel `step`/`result`/`error` values so "showing a result with no
+ * operation" is not representable.
+ */
+type Phase =
+  | { name: "compose" }
+  | { name: "review"; error: string | null }
+  | { name: "result"; operation: RingsOperationDetail };
 
 /** Everything the compose form has collected. */
 interface ComposerDraft {
@@ -140,12 +148,10 @@ export function OperationComposer({
 }) {
   const t = useTranslations();
 
-  const [step, setStep] = useState<Step>("compose");
+  const [phase, setPhase] = useState<Phase>({ name: "compose" });
   const [draft, setDraft] = useState<ComposerDraft>(EMPTY_DRAFT);
   const [anonymousAcknowledged, setAnonymousAcknowledged] = useState(false);
   const [submitting, setSubmitting] = useState(false);
-  const [result, setResult] = useState<RingsOperationDetail | null>(null);
-  const [error, setError] = useState<string | null>(null);
 
   const { zones } = useRingsZones(draft.walletId, t("DashboardHeliusRings.errors.loadFailed"));
 
@@ -154,17 +160,15 @@ export function OperationComposer({
   }, []);
 
   const reset = useCallback(() => {
-    setStep("compose");
+    setPhase({ name: "compose" });
     setDraft((current) => ({ ...EMPTY_DRAFT, walletId: current.walletId }));
     setAnonymousAcknowledged(false);
-    setResult(null);
-    setError(null);
   }, []);
 
   const handleConfirm = useCallback(async () => {
     if (!draft.walletId) return;
     setSubmitting(true);
-    setError(null);
+    setPhase({ name: "review", error: null });
     const asset = RINGS_ALLOWLISTED_ASSETS.find((entry) => entry.mint === draft.assetMint);
     let prepared: Awaited<ReturnType<typeof prepareRingsOperation>>;
     try {
@@ -190,11 +194,13 @@ export function OperationComposer({
       setSubmitting(false);
     }
     if (prepared.error || !prepared.operation) {
-      setError(prepared.error ?? t("DashboardHeliusRings.composer.prepareFailed"));
+      setPhase({
+        name: "review",
+        error: prepared.error ?? t("DashboardHeliusRings.composer.prepareFailed"),
+      });
       return;
     }
-    setResult(prepared.operation);
-    setStep("result");
+    setPhase({ name: "result", operation: prepared.operation });
     await onPrepared();
   }, [draft, onPrepared, t]);
 
@@ -210,29 +216,29 @@ export function OperationComposer({
         <CardDescription>{t("DashboardHeliusRings.composer.description")}</CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
-        {step === "compose" ? (
+        {phase.name === "compose" ? (
           <ComposeStep
             draft={draft}
             wallets={wallets}
             zones={zones}
             onPatch={patchDraft}
-            onReview={() => setStep("review")}
+            onReview={() => setPhase({ name: "review", error: null })}
           />
         ) : null}
-        {step === "review" ? (
+        {phase.name === "review" ? (
           <ReviewStep
             rows={summaryRows}
             isAnonymous={draft.opType === "transfer_anonymous"}
             acknowledged={anonymousAcknowledged}
             onAcknowledge={setAnonymousAcknowledged}
             gatewayRed={gatewayRed}
-            error={error}
+            error={phase.error}
             submitting={submitting}
-            onBack={() => setStep("compose")}
+            onBack={() => setPhase({ name: "compose" })}
             onConfirm={() => void handleConfirm()}
           />
         ) : null}
-        {step === "result" && result ? <ResultStep result={result} onReset={reset} /> : null}
+        {phase.name === "result" ? <ResultStep result={phase.operation} onReset={reset} /> : null}
       </CardContent>
     </Card>
   );

--- a/apps/sdp-web/src/app/dashboard/helius-rings/operation-detail-drawer.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/operation-detail-drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Callout } from "@/components/ui/callout";
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer";
@@ -33,6 +33,19 @@ export function OperationDetailDrawer({
       .then((result) => setDetail(result.operation))
       .catch((cause: unknown) => setError(cause instanceof Error ? cause.message : loadFailedCopy));
   }, [operationId, loadFailedCopy]);
+
+  // Content-derived keys: the timeline is append-only, so kind + timestamp
+  // plus an occurrence counter is stable across re-renders without leaning on
+  // the array index.
+  const keyedEvents = useMemo(() => {
+    const seen = new Map<string, number>();
+    return (detail?.events ?? []).map((event) => {
+      const base = `${event.kind}:${event.createdAt}`;
+      const occurrence = (seen.get(base) ?? 0) + 1;
+      seen.set(base, occurrence);
+      return { ...event, key: `${base}:${occurrence}` };
+    });
+  }, [detail]);
 
   return (
     <Drawer open={operationId !== null} onOpenChange={(open) => !open && onClose()}>
@@ -91,11 +104,8 @@ export function OperationDetailDrawer({
                 </p>
               ) : (
                 <ol className="flex flex-col gap-1.5">
-                  {detail.events.map((event, index) => (
-                    <li
-                      key={`${event.kind}-${index}`}
-                      className="flex items-baseline justify-between gap-4"
-                    >
+                  {keyedEvents.map((event) => (
+                    <li key={event.key} className="flex items-baseline justify-between gap-4">
                       <span className="text-sm text-primary">{event.kind}</span>
                       <span className="text-sm text-secondary">
                         {new Date(event.createdAt).toLocaleTimeString()}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/operation-detail-drawer.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/operation-detail-drawer.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Callout } from "@/components/ui/callout";
+import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer";
+import { useTranslations } from "@/i18n/provider";
+import { fetchRingsOperationDetail, type RingsOperationDetail } from "./helius-rings.data";
+
+/**
+ * Operation detail: identity, failure (code + message, verbatim), and the
+ * event timeline oldest-first. Payloads shown here were redacted at write
+ * time, so nothing sensitive can surface however the operation went.
+ */
+export function OperationDetailDrawer({
+  operationId,
+  onClose,
+}: {
+  operationId: string | null;
+  onClose: () => void;
+}) {
+  const t = useTranslations();
+  const [detail, setDetail] = useState<RingsOperationDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadFailedCopy = t("DashboardHeliusRings.errors.loadFailed");
+
+  useEffect(() => {
+    setDetail(null);
+    setError(null);
+    if (!operationId) return;
+    fetchRingsOperationDetail(operationId, loadFailedCopy)
+      .then((result) => setDetail(result.operation))
+      .catch((cause: unknown) => setError(cause instanceof Error ? cause.message : loadFailedCopy));
+  }, [operationId, loadFailedCopy]);
+
+  return (
+    <Drawer open={operationId !== null} onOpenChange={(open) => !open && onClose()}>
+      <DrawerContent className="flex w-full max-w-md flex-col gap-4 p-6">
+        <DrawerTitle>{t("DashboardHeliusRings.detail.title")}</DrawerTitle>
+
+        {error ? <Callout variant="danger">{error}</Callout> : null}
+
+        {detail ? (
+          <>
+            <dl className="flex flex-col gap-2">
+              <DetailRow label={t("DashboardHeliusRings.detail.operationId")} value={detail.id} />
+              <DetailRow
+                label={t("DashboardHeliusRings.activity.operation")}
+                value={t(`DashboardHeliusRings.activity.opType_${detail.opType}`)}
+              />
+              <div className="flex items-baseline justify-between gap-4">
+                <dt className="text-sm text-secondary">
+                  {t("DashboardHeliusRings.activity.state")}
+                </dt>
+                <dd>
+                  <Badge variant={detail.state === "failed" ? "danger" : "default"}>
+                    {t(`DashboardHeliusRings.activity.state_${detail.state}`)}
+                  </Badge>
+                </dd>
+              </div>
+              {detail.amountRaw ? (
+                <DetailRow
+                  label={t("DashboardHeliusRings.activity.amount")}
+                  value={detail.amountRaw}
+                />
+              ) : null}
+              <DetailRow
+                label={t("DashboardHeliusRings.activity.created")}
+                value={new Date(detail.createdAt).toLocaleString()}
+              />
+            </dl>
+
+            {detail.failure ? (
+              <Callout variant="danger">
+                <span className="font-medium">{detail.failure.code}</span> —{" "}
+                {detail.failure.message}
+                {detail.failure.retryable
+                  ? ` ${t("DashboardHeliusRings.detail.retryable")}`
+                  : ` ${t("DashboardHeliusRings.detail.notRetryable")}`}
+              </Callout>
+            ) : null}
+
+            <div className="flex flex-col gap-1.5">
+              <span className="text-sm font-medium text-primary">
+                {t("DashboardHeliusRings.detail.timeline")}
+              </span>
+              {detail.events.length === 0 ? (
+                <p className="text-sm text-secondary">
+                  {t("DashboardHeliusRings.detail.timelineEmpty")}
+                </p>
+              ) : (
+                <ol className="flex flex-col gap-1.5">
+                  {detail.events.map((event, index) => (
+                    <li
+                      key={`${event.kind}-${index}`}
+                      className="flex items-baseline justify-between gap-4"
+                    >
+                      <span className="text-sm text-primary">{event.kind}</span>
+                      <span className="text-sm text-secondary">
+                        {new Date(event.createdAt).toLocaleTimeString()}
+                      </span>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </div>
+          </>
+        ) : null}
+      </DrawerContent>
+    </Drawer>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-4">
+      <dt className="text-sm text-secondary">{label}</dt>
+      <dd className="break-all text-right text-sm text-primary">{value}</dd>
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/operation-detail-drawer.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/operation-detail-drawer.tsx
@@ -4,8 +4,9 @@ import { useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Callout } from "@/components/ui/callout";
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer";
-import { useTranslations } from "@/i18n/provider";
+import { useLocale, useTranslations } from "@/i18n/provider";
 import { fetchRingsOperationDetail, type RingsOperationDetail } from "./helius-rings.data";
+import { formatTimeOfDay, formatWhen } from "./helius-rings.utils";
 
 /**
  * Operation detail: identity, failure (code + message, verbatim), and the
@@ -20,6 +21,7 @@ export function OperationDetailDrawer({
   onClose: () => void;
 }) {
   const t = useTranslations();
+  const locale = useLocale();
   const [detail, setDetail] = useState<RingsOperationDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -80,7 +82,7 @@ export function OperationDetailDrawer({
               ) : null}
               <DetailRow
                 label={t("DashboardHeliusRings.activity.created")}
-                value={new Date(detail.createdAt).toLocaleString()}
+                value={formatWhen(detail.createdAt, locale)}
               />
             </dl>
 
@@ -108,7 +110,7 @@ export function OperationDetailDrawer({
                     <li key={event.key} className="flex items-baseline justify-between gap-4">
                       <span className="text-sm text-primary">{event.kind}</span>
                       <span className="text-sm text-secondary">
-                        {new Date(event.createdAt).toLocaleTimeString()}
+                        {formatTimeOfDay(event.createdAt, locale)}
                       </span>
                     </li>
                   ))}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/page.tsx
@@ -1,15 +1,63 @@
-import { notFound } from "next/navigation";
+import { auth } from "@clerk/nextjs/server";
+import { notFound, redirect } from "next/navigation";
 import { heliusRings } from "@/flags";
+import { getAuthEntryPath } from "@/lib/auth-entry";
+import { createRequestScopedSdpApiClients } from "@/lib/sdp-api";
+import { HeliusRingsWorkspace } from "./helius-rings-workspace";
 
+export const dynamic = "force-dynamic";
+
+interface CustodyWalletOption {
+  walletId: string;
+  label: string | null;
+  publicKey: string;
+}
+
+/**
+ * Helius Rings overview — devnet-only shielded wallet workspace. Live data
+ * flows through the /api/dashboard/helius-rings BFF proxies; the custody
+ * wallet options for the create form are resolved server-side. Degraded
+ * upstreams render honestly: red health, pending wallets, failed operations.
+ */
 export default async function HeliusRingsPage() {
   if (!(await heliusRings())) {
     notFound();
   }
+  const { userId, orgId } = await auth();
+  if (!userId) {
+    redirect(await getAuthEntryPath());
+  }
+  if (!orgId) {
+    redirect("/dashboard");
+  }
+
+  // Best-effort: losing the wallet list costs the reader the create form,
+  // never the health card or the activity table beside it.
+  let custodyWallets: CustodyWalletOption[] = [];
+  try {
+    const { projectClient } = await createRequestScopedSdpApiClients();
+    if (projectClient) {
+      const response = await projectClient.request("/v1/wallets?view=summary", { method: "GET" });
+      if (response.ok) {
+        const body = (await response.json()) as {
+          data?: {
+            wallets?: Array<{ walletId: string; label?: string | null; publicKey: string }>;
+          };
+        };
+        custodyWallets = (body.data?.wallets ?? []).map((wallet) => ({
+          walletId: wallet.walletId,
+          label: wallet.label ?? null,
+          publicKey: wallet.publicKey,
+        }));
+      }
+    }
+  } catch {
+    // The workspace renders its own empty-state copy.
+  }
 
   return (
-    <div className="mx-auto max-w-2xl px-6 py-16">
-      <h1 className="text-2xl font-semibold tracking-tight text-primary">Helius Rings</h1>
-      <p className="mt-2 text-sm text-secondary">Coming soon.</p>
+    <div className="mx-auto flex max-w-5xl flex-col gap-6 px-6 py-8">
+      <HeliusRingsWorkspace custodyWallets={custodyWallets} />
     </div>
   );
 }

--- a/apps/sdp-web/src/app/dashboard/helius-rings/recovery-card.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/recovery-card.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/table";
 import { useLocale, useTranslations } from "@/i18n/provider";
 import { type RingsOperationSummary, retryRingsOperation } from "./helius-rings.data";
+import { formatWhen } from "./helius-rings.utils";
 
 /**
  * Failed operations with a retry action. Retryability is enforced server-side
@@ -79,12 +80,7 @@ export function RecoveryCard({
                       </Badge>
                     </span>
                   </TableCell>
-                  <TableCell>
-                    {new Date(operation.createdAt).toLocaleString(locale, {
-                      dateStyle: "medium",
-                      timeStyle: "short",
-                    })}
-                  </TableCell>
+                  <TableCell>{formatWhen(operation.createdAt, locale)}</TableCell>
                   <TableCell>
                     <Button
                       variant="secondary"

--- a/apps/sdp-web/src/app/dashboard/helius-rings/recovery-card.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/recovery-card.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Callout } from "@/components/ui/callout";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useTranslations } from "@/i18n/provider";
+import { type RingsOperationSummary, retryRingsOperation } from "./helius-rings.data";
+
+/**
+ * Failed operations with a retry action. Retryability is enforced server-side
+ * (non-retryable failures and exhausted chains reject); the card just relays
+ * the verdict.
+ */
+export function RecoveryCard({
+  operations,
+  onRetried,
+}: {
+  operations: RingsOperationSummary[];
+  onRetried: () => Promise<void>;
+}) {
+  const t = useTranslations();
+  const [retryingId, setRetryingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const failed = operations.filter((operation) => operation.state === "failed");
+
+  const handleRetry = useCallback(
+    async (operationId: string) => {
+      setRetryingId(operationId);
+      setError(null);
+      const result = await retryRingsOperation(operationId);
+      setRetryingId(null);
+      if (result.error) {
+        setError(result.error);
+      }
+      await onRetried();
+    },
+    [onRetried]
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("DashboardHeliusRings.recovery.title")}</CardTitle>
+        <CardDescription>{t("DashboardHeliusRings.recovery.description")}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {error ? <Callout variant="danger">{error}</Callout> : null}
+        {failed.length === 0 ? (
+          <p className="text-sm text-secondary">{t("DashboardHeliusRings.recovery.empty")}</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{t("DashboardHeliusRings.activity.operation")}</TableHead>
+                <TableHead>{t("DashboardHeliusRings.activity.created")}</TableHead>
+                <TableHead />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {failed.map((operation) => (
+                <TableRow key={operation.id}>
+                  <TableCell>
+                    <span className="flex items-center gap-2">
+                      {t(`DashboardHeliusRings.activity.opType_${operation.opType}`)}
+                      <Badge variant="danger">
+                        {t("DashboardHeliusRings.activity.state_failed")}
+                      </Badge>
+                    </span>
+                  </TableCell>
+                  <TableCell>{new Date(operation.createdAt).toLocaleString()}</TableCell>
+                  <TableCell>
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      disabled={retryingId === operation.id}
+                      onClick={() => void handleRetry(operation.id)}
+                    >
+                      {retryingId === operation.id
+                        ? t("DashboardHeliusRings.recovery.retrying")
+                        : t("DashboardHeliusRings.recovery.retry")}
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/recovery-card.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/recovery-card.tsx
@@ -14,40 +14,51 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { useLocale, useTranslations } from "@/i18n/provider";
-import { type RingsOperationSummary, retryRingsOperation } from "./helius-rings.data";
+import {
+  executeRingsOperation,
+  type RingsOperationSummary,
+  retryRingsOperation,
+} from "./helius-rings.data";
 import { formatWhen } from "./helius-rings.utils";
 
 /**
- * Failed operations with a retry action. Retryability is enforced server-side
- * (non-retryable failures and exhausted chains reject); the card just relays
- * the verdict.
+ * The two states an operation rests in waiting on a human: `approval_required`
+ * (execute it) and `failed` (file a retry). Both verdicts are enforced
+ * server-side — the approval is read from the stored request, and retryability
+ * rejects non-retryable failures and exhausted chains — so this card only
+ * relays the outcome.
  */
 export function RecoveryCard({
   operations,
-  onRetried,
+  onChanged,
 }: {
   operations: RingsOperationSummary[];
-  onRetried: () => Promise<void>;
+  onChanged: () => Promise<void>;
 }) {
   const t = useTranslations();
   const locale = useLocale();
-  const [retryingId, setRetryingId] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const failed = operations.filter((operation) => operation.state === "failed");
+  const waiting = operations.filter(
+    (operation) => operation.state === "approval_required" || operation.state === "failed"
+  );
 
-  const handleRetry = useCallback(
-    async (operationId: string) => {
-      setRetryingId(operationId);
+  const handleAction = useCallback(
+    async (operation: RingsOperationSummary) => {
+      setBusyId(operation.id);
       setError(null);
-      const result = await retryRingsOperation(operationId);
-      setRetryingId(null);
+      const result =
+        operation.state === "approval_required"
+          ? await executeRingsOperation(operation.id)
+          : await retryRingsOperation(operation.id);
+      setBusyId(null);
       if (result.error) {
         setError(result.error);
       }
-      await onRetried();
+      await onChanged();
     },
-    [onRetried]
+    [onChanged]
   );
 
   return (
@@ -58,7 +69,7 @@ export function RecoveryCard({
       </CardHeader>
       <CardContent className="flex flex-col gap-3">
         {error ? <Callout variant="danger">{error}</Callout> : null}
-        {failed.length === 0 ? (
+        {waiting.length === 0 ? (
           <p className="text-sm text-secondary">{t("DashboardHeliusRings.recovery.empty")}</p>
         ) : (
           <Table>
@@ -70,31 +81,43 @@ export function RecoveryCard({
               </TableRow>
             </TableHeader>
             <TableBody>
-              {failed.map((operation) => (
-                <TableRow key={operation.id}>
-                  <TableCell>
-                    <span className="flex items-center gap-2">
-                      {t(`DashboardHeliusRings.activity.opType_${operation.opType}`)}
-                      <Badge variant="danger">
-                        {t("DashboardHeliusRings.activity.state_failed")}
-                      </Badge>
-                    </span>
-                  </TableCell>
-                  <TableCell>{formatWhen(operation.createdAt, locale)}</TableCell>
-                  <TableCell>
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      disabled={retryingId === operation.id}
-                      onClick={() => void handleRetry(operation.id)}
-                    >
-                      {retryingId === operation.id
-                        ? t("DashboardHeliusRings.recovery.retrying")
-                        : t("DashboardHeliusRings.recovery.retry")}
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              ))}
+              {waiting.map((operation) => {
+                const awaitingApproval = operation.state === "approval_required";
+                const busy = busyId === operation.id;
+                return (
+                  <TableRow key={operation.id}>
+                    <TableCell>
+                      <span className="flex items-center gap-2">
+                        {t(`DashboardHeliusRings.activity.opType_${operation.opType}`)}
+                        <Badge variant={awaitingApproval ? "warning" : "danger"}>
+                          {t(`DashboardHeliusRings.activity.state_${operation.state}`)}
+                        </Badge>
+                      </span>
+                    </TableCell>
+                    <TableCell>{formatWhen(operation.createdAt, locale)}</TableCell>
+                    <TableCell>
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        disabled={busy}
+                        onClick={() => void handleAction(operation)}
+                      >
+                        {awaitingApproval
+                          ? t(
+                              busy
+                                ? "DashboardHeliusRings.recovery.executing"
+                                : "DashboardHeliusRings.recovery.execute"
+                            )
+                          : t(
+                              busy
+                                ? "DashboardHeliusRings.recovery.retrying"
+                                : "DashboardHeliusRings.recovery.retry"
+                            )}
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
         )}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/recovery-card.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/recovery-card.tsx
@@ -13,7 +13,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { useTranslations } from "@/i18n/provider";
+import { useLocale, useTranslations } from "@/i18n/provider";
 import { type RingsOperationSummary, retryRingsOperation } from "./helius-rings.data";
 
 /**
@@ -29,6 +29,7 @@ export function RecoveryCard({
   onRetried: () => Promise<void>;
 }) {
   const t = useTranslations();
+  const locale = useLocale();
   const [retryingId, setRetryingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -78,7 +79,12 @@ export function RecoveryCard({
                       </Badge>
                     </span>
                   </TableCell>
-                  <TableCell>{new Date(operation.createdAt).toLocaleString()}</TableCell>
+                  <TableCell>
+                    {new Date(operation.createdAt).toLocaleString(locale, {
+                      dateStyle: "medium",
+                      timeStyle: "short",
+                    })}
+                  </TableCell>
                   <TableCell>
                     <Button
                       variant="secondary"

--- a/apps/sdp-web/src/app/dashboard/helius-rings/use-rings-zones.ts
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/use-rings-zones.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { fetchRingsZones, type RingsZone } from "./helius-rings.data";
+
+/**
+ * Zones for one wallet. Every consumer loads for the wallet *it* has selected,
+ * so a selector in one card can never surface its wallet's zones in another.
+ */
+export function useRingsZones(walletId: string | null, loadFailedCopy: string) {
+  const [zones, setZones] = useState<RingsZone[]>([]);
+
+  const reload = useCallback(async () => {
+    if (!walletId) {
+      setZones([]);
+      return;
+    }
+    try {
+      const result = await fetchRingsZones(walletId, loadFailedCopy);
+      setZones(result.zones);
+    } catch {
+      setZones([]);
+    }
+  }, [walletId, loadFailedCopy]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  return { zones, reload };
+}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/zones-card.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/zones-card.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Select, SelectItem } from "@/components/ui/select";
+import { useTranslations } from "@/i18n/provider";
+import {
+  createRingsZone,
+  fetchRingsZones,
+  type RingsWallet,
+  type RingsZone,
+} from "./helius-rings.data";
+
+/**
+ * Zone management for one wallet. Zones are SDP-owned metadata, so this card
+ * is fully functional today — no gateway involved.
+ */
+export function ZonesCard({
+  wallets,
+  onZonesChanged,
+}: {
+  wallets: RingsWallet[];
+  onZonesChanged: (zones: RingsZone[]) => void;
+}) {
+  const t = useTranslations();
+
+  const [walletId, setWalletId] = useState<string | null>(wallets[0]?.id ?? null);
+  const [zones, setZones] = useState<RingsZone[]>([]);
+  const [name, setName] = useState("");
+  const [kind, setKind] = useState<RingsZone["kind"]>("treasury");
+  const [creating, setCreating] = useState(false);
+
+  const loadFailedCopy = t("DashboardHeliusRings.errors.loadFailed");
+
+  const refresh = useCallback(async () => {
+    if (!walletId) {
+      setZones([]);
+      onZonesChanged([]);
+      return;
+    }
+    try {
+      const result = await fetchRingsZones(walletId, loadFailedCopy);
+      setZones(result.zones);
+      onZonesChanged(result.zones);
+    } catch {
+      setZones([]);
+      onZonesChanged([]);
+    }
+  }, [walletId, loadFailedCopy, onZonesChanged]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleCreate = useCallback(async () => {
+    if (!walletId || !name.trim()) return;
+    setCreating(true);
+    await createRingsZone({ walletId, name: name.trim(), kind });
+    setCreating(false);
+    setName("");
+    await refresh();
+  }, [walletId, name, kind, refresh]);
+
+  if (wallets.length === 0) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("DashboardHeliusRings.zones.title")}</CardTitle>
+        <CardDescription>{t("DashboardHeliusRings.zones.description")}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex min-w-52 flex-col gap-1.5">
+          <span className="text-sm font-medium text-primary">
+            {t("DashboardHeliusRings.composer.wallet")}
+          </span>
+          <Select
+            ariaLabel={t("DashboardHeliusRings.composer.wallet")}
+            value={walletId}
+            onValueChange={setWalletId}
+          >
+            {wallets.map((wallet) => (
+              <SelectItem key={wallet.id} value={wallet.id}>
+                {wallet.name}
+              </SelectItem>
+            ))}
+          </Select>
+        </div>
+
+        {zones.length === 0 ? (
+          <p className="text-sm text-secondary">{t("DashboardHeliusRings.zones.empty")}</p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {zones.map((zone) => (
+              <li key={zone.id} className="flex items-center gap-2">
+                <span className="text-sm text-primary">{zone.name}</span>
+                <Badge variant="outline">{t(`DashboardHeliusRings.zones.kind_${zone.kind}`)}</Badge>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="flex min-w-44 flex-col gap-1.5">
+            <span className="text-sm font-medium text-primary">
+              {t("DashboardHeliusRings.zones.nameLabel")}
+            </span>
+            <Input
+              value={name}
+              placeholder={t("DashboardHeliusRings.zones.namePlaceholder")}
+              onChange={(event) => setName(event.target.value)}
+            />
+          </div>
+          <div className="flex min-w-40 flex-col gap-1.5">
+            <span className="text-sm font-medium text-primary">
+              {t("DashboardHeliusRings.zones.kindLabel")}
+            </span>
+            <Select
+              ariaLabel={t("DashboardHeliusRings.zones.kindLabel")}
+              value={kind}
+              onValueChange={(value) => {
+                if (value) setKind(value as RingsZone["kind"]);
+              }}
+            >
+              <SelectItem value="treasury">
+                {t("DashboardHeliusRings.zones.kind_treasury")}
+              </SelectItem>
+              <SelectItem value="public">{t("DashboardHeliusRings.zones.kind_public")}</SelectItem>
+            </Select>
+          </div>
+          <Button disabled={creating || !name.trim()} onClick={() => void handleCreate()}>
+            {t("DashboardHeliusRings.zones.create")}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/zones-card.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/zones-card.tsx
@@ -1,59 +1,28 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Select, SelectItem } from "@/components/ui/select";
 import { useTranslations } from "@/i18n/provider";
-import {
-  createRingsZone,
-  fetchRingsZones,
-  type RingsWallet,
-  type RingsZone,
-} from "./helius-rings.data";
+import { createRingsZone, type RingsWallet, type RingsZone } from "./helius-rings.data";
+import { useRingsZones } from "./use-rings-zones";
 
 /**
  * Zone management for one wallet. Zones are SDP-owned metadata, so this card
  * is fully functional today — no gateway involved.
  */
-export function ZonesCard({
-  wallets,
-  onZonesChanged,
-}: {
-  wallets: RingsWallet[];
-  onZonesChanged: (zones: RingsZone[]) => void;
-}) {
+export function ZonesCard({ wallets }: { wallets: RingsWallet[] }) {
   const t = useTranslations();
 
   const [walletId, setWalletId] = useState<string | null>(wallets[0]?.id ?? null);
-  const [zones, setZones] = useState<RingsZone[]>([]);
   const [name, setName] = useState("");
   const [kind, setKind] = useState<RingsZone["kind"]>("treasury");
   const [creating, setCreating] = useState(false);
 
-  const loadFailedCopy = t("DashboardHeliusRings.errors.loadFailed");
-
-  const refresh = useCallback(async () => {
-    if (!walletId) {
-      setZones([]);
-      onZonesChanged([]);
-      return;
-    }
-    try {
-      const result = await fetchRingsZones(walletId, loadFailedCopy);
-      setZones(result.zones);
-      onZonesChanged(result.zones);
-    } catch {
-      setZones([]);
-      onZonesChanged([]);
-    }
-  }, [walletId, loadFailedCopy, onZonesChanged]);
-
-  useEffect(() => {
-    void refresh();
-  }, [refresh]);
+  const { zones, reload } = useRingsZones(walletId, t("DashboardHeliusRings.errors.loadFailed"));
 
   const handleCreate = useCallback(async () => {
     if (!walletId || !name.trim()) return;
@@ -61,8 +30,8 @@ export function ZonesCard({
     await createRingsZone({ walletId, name: name.trim(), kind });
     setCreating(false);
     setName("");
-    await refresh();
-  }, [walletId, name, kind, refresh]);
+    await reload();
+  }, [walletId, name, kind, reload]);
 
   if (wallets.length === 0) return null;
 

--- a/apps/sdp-web/src/i18n/messages.ts
+++ b/apps/sdp-web/src/i18n/messages.ts
@@ -2,6 +2,9 @@ import type { AppLocale } from "@/i18n/config";
 import dashboardApprovals from "../../messages/en/dashboard-approvals.json";
 import dashboardCustody from "../../messages/en/dashboard-custody.json";
 import dashboardEarn from "../../messages/en/dashboard-earn.json";
+// No localized dashboard-helius-rings.json yet: product branches ship English
+// source only; localized copy lands via the translation bot on the release PR.
+import dashboardHeliusRings from "../../messages/en/dashboard-helius-rings.json";
 import dashboardIssuance from "../../messages/en/dashboard-issuance.json";
 import dashboardPayments from "../../messages/en/dashboard-payments.json";
 import dashboardPolicies from "../../messages/en/dashboard-policies.json";
@@ -49,6 +52,7 @@ const enMessages = {
   ...dashboardApprovals,
   ...dashboardCustody,
   ...dashboardEarn,
+  ...dashboardHeliusRings,
   ...dashboardIssuance,
   ...dashboardPayments,
   ...dashboardPolicies,

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -14,7 +14,7 @@ This map is generated from the module-boundary check. It records the permitted w
 
 | Module | Purpose | Allowed workspace dependencies |
 | --- | --- | --- |
-| `@sdp/api` | Node.js API and application composition root. | `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/issuance`, `@sdp/kamino`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types` |
+| `@sdp/api` | Node.js API and application composition root. | `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/helius-rings`, `@sdp/issuance`, `@sdp/kamino`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types` |
 | `@sdp/api-integration` | Maintainer integration harness for API endpoint and provider coverage. | `@sdp/api`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/spc-escrow`, `@sdp/types` |
 | `@sdp/custody` | Custody provider abstractions and keychain adapters. | `@sdp/types` |
 | `@sdp/earn` | Earn domain services, yield strategies, and vault-infra providers. | `@sdp/payments`, `@sdp/rpc`, `@sdp/solana`, `@sdp/types` |
@@ -37,7 +37,7 @@ This map is generated from the module-boundary check. It records the permitted w
 
 ## Declared Workspace Graph
 
-- `@sdp/api` -> `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/issuance`, `@sdp/kamino`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types`
+- `@sdp/api` -> `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/helius-rings`, `@sdp/issuance`, `@sdp/kamino`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types`
 - `@sdp/api-integration` -> `@sdp/api`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/spc-escrow`, `@sdp/types`
 - `@sdp/custody` -> `@sdp/types`
 - `@sdp/earn` -> `@sdp/types`

--- a/docs/ops/helius-rings.md
+++ b/docs/ops/helius-rings.md
@@ -1,0 +1,128 @@
+# Helius Rings — operations reference
+
+Helius Rings is SDP's devnet-only shielded-wallet module: private wallets bound
+to SDP custody wallets, with shielded transfers built on Zolana. This document
+covers the architecture an operator needs: the state machine, failure codes,
+configuration, and the seams that stay dark until the external integration
+(Track B) lands.
+
+## Architecture
+
+```
+routes (/v1/helius-rings)               flag-gated, real policy enforcement
+  └─ HeliusRingsService                 devnet guard, intent reservation,
+       │                                prepare-through-policy, retry lineage
+       ├─ repositories (Postgres)       wallets, operations+timelocks,
+       │                                key refs, zones, events, health
+       ├─ signer adapter                createOrgSigner → custody signing
+       ├─ RPC adapter                   shared sendTransaction path
+       └─ RingsGatewayPort              THE seam. Production wiring is
+                                        NotImplementedRingsGateway until the
+                                        live HTTP adapter replaces it.
+```
+
+`RingsGatewayPort` is the only place external Rings infrastructure (Zolana
+sidecar, Photon indexer, prover, key authority) is called. Everything on the
+SDP side of the port is real and fully tested; everything behind it throws
+`gateway_unavailable` until Track B wires the live adapter. No mocks ship: the
+test double lives behind the `@sdp/helius-rings/testing` subpath and is not
+selectable in production.
+
+## Configuration
+
+| Variable | Values | Meaning |
+| --- | --- | --- |
+| `HELIUS_RINGS_ENABLED` | `false` (default) / `true` | Gates the API routes, the dashboard workspace, and the indexing-poll job. |
+| `HELIUS_RINGS_ADAPTER` | `none` (default) / `http` | Gateway selector. Only `http` activates the live adapter and the indexing poll; anything else keeps `NotImplementedRingsGateway`. |
+| `SOLANA_NETWORK` | must be `devnet` | `HeliusRingsService` refuses to construct on any other network, and the schema pins `helius_rings_wallets.network` to `'devnet'`. Going to mainnet is a deliberate forward migration, not a config flip. |
+
+## State machine
+
+```
+draft → preparing → approval_required → proving → ready_to_sign
+      → submitted → indexing → completed
+```
+
+Every non-terminal state has one typed fail edge; `failed` rows always carry
+`failure_code`, `failure_message`, and `retryable` together (DB CHECK). All
+transitions run compare-and-swap under `SELECT … FOR UPDATE`, so two workers
+cannot advance the same operation twice.
+
+States an operator will actually observe at rest: `approval_required`
+(waiting on a reviewer), `indexing` (waiting on Photon), `completed`, and
+`failed`. The remaining states are transient — the prepare pipeline drives
+through them in one pass.
+
+## Failure codes
+
+| Code | Fails from | Retryable | Meaning |
+| --- | --- | --- | --- |
+| `policy_denied` | preparing | no | Wallet/API-key policy denied the operation. |
+| `approval_rejected` | approval_required | no | The approval request was rejected, canceled, or expired. |
+| `proof_failed` | proving | yes | Prover returned an error. |
+| `signer_failed` | ready_to_sign | varies | Custody signing failed; `WALLET_NOT_FOUND`-class errors are non-retryable. |
+| `submit_failed` | submitted | yes | RPC broadcast failed; the intent key makes resubmission safe. |
+| `indexing_timeout` | indexing | yes | Photon did not index within 30 minutes (`RINGS_INDEXING_TIMEOUT_MS`). |
+| `gateway_unavailable` | any port call | yes | The gateway seam is not implemented or unreachable. The expected failure until Track B lands. |
+| `invalid_input` | preparing | varies | Policy evaluation threw, or an inconsistent row was found. |
+
+## Idempotency and retries
+
+- `intent_key = sha256(walletId, opType, canonical(input), clientNonce)` with a
+  unique index. A replayed prepare returns the operation already reserved —
+  never a duplicate.
+- A retry files a **new** operation with a new client nonce, linked via
+  `retry_of_operation_id`, and re-runs the full policy path — a retry re-earns
+  its verdict, never inherits one. Chains are capped at 5; the original failed
+  row is never mutated (lineage is audit evidence).
+- Approval verdicts are read from the stored approval request server-side.
+  `POST /operations/:id/execute` carries no trusted body.
+
+## Secret handling
+
+- Viewing keys, nullifier keys, and proof internals travel as `SecretRef<T>`
+  (`toJSON`/`toString` → `"[REDACTED]"`). `scripts/check-secretref-serialization.mjs`
+  fails CI when a `reveal()` result — direct or via alias — reaches a logger,
+  `JSON.stringify`, `String()`, or a template literal.
+- The pino redaction registry (`apps/sdp-api/src/runtime/log-redaction.ts`)
+  censors `viewingKey`, `nullifierKey`, `ringsMetadata`, `proof.ref`,
+  `proof.internal`, and `keyRefs[*].material`.
+- Event payloads are redacted at write time (arbitrary depth), so the timeline
+  table cannot accumulate secret material.
+- Key material is not persisted by the service. Sealed storage through
+  custody-cipher into `helius_rings_key_refs` is the key-authority work
+  (Track B4).
+
+## Background jobs
+
+`poll-rings-indexing` runs every minute (registered unconditionally, inert
+unless `HELIUS_RINGS_ENABLED=true` and `HELIUS_RINGS_ADAPTER=http`):
+
+1. Operations in `indexing` poll `verifyIndexed` through the port; a hit
+   completes them.
+2. Operations stuck in `indexing` past 30 minutes fail as `indexing_timeout`
+   (retryable).
+
+## Diagnostics
+
+- `GET /v1/helius-rings/health` probes the gateway and records one row per
+  component (`rpc`, `prover`, `photon`, `gateway`) in
+  `helius_rings_runtime_health`. A component that has never been observed
+  reads **red**, not green.
+- The dashboard workspace (`/dashboard/helius-rings`) renders the health
+  board, wallets, composers, activity, the operation detail timeline, and the
+  recovery card. Degraded states render honestly: a wallet whose provisioning
+  hit the seam stays `pending`; failed operations show their code verbatim.
+
+## What stays dark until Track B
+
+| Surface | Behavior today |
+| --- | --- |
+| Wallet provisioning | `503` seam response; wallet stays `pending`. |
+| Any operation past policy | `failed:gateway_unavailable` (retryable). |
+| Balances / Photon sync | Not rendered; no fake cursor ever advances. |
+| Health board | `gateway` red; unobserved components red. |
+
+Track B replaces `NotImplementedRingsGateway` with the live HTTP adapter one
+method at a time (health first), flipping `HELIUS_RINGS_ADAPTER=http` when the
+sidecar is reachable.

--- a/docs/ops/helius-rings.md
+++ b/docs/ops/helius-rings.md
@@ -101,10 +101,18 @@ Cloud Run deployment gets — web replicas skip the in-process scheduler under
 `K_SERVICE`). Registered unconditionally in both, inert unless
 `HELIUS_RINGS_ENABLED=true` and `HELIUS_RINGS_ADAPTER=http`:
 
-1. Operations in `indexing` poll `verifyIndexed` through the port; a hit
+1. Operations in `submitted` are advanced to `indexing` and polled in the same
+   call. This is the crash-recovery path: the broadcast happens inside
+   `submitted`, so a process that dies before the indexing transition commits
+   leaves a live transaction there. The signed bytes are not persisted, so
+   there is nothing to resubmit — the signature is handed to Photon and the
+   indexing budget settles it either way.
+2. Operations in `indexing` poll `verifyIndexed` through the port; a hit
    completes them.
-2. Operations stuck in `indexing` past 30 minutes fail as `indexing_timeout`
-   (retryable).
+3. Operations stuck in `indexing` past 30 minutes fail as `indexing_timeout`
+   (retryable). The budget is not applied to a resumed `submitted` row: it
+   measures how long Photon has been asked, and that row has not been asked
+   yet.
 
 ## Diagnostics
 
@@ -131,7 +139,13 @@ method at a time (health first), flipping `HELIUS_RINGS_ADAPTER=http` when the
 sidecar is reachable.
 
 One gap remains in `runPipeline` for the moment that flip happens: **nothing
-sweeps `ready_to_sign` or `submitted`.** `poll-rings-indexing` only picks up
-`indexing`, so an operation that dies mid-transition needs a human. The
-signature is persisted before the broadcast, so the recovery is a lookup rather
-than a search — but the sweep itself is still to write.
+sweeps `ready_to_sign`.** An operation that dies between the proof landing and
+the signature being persisted needs a human. Nothing was broadcast in that
+window, so there is no on-chain effect to reconcile — the row is stale state,
+not a lost transaction.
+
+`submitted` is covered. The broadcast happens inside `submitted`, so that was
+the one window where a crash could strand a live transaction; the sweep now
+picks those rows up and `executeOperation` treats `submitted` as executable, so
+a stranded broadcast either completes on a Photon hit or fails retryably at the
+indexing budget.

--- a/docs/ops/helius-rings.md
+++ b/docs/ops/helius-rings.md
@@ -95,8 +95,11 @@ through them in one pass.
 
 ## Background jobs
 
-`poll-rings-indexing` runs every minute (registered unconditionally, inert
-unless `HELIUS_RINGS_ENABLED=true` and `HELIUS_RINGS_ADAPTER=http`):
+`poll-rings-indexing` runs every minute in-process (`cron/runner.ts`) and once
+per managed-job execution every five minutes (`src/job.ts`, the only tick a
+Cloud Run deployment gets — web replicas skip the in-process scheduler under
+`K_SERVICE`). Registered unconditionally in both, inert unless
+`HELIUS_RINGS_ENABLED=true` and `HELIUS_RINGS_ADAPTER=http`:
 
 1. Operations in `indexing` poll `verifyIndexed` through the port; a hit
    completes them.

--- a/docs/ops/helius-rings.md
+++ b/docs/ops/helius-rings.md
@@ -130,16 +130,8 @@ Track B replaces `NotImplementedRingsGateway` with the live HTTP adapter one
 method at a time (health first), flipping `HELIUS_RINGS_ADAPTER=http` when the
 sidecar is reachable.
 
-Two defects in `runPipeline` become reachable the moment that flip happens, and
-must be closed first (both are marked at the call site in `service.ts`):
-
-- The outer transaction is **broadcast while the operation is still
-  `ready_to_sign`**. Losing the process after the RPC accepts it leaves a live
-  transaction on chain whose signature was never persisted, and no job sweeps
-  `ready_to_sign`, so the operation strands with funds moved.
-- Because of that ordering, an RPC failure takes `ready_to_sign`'s fail edge
-  (`signer_failed`) rather than `submit_failed`, so the failure code lies about
-  what broke and `submit_failed` is currently unreachable.
-
-Both close together: derive the signature from the signed bytes, persist it via
-the `signed` guard, then broadcast from inside `submitted`.
+One gap remains in `runPipeline` for the moment that flip happens: **nothing
+sweeps `ready_to_sign` or `submitted`.** `poll-rings-indexing` only picks up
+`indexing`, so an operation that dies mid-transition needs a human. The
+signature is persisted before the broadcast, so the recovery is a lookup rather
+than a search — but the sweep itself is still to write.

--- a/docs/ops/helius-rings.md
+++ b/docs/ops/helius-rings.md
@@ -129,3 +129,17 @@ Cloud Run deployment gets — web replicas skip the in-process scheduler under
 Track B replaces `NotImplementedRingsGateway` with the live HTTP adapter one
 method at a time (health first), flipping `HELIUS_RINGS_ADAPTER=http` when the
 sidecar is reachable.
+
+Two defects in `runPipeline` become reachable the moment that flip happens, and
+must be closed first (both are marked at the call site in `service.ts`):
+
+- The outer transaction is **broadcast while the operation is still
+  `ready_to_sign`**. Losing the process after the RPC accepts it leaves a live
+  transaction on chain whose signature was never persisted, and no job sweeps
+  `ready_to_sign`, so the operation strands with funds moved.
+- Because of that ordering, an RPC failure takes `ready_to_sign`'s fail edge
+  (`signer_failed`) rather than `submit_failed`, so the failure code lies about
+  what broke and `submit_failed` is currently unreachable.
+
+Both close together: derive the signature from the signed bytes, persist it via
+the `signed` guard, then broadcast from inside `submitted`.

--- a/infra/self-hosted/.env.example
+++ b/infra/self-hosted/.env.example
@@ -73,6 +73,8 @@ PRIVATE_CHANNELS_ENABLED=false
 # routes and the dashboard workspace; production wiring stays off until the
 # live gateway integration lands.
 HELIUS_RINGS_ENABLED=false
+# Rings gateway selector; only "http" activates the live adapter (Track B).
+HELIUS_RINGS_ADAPTER=none
 
 # Authentication (Clerk) — required.
 # See apps/sdp-api/docs/self-hosting/clerk-setup.md for full walkthrough.

--- a/infra/self-hosted/.env.example
+++ b/infra/self-hosted/.env.example
@@ -69,6 +69,11 @@ SELF_HOSTED_STORED_CONNECTION_SETUP_ENABLED=false
 # dashboard workspace. Set SPC_CREDENTIAL_ENCRYPTION_KEY above when enabling.
 PRIVATE_CHANNELS_ENABLED=false
 
+# Helius Rings is opt-in and devnet-only. Gates the shielded-wallet API
+# routes and the dashboard workspace; production wiring stays off until the
+# live gateway integration lands.
+HELIUS_RINGS_ENABLED=false
+
 # Authentication (Clerk) — required.
 # See apps/sdp-api/docs/self-hosting/clerk-setup.md for full walkthrough.
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "check:module-boundaries": "node scripts/check-module-boundaries.mjs",
     "check:pinned-dependencies": "node scripts/check-pinned-dependency-versions.mjs",
     "check:kamino-dependency-boundary": "node scripts/check-kamino-dependency-boundary.mjs",
+    "check:secretref-serialization": "node scripts/check-secretref-serialization.mjs",
     "check:well-known-mints": "pnpm --filter @sdp/api exec tsx ../../scripts/check-well-known-mints.mjs",
     "check:api-playground": "pnpm -C apps/sdp-api playground:check",
     "generate:api-playground": "pnpm -C apps/sdp-api playground:generate",

--- a/packages/sdp-env-config/src/fields.ts
+++ b/packages/sdp-env-config/src/fields.ts
@@ -714,6 +714,18 @@ export const FIELDS: EnvField[] = [
     help: "Gates Private Channels API routes and deposit/withdrawal reconcilers.",
   },
   {
+    key: "HELIUS_RINGS_ENABLED",
+    section: "advanced",
+    kind: "select",
+    label: "Helius Rings enabled",
+    defaultValue: "false",
+    options: [
+      { value: "false", label: "Disabled" },
+      { value: "true", label: "Enabled" },
+    ],
+    help: "Gates the devnet-only Helius Rings shielded wallet API routes.",
+  },
+  {
     key: "SPC_CREDENTIAL_ENCRYPTION_KEY",
     section: "secrets",
     kind: "secret",

--- a/packages/sdp-env-config/src/fields.ts
+++ b/packages/sdp-env-config/src/fields.ts
@@ -726,6 +726,18 @@ export const FIELDS: EnvField[] = [
     help: "Gates the devnet-only Helius Rings shielded wallet API routes.",
   },
   {
+    key: "HELIUS_RINGS_ADAPTER",
+    section: "advanced",
+    kind: "select",
+    label: "Helius Rings gateway adapter",
+    defaultValue: "none",
+    options: [
+      { value: "none", label: "Not implemented (default)" },
+      { value: "http", label: "Live HTTP gateway" },
+    ],
+    help: 'Only "http" activates the live Rings gateway and the indexing-poll job.',
+  },
+  {
     key: "SPC_CREDENTIAL_ENCRYPTION_KEY",
     section: "secrets",
     kind: "secret",

--- a/packages/sdp-helius-rings/package.json
+++ b/packages/sdp-helius-rings/package.json
@@ -8,6 +8,11 @@
       "types": "./src/index.ts",
       "import": "./src/index.ts",
       "default": "./src/index.ts"
+    },
+    "./testing": {
+      "types": "./src/testing/index.ts",
+      "import": "./src/testing/index.ts",
+      "default": "./src/testing/index.ts"
     }
   },
   "scripts": {

--- a/packages/sdp-helius-rings/src/index.ts
+++ b/packages/sdp-helius-rings/src/index.ts
@@ -11,6 +11,18 @@ export {
   ZONE_KINDS,
 } from "./constants";
 export { HeliusRingsError, type HeliusRingsErrorCode } from "./errors";
+export { NotImplementedRingsGateway } from "./not-implemented-gateway";
+export type {
+  BuildOperationInput,
+  BuildOperationResult,
+  ProvisionIdentityInput,
+  ProvisionIdentityResult,
+  RequestProofInput,
+  RingsGatewayPort,
+  SyncPhotonInput,
+  SyncPhotonResult,
+  VerifyIndexedResult,
+} from "./port";
 export { type RevealScope, SecretRef } from "./secrets";
 export {
   type FailEdge,

--- a/packages/sdp-helius-rings/src/not-implemented-gateway.test.ts
+++ b/packages/sdp-helius-rings/src/not-implemented-gateway.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { HeliusRingsError } from "./errors";
+import { NotImplementedRingsGateway } from "./not-implemented-gateway";
+import type { RingsGatewayPort } from "./port";
+
+describe("NotImplementedRingsGateway", () => {
+  const gateway: RingsGatewayPort = new NotImplementedRingsGateway();
+
+  const calls: Array<[string, () => Promise<unknown>]> = [
+    ["probeHealth", () => gateway.probeHealth()],
+    [
+      "provisionIdentity",
+      () => gateway.provisionIdentity({ walletId: "hrw_1", sdpAddress: "addr" }),
+    ],
+    ["syncPhoton", () => gateway.syncPhoton({ walletId: "hrw_1", cursor: null })],
+    ["buildOperation", () => gateway.buildOperation({ operation: {} as never, keyRefs: [] })],
+    [
+      "requestProof",
+      () => gateway.requestProof({ operationId: "hro_1", ringsMetadata: {} as never }),
+    ],
+    ["verifyIndexed", () => gateway.verifyIndexed("sig")],
+  ];
+
+  it.each(calls)("%s throws gateway_unavailable naming the seam", async (method, call) => {
+    const error = await call().then(
+      () => null,
+      (thrown: unknown) => thrown
+    );
+
+    expect(error).toBeInstanceOf(HeliusRingsError);
+    expect((error as HeliusRingsError).code).toBe("gateway_unavailable");
+    expect((error as HeliusRingsError).message).toContain(method);
+  });
+});

--- a/packages/sdp-helius-rings/src/not-implemented-gateway.ts
+++ b/packages/sdp-helius-rings/src/not-implemented-gateway.ts
@@ -1,0 +1,42 @@
+import { HeliusRingsError } from "./errors";
+import type { RingsGatewayPort } from "./port";
+
+/**
+ * The production gateway until Track B lands the live HTTP adapter. Every
+ * method throws `gateway_unavailable` naming its seam, so an operation that
+ * reaches the port ends in `failed:gateway_unavailable` (retryable) and the UI
+ * reports the integration honestly instead of simulating it.
+ */
+
+function notImplemented(method: string): never {
+  throw new HeliusRingsError(
+    "gateway_unavailable",
+    `${method} awaiting Zolana sidecar integration`
+  );
+}
+
+export class NotImplementedRingsGateway implements RingsGatewayPort {
+  async probeHealth(): Promise<never> {
+    return notImplemented("probeHealth");
+  }
+
+  async provisionIdentity(): Promise<never> {
+    return notImplemented("provisionIdentity");
+  }
+
+  async syncPhoton(): Promise<never> {
+    return notImplemented("syncPhoton");
+  }
+
+  async buildOperation(): Promise<never> {
+    return notImplemented("buildOperation");
+  }
+
+  async requestProof(): Promise<never> {
+    return notImplemented("requestProof");
+  }
+
+  async verifyIndexed(): Promise<never> {
+    return notImplemented("verifyIndexed");
+  }
+}

--- a/packages/sdp-helius-rings/src/port.ts
+++ b/packages/sdp-helius-rings/src/port.ts
@@ -1,0 +1,64 @@
+import type { SecretRef } from "./secrets";
+import type { KeyRef, PrivateOperation, ProofArtifact, RuntimeHealth } from "./types";
+
+/**
+ * The only seam between SDP and the Rings upstreams (Zolana sidecar, Photon,
+ * prover, key authority). Track A ships NotImplementedRingsGateway behind it;
+ * Track B replaces that with the live HTTP adapter. Nothing else in the
+ * codebase may talk to those upstreams directly.
+ */
+
+export interface ProvisionIdentityInput {
+  walletId: string;
+  sdpAddress: string;
+}
+
+export interface ProvisionIdentityResult {
+  shieldedAddress: string;
+  keyRefs: KeyRef[];
+}
+
+export interface SyncPhotonInput {
+  walletId: string;
+  /** Null on the first sync. */
+  cursor: string | null;
+}
+
+export interface SyncPhotonResult {
+  cursor: string;
+  balances: Array<{ mint: string; amountRaw: string; decimals: number; symbol: string }>;
+  /** Outer tx signatures Photon has indexed since the previous cursor. */
+  indexedOperationSignatures: string[];
+}
+
+export interface BuildOperationInput {
+  operation: PrivateOperation;
+  keyRefs: KeyRef[];
+}
+
+export interface BuildOperationResult {
+  outerUnsignedTxBase64: string;
+  requiredSigners: string[];
+  /** Opaque gateway state carried into requestProof; never logged or persisted raw. */
+  ringsMetadata: SecretRef<Record<string, unknown>>;
+}
+
+export interface RequestProofInput {
+  operationId: string;
+  ringsMetadata: SecretRef<Record<string, unknown>>;
+}
+
+export interface VerifyIndexedResult {
+  indexedAt: string;
+  photonRef: string;
+}
+
+export interface RingsGatewayPort {
+  probeHealth(): Promise<RuntimeHealth>;
+  provisionIdentity(input: ProvisionIdentityInput): Promise<ProvisionIdentityResult>;
+  syncPhoton(input: SyncPhotonInput): Promise<SyncPhotonResult>;
+  buildOperation(input: BuildOperationInput): Promise<BuildOperationResult>;
+  requestProof(input: RequestProofInput): Promise<ProofArtifact>;
+  /** Null while Photon has not indexed the signature yet. */
+  verifyIndexed(signature: string): Promise<VerifyIndexedResult | null>;
+}

--- a/packages/sdp-helius-rings/src/secrets.ts
+++ b/packages/sdp-helius-rings/src/secrets.ts
@@ -1,10 +1,16 @@
 /**
  * Wraps a secret value so it never leaks through logs, JSON serialization, or
- * template literals. `reveal()` is the only path to the raw value; the scope
- * argument is a documentation-level contract for reviewers, not enforced at
- * runtime. A lint rule (A23) will forbid `JSON.stringify` on any value typed
- * `SecretRef<*>`; until then the `toJSON`/`toString` overrides are the safety
- * net.
+ * template literals. The `toJSON`/`toString` overrides mean a wrapped secret is
+ * safe wherever it is serialized or interpolated, at any depth.
+ *
+ * `reveal()` is the only path to the raw value, and the only real leak vector:
+ * the result is an ordinary string or Uint8Array with no redaction behaviour.
+ * The scope argument is a documentation-level contract for reviewers, not
+ * enforced at runtime. `scripts/check-secretref-serialization.mjs` fails the
+ * build if a `reveal()` result reaches `JSON.stringify`, a logger, `String()`,
+ * or a template literal — test files excepted, which is what the "test" scope is
+ * for. Plaintext key material that never got wrapped is caught separately by the
+ * log redaction registry in `apps/sdp-api/src/runtime/log-redaction.ts`.
  */
 export type RevealScope = "adapter" | "signer" | "test";
 

--- a/packages/sdp-helius-rings/src/testing/in-memory-gateway.test.ts
+++ b/packages/sdp-helius-rings/src/testing/in-memory-gateway.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import type { PrivateOperation } from "../types";
+import { InMemoryRingsGateway } from "./in-memory-gateway";
+
+const OPERATION = {
+  walletId: "hrw_1",
+  opType: "shield",
+  intentKey: "sha256:abc",
+} as PrivateOperation;
+
+describe("InMemoryRingsGateway", () => {
+  it("is deterministic: same inputs produce identical outputs", async () => {
+    const a = new InMemoryRingsGateway({ now: () => "2026-08-17T00:00:00.000Z" });
+    const b = new InMemoryRingsGateway({ now: () => "2026-08-17T00:00:00.000Z" });
+
+    const [identityA, identityB] = await Promise.all([
+      a.provisionIdentity({ walletId: "hrw_1", sdpAddress: "addr" }),
+      b.provisionIdentity({ walletId: "hrw_1", sdpAddress: "addr" }),
+    ]);
+    expect(identityA.shieldedAddress).toBe(identityB.shieldedAddress);
+    expect(identityA.keyRefs[0].material.reveal("test")).toEqual(
+      identityB.keyRefs[0].material.reveal("test")
+    );
+
+    const [builtA, builtB] = await Promise.all([
+      a.buildOperation({ operation: OPERATION, keyRefs: [] }),
+      b.buildOperation({ operation: OPERATION, keyRefs: [] }),
+    ]);
+    expect(builtA.outerUnsignedTxBase64).toBe(builtB.outerUnsignedTxBase64);
+  });
+
+  it("returns all-green health by default and honours an override", async () => {
+    expect(await new InMemoryRingsGateway().probeHealth()).toEqual({
+      rpc: "green",
+      prover: "green",
+      photon: "green",
+      gateway: "green",
+    });
+
+    const degraded = new InMemoryRingsGateway({
+      health: { rpc: "green", prover: "red", photon: "amber", gateway: "green" },
+    });
+    expect((await degraded.probeHealth()).prover).toBe("red");
+  });
+
+  it("provisions exactly a viewing and a nullifier key, both simulated", async () => {
+    const identity = await new InMemoryRingsGateway().provisionIdentity({
+      walletId: "hrw_1",
+      sdpAddress: "addr",
+    });
+
+    expect(identity.keyRefs.map((keyRef) => keyRef.kind)).toEqual(["viewing", "nullifier"]);
+    expect(identity.keyRefs.every((keyRef) => keyRef.materialTag === "simulated")).toBe(true);
+    // The wrapper must be real — the downstream chain handles SecretRef before
+    // the live adapter exists.
+    expect(JSON.stringify(identity.keyRefs[0].material)).toBe('"[REDACTED]"');
+  });
+
+  it("advances a monotonic sync cursor per wallet", async () => {
+    const gateway = new InMemoryRingsGateway();
+
+    expect((await gateway.syncPhoton({ walletId: "hrw_1", cursor: null })).cursor).toBe("slot:1");
+    expect((await gateway.syncPhoton({ walletId: "hrw_1", cursor: "slot:1" })).cursor).toBe(
+      "slot:2"
+    );
+    expect((await gateway.syncPhoton({ walletId: "hrw_2", cursor: null })).cursor).toBe("slot:1");
+  });
+
+  it("always marks proofs simulated", async () => {
+    const proof = await new InMemoryRingsGateway({
+      now: () => "2026-08-17T00:00:00.000Z",
+    }).requestProof({ operationId: "hro_1", ringsMetadata: {} as never });
+
+    expect(proof.source).toBe("simulated");
+    expect(proof.createdAt).toBe("2026-08-17T00:00:00.000Z");
+  });
+
+  it("reports indexed only after the delay elapses on the injected clock", async () => {
+    let now = "2026-08-17T00:00:00.000Z";
+    const gateway = new InMemoryRingsGateway({ now: () => now, indexingDelayMs: 1000 });
+
+    expect(await gateway.verifyIndexed("sig")).toBeNull();
+
+    gateway.recordSubmission("sig");
+    expect(await gateway.verifyIndexed("sig")).toBeNull();
+
+    now = "2026-08-17T00:00:01.000Z";
+    expect(await gateway.verifyIndexed("sig")).toMatchObject({ indexedAt: now });
+  });
+
+  it("lets a test inject a signable unsigned tx", async () => {
+    const gateway = new InMemoryRingsGateway({ buildUnsignedTx: () => "c2lnbmFibGU=" });
+
+    const built = await gateway.buildOperation({ operation: OPERATION, keyRefs: [] });
+    expect(built.outerUnsignedTxBase64).toBe("c2lnbmFibGU=");
+  });
+});

--- a/packages/sdp-helius-rings/src/testing/in-memory-gateway.ts
+++ b/packages/sdp-helius-rings/src/testing/in-memory-gateway.ts
@@ -1,0 +1,167 @@
+import type {
+  BuildOperationInput,
+  BuildOperationResult,
+  ProvisionIdentityInput,
+  ProvisionIdentityResult,
+  RequestProofInput,
+  RingsGatewayPort,
+  SyncPhotonInput,
+  SyncPhotonResult,
+  VerifyIndexedResult,
+} from "../port";
+import { SecretRef } from "../secrets";
+import type { ProofArtifact, RuntimeHealth } from "../types";
+
+/**
+ * Test-only implementation of RingsGatewayPort. Never shipped: it lives under
+ * src/testing/, is exported only via the `@sdp/helius-rings/testing` subpath,
+ * and is not selectable by environment. Production uses
+ * NotImplementedRingsGateway until Track B lands the live adapter.
+ *
+ * Deterministic by construction — outputs derive from a hash of the inputs,
+ * and time comes from the injected clock — so the same test always sees the
+ * same values.
+ */
+
+export interface InMemoryRingsGatewayOptions {
+  /** Injected clock; defaults to the real one. */
+  now?: () => string;
+  /** Health returned by probeHealth; defaults to all green. */
+  health?: RuntimeHealth;
+  /** How long after submission verifyIndexed starts reporting indexed. */
+  indexingDelayMs?: number;
+  /** Override for tests that need a signable unsigned tx (A8/A9). */
+  buildUnsignedTx?: (input: BuildOperationInput) => string;
+}
+
+const ALL_GREEN: RuntimeHealth = {
+  rpc: "green",
+  prover: "green",
+  photon: "green",
+  gateway: "green",
+};
+
+/** FNV-1a, hex-encoded — deterministic bytes without a crypto dependency. */
+function hashHex(seed: string, bytes: number): string {
+  let hash = 0x811c9dc5;
+  let out = "";
+  for (let round = 0; out.length < bytes * 2; round++) {
+    const input = `${seed}:${round}`;
+    for (let i = 0; i < input.length; i++) {
+      hash ^= input.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+    out += hash.toString(16).padStart(8, "0");
+  }
+  return out.slice(0, bytes * 2);
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+// biome-ignore lint/security/noSecrets: character alphabet, not a secret.
+const BASE64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/** Dependency-free base64 so the package needs neither Buffer nor btoa types. */
+function bytesToBase64(bytes: Uint8Array): string {
+  let out = "";
+  for (let i = 0; i < bytes.length; i += 3) {
+    const [a, b, c] = [bytes[i], bytes[i + 1], bytes[i + 2]];
+    out += BASE64_ALPHABET[a >> 2];
+    out += BASE64_ALPHABET[((a & 3) << 4) | ((b ?? 0) >> 4)];
+    out += b === undefined ? "=" : BASE64_ALPHABET[((b & 15) << 2) | ((c ?? 0) >> 6)];
+    out += c === undefined ? "=" : BASE64_ALPHABET[c & 63];
+  }
+  return out;
+}
+
+export class InMemoryRingsGateway implements RingsGatewayPort {
+  private readonly now: () => string;
+  private readonly health: RuntimeHealth;
+  private readonly indexingDelayMs: number;
+  private readonly buildUnsignedTx?: (input: BuildOperationInput) => string;
+  private readonly syncCounters = new Map<string, number>();
+  private readonly submittedAt = new Map<string, number>();
+
+  constructor(options: InMemoryRingsGatewayOptions = {}) {
+    this.now = options.now ?? (() => new Date().toISOString());
+    this.health = options.health ?? ALL_GREEN;
+    this.indexingDelayMs = options.indexingDelayMs ?? 0;
+    this.buildUnsignedTx = options.buildUnsignedTx;
+  }
+
+  async probeHealth(): Promise<RuntimeHealth> {
+    return { ...this.health };
+  }
+
+  async provisionIdentity(input: ProvisionIdentityInput): Promise<ProvisionIdentityResult> {
+    const seed = `${input.walletId}:${input.sdpAddress}`;
+    return {
+      shieldedAddress: `rings1${hashHex(`${seed}:address`, 16)}`,
+      keyRefs: (["viewing", "nullifier"] as const).map((kind) => ({
+        kind,
+        material: new SecretRef(hexToBytes(hashHex(`${seed}:${kind}`, 32))),
+        materialTag: "simulated",
+        keyVersion: "v1",
+      })),
+    };
+  }
+
+  async syncPhoton(input: SyncPhotonInput): Promise<SyncPhotonResult> {
+    const next = (this.syncCounters.get(input.walletId) ?? 0) + 1;
+    this.syncCounters.set(input.walletId, next);
+    return {
+      cursor: `slot:${next}`,
+      balances: [
+        {
+          // biome-ignore lint/security/noSecrets: wrapped SOL mint address, not a secret.
+          mint: "So11111111111111111111111111111111111111112",
+          amountRaw: String(1_000_000_000 * next),
+          decimals: 9,
+          symbol: "SOL",
+        },
+      ],
+      indexedOperationSignatures: [],
+    };
+  }
+
+  async buildOperation(input: BuildOperationInput): Promise<BuildOperationResult> {
+    const seed = `${input.operation.walletId}:${input.operation.opType}:${input.operation.intentKey}`;
+    const outerUnsignedTxBase64 =
+      this.buildUnsignedTx?.(input) ?? bytesToBase64(hexToBytes(hashHex(`${seed}:tx`, 64)));
+    return {
+      outerUnsignedTxBase64,
+      requiredSigners: [input.operation.walletId],
+      ringsMetadata: new SecretRef({ seed: hashHex(`${seed}:metadata`, 16) }),
+    };
+  }
+
+  async requestProof(input: RequestProofInput): Promise<ProofArtifact> {
+    return {
+      source: "simulated",
+      ref: new SecretRef(hashHex(`${input.operationId}:proof`, 32)),
+      createdAt: this.now(),
+    };
+  }
+
+  /** Tests call this to start the indexing clock for a signature. */
+  recordSubmission(signature: string): void {
+    this.submittedAt.set(signature, Date.parse(this.now()));
+  }
+
+  async verifyIndexed(signature: string): Promise<VerifyIndexedResult | null> {
+    const submitted = this.submittedAt.get(signature);
+    if (submitted === undefined) return null;
+    const elapsed = Date.parse(this.now()) - submitted;
+    if (elapsed < this.indexingDelayMs) return null;
+    return {
+      indexedAt: this.now(),
+      photonRef: `photon:${hashHex(signature, 8)}`,
+    };
+  }
+}

--- a/packages/sdp-helius-rings/src/testing/index.ts
+++ b/packages/sdp-helius-rings/src/testing/index.ts
@@ -1,0 +1,1 @@
+export { InMemoryRingsGateway, type InMemoryRingsGatewayOptions } from "./in-memory-gateway";

--- a/packages/sdp-types/src/policy.ts
+++ b/packages/sdp-types/src/policy.ts
@@ -16,6 +16,18 @@ export const WALLET_OPERATION_TYPES = [
   "recurring_payment_collection",
   "recurring_payment_create",
   "recurring_payment_update",
+  // Helius Rings shielded operations. Mirror OP_TYPES in
+  // packages/sdp-helius-rings/src/constants.ts; the template type
+  // `rings_${OpType}` in the rings policy envelope fails to compile if the
+  // two lists drift.
+  "rings_shield",
+  "rings_transfer_registered",
+  "rings_transfer_anonymous",
+  "rings_withdraw",
+  "rings_merge",
+  "rings_timelock_create",
+  "rings_timelock_settle",
+  "rings_zone_create",
 ] as const;
 
 export type WalletOperationType = (typeof WALLET_OPERATION_TYPES)[number];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       '@sdp/env-config':
         specifier: workspace:*
         version: link:../../packages/sdp-env-config
+      '@sdp/helius-rings':
+        specifier: workspace:*
+        version: link:../../packages/sdp-helius-rings
       '@sdp/issuance':
         specifier: workspace:*
         version: link:../../packages/sdp-issuance

--- a/scripts/check-module-boundaries.mjs
+++ b/scripts/check-module-boundaries.mjs
@@ -23,6 +23,7 @@ const MODULE_METADATA = [
       "@sdp/custody",
       "@sdp/earn",
       "@sdp/env-config",
+      "@sdp/helius-rings",
       "@sdp/issuance",
       "@sdp/kamino",
       "@sdp/payments",

--- a/scripts/check-secretref-serialization.mjs
+++ b/scripts/check-secretref-serialization.mjs
@@ -18,6 +18,12 @@
  *   2. a logger or console call
  *   3. a template literal or String()
  *
+ * "Flowing into" covers the direct call and one indirection: identifiers
+ * assigned a reveal() result (or an alias of one) are tracked per file and
+ * flagged at the same sinks. Aliasing is deliberately direct-only — a value
+ * that passed through another call (a hash, an encryptor) is considered
+ * transformed and is the sanctioned way to log.
+ *
  * It also flags `JSON.stringify` applied directly to a `SecretRef` construction,
  * which is harmless at runtime but always means the author misunderstood the
  * wrapper.
@@ -115,6 +121,58 @@ function isSecretRefConstruction(node) {
   );
 }
 
+/** Strips wrappers that do not change what a value is. */
+function unwrapExpression(node) {
+  while (
+    ts.isParenthesizedExpression(node) ||
+    ts.isAwaitExpression(node) ||
+    ts.isAsExpression(node) ||
+    ts.isNonNullExpression(node) ||
+    ts.isSatisfiesExpression(node)
+  ) {
+    node = node.expression;
+  }
+  return node;
+}
+
+/**
+ * Names bound to a reveal() result in this file, direct aliases included
+ * (`const v = ref.reveal(...)`, `w = v`). Name-based and file-scoped — a
+ * same-named variable elsewhere in the file is treated as tainted too, which
+ * errs toward flagging.
+ */
+function collectRevealedAliases(sourceFile) {
+  const aliases = new Set();
+  const taintsFrom = (initializer) => {
+    const value = unwrapExpression(initializer);
+    return isRevealCall(value) || (ts.isIdentifier(value) && aliases.has(value.text));
+  };
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    const visit = (node) => {
+      let name = null;
+      if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+        if (taintsFrom(node.initializer)) name = node.name.text;
+      } else if (
+        ts.isBinaryExpression(node) &&
+        node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        ts.isIdentifier(node.left)
+      ) {
+        if (taintsFrom(node.right)) name = node.left.text;
+      }
+      if (name && !aliases.has(name)) {
+        aliases.add(name);
+        changed = true;
+      }
+      ts.forEachChild(node, visit);
+    };
+    ts.forEachChild(sourceFile, visit);
+  }
+  return aliases;
+}
+
 /** Walks `root` (inclusive) looking for any node satisfying `predicate`. */
 function containsNode(root, predicate) {
   let found = false;
@@ -134,9 +192,9 @@ function lineOf(sourceFile, node) {
   return sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
 }
 
-/** True when any argument of a call contains a reveal(). */
-function hasRevealedArgument(node) {
-  return node.arguments.some((argument) => containsNode(argument, isRevealCall));
+/** True when any argument of a call contains a revealed value. */
+function hasRevealedArgument(node, isRevealedValue) {
+  return node.arguments.some((argument) => containsNode(argument, isRevealedValue));
 }
 
 /**
@@ -145,11 +203,11 @@ function hasRevealedArgument(node) {
  * adding a rule does not push the walker past the repo's complexity ceiling.
  */
 const RULES = [
-  function serialization(node) {
+  function serialization(node, isRevealedValue) {
     if (!isJsonStringifyCall(node)) return null;
     const [argument] = node.arguments;
     if (!argument) return null;
-    if (containsNode(argument, isRevealCall)) {
+    if (containsNode(argument, isRevealedValue)) {
       return "JSON.stringify() receives a revealed SecretRef. Serialize the wrapper, or a hash of the value, not reveal().";
     }
     if (containsNode(argument, isSecretRefConstruction)) {
@@ -158,20 +216,20 @@ const RULES = [
     return null;
   },
 
-  function logging(node) {
-    if (!isLogCall(node) || !hasRevealedArgument(node)) return null;
+  function logging(node, isRevealedValue) {
+    if (!isLogCall(node) || !hasRevealedArgument(node, isRevealedValue)) return null;
     return `${node.expression.name.text}() receives a revealed SecretRef. Log an identifier or a hash, never the material.`;
   },
 
-  function stringCoercion(node) {
-    if (!isStringCoercionCall(node) || !hasRevealedArgument(node)) return null;
+  function stringCoercion(node, isRevealedValue) {
+    if (!isStringCoercionCall(node) || !hasRevealedArgument(node, isRevealedValue)) return null;
     return 'String() receives a revealed SecretRef. Coerce the wrapper instead — it yields "[REDACTED]".';
   },
 
-  function interpolation(node) {
+  function interpolation(node, isRevealedValue) {
     if (!ts.isTemplateExpression(node)) return null;
     const interpolatesReveal = node.templateSpans.some((span) =>
-      containsNode(span.expression, isRevealCall)
+      containsNode(span.expression, isRevealedValue)
     );
     if (!interpolatesReveal) return null;
     return 'Template literal interpolates a revealed SecretRef. Interpolate the wrapper instead — it yields "[REDACTED]".';
@@ -192,9 +250,20 @@ export function findSecretRefViolations(sourceText, relativePath) {
     relativePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS
   );
 
+  const aliases = collectRevealedAliases(sourceFile);
+  const isRevealedValue = (node) => {
+    if (isRevealCall(node)) return true;
+    if (!ts.isIdentifier(node) || !aliases.has(node.text)) return false;
+    // A same-named property (`obj.v`, `{ v: x }`) is not the variable.
+    const parent = node.parent;
+    if (parent && ts.isPropertyAccessExpression(parent) && parent.name === node) return false;
+    if (parent && ts.isPropertyAssignment(parent) && parent.name === node) return false;
+    return true;
+  };
+
   const visit = (node) => {
     for (const rule of RULES) {
-      const message = rule(node);
+      const message = rule(node, isRevealedValue);
       if (message) {
         violations.push(`${relativePath}:${lineOf(sourceFile, node)}: ${message}`);
       }

--- a/scripts/check-secretref-serialization.mjs
+++ b/scripts/check-secretref-serialization.mjs
@@ -1,0 +1,265 @@
+/**
+ * Forbids revealed `SecretRef` material from reaching a serializer, a logger, or
+ * a string.
+ *
+ * `SecretRef<T>` (packages/sdp-helius-rings/src/secrets.ts) wraps viewing keys,
+ * nullifier keys and proof internals. Its `toJSON()`/`toString()` overrides
+ * already return "[REDACTED]", so passing a *wrapped* secret to
+ * `JSON.stringify` or a log call is safe by construction — the plan's original
+ * wording ("forbid JSON.stringify on any value typed SecretRef<*>") targets a
+ * pattern that cannot actually leak.
+ *
+ * The pattern that leaks is `reveal()`. Once unwrapped, the value is an ordinary
+ * string or Uint8Array with no redaction behaviour at all, and the wrapper's
+ * whole purpose is gone. So this check follows the intent rather than the letter
+ * and flags reveal() results flowing into:
+ *
+ *   1. JSON.stringify / JSON.stringify-like serialization
+ *   2. a logger or console call
+ *   3. a template literal or String()
+ *
+ * It also flags `JSON.stringify` applied directly to a `SecretRef` construction,
+ * which is harmless at runtime but always means the author misunderstood the
+ * wrapper.
+ *
+ * `reveal("test")` inside test files is the sanctioned path — `RevealScope`
+ * includes "test" precisely so tests can assert on real values — so test files
+ * are exempt.
+ *
+ * This is a standalone script rather than a lint rule because the repo lints
+ * with Biome, which has no custom-rule authoring mechanism in use here, and the
+ * established convention for bespoke static checks is scripts/check-*.mjs with a
+ * sibling .test.mjs (see check-module-boundaries.mjs, check-env-contract.mjs).
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+/** Methods that write somewhere a human or a log sink can read. */
+const LOG_METHODS = new Set([
+  "log",
+  "info",
+  "warn",
+  "error",
+  "debug",
+  "trace",
+  "fatal",
+  "captureException",
+  "captureMessage",
+]);
+
+const SCAN_ROOTS = ["apps", "packages"];
+
+/** Files that legitimately handle raw secret material. */
+const EXEMPT_SUFFIXES = [
+  "packages/sdp-helius-rings/src/secrets.ts",
+  "scripts/check-secretref-serialization.mjs",
+];
+
+function isTestFile(relativePath) {
+  return (
+    /\.(test|spec)\.(ts|tsx|mts)$/.test(relativePath) || /(^|\/)(test|tests)\//.test(relativePath)
+  );
+}
+
+function isExempt(relativePath) {
+  return EXEMPT_SUFFIXES.some((suffix) => relativePath.endsWith(suffix));
+}
+
+/** True when `node` is a `<something>.reveal(...)` call. */
+function isRevealCall(node) {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === "reveal"
+  );
+}
+
+/** True when `node` is `JSON.stringify(...)`. */
+function isJsonStringifyCall(node) {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === "stringify" &&
+    ts.isIdentifier(node.expression.expression) &&
+    node.expression.expression.text === "JSON"
+  );
+}
+
+/** True when `node` is a `<obj>.info(...)`-style call onto a log-ish method. */
+function isLogCall(node) {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    LOG_METHODS.has(node.expression.name.text)
+  );
+}
+
+/** True when `node` is `String(...)`. */
+function isStringCoercionCall(node) {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    node.expression.text === "String"
+  );
+}
+
+/** True when `node` is `new SecretRef(...)`. */
+function isSecretRefConstruction(node) {
+  return (
+    ts.isNewExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    node.expression.text === "SecretRef"
+  );
+}
+
+/** Walks `root` (inclusive) looking for any node satisfying `predicate`. */
+function containsNode(root, predicate) {
+  let found = false;
+  const visit = (node) => {
+    if (found) return;
+    if (predicate(node)) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(root);
+  return found;
+}
+
+function lineOf(sourceFile, node) {
+  return sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+}
+
+/** True when any argument of a call contains a reveal(). */
+function hasRevealedArgument(node) {
+  return node.arguments.some((argument) => containsNode(argument, isRevealCall));
+}
+
+/**
+ * The rules. Each takes a node and returns the violation message for it, or
+ * null. Kept as separate small functions rather than one branching visitor so
+ * adding a rule does not push the walker past the repo's complexity ceiling.
+ */
+const RULES = [
+  function serialization(node) {
+    if (!isJsonStringifyCall(node)) return null;
+    const [argument] = node.arguments;
+    if (!argument) return null;
+    if (containsNode(argument, isRevealCall)) {
+      return "JSON.stringify() receives a revealed SecretRef. Serialize the wrapper, or a hash of the value, not reveal().";
+    }
+    if (containsNode(argument, isSecretRefConstruction)) {
+      return 'JSON.stringify() receives a SecretRef. It serializes to "[REDACTED]" and carries no information — drop the call.';
+    }
+    return null;
+  },
+
+  function logging(node) {
+    if (!isLogCall(node) || !hasRevealedArgument(node)) return null;
+    return `${node.expression.name.text}() receives a revealed SecretRef. Log an identifier or a hash, never the material.`;
+  },
+
+  function stringCoercion(node) {
+    if (!isStringCoercionCall(node) || !hasRevealedArgument(node)) return null;
+    return 'String() receives a revealed SecretRef. Coerce the wrapper instead — it yields "[REDACTED]".';
+  },
+
+  function interpolation(node) {
+    if (!ts.isTemplateExpression(node)) return null;
+    const interpolatesReveal = node.templateSpans.some((span) =>
+      containsNode(span.expression, isRevealCall)
+    );
+    if (!interpolatesReveal) return null;
+    return 'Template literal interpolates a revealed SecretRef. Interpolate the wrapper instead — it yields "[REDACTED]".';
+  },
+];
+
+/**
+ * Returns violation strings for one file's source text. Exported so the sibling
+ * test can drive it without touching the filesystem.
+ */
+export function findSecretRefViolations(sourceText, relativePath) {
+  const violations = [];
+  const sourceFile = ts.createSourceFile(
+    relativePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    relativePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+
+  const visit = (node) => {
+    for (const rule of RULES) {
+      const message = rule(node);
+      if (message) {
+        violations.push(`${relativePath}:${lineOf(sourceFile, node)}: ${message}`);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  ts.forEachChild(sourceFile, visit);
+  return violations;
+}
+
+function collectSourceFiles(repositoryRoot) {
+  const files = [];
+
+  for (const root of SCAN_ROOTS) {
+    const absoluteRoot = path.join(repositoryRoot, root);
+    let entries;
+    try {
+      if (!statSync(absoluteRoot).isDirectory()) continue;
+      entries = readdirSync(absoluteRoot, { recursive: true, encoding: "utf8" });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!/\.(ts|tsx|mts)$/.test(entry)) continue;
+      if (/(^|\/)(node_modules|dist|build|\.next|\.turbo)(\/|$)/.test(entry)) continue;
+      if (entry.endsWith(".d.ts")) continue;
+
+      const relativePath = path.posix.join(root, entry.split(path.sep).join("/"));
+      if (isTestFile(relativePath) || isExempt(relativePath)) continue;
+      files.push(relativePath);
+    }
+  }
+
+  return files.sort();
+}
+
+export function checkSecretRefSerialization(repositoryRoot) {
+  const violations = [];
+
+  for (const relativePath of collectSourceFiles(repositoryRoot)) {
+    const sourceText = readFileSync(path.join(repositoryRoot, relativePath), "utf8");
+    // Cheap prefilter: parsing every file in the monorepo to find a handful of
+    // reveal() calls is wasted work.
+    if (!sourceText.includes("reveal(") && !sourceText.includes("SecretRef")) continue;
+    violations.push(...findSecretRefViolations(sourceText, relativePath));
+  }
+
+  return violations;
+}
+
+const isMainModule = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMainModule) {
+  const repositoryRoot = path.resolve(
+    process.argv[2] ?? path.dirname(fileURLToPath(import.meta.url)),
+    ".."
+  );
+  const violations = checkSecretRefSerialization(repositoryRoot);
+
+  if (violations.length > 0) {
+    console.error("SecretRef serialization violations:\n");
+    console.error(violations.map((violation) => `- ${violation}`).join("\n"));
+    process.exitCode = 1;
+  } else {
+    console.log("SecretRef serialization check passed.");
+  }
+}

--- a/scripts/check-secretref-serialization.test.mjs
+++ b/scripts/check-secretref-serialization.test.mjs
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { findSecretRefViolations } from "./check-secretref-serialization.mjs";
+
+test("flags a revealed secret passed to JSON.stringify", () => {
+  const violations = findSecretRefViolations(
+    `const payload = JSON.stringify({ key: keyRef.material.reveal("adapter") });\n`,
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /^apps\/sdp-api\/src\/services\/helius-rings\/example\.ts:1: /);
+  assert.match(violations[0], /JSON\.stringify\(\) receives a revealed SecretRef/);
+});
+
+test("flags a revealed secret passed to a logger", () => {
+  const violations = findSecretRefViolations(
+    `getLogger().info({ viewingKey: keys.viewing.reveal("adapter") }, "provisioned");\n`,
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /info\(\) receives a revealed SecretRef/);
+});
+
+test("flags a revealed secret interpolated into a template literal", () => {
+  const violations = findSecretRefViolations(
+    `const message = \`viewing key is \${secret.reveal("signer")}\`;\n`,
+    "packages/sdp-helius-rings/src/example.ts"
+  );
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /Template literal interpolates a revealed SecretRef/);
+});
+
+test("flags a revealed secret coerced with String()", () => {
+  const violations = findSecretRefViolations(
+    `const asText = String(secret.reveal("adapter"));\n`,
+    "packages/sdp-helius-rings/src/example.ts"
+  );
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /String\(\) receives a revealed SecretRef/);
+});
+
+test("flags stringifying a SecretRef as pointless rather than dangerous", () => {
+  const violations = findSecretRefViolations(
+    `const encoded = JSON.stringify(new SecretRef("hunter2"));\n`,
+    "packages/sdp-helius-rings/src/example.ts"
+  );
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /carries no information/);
+});
+
+test("finds a reveal nested deep inside a log argument", () => {
+  const violations = findSecretRefViolations(
+    `logger.error({ op: { detail: { material: ref.material.reveal("signer") } } }, "failed");\n`,
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /error\(\) receives a revealed SecretRef/);
+});
+
+test("reports each offending call once, with its own line", () => {
+  const violations = findSecretRefViolations(
+    [
+      `logger.info({ a: s.reveal("adapter") }, "one");`,
+      `const t = \`\${s.reveal("adapter")}\`;`,
+    ].join("\n"),
+    "apps/sdp-api/src/example.ts"
+  );
+
+  assert.equal(violations.length, 2);
+  assert.match(violations[0], /:1: /);
+  assert.match(violations[1], /:2: /);
+});
+
+test("allows passing the wrapper itself to a logger or serializer", () => {
+  const violations = findSecretRefViolations(
+    [
+      `getLogger().info({ proof: operation.proof }, "prepared");`,
+      `const body = JSON.stringify({ ref: operation.proof.ref });`,
+      `const shown = \`proof \${operation.proof.ref}\`;`,
+    ].join("\n"),
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  assert.deepEqual(violations, []);
+});
+
+test("allows reveal() where it belongs — handed to an adapter or signer", () => {
+  const violations = findSecretRefViolations(
+    [
+      `await gateway.buildOperation({ material: keyRef.material.reveal("adapter") });`,
+      `const signature = await signer.sign(payload, key.reveal("signer"));`,
+    ].join("\n"),
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  assert.deepEqual(violations, []);
+});
+
+test("does not confuse an unrelated reveal() method", () => {
+  const violations = findSecretRefViolations(
+    `logger.info({ state: animation.reveal() }, "toggled");\n`,
+    "apps/sdp-web/src/example.ts"
+  );
+
+  // A false positive here is acceptable and deliberate: the check is
+  // name-based, and `reveal()` is rare enough outside SecretRef that catching
+  // the leak is worth the occasional rename. Documented so the behaviour is a
+  // decision rather than a surprise.
+  assert.equal(violations.length, 1);
+});

--- a/scripts/check-secretref-serialization.test.mjs
+++ b/scripts/check-secretref-serialization.test.mjs
@@ -102,6 +102,62 @@ test("allows reveal() where it belongs — handed to an adapter or signer", () =
   assert.deepEqual(violations, []);
 });
 
+test("flags a revealed secret logged through a variable", () => {
+  const violations = findSecretRefViolations(
+    [
+      `const material = keyRef.material.reveal("adapter");`,
+      `logger.info({ material }, "provisioned");`,
+    ].join("\n"),
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /:2: info\(\) receives a revealed SecretRef/);
+});
+
+test("follows an alias chain and reassignment to a sink", () => {
+  const violations = findSecretRefViolations(
+    [
+      `let value = other;`,
+      `value = secret.reveal("signer");`,
+      `const copy = value;`,
+      `const body = JSON.stringify({ copy });`,
+      `const shown = \`key \${copy}\`;`,
+    ].join("\n"),
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  assert.equal(violations.length, 2);
+  assert.match(violations[0], /:4: JSON\.stringify\(\) receives a revealed SecretRef/);
+  assert.match(violations[1], /:5: Template literal interpolates a revealed SecretRef/);
+});
+
+test("does not taint values transformed by another call", () => {
+  const violations = findSecretRefViolations(
+    [
+      `const digest = sha256(secret.reveal("adapter"));`,
+      `logger.info({ digest }, "provisioned");`,
+    ].join("\n"),
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  // Hashing is the sanctioned way to log; only direct aliases are tracked.
+  assert.deepEqual(violations, []);
+});
+
+test("does not flag a same-named property on another object", () => {
+  const violations = findSecretRefViolations(
+    [
+      `const material = keyRef.material.reveal("adapter");`,
+      `await gateway.buildOperation({ material });`,
+      `logger.info({ kind: row.material }, "stored");`,
+    ].join("\n"),
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  assert.deepEqual(violations, []);
+});
+
 test("does not confuse an unrelated reveal() method", () => {
   const violations = findSecretRefViolations(
     `logger.info({ state: animation.reveal() }, "toggled");\n`,


### PR DESCRIPTION
Adds the Helius Rings shielded-wallet module. Authored by @nbaztec; this is the complete
feature on one branch, with the 24 commits preserved so it can be reviewed layer by layer
from the Commits tab.

## What

A **devnet-only** shielded-wallet module that binds a Helius Rings private identity to an
existing SDP custody wallet and drives shielded operations through a persisted state
machine. Scope is the default ring only: instruction tags 11 (`DEPOSIT`), 12 (`TRANSACT`),
13 (`MERGE_TRANSACT`).

Everything on SDP's side of the boundary is real, wired, tenant-scoped and tested. The
module reuses SDP's own custody signer, RPC submit path, and wallet-policy engine
unchanged — a rings operation is a `transfer` under the policy envelope, not a new policy
vocabulary.

## The seam

`RingsGatewayPort` is the single boundary to the Rings upstreams (Zolana sidecar, Photon
indexer, prover, key authority). Nothing else in the codebase may talk to them.

Production wiring gets `NotImplementedRingsGateway`: all six methods throw
`gateway_unavailable` naming their seam. **Nothing is simulated.** An unprovisioned wallet
stays `pending`, an operation ends `failed:gateway_unavailable`, and a health component
never observed reads red rather than green.

`InMemoryRingsGateway` is test-only — exported through the `@sdp/helius-rings/testing`
subpath, absent from the package root, and not selectable by any environment variable, so
no mock can reach production.

## Data model

`0057_helius_rings.sql` — 8 tables: wallets, key_refs, zones, operations, timelocks,
events, asset_allowlist, runtime_health.

- The operation row **is** the lifecycle: 26 columns spanning intent, policy verdict, proof
  handle, signature, indexing timestamp and failure detail. No status table, no attempt
  table.
- `intent_key` carries a unique index — the idempotency contract behind `reserveIntent`.
- Tenant integrity travels in the key, not just the predicate: operations → wallets on
  `(id, organization_id, project_id)`, operations → zones on `(id, wallet_id)`. A
  cross-tenant or cross-wallet reference is an FK error, not a query bug.
- The failure triple is CHECK-tied to the `failed` state, and `transfer_mode` is pinned to
  `op_type` in both directions — an anonymous transfer can never render as registered.
- Timelock timestamps are CHECK-pinned to the fixed-width `sdp_iso_now()` UTC shape, so
  lexical ordering is chronological.
- Retry lineage is a self-referential FK with `ON DELETE SET NULL`.

Six repositories (interface + Postgres impl) sit on top, with no state-machine knowledge:
transitions are CAS-guarded under `SELECT … FOR UPDATE`, sparse patches never blank earlier
columns, the key-ref repo never decrypts, and timelock release is single-shot.

## Operation lifecycle

`HeliusRingsService` owns the order of calls and nothing else — no SQL, no HTTP, no crypto.

```
draft → preparing → approval_required → proving → ready_to_sign → submitted
      → indexing → completed | failed
```

- `prepareOperation` reserves the intent idempotently (sha256 intent key), then runs the
  policy envelope. A replay returns the existing row and runs no side effects at all.
- The pipeline is gateway build + proof → custody sign → RPC submit → `indexing`, each hop
  CAS-guarded and recorded on an append-only event feed.
- `executeOperation` advances an approved operation and polls `verifyIndexed` idempotently.
- `retryOperation` accepts only failed-and-retryable operations, re-runs the full
  prepare-through-policy path so a retry **re-earns** its policy verdict rather than
  inheriting one, and caps lineage at 5 with a walk that terminates even against a cycle.
- A devnet guard at construction refuses any `SOLANA_NETWORK !== "devnet"`; the schema's
  network CHECK is the other half.

## Policy and approvals

Every one of the op types maps to `operationFamily: "transfer"` with a `rings_*` operation
type, so a rule gating transfers on a wallet gates every rings operation rooted in it —
**rings cannot be an approval bypass**, and a test asserts that across every op type.
Finer rules can target an individual `rings_*` type. `transferMode` is surfaced in the
policy context deliberately: anonymous transfers are not lower-risk than registered ones,
so reviewers see the mode explicitly.

`executeOperation` reads the approval verdict from the stored approval request, never from
the caller — the endpoint accepts no request body at all.

## Secret handling

- Key material is encrypted at rest with custody-cipher; plaintext never lands in
  `helius_rings_key_refs`, and repositories pass ciphertext through untouched.
- A log-redaction registry covers `viewingKey`, `nullifierKey`, `ringsMetadata`,
  `proof.ref` / `proof.internal` and `keyRefs[*].material`, wired into pino through
  `baseLoggerOptions()`.
- Event payloads are redacted **at write time**, so the detail timeline cannot surface
  secret material regardless of what an operation carried.
- `scripts/check-secretref-serialization.mjs` fails the build when a `reveal()` result —
  directly or through a variable alias — reaches `JSON.stringify`, a logger, `String()` or
  a template literal. Runs repo-wide in about a second, wired into the Unit Tests job.
- Neither the signer nor the RPC adapter contains a single logger call: transaction bytes
  can carry routing metadata the registry does not model.

## API surface

`/v1/helius-rings`, behind a router-wide `HELIUS_RINGS_ENABLED` gate that returns 403
before auth, mirroring private-channels.

| Method | Path | Perm |
| --- | --- | --- |
| `GET` | `/health` | `payments:read` |
| `GET` `POST` | `/wallets` | read / write |
| `GET` | `/wallets/:walletId` | `payments:read` |
| `GET` `POST` | `/wallets/:walletId/zones` | read / write |
| `GET` `POST` | `/operations` | read / write |
| `GET` | `/operations/:operationId` | `payments:read` |
| `POST` | `/operations/:operationId/execute` | `payments:write` |
| `POST` | `/operations/:operationId/retry` | `payments:write` |

`POST /wallets` returns a 503 seam marker until the live gateway; the row is inserted
`pending` first, so the response is literally true rather than a euphemism and the retry is
safe through the `(project_id, sdp_wallet_id)` upsert. `HeliusRingsError` maps to
`AppError`, with `gateway_unavailable` and `config_error` becoming 503.

## Dashboard

Replaces the "Coming soon" stub with the workspace: devnet banner, runtime health board,
private wallets card with create form, activity table, and a composer for every shielded op
kind — shield, send (registered / anonymous), withdraw, merge, timelock — as
compose → review → confirm.

- Anonymous transfers require an explicit acknowledgement on the review step before Confirm
  unlocks, and the copy states they are not lower-risk than registered ones.
- Zone management is fully functional today: zones are SDP-owned metadata with no gateway
  involved.
- Activity rows open a right-side drawer with the state badge, the verbatim failure code and
  message with its retryability, and the append-only event timeline.
- A recovery card lists failed operations with a Retry action; retryability and chain limits
  are enforced server-side and the card relays the verdict.
- Degraded states are honest throughout: health renders red until the live adapter, a 503 on
  create shows "integration pending" and leaves the wallet `Pending`, and the composer's
  result step reports the operation's real landing state.

Copy lives in `messages/en/dashboard-helius-rings.json`, English-only per the earn
precedent.

## Indexing job

`poll-rings-indexing` runs every minute: operations in `indexing` poll `verifyIndexed`
through the port, a hit completes them, and anything stuck past 30 minutes fails as
`indexing_timeout` (retryable) so nothing sits in limbo. It ships **inert** — it early
returns before opening a database connection unless `HELIUS_RINGS_ENABLED=true` **and**
`HELIUS_RINGS_ADAPTER=http`.

## Gating

| Variable | Default | Gates |
| --- | --- | --- |
| `HELIUS_RINGS_ENABLED` | `false` | API routes, dashboard workspace, indexing job |
| `HELIUS_RINGS_ADAPTER` | `none` | the indexing job today; the live-gateway selector later |
| `SOLANA_NETWORK` | must be `devnet` | service construction |

Both new variables are declared in `env.d.ts`, env-config fields, and both `.env.example`
files.

## What stays dark until the live adapter

Stated plainly because the UI states it too: shielded-address provisioning, key material,
Photon balances and cursor advance, and any operation reaching `indexing` or `completed`.
Zone CRUD is the one write path with real effect today. Custody signing and RPC submission
are real and unit-tested but unreachable at runtime, because the gateway build fails first.

`docs/ops/helius-rings.md` carries the architecture, the configuration table, the state
machine and failure-code reference, idempotency and retry semantics, secret handling, the
indexing job, diagnostics, and exactly which surfaces stay dark.

## Test plan

- 20 behavioural migration tests — constraint violations by SQLSTATE, cascade, re-run
  no-op, seed
- 60 repository tests against the real testcontainer schema
- 19 DB-backed service tests across both gateway variants
- 13 gateway-port tests — seam errors per method, determinism, health override,
  simulated-proof tagging, indexing-delay clock semantics
- 10 route tests, including proof that an implicit-allow policy advances an operation to the
  port and ends `failed:gateway_unavailable`, and that enforcement refuses a wallet the
  tenant does not own
- 10 adapter tests over a fake partial signer and a stub RPC
- 3 DB-backed job tests — dormant without the selector, completes on a Photon hit, times out
  past the budget
- 14 serialization-checker tests plus the redaction registry unit tests
