### PR TITLE
refactor(rpc): use kit primitives for airdrop and commitment ordering

### DIFF
--- a/packages/sdp-rpc/src/solana.ts
+++ b/packages/sdp-rpc/src/solana.ts
@@ -7,15 +7,18 @@
 
 import {
   type Address,
+  airdropFactory,
   type Base64EncodedWireTransaction,
   type Blockhash,
   type Commitment,
+  commitmentComparator,
   createDefaultRpcTransport,
   type createSolanaRpc,
   createSolanaRpcFromTransport,
   createSolanaRpcSubscriptions,
   getBase64Decoder,
   getTransactionDecoder,
+  lamports as kitLamports,
   type RpcTransport,
   type Signature,
   type Slot,
@@ -330,9 +333,8 @@ export async function confirmTransaction(
 
     if (result) {
       const isConfirmed =
-        result.confirmationStatus === commitment ||
-        (commitment === "confirmed" && result.confirmationStatus === "finalized") ||
-        result.confirmationStatus === "finalized";
+        result.confirmationStatus !== null &&
+        commitmentComparator(result.confirmationStatus, commitment) >= 0;
 
       if (isConfirmed || result.err) {
         return {
@@ -362,43 +364,20 @@ export async function requestAndConfirmAirdrop(
     timeoutMs?: number;
   }
 ): Promise<TransactionConfirmation> {
-  const rpcUrl = getSolanaConfig(env).rpcUrl;
-  const response = await fetch(rpcUrl, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "requestAirdrop",
-      params: [address, Number(lamports)],
-    }),
+  const rpc = createRpc(env);
+  const commitment = options?.commitment ?? "confirmed";
+  const airdrop = airdropFactory({
+    rpc,
+    rpcSubscriptions: createRpcSubscriptions(env),
+  } as unknown as Parameters<typeof airdropFactory>[0]);
+
+  const signature = await airdrop({
+    commitment,
+    lamports: kitLamports(BigInt(lamports)),
+    recipientAddress: address,
   });
 
-  if (!response.ok) {
-    throw new Error(`Airdrop request failed with HTTP ${response.status}`);
-  }
-
-  const payload = (await response.json()) as {
-    result?: string;
-    error?: {
-      code?: number;
-      message?: string;
-      data?: unknown;
-    };
-  };
-
-  if (payload.error) {
-    throw new Error(payload.error.message ?? "Airdrop request failed");
-  }
-
-  if (!payload.result) {
-    throw new Error("Airdrop request returned no signature");
-  }
-
-  const rpc = createRpc(env);
-  const confirmation = await confirmTransaction(rpc, payload.result as Signature, {
+  const confirmation = await confirmTransaction(rpc, signature, {
     commitment: options?.commitment,
     timeoutMs: options?.timeoutMs,
   });


### PR DESCRIPTION
## Summary

Follow-up to the review comments on #1430 — two spots in `packages/sdp-rpc/src/solana.ts` reimplementing things `@solana/kit` already ships.

## Changes

**`requestAndConfirmAirdrop`** — replaced the hand-rolled `fetch` + JSON-RPC body with `airdropFactory`. The old code cast `payload.result as Signature` on unvalidated JSON, so an error-shaped or malformed response could be passed on as a signature; the factory returns a typed signature and confirms through subscriptions. `airdropFactory` is typed for test clusters only, so the client is narrowed at that call — a cast of our own RPC client rather than of untrusted response data. Nothing in the repo calls this function today.

**`confirmTransaction`** — replaced the hand-written processed/confirmed/finalized OR-chain with `commitmentComparator(result.confirmationStatus, commitment) >= 0`, with an explicit null guard since the status can be absent. Verified the comparator encodes the same ordering.

## Dropped from this PR: the base64 change

The third suggestion — swapping `Buffer.from(...).toString("base64")` for `getBase64Decoder()` in `sendTransaction`/`simulateTransaction` — broke the Surfpool issuance-prepare suite and is not included.

The failure: `base64 encoded VersionedTransaction too large: 87384 bytes (max: encoded/raw 5464/4096)`. 87384 is exactly the base64 length of 65536 bytes, i.e. the whole of Node's 64 KiB buffer pool got encoded instead of the transaction. The transaction bytes reaching `simulateTransaction` on that path come from `Buffer.from(prepared.serializedTx, "base64")`, which for sub-4 KiB payloads is a view into the shared pool, and the kit decoder encoded the backing buffer rather than the view.

I could not reproduce it in isolation — a pooled `Buffer` and an explicit `subarray` both encode correctly through `getBase64Decoder()` locally on the same kit version — which is itself a reason to leave the working code alone: the two encoders are not interchangeable in a way I can fully characterise, and this path carries real transactions. Issuance Prepare passes on #1431 and #1432 from the same base and failed only here, so the attribution is clear.

Consequence: the hand-declared `Buffer` block stays for now.

## Testing

`pnpm --filter @sdp/rpc test` 12/12; typecheck clean for `@sdp/rpc`, `@sdp/api`, `@sdp/payments`.