### PR TITLE
fix(payments): make the recurring detail amount label match exactly one node

### DIFF
--- a/apps/sdp-web/playwright/support/local-issuance-bootstrap.ts
+++ b/apps/sdp-web/playwright/support/local-issuance-bootstrap.ts
@@ -89,7 +89,6 @@ async function createFixtureToken(
     symbol: input.symbol,
     template: "stablecoin",
     uri: input.uri,
-    imageUrl: "https://example.com/assets/sdp-e2e-token.png",
     description: `${input.name} description`,
     signingWalletId: input.signingWalletId,
     requiresAllowlist: input.requiresAllowlist,

--- a/apps/sdp-web/playwright/tests/payments-recurring.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/payments-recurring.e2e.spec.ts
@@ -124,7 +124,9 @@ test.describe
       recurringPaymentId = page.url().split("/").pop() ?? "";
       expect(recurringPaymentId).toMatch(/^prp_/);
       await expect(page.getByText(recurringCounterpartyName).first()).toBeVisible();
-      await expect(page.getByText(`7.50 ${recurringTokenSymbol}`, { exact: true })).toBeVisible();
+      await expect(
+        page.getByText(`7.50 ${recurringTokenSymbol}`, { exact: true }).first()
+      ).toBeVisible();
       await expect(page.getByText("Pending activation", { exact: true })).toBeVisible();
       await expect(page.getByText("Every day", { exact: true }).first()).toBeVisible();
 

--- a/apps/sdp-web/playwright/tests/wallets.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/wallets.e2e.spec.ts
@@ -110,7 +110,6 @@ async function createAndDeployWalletActivityToken(
     template: "stablecoin",
     decimals: 6,
     uri: `https://example.com/metadata/e2e-wallet-burn-${suffix.toLowerCase()}.json`,
-    imageUrl: "https://example.com/assets/e2e-wallet-burn.png",
     description: "Wallet activity burn coverage token",
     signingWalletId,
     requiresAllowlist: false,

--- a/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payment-detail-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payment-detail-workspace.tsx
@@ -559,7 +559,7 @@ export function RecurringPaymentDetailWorkspace({
                   logoUrl={resolvedToken.metadataImageUrl}
                   size="sm"
                 />
-                {amountLabel}
+                <span>{amountLabel}</span>
               </p>
             </div>
             <div>


### PR DESCRIPTION
## Summary

`payments-recurring.e2e.spec.ts:127` failed intermittently with `strict mode violation: getByText('7.50 E2EOPN', { exact: true }) resolved to 2 elements`. Two independent defects combined to make the DOM depend on a network request.

The recurring payment detail page renders the amount twice: the header stat (`recurring-payment-detail-workspace.tsx:555`) and the Payment detail row (`:621`). The details row wraps the label in its own `span`; the header interpolated it as a bare text node next to `TokenMark`. `TokenMark` is decorative (`aria-hidden`, `alt=""`), but its monogram fallback is a real DOM text node, and `aria-hidden` does not hide text from `getByText`, only from role and accessible-name queries.

Meanwhile every fixture token was created with `imageUrl: "https://example.com/assets/sdp-e2e-token.png"`, a path that does not exist. `TokenMark` took the `img` branch, the browser issued a real cross-origin request, and only after it failed did `onError` swap in the monogram `"E2E"`. So the header paragraph's text content was `"7.50 E2EOPN"` while the request was in flight and `"E2E7.50 E2EOPN"` afterwards.

Playwright returns an element only when its own text matches and no child element also matches, so the locator resolved to 2 elements in the first state and 1 in the second. The assertion passed only when the doomed request failed inside the 5s default expect timeout, which is why it tracked network and egress conditions rather than anything about the token.

This dates to #1111 (`64235fa5`), which added `TokenMark`, its `logoUrl`/`onError` path, both render sites and the spec together. The test has been flaky since it was written.

## Changes

- `recurring-payment-detail-workspace.tsx:562`: wrap the header amount in its own `span`, mirroring the details row. The paragraph now always has a matching child, so it is pruned as `selfAndChildren` in both `TokenMark` states and is never a match target. The match count is 2 regardless of what renders.
- `payments-recurring.e2e.spec.ts:127`: add `.first()`, matching lines 126 and 129. The wrap is what makes this correct rather than a coin flip: without it, `.first()` resolves to the header while the image is in flight and to the details row afterwards, so the assertion silently checks a different element each run.
- `local-issuance-bootstrap.ts:92` and `wallets.e2e.spec.ts:113`: drop the dead `example.com` image URLs. `imageUrl` is optional on the create-token schema (`apps/sdp-api/src/routes/issuance/schemas.ts:87`) and no spec asserts on the token image. This removes a live external request from every `TokenMark` render, which was a latent flake source for any other `getByText` near one.

Tradeoff: e2e no longer exercises the issuer-logo `img` branch. That is better covered by a component test than by a suite that waits for a real request to fail.

## Testing

Controlled experiment on the local Surfpool stack, with the fixture image temporarily repointed at an asset the app itself serves so it loads and never errors. That pins the previously-intermittent 2-match state, so only the fix varies:

| Code | Fixture image | Result |
| --- | --- | --- |
| before this PR | pinned, always loads | 3/3 failed, `resolved to 2 elements` |
| after this PR | pinned, always loads | 3/3 passed |
| after this PR | removed, as shipped here | 10/10 passed, 4.8-5.8s |

The failures named exactly the two expected elements: the header `<p class="mt-1 flex items-center gap-2 ...">` and `<span>7.50 E2EOPN</span>`.

- `pnpm --filter sdp-web run test:e2e:dashboard-transactions` under `kora:surfpool:run`: 11 passed, 1 skipped, exit 0. The skip is the pre-existing quarantined burn test at `wallets.e2e.spec.ts:634`.
- `pnpm --filter sdp-web exec vitest run src/app/dashboard/payments`: 33 files, 205 tests passed.
- Biome and `tsc --noEmit` clean.

Note that the `wallets.e2e.spec.ts:113` change is unexercised: its only caller (`:660`) is inside that quarantined test.
