### PR TITLE
fix(payments): extend durable submission to batches and recurring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,10 +503,10 @@ jobs:
             test_files: src/tests/payments-wallet-scope.test.ts src/tests/api-keys-flow.test.ts src/tests/api-keys-rotation.test.ts src/tests/custody-local.test.ts
             rpc_provider: alchemy
             custody_provider: local
-          - name: Surfpool / Token Flows (Kora)
+          - name: Surfpool / Token and Payment Flows (Kora)
             provider: surfpool
             kora_mode: docker
-            test_files: src/tests/deploy.test.ts src/tests/mint.test.ts src/tests/burn.test.ts src/tests/freeze.test.ts
+            test_files: src/tests/deploy.test.ts src/tests/mint.test.ts src/tests/burn.test.ts src/tests/freeze.test.ts src/tests/transfer-batches.test.ts
             rpc_provider: alchemy
             custody_provider: local
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -599,6 +599,8 @@ jobs:
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
           DOPPLER_CONFIG: dev_ci
+          DOPPLER_PRESERVE_ENV: TEST_DATABASE_URL,REDIS_URL,SOLANA_NETWORK,KORA_SURFPOOL_MODE,COUNTERPARTY_PII_ENCRYPTION_KEY
+          COUNTERPARTY_PII_ENCRYPTION_KEY: BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=
           SDP_INTEGRATION_CUSTODY_PROVIDER: ${{ matrix.custody_provider }}
         run: |
           read -r -a test_files <<< "${INTEGRATION_TEST_FILES}"

--- a/apps/sdp-api/src/openapi/paths/payments.ts
+++ b/apps/sdp-api/src/openapi/paths/payments.ts
@@ -480,7 +480,7 @@ export function registerPaymentsPaths(registry: OpenAPIRegistry) {
     summary: "Cancel recurring payment",
     operationId: "cancelPaymentRecurringPayment",
     description:
-      "Cancels an active SDP-custody recurring payment by submitting the Solana subscriptions cancellation transaction and storing the resulting lifecycle state.",
+      "Stops future collections for an active SDP-custody recurring payment by submitting the Solana subscriptions cancellation transaction. A collection already in processing may still settle independently.",
     security: [{ apiKeyAuth: [] }],
     request: {
       headers: projectScopeHeaders,
@@ -502,7 +502,7 @@ export function registerPaymentsPaths(registry: OpenAPIRegistry) {
     summary: "Collect recurring payment",
     operationId: "collectPaymentRecurringPayment",
     description:
-      "Manually collects a due active SDP-custody recurring payment by submitting the Solana subscriptions collection transaction, creating a linked payment transfer, recording the collection attempt, and advancing the next due time.",
+      "Manually starts a due active SDP-custody recurring payment collection, creating a linked payment transfer and collection attempt. If submission cannot be confirmed immediately, a 200 response returns the same transfer as `processing` with its known signature; reconciliation settles it, and the next due time advances only after exact on-chain confirmation.",
     security: [{ apiKeyAuth: [] }],
     request: {
       headers: projectScopeHeaders,
@@ -510,7 +510,7 @@ export function registerPaymentsPaths(registry: OpenAPIRegistry) {
     },
     responses: {
       200: {
-        description: "Recurring payment collected",
+        description: "Recurring payment collection result",
         content: jsonContent(paymentRecurringPaymentCollectionResponse),
       },
       ...errorResponses(errorResponseSchema, [400, 401, 403, 404, 409, 500]),

--- a/apps/sdp-api/src/routes/payments.recurring.test.ts
+++ b/apps/sdp-api/src/routes/payments.recurring.test.ts
@@ -2124,6 +2124,93 @@ describe("Payments routes — recurring", () => {
     expect(submission?.submission_started_at).toBeTruthy();
   });
 
+  it("rolls back the collection transfer when attempt linking fails", async () => {
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValue(sourceSigner);
+    mockRecurringActivationRpc();
+    const signAndSendMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy" as Signature
+      )
+      .mockResolvedValueOnce(
+        "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV" as Signature
+      );
+    createFeePaymentAdapterMock.mockReturnValue({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
+      signAndSend: signAndSendMock,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    const headers = {
+      Authorization: `Bearer ${TEST_API_KEY.raw}`,
+      "Content-Type": "application/json",
+    };
+    const activated = await activateRecurringPaymentForTest(headers);
+    const dueAt = new Date(Date.now() - 60 * 1000).toISOString();
+    await getDb(env)
+      .prepare("UPDATE payment_recurring_payments SET next_collection_due_at = ? WHERE id = ?")
+      .bind(dueAt, activated.id)
+      .run();
+    await getDb(env)
+      .prepare("UPDATE payment_subscriptions SET next_collection_due_at = ? WHERE id = ?")
+      .bind(dueAt, activated.subscriptionId)
+      .run();
+
+    const createSubscriptionsRepository =
+      paymentSubscriptionsRepositoryPostgres.createPostgresPaymentSubscriptionsRepository;
+    const subscriptionsRepositorySpy = vi
+      .spyOn(paymentSubscriptionsRepositoryPostgres, "createPostgresPaymentSubscriptionsRepository")
+      .mockImplementation((db) => {
+        const repository = createSubscriptionsRepository(db);
+        return {
+          ...repository,
+          updateCollectionAttempt: vi.fn(async (input) => {
+            if (input.transferId && input.status === "processing") {
+              throw new Error("collection attempt link unavailable");
+            }
+            return repository.updateCollectionAttempt(input);
+          }),
+        };
+      });
+    let collectRes: Response;
+    try {
+      collectRes = await app.request(
+        `/v1/payments/recurring-payments/${activated.id}/collect`,
+        { method: "POST", headers, body: "{}" },
+        env
+      );
+    } finally {
+      subscriptionsRepositorySpy.mockRestore();
+    }
+
+    expect(collectRes.status).toBe(500);
+    expect(sendTransactionMock).not.toHaveBeenCalled();
+    expect(signAndSendMock).toHaveBeenCalledTimes(2);
+    const attempt = await getDb(env)
+      .prepare(
+        `SELECT status, transfer_id
+           FROM payment_subscription_collection_attempts
+          WHERE subscription_id = ? AND due_at = ?`
+      )
+      .bind(activated.subscriptionId, dueAt)
+      .first<{ status: string; transfer_id: string | null }>();
+    expect(attempt).toEqual({ status: "failed", transfer_id: null });
+    const transfers = await getDb(env)
+      .prepare(
+        `SELECT COUNT(*)::integer AS count
+           FROM payment_transfers
+          WHERE organization_id = ?
+            AND project_id = ?
+            AND provider_data ->> 'recurringPaymentId' = ?`
+      )
+      .bind(TEST_ORG.id, TEST_PROJECT.id, activated.id)
+      .first<{ count: number }>();
+    expect(transfers?.count).toBe(0);
+  });
+
   it("keeps ambiguous collections processing and rejects corrupt recovery signatures", async () => {
     const warn = vi.spyOn(rootLogger, "warn").mockImplementation(() => undefined);
     const sourceSigner = await generateKeyPairSigner();

--- a/apps/sdp-api/src/routes/payments.recurring.test.ts
+++ b/apps/sdp-api/src/routes/payments.recurring.test.ts
@@ -36,6 +36,7 @@ import {
   seedCachedKey,
   seedCounterparty,
   sendTransactionMock,
+  sendTransactionPreflightError,
   TEST_API_KEY,
   TEST_KORA_FEE_PAYER,
   TEST_ORG,
@@ -2352,6 +2353,61 @@ describe("Payments routes — recurring", () => {
     expect(signAndSendMock).toHaveBeenCalledTimes(2);
     expect(sendTransactionMock).toHaveBeenCalledTimes(1);
     warn.mockRestore();
+  });
+
+  it("fails a collection when first-attempt preflight proves its account is frozen", async () => {
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValue(sourceSigner);
+    mockRecurringActivationRpc();
+    createFeePaymentAdapterMock.mockReturnValue({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
+      signAndSend: vi
+        .fn()
+        .mockResolvedValue(
+          "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy" as Signature
+        ),
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    const headers = {
+      Authorization: `Bearer ${TEST_API_KEY.raw}`,
+      "Content-Type": "application/json",
+    };
+    const activated = await activateRecurringPaymentForTest(headers);
+    const dueAt = new Date(Date.now() - 60 * 1000).toISOString();
+    await getDb(env)
+      .prepare("UPDATE payment_recurring_payments SET next_collection_due_at = ? WHERE id = ?")
+      .bind(dueAt, activated.id)
+      .run();
+    await getDb(env)
+      .prepare("UPDATE payment_subscriptions SET next_collection_due_at = ? WHERE id = ?")
+      .bind(dueAt, activated.subscriptionId)
+      .run();
+    sendTransactionMock.mockRejectedValueOnce(sendTransactionPreflightError(17));
+
+    const collectRes = await app.request(
+      `/v1/payments/recurring-payments/${activated.id}/collect`,
+      { method: "POST", headers, body: "{}" },
+      env
+    );
+
+    expect(collectRes.status).toBe(400);
+    await expect(collectRes.json()).resolves.toMatchObject({ error: { code: "ACCOUNT_FROZEN" } });
+    const attempt = await getDb(env)
+      .prepare(
+        "SELECT status, transfer_id FROM payment_subscription_collection_attempts WHERE subscription_id = ?"
+      )
+      .bind(activated.subscriptionId)
+      .first<{ status: string; transfer_id: string | null }>();
+    expect(attempt?.status).toBe("failed");
+    const transfer = await getDb(env)
+      .prepare("SELECT status, signature FROM payment_transfers WHERE id = ?")
+      .bind(attempt?.transfer_id)
+      .first<{ status: string; signature: string | null }>();
+    expect(transfer?.status).toBe("failed");
+    expect(transfer?.signature).toBeTruthy();
   });
 
   it("does not advance billing when the confirmed pull amount differs", async () => {

--- a/apps/sdp-api/src/routes/payments.recurring.test.ts
+++ b/apps/sdp-api/src/routes/payments.recurring.test.ts
@@ -14,7 +14,9 @@ import { findAssociatedTokenPda } from "@solana-program/token-2022";
 import { describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
 import { createPostgresPaymentSubscriptionsRepository } from "@/db/repositories";
+import * as paymentSubscriptionsRepositoryPostgres from "@/db/repositories/payment-subscriptions.repository.postgres";
 import app from "@/index";
+import { rootLogger } from "@/runtime/logger";
 import { TEST_SOLANA_ADDRESSES } from "@/test/fixtures/tokens";
 import { env } from "@/test/helpers/env";
 import {
@@ -23,6 +25,7 @@ import {
   createOrgSignerMock,
   DEVNET_USDC_MINT,
   fetchMaybeSubscriptionDelegationMock,
+  fullySignTestTransaction,
   getAccountInfoMock,
   getRecentBlockhashMock,
   getTransactionMock,
@@ -32,6 +35,7 @@ import {
   recurringCollectionTransactionForSignature,
   seedCachedKey,
   seedCounterparty,
+  sendTransactionMock,
   TEST_API_KEY,
   TEST_KORA_FEE_PAYER,
   TEST_ORG,
@@ -416,7 +420,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -681,7 +685,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -787,7 +791,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -907,7 +911,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -1007,7 +1011,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -1094,7 +1098,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -1216,7 +1220,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -1273,7 +1277,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -1388,7 +1392,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -1471,7 +1475,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -1570,7 +1574,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -1654,7 +1658,7 @@ describe("Payments routes — recurring", () => {
     });
   });
 
-  it("blocks recurring payment cancellation while a fresh collection is processing", async () => {
+  it("cancels future collections while the current collection is processing", async () => {
     const sourceSigner = await generateKeyPairSigner();
     await updateSeededWalletPublicKey(sourceSigner.address);
     createOrgSignerMock.mockResolvedValue(sourceSigner);
@@ -1666,12 +1670,15 @@ describe("Payments routes — recurring", () => {
       )
       .mockResolvedValueOnce(
         "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV" as Signature
+      )
+      .mockResolvedValueOnce(
+        "4rNhfL5s9hQfCjVxrTQDAZECJ5M99kzF8JRgWEzZEijj73D4Jsiz82cgwxUc71vWR9NBdk2zX9qQREx9UvP4QREe" as Signature
       );
     createFeePaymentAdapterMock.mockReturnValue({
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -1681,6 +1688,7 @@ describe("Payments routes — recurring", () => {
     const activated = await activateRecurringPaymentForTest(headers);
     const dueAt = new Date(Date.now() - 60 * 1000).toISOString();
     const now = new Date().toISOString();
+    const attemptId = `psca_${crypto.randomUUID()}`;
     await getDb(env)
       .prepare("UPDATE payment_recurring_payments SET next_collection_due_at = ? WHERE id = ?")
       .bind(dueAt, activated.id)
@@ -1708,7 +1716,7 @@ describe("Payments routes — recurring", () => {
          ) VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?::jsonb, ?, ?)`
       )
       .bind(
-        `psca_${crypto.randomUUID()}`,
+        attemptId,
         TEST_ORG.id,
         TEST_PROJECT.id,
         activated.subscriptionId,
@@ -1727,19 +1735,42 @@ describe("Payments routes — recurring", () => {
       )
       .run();
 
+    const updateRes = await app.request(
+      `/v1/payments/recurring-payments/${activated.id}`,
+      {
+        method: "PATCH",
+        headers,
+        body: JSON.stringify({ metadataUri: "https://example.com/recurring/wait.json" }),
+      },
+      env
+    );
+    expect(updateRes.status).toBe(409);
+
     const cancelRes = await app.request(
       `/v1/payments/recurring-payments/${activated.id}/cancel`,
       { method: "POST", headers, body: "{}" },
       env
     );
 
-    expect(cancelRes.status).toBe(409);
+    expect(cancelRes.status).toBe(200);
     const row = await getDb(env)
-      .prepare("SELECT status FROM payment_recurring_payments WHERE id = ?")
+      .prepare("SELECT status, next_collection_due_at FROM payment_recurring_payments WHERE id = ?")
       .bind(activated.id)
+      .first<{ status: string; next_collection_due_at: string }>();
+    expect(row).toMatchObject({ status: "canceled", next_collection_due_at: dueAt });
+    const attempt = await getDb(env)
+      .prepare("SELECT status FROM payment_subscription_collection_attempts WHERE id = ?")
+      .bind(attemptId)
       .first<{ status: string }>();
-    expect(row?.status).toBe("active");
-    expect(signAndSendMock).toHaveBeenCalledTimes(2);
+    expect(attempt?.status).toBe("processing");
+
+    const resumeRes = await app.request(
+      `/v1/payments/recurring-payments/${activated.id}/resume`,
+      { method: "POST", headers, body: "{}" },
+      env
+    );
+    expect(resumeRes.status).toBe(409);
+    expect(signAndSendMock).toHaveBeenCalledTimes(3);
   });
 
   it("resets recurring payment cancellation claims when subscription validation fails", async () => {
@@ -1759,7 +1790,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -1804,7 +1835,7 @@ describe("Payments routes — recurring", () => {
     expect(signAndSendMock).toHaveBeenCalledTimes(2);
   });
 
-  it("recovers confirmed recurring payment collections before cancellation", async () => {
+  it("cancels without waiting for confirmed collection finalization", async () => {
     const sourceSigner = await generateKeyPairSigner();
     await updateSeededWalletPublicKey(sourceSigner.address);
     createOrgSignerMock.mockResolvedValue(sourceSigner);
@@ -1826,7 +1857,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -1939,9 +1970,7 @@ describe("Payments routes — recurring", () => {
       data: { recurringPayment: { status: string; nextCollectionDueAt: string } };
     };
     expect(cancelBody.data.recurringPayment.status).toBe("canceled");
-    expect(new Date(cancelBody.data.recurringPayment.nextCollectionDueAt).getTime()).toBe(
-      new Date(dueAt).getTime() + 24 * 60 * 60 * 1000
-    );
+    expect(cancelBody.data.recurringPayment.nextCollectionDueAt).toBe(dueAt);
     const recoveredAttempt = await getDb(env)
       .prepare(
         "SELECT status, signature FROM payment_subscription_collection_attempts WHERE id = ?"
@@ -1960,8 +1989,7 @@ describe("Payments routes — recurring", () => {
     await updateSeededWalletPublicKey(sourceSigner.address);
     createOrgSignerMock.mockResolvedValue(sourceSigner);
     mockRecurringActivationRpc();
-    const collectionSignature =
-      "3hdAMf5sGEHn2UAjViFvX9YtZQdRfeHEGwNEc8GjVKFG5MGNs27jVrNuQXHcr1JAkzjcJtS4Lo6z33Z5fbT2gq13" as Signature;
+    const signAsFeePayerMock = vi.fn().mockImplementation(fullySignTestTransaction);
     const signAndSendMock = vi
       .fn()
       .mockResolvedValueOnce(
@@ -1969,13 +1997,12 @@ describe("Payments routes — recurring", () => {
       )
       .mockResolvedValueOnce(
         "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV" as Signature
-      )
-      .mockResolvedValueOnce(collectionSignature);
+      );
     createFeePaymentAdapterMock.mockReturnValue({
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: signAsFeePayerMock,
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -2057,9 +2084,9 @@ describe("Payments routes — recurring", () => {
     );
     expect(collectBody.data.collectionAttempt).toMatchObject({
       status: "confirmed",
-      signature: collectionSignature,
       dueAt,
     });
+    expect(collectBody.data.collectionAttempt.signature).toBeTruthy();
     const manualAttempt = await getDb(env)
       .prepare("SELECT metadata FROM payment_subscription_collection_attempts WHERE id = ?")
       .bind(collectBody.data.collectionAttempt.id)
@@ -2071,20 +2098,38 @@ describe("Payments routes — recurring", () => {
     expect(collectBody.data.transfer).toMatchObject({
       id: collectBody.data.collectionAttempt.transferId,
       status: "confirmed",
-      signature: collectionSignature,
+      signature: collectBody.data.collectionAttempt.signature,
       source: sourceSigner.address,
       destination: TEST_SOLANA_ADDRESSES.wallet2,
     });
-    expect(signAndSendMock).toHaveBeenCalledTimes(3);
+    expect(signAndSendMock).toHaveBeenCalledTimes(2);
+    expect(signAsFeePayerMock).toHaveBeenCalledTimes(1);
+    expect(sendTransactionMock).toHaveBeenCalledTimes(1);
+    const submission = await getDb(env)
+      .prepare(
+        `SELECT signed_transaction, last_valid_block_height, submission_started_at
+           FROM payment_transfers
+          WHERE id = ?`
+      )
+      .bind(collectBody.data.transfer.id)
+      .first<{
+        signed_transaction: string | null;
+        last_valid_block_height: string | null;
+        submission_started_at: string | null;
+      }>();
+    expect(submission).toMatchObject({
+      last_valid_block_height: "1000",
+    });
+    expect(submission?.signed_transaction).toBeTruthy();
+    expect(submission?.submission_started_at).toBeTruthy();
   });
 
-  it("does not advance billing when the confirmed pull amount differs", async () => {
+  it("keeps ambiguous collections processing and rejects corrupt recovery signatures", async () => {
+    const warn = vi.spyOn(rootLogger, "warn").mockImplementation(() => undefined);
     const sourceSigner = await generateKeyPairSigner();
     await updateSeededWalletPublicKey(sourceSigner.address);
     createOrgSignerMock.mockResolvedValue(sourceSigner);
     mockRecurringActivationRpc();
-    const collectionSignature =
-      "3hdAMf5sGEHn2UAjViFvX9YtZQdRfeHEGwNEc8GjVKFG5MGNs27jVrNuQXHcr1JAkzjcJtS4Lo6z33Z5fbT2gq13" as Signature;
     const signAndSendMock = vi
       .fn()
       .mockResolvedValueOnce(
@@ -2092,13 +2137,12 @@ describe("Payments routes — recurring", () => {
       )
       .mockResolvedValueOnce(
         "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV" as Signature
-      )
-      .mockResolvedValueOnce(collectionSignature);
+      );
     createFeePaymentAdapterMock.mockReturnValue({
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -2115,13 +2159,153 @@ describe("Payments routes — recurring", () => {
       .prepare("UPDATE payment_subscriptions SET next_collection_due_at = ? WHERE id = ?")
       .bind(dueAt, activated.subscriptionId)
       .run();
-    getTransactionMock.mockImplementationOnce(async (_rpc, signature) => {
+    sendTransactionMock.mockRejectedValueOnce(new Error("RPC response lost"));
+
+    const collectRes = await app.request(
+      `/v1/payments/recurring-payments/${activated.id}/collect`,
+      { method: "POST", headers, body: "{}" },
+      env
+    );
+
+    expect(collectRes.status).toBe(200);
+    const collectBody = (await collectRes.json()) as {
+      data: {
+        collectionAttempt: { id: string; status: string; signature: string };
+        transfer: { id: string; status: string; signature: string };
+      };
+    };
+    expect(collectBody.data.collectionAttempt).toMatchObject({ status: "processing" });
+    expect(collectBody.data.collectionAttempt.signature).toBeTruthy();
+    expect(collectBody.data.transfer).toMatchObject({
+      status: "processing",
+      signature: collectBody.data.collectionAttempt.signature,
+    });
+    const recurringPayment = await getDb(env)
+      .prepare("SELECT next_collection_due_at FROM payment_recurring_payments WHERE id = ?")
+      .bind(activated.id)
+      .first<{ next_collection_due_at: string }>();
+    expect(recurringPayment?.next_collection_due_at).toBe(dueAt);
+    const attempt = await getDb(env)
+      .prepare(
+        "SELECT status FROM payment_subscription_collection_attempts WHERE subscription_id = ?"
+      )
+      .bind(activated.subscriptionId)
+      .first<{ status: string }>();
+    expect(attempt?.status).toBe("processing");
+    expect(signAndSendMock).toHaveBeenCalledTimes(2);
+    expect(sendTransactionMock).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "sdp_api_payment_submission_unresolved",
+        flow: "recurring",
+        reason: "submission_unconfirmed",
+        organization_id: TEST_ORG.id,
+        project_id: TEST_PROJECT.id,
+        transfer_id: collectBody.data.transfer.id,
+        signature: collectBody.data.transfer.signature,
+        error: "RPC response lost",
+      }),
+      "sdp_api_payment_submission_unresolved"
+    );
+
+    const submittedSignature = collectBody.data.collectionAttempt.signature;
+    await getDb(env)
+      .prepare("UPDATE payment_subscription_collection_attempts SET signature = ? WHERE id = ?")
+      .bind("not-a-solana-signature", collectBody.data.collectionAttempt.id)
+      .run();
+    await getDb(env)
+      .prepare("UPDATE payment_transfers SET signature = ? WHERE id = ?")
+      .bind("not-a-solana-signature", collectBody.data.transfer.id)
+      .run();
+    confirmTransactionMock.mockClear();
+    getTransactionMock.mockClear();
+
+    const invalidRecoveryRes = await app.request(
+      `/v1/payments/recurring-payments/${activated.id}/collect`,
+      { method: "POST", headers, body: "{}" },
+      env
+    );
+
+    expect(invalidRecoveryRes.status).toBe(500);
+    expect(confirmTransactionMock).not.toHaveBeenCalled();
+    expect(getTransactionMock).not.toHaveBeenCalled();
+    const invalidAttempt = await getDb(env)
+      .prepare("SELECT status FROM payment_subscription_collection_attempts WHERE id = ?")
+      .bind(collectBody.data.collectionAttempt.id)
+      .first<{ status: string }>();
+    const invalidTransfer = await getDb(env)
+      .prepare("SELECT status FROM payment_transfers WHERE id = ?")
+      .bind(collectBody.data.transfer.id)
+      .first<{ status: string }>();
+    expect(invalidAttempt?.status).toBe("processing");
+    expect(invalidTransfer?.status).toBe("processing");
+
+    await getDb(env)
+      .prepare("UPDATE payment_subscription_collection_attempts SET signature = ? WHERE id = ?")
+      .bind(submittedSignature, collectBody.data.collectionAttempt.id)
+      .run();
+    await getDb(env)
+      .prepare("UPDATE payment_transfers SET signature = ? WHERE id = ?")
+      .bind(submittedSignature, collectBody.data.transfer.id)
+      .run();
+
+    const recoveredRes = await app.request(
+      `/v1/payments/recurring-payments/${activated.id}/collect`,
+      { method: "POST", headers, body: "{}" },
+      env
+    );
+    expect(recoveredRes.status).toBe(200);
+    const recoveredBody = (await recoveredRes.json()) as {
+      data: { collectionAttempt: { status: string; signature: string } };
+    };
+    expect(recoveredBody.data.collectionAttempt).toMatchObject({
+      status: "confirmed",
+      signature: collectBody.data.collectionAttempt.signature,
+    });
+    expect(signAndSendMock).toHaveBeenCalledTimes(2);
+    expect(sendTransactionMock).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it("does not advance billing when the confirmed pull amount differs", async () => {
+    const errorLog = vi.spyOn(rootLogger, "error").mockImplementation(() => undefined);
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValue(sourceSigner);
+    mockRecurringActivationRpc();
+    const signAndSendMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy" as Signature
+      )
+      .mockResolvedValueOnce(
+        "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV" as Signature
+      );
+    createFeePaymentAdapterMock.mockReturnValue({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
+      signAndSend: signAndSendMock,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    const headers = {
+      Authorization: `Bearer ${TEST_API_KEY.raw}`,
+      "Content-Type": "application/json",
+    };
+    const activated = await activateRecurringPaymentForTest(headers);
+    const dueAt = new Date(Date.now() - 60 * 1000).toISOString();
+    await getDb(env)
+      .prepare("UPDATE payment_recurring_payments SET next_collection_due_at = ? WHERE id = ?")
+      .bind(dueAt, activated.id)
+      .run();
+    await getDb(env)
+      .prepare("UPDATE payment_subscriptions SET next_collection_due_at = ? WHERE id = ?")
+      .bind(dueAt, activated.subscriptionId)
+      .run();
+    getTransactionMock.mockImplementation(async (_rpc, signature) => {
       const transaction = await recurringCollectionTransactionForSignature(signature);
-      if (!transaction) {
-        return null;
-      }
-      const instruction = transaction.instructions[0];
-      if (!instruction?.data) {
+      const instruction = transaction?.instructions[0];
+      if (!transaction || !instruction?.data) {
         throw new Error("Expected recurring-payment transfer instruction data");
       }
       const decoded = subscriptionsProgram
@@ -2153,34 +2337,159 @@ describe("Payments routes — recurring", () => {
     );
 
     expect(collectRes.status).toBe(409);
-    const collectBody = (await collectRes.json()) as { error: { message: string } };
+    const collectBody = (await collectRes.json()) as {
+      error: { code: string; message: string };
+    };
+    expect(collectBody.error).toMatchObject({ code: "CONFLICT" });
     expect(collectBody.error.message).toContain("does not prove");
+    const attempt = await getDb(env)
+      .prepare(
+        `SELECT id, transfer_id, status, signature, error
+           FROM payment_subscription_collection_attempts
+          WHERE subscription_id = ? AND due_at = ?`
+      )
+      .bind(activated.subscriptionId, dueAt)
+      .first<{
+        id: string;
+        transfer_id: string;
+        status: string;
+        signature: string | null;
+        error: string | null;
+      }>();
+    expect(attempt).toMatchObject({ status: "processing", error: null });
+    expect(attempt?.signature).toBeTruthy();
+    const transfer = await getDb(env)
+      .prepare(
+        `SELECT status, signature, signed_transaction, submission_started_at, error
+           FROM payment_transfers
+          WHERE id = ?`
+      )
+      .bind(attempt?.transfer_id)
+      .first<{
+        status: string;
+        signature: string | null;
+        signed_transaction: string | null;
+        submission_started_at: string | null;
+        error: string | null;
+      }>();
+    expect(transfer).toMatchObject({
+      status: "processing",
+      signature: attempt?.signature,
+      error: null,
+    });
+    expect(transfer?.signed_transaction).toBeTruthy();
+    expect(transfer?.submission_started_at).toBeTruthy();
     const recurringPayment = await getDb(env)
       .prepare("SELECT next_collection_due_at FROM payment_recurring_payments WHERE id = ?")
       .bind(activated.id)
       .first<{ next_collection_due_at: string }>();
     expect(recurringPayment?.next_collection_due_at).toBe(dueAt);
-    const attempt = await getDb(env)
+
+    const createSubscriptionsRepository =
+      paymentSubscriptionsRepositoryPostgres.createPostgresPaymentSubscriptionsRepository;
+    const updateCollectionAttempt = vi
+      .fn()
+      .mockRejectedValue(new Error("collection journal unavailable"));
+    const subscriptionsRepositorySpy = vi
+      .spyOn(paymentSubscriptionsRepositoryPostgres, "createPostgresPaymentSubscriptionsRepository")
+      .mockImplementation((db) => ({
+        ...createSubscriptionsRepository(db),
+        updateCollectionAttempt,
+      }));
+    let recoveryRes: Response;
+    try {
+      recoveryRes = await app.request(
+        `/v1/payments/recurring-payments/${activated.id}/collect`,
+        { method: "POST", headers, body: "{}" },
+        env
+      );
+    } finally {
+      subscriptionsRepositorySpy.mockRestore();
+    }
+    expect(recoveryRes.status).toBe(409);
+    const recoveryBody = (await recoveryRes.json()) as {
+      error: { code: string; message: string };
+    };
+    expect(recoveryBody.error).toMatchObject({ code: "CONFLICT" });
+    expect(recoveryBody.error.message).toContain("does not prove");
+    expect(updateCollectionAttempt).toHaveBeenCalledOnce();
+    const recoveredAttempt = await getDb(env)
       .prepare(
-        "SELECT status FROM payment_subscription_collection_attempts WHERE subscription_id = ?"
+        "SELECT status, signature, error FROM payment_subscription_collection_attempts WHERE id = ?"
       )
-      .bind(activated.subscriptionId)
-      .first<{ status: string }>();
-    expect(attempt?.status).toBe("processing");
+      .bind(attempt?.id)
+      .first<{ status: string; signature: string | null; error: string | null }>();
+    const recoveredTransfer = await getDb(env)
+      .prepare("SELECT status, signature, error FROM payment_transfers WHERE id = ?")
+      .bind(attempt?.transfer_id)
+      .first<{ status: string; signature: string | null; error: string | null }>();
+    expect(recoveredAttempt).toMatchObject({
+      status: "processing",
+      signature: attempt?.signature,
+      error: null,
+    });
+    expect(recoveredTransfer).toMatchObject({
+      status: "processing",
+      signature: attempt?.signature,
+      error: null,
+    });
+    expect(signAndSendMock).toHaveBeenCalledTimes(2);
+    expect(sendTransactionMock).toHaveBeenCalledTimes(1);
+    const proofMismatchEvents = errorLog.mock.calls.filter(
+      ([payload]) =>
+        (payload as { event?: string }).event ===
+        "sdp_api_recurring_payment_collection_proof_mismatch"
+    );
+    expect(proofMismatchEvents).toHaveLength(2);
+    for (const [payload, message] of proofMismatchEvents) {
+      expect(payload).toEqual(
+        expect.objectContaining({
+          event: "sdp_api_recurring_payment_collection_proof_mismatch",
+          reason: "on_chain_instruction_mismatch",
+          organization_id: TEST_ORG.id,
+          project_id: TEST_PROJECT.id,
+          recurring_payment_id: activated.id,
+          subscription_id: activated.subscriptionId,
+          attempt_id: attempt?.id,
+          transfer_id: attempt?.transfer_id,
+          signature: attempt?.signature,
+        })
+      );
+      expect(message).toBe("sdp_api_recurring_payment_collection_proof_mismatch");
+    }
+    errorLog.mockRestore();
   });
 
   it.each([
-    { journaledRecord: "transfer", attemptHasSignature: false, transferHasSignature: true },
-    { journaledRecord: "attempt", attemptHasSignature: true, transferHasSignature: false },
+    {
+      journaledRecord: "transfer",
+      attemptHasSignature: false,
+      transferHasSignature: true,
+      signaturesConflict: false,
+    },
+    {
+      journaledRecord: "attempt",
+      attemptHasSignature: true,
+      transferHasSignature: false,
+      signaturesConflict: false,
+    },
+    {
+      journaledRecord: "conflicting attempt and transfer",
+      attemptHasSignature: true,
+      transferHasSignature: true,
+      signaturesConflict: true,
+    },
   ])(
-    "recovers submitted recurring payment collection attempts from the $journaledRecord journal",
-    async ({ attemptHasSignature, transferHasSignature }) => {
+    "handles submitted recurring payment collection attempts from the $journaledRecord journal",
+    async ({ attemptHasSignature, transferHasSignature, signaturesConflict }) => {
       const sourceSigner = await generateKeyPairSigner();
       await updateSeededWalletPublicKey(sourceSigner.address);
       createOrgSignerMock.mockResolvedValue(sourceSigner);
       mockRecurringActivationRpc();
       const submittedSignature =
         "3hdAMf5sGEHn2UAjViFvX9YtZQdRfeHEGwNEc8GjVKFG5MGNs27jVrNuQXHcr1JAkzjcJtS4Lo6z33Z5fbT2gq13" as Signature;
+      const conflictingSignature =
+        "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy" as Signature;
       const signAndSendMock = vi
         .fn()
         .mockResolvedValueOnce(
@@ -2193,7 +2502,7 @@ describe("Payments routes — recurring", () => {
         providerId: "mock",
         getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
         getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-        signAsFeePayer: vi.fn(),
+        signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
         signAndSend: signAndSendMock,
       } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
       const headers = {
@@ -2294,7 +2603,11 @@ describe("Payments routes — recurring", () => {
           dueAt,
           now,
           "processing",
-          attemptHasSignature ? submittedSignature : null,
+          attemptHasSignature
+            ? signaturesConflict
+              ? conflictingSignature
+              : submittedSignature
+            : null,
           JSON.stringify({ recurringPaymentId }),
           now,
           now
@@ -2305,12 +2618,44 @@ describe("Payments routes — recurring", () => {
         tokenProgram: address("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"),
         mint: address(DEVNET_USDC_MINT),
       });
+      const errorLog = signaturesConflict
+        ? vi.spyOn(rootLogger, "error").mockImplementation(() => undefined)
+        : null;
+      confirmTransactionMock.mockClear();
+      getTransactionMock.mockClear();
 
       const collectRes = await app.request(
         `/v1/payments/recurring-payments/${recurringPaymentId}/collect`,
         { method: "POST", headers, body: "{}" },
         env
       );
+
+      if (signaturesConflict) {
+        expect(collectRes.status).toBe(409);
+        const body = (await collectRes.json()) as { error: { code: string; message: string } };
+        expect(body.error).toMatchObject({ code: "CONFLICT" });
+        expect(body.error.message).toContain("signatures do not match");
+        expect(confirmTransactionMock).not.toHaveBeenCalled();
+        expect(getTransactionMock).not.toHaveBeenCalled();
+        expect(errorLog).toHaveBeenCalledWith(
+          expect.objectContaining({
+            event: "sdp_api_recurring_payment_collection_proof_mismatch",
+            reason: "persisted_evidence_mismatch",
+            mismatch: "attempt_transfer_signature",
+            organization_id: TEST_ORG.id,
+            project_id: TEST_PROJECT.id,
+            recurring_payment_id: recurringPaymentId,
+            subscription_id: activateBody.data.recurringPayment.subscriptionId,
+            attempt_id: attemptId,
+            transfer_id: transferId,
+            attempt_signature: conflictingSignature,
+            transfer_signature: submittedSignature,
+          }),
+          "sdp_api_recurring_payment_collection_proof_mismatch"
+        );
+        errorLog?.mockRestore();
+        return;
+      }
 
       expect(collectRes.status).toBe(200);
       const collectBody = (await collectRes.json()) as {
@@ -2475,7 +2820,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -2495,6 +2840,7 @@ describe("Payments routes — recurring", () => {
     };
     const dueAt = new Date(Date.now() - 60 * 1000).toISOString();
     const now = new Date().toISOString();
+    const staleAt = new Date(Date.now() - 20 * 60 * 1000).toISOString();
     const transferId = `xfr_${crypto.randomUUID()}`;
     const attemptId = `psca_${crypto.randomUUID()}`;
     await getDb(env)
@@ -2550,15 +2896,15 @@ describe("Payments routes — recurring", () => {
         "25.00",
         "transfer",
         "outbound",
-        "confirmed",
+        "processing",
         JSON.stringify({
           recurringPaymentId,
           subscriptionId: activateBody.data.recurringPayment.subscriptionId,
           collectionDueAt: dueAt,
         }),
         submittedSignature,
-        now,
-        now
+        staleAt,
+        staleAt
       )
       .run();
     await getDb(env)
@@ -2590,17 +2936,40 @@ describe("Payments routes — recurring", () => {
         "25.00",
         dueAt,
         now,
-        "confirmed",
+        "processing",
         submittedSignature,
         JSON.stringify({
           recurringPaymentId,
           subscriptionId: activateBody.data.recurringPayment.subscriptionId,
           collectionDueAt: dueAt,
         }),
-        now,
-        now
+        staleAt,
+        staleAt
       )
       .run();
+
+    getTransactionMock.mockResolvedValueOnce(null);
+    const uncertainRes = await app.request(
+      `/v1/payments/recurring-payments/${recurringPaymentId}/collect`,
+      { method: "POST", headers, body: "{}" },
+      env
+    );
+    expect(uncertainRes.status).toBe(502);
+    const uncertainAttempt = await getDb(env)
+      .prepare(
+        `SELECT status, signature, updated_at
+           FROM payment_subscription_collection_attempts
+          WHERE id = ?`
+      )
+      .bind(attemptId)
+      .first<{ status: string; signature: string | null; updated_at: string }>();
+    expect(uncertainAttempt).toMatchObject({
+      status: "processing",
+      signature: submittedSignature,
+    });
+    expect(new Date(uncertainAttempt?.updated_at ?? 0).getTime()).toBeGreaterThan(
+      new Date(staleAt).getTime()
+    );
 
     const collectRes = await app.request(
       `/v1/payments/recurring-payments/${recurringPaymentId}/collect`,
@@ -2638,8 +3007,8 @@ describe("Payments routes — recurring", () => {
     await updateSeededWalletPublicKey(sourceSigner.address);
     createOrgSignerMock.mockResolvedValue(sourceSigner);
     mockRecurringActivationRpc();
-    const retrySignature =
-      "4rNhfL5s9hQfCjVxrTQDAZECJ5M99kzF8JRgWEzZEijj73D4Jsiz82cgwxUc71vWR9NBdk2zX9qQREx9UvP4QREe" as Signature;
+    const abandonedSignature =
+      "3hdAMf5sGEHn2UAjViFvX9YtZQdRfeHEGwNEc8GjVKFG5MGNs27jVrNuQXHcr1JAkzjcJtS4Lo6z33Z5fbT2gq13" as Signature;
     const signAndSendMock = vi
       .fn()
       .mockResolvedValueOnce(
@@ -2647,13 +3016,12 @@ describe("Payments routes — recurring", () => {
       )
       .mockResolvedValueOnce(
         "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV" as Signature
-      )
-      .mockResolvedValueOnce(retrySignature);
+      );
     createFeePaymentAdapterMock.mockReturnValue({
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -2702,9 +3070,12 @@ describe("Payments routes — recurring", () => {
            status,
            provider_data,
            signature,
+           signed_transaction,
+           last_valid_block_height,
+           submission_started_at,
            created_at,
            updated_at
-         ) VALUES (?, ?, ?, ?, (SELECT counterparty_id FROM payment_recurring_payments WHERE id = ?), ?, ?, ?, ?, NULL, ?, ?, ?, ?::jsonb, ?, ?, ?)`
+         ) VALUES (?, ?, ?, ?, (SELECT counterparty_id FROM payment_recurring_payments WHERE id = ?), ?, ?, ?, ?, NULL, ?, ?, ?, ?::jsonb, ?, ?, ?::numeric, NULL, ?, ?)`
       )
       .bind(
         transferId,
@@ -2724,7 +3095,9 @@ describe("Payments routes — recurring", () => {
           subscriptionId: activateBody.data.recurringPayment.subscriptionId,
           collectionDueAt: dueAt,
         }),
-        null,
+        abandonedSignature,
+        "AQ==",
+        "1000",
         staleAt,
         staleAt
       )
@@ -2770,6 +3143,35 @@ describe("Payments routes — recurring", () => {
       )
       .run();
 
+    confirmTransactionMock.mockRejectedValueOnce(new Error("Signature is not confirmed"));
+    getTransactionMock.mockResolvedValueOnce(null);
+    const beforeExpiryRes = await app.request(
+      `/v1/payments/recurring-payments/${recurringPaymentId}/collect`,
+      { method: "POST", headers, body: "{}" },
+      env
+    );
+    expect(beforeExpiryRes.status).toBe(502);
+    expect(
+      (
+        await getDb(env)
+          .prepare("SELECT status FROM payment_transfers WHERE id = ?")
+          .bind(transferId)
+          .first<{ status: string }>()
+      )?.status
+    ).toBe("processing");
+    expect(sendTransactionMock).not.toHaveBeenCalled();
+    const abandonedLookupsBeforeExpiry = getTransactionMock.mock.calls.filter(
+      ([, signature]) => signature === abandonedSignature
+    ).length;
+    await getDb(env)
+      .prepare("UPDATE payment_transfers SET status = 'failed' WHERE id = ?")
+      .bind(transferId)
+      .run();
+    await getDb(env)
+      .prepare("UPDATE payment_subscription_collection_attempts SET updated_at = ? WHERE id = ?")
+      .bind(staleAt, attemptId)
+      .run();
+
     const collectRes = await app.request(
       `/v1/payments/recurring-payments/${recurringPaymentId}/collect`,
       { method: "POST", headers, body: "{}" },
@@ -2785,12 +3187,12 @@ describe("Payments routes — recurring", () => {
     };
     expect(collectBody.data.collectionAttempt).toMatchObject({
       status: "confirmed",
-      signature: retrySignature,
     });
+    expect(collectBody.data.collectionAttempt.signature).toBeTruthy();
     expect(collectBody.data.collectionAttempt.id).not.toBe(attemptId);
     expect(collectBody.data.transfer).toMatchObject({
       status: "confirmed",
-      signature: retrySignature,
+      signature: collectBody.data.collectionAttempt.signature,
     });
     expect(collectBody.data.transfer.id).not.toBe(transferId);
     const staleAttempt = await getDb(env)
@@ -2802,7 +3204,7 @@ describe("Payments routes — recurring", () => {
       .bind(attemptId)
       .first<{ status: string; error: string | null; metadata: { retryAfterAt?: string } }>();
     expect(staleAttempt?.status).toBe("failed");
-    expect(staleAttempt?.error).toContain("interrupted before submission");
+    expect(staleAttempt?.error).toContain("interrupted before broadcast");
     expect(staleAttempt?.metadata.retryAfterAt).toBeTruthy();
     const staleTransfer = await getDb(env)
       .prepare("SELECT status, error, signature FROM payment_transfers WHERE id = ?")
@@ -2810,10 +3212,14 @@ describe("Payments routes — recurring", () => {
       .first<{ status: string; error: string | null; signature: string | null }>();
     expect(staleTransfer).toMatchObject({
       status: "failed",
-      signature: null,
+      signature: abandonedSignature,
     });
-    expect(staleTransfer?.error).toContain("interrupted before submission");
-    expect(signAndSendMock).toHaveBeenCalledTimes(3);
+    expect(staleTransfer?.error).toContain("interrupted before broadcast");
+    expect(signAndSendMock).toHaveBeenCalledTimes(2);
+    expect(sendTransactionMock).toHaveBeenCalledTimes(1);
+    expect(
+      getTransactionMock.mock.calls.filter(([, signature]) => signature === abandonedSignature)
+    ).toHaveLength(abandonedLookupsBeforeExpiry);
   });
 
   it("does not fail fresh transferless recurring payment attempts during recovery", async () => {
@@ -2833,7 +3239,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -2937,7 +3343,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -3086,8 +3492,6 @@ describe("Payments routes — recurring", () => {
     mockRecurringActivationRpc();
     const submittedSignature =
       "3hdAMf5sGEHn2UAjViFvX9YtZQdRfeHEGwNEc8GjVKFG5MGNs27jVrNuQXHcr1JAkzjcJtS4Lo6z33Z5fbT2gq13" as Signature;
-    const retrySignature =
-      "4rNhfL5s9hQfCjVxrTQDAZECJ5M99kzF8JRgWEzZEijj73D4Jsiz82cgwxUc71vWR9NBdk2zX9qQREx9UvP4QREe" as Signature;
     const signAndSendMock = vi
       .fn()
       .mockResolvedValueOnce(
@@ -3095,13 +3499,12 @@ describe("Payments routes — recurring", () => {
       )
       .mockResolvedValueOnce(
         "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV" as Signature
-      )
-      .mockResolvedValueOnce(retrySignature);
+      );
     createFeePaymentAdapterMock.mockReturnValue({
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -3254,68 +3657,70 @@ describe("Payments routes — recurring", () => {
     expect(failedTransfer?.error).toContain("collection failed on-chain");
     expect(collectBody.data.collectionAttempt).toMatchObject({
       status: "confirmed",
-      signature: retrySignature,
     });
+    expect(collectBody.data.collectionAttempt.signature).toBeTruthy();
     expect(collectBody.data.collectionAttempt.id).not.toBe(attemptId);
     expect(collectBody.data.transfer).toMatchObject({
       status: "confirmed",
-      signature: retrySignature,
+      signature: collectBody.data.collectionAttempt.signature,
     });
-    expect(signAndSendMock).toHaveBeenCalledTimes(3);
+    expect(signAndSendMock).toHaveBeenCalledTimes(2);
   });
 
-  it("recovers confirmed collection transfers without reopening the due period", async () => {
-    const sourceSigner = await generateKeyPairSigner();
-    await updateSeededWalletPublicKey(sourceSigner.address);
-    createOrgSignerMock.mockResolvedValue(sourceSigner);
-    mockRecurringActivationRpc();
-    const submittedSignature =
-      "3hdAMf5sGEHn2UAjViFvX9YtZQdRfeHEGwNEc8GjVKFG5MGNs27jVrNuQXHcr1JAkzjcJtS4Lo6z33Z5fbT2gq13" as Signature;
-    const signAndSendMock = vi
-      .fn()
-      .mockResolvedValueOnce(
-        "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy" as Signature
-      )
-      .mockResolvedValueOnce(
-        "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV" as Signature
-      );
-    createFeePaymentAdapterMock.mockReturnValue({
-      providerId: "mock",
-      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
-      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
-      signAndSend: signAndSendMock,
-    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
-    const headers = {
-      Authorization: `Bearer ${TEST_API_KEY.raw}`,
-      "Content-Type": "application/json",
-    };
-    const recurringPaymentId = await createRecurringPaymentForActivation(headers);
+  it.each(["confirmed", "finalized"] as const)(
+    "recovers %s collection transfers without reopening the due period",
+    async (transferStatus) => {
+      const sourceSigner = await generateKeyPairSigner();
+      await updateSeededWalletPublicKey(sourceSigner.address);
+      createOrgSignerMock.mockResolvedValue(sourceSigner);
+      mockRecurringActivationRpc();
+      const submittedSignature =
+        "3hdAMf5sGEHn2UAjViFvX9YtZQdRfeHEGwNEc8GjVKFG5MGNs27jVrNuQXHcr1JAkzjcJtS4Lo6z33Z5fbT2gq13" as Signature;
+      const signAndSendMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy" as Signature
+        )
+        .mockResolvedValueOnce(
+          "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV" as Signature
+        );
+      createFeePaymentAdapterMock.mockReturnValue({
+        providerId: "mock",
+        getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+        getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
+        signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
+        signAndSend: signAndSendMock,
+      } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+      const headers = {
+        Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        "Content-Type": "application/json",
+      };
+      const recurringPaymentId = await createRecurringPaymentForActivation(headers);
 
-    const activateRes = await app.request(
-      `/v1/payments/recurring-payments/${recurringPaymentId}/activate`,
-      { method: "POST", headers, body: "{}" },
-      env
-    );
-    expect(activateRes.status).toBe(200);
-    const activateBody = (await activateRes.json()) as {
-      data: { recurringPayment: { subscriptionId: string } };
-    };
-    const dueAt = new Date(Date.now() - 60 * 1000).toISOString();
-    const now = new Date().toISOString();
-    const transferId = `xfr_${crypto.randomUUID()}`;
-    const attemptId = `psca_${crypto.randomUUID()}`;
-    await getDb(env)
-      .prepare("UPDATE payment_recurring_payments SET next_collection_due_at = ? WHERE id = ?")
-      .bind(dueAt, recurringPaymentId)
-      .run();
-    await getDb(env)
-      .prepare("UPDATE payment_subscriptions SET next_collection_due_at = ? WHERE id = ?")
-      .bind(dueAt, activateBody.data.recurringPayment.subscriptionId)
-      .run();
-    await getDb(env)
-      .prepare(
-        `INSERT INTO payment_transfers (
+      const activateRes = await app.request(
+        `/v1/payments/recurring-payments/${recurringPaymentId}/activate`,
+        { method: "POST", headers, body: "{}" },
+        env
+      );
+      expect(activateRes.status).toBe(200);
+      const activateBody = (await activateRes.json()) as {
+        data: { recurringPayment: { subscriptionId: string } };
+      };
+      const dueAt = new Date(Date.now() - 60 * 1000).toISOString();
+      const now = new Date().toISOString();
+      const transferId = `xfr_${crypto.randomUUID()}`;
+      const attemptId = `psca_${crypto.randomUUID()}`;
+      await getDb(env)
+        .prepare("UPDATE payment_recurring_payments SET next_collection_due_at = ? WHERE id = ?")
+        .bind(dueAt, recurringPaymentId)
+        .run();
+      await getDb(env)
+        .prepare("UPDATE payment_subscriptions SET next_collection_due_at = ? WHERE id = ?")
+        .bind(dueAt, activateBody.data.recurringPayment.subscriptionId)
+        .run();
+      await getDb(env)
+        .prepare(
+          `INSERT INTO payment_transfers (
            id,
            organization_id,
            project_id,
@@ -3334,33 +3739,33 @@ describe("Payments routes — recurring", () => {
            created_at,
            updated_at
          ) VALUES (?, ?, ?, ?, (SELECT counterparty_id FROM payment_recurring_payments WHERE id = ?), ?, ?, ?, ?, NULL, ?, ?, ?, ?::jsonb, ?, ?, ?)`
-      )
-      .bind(
-        transferId,
-        TEST_ORG.id,
-        TEST_PROJECT.id,
-        TEST_WALLET_ID,
-        recurringPaymentId,
-        sourceSigner.address,
-        TEST_SOLANA_ADDRESSES.wallet2,
-        DEVNET_USDC_MINT,
-        "25.00",
-        "transfer",
-        "outbound",
-        "confirmed",
-        JSON.stringify({
+        )
+        .bind(
+          transferId,
+          TEST_ORG.id,
+          TEST_PROJECT.id,
+          TEST_WALLET_ID,
           recurringPaymentId,
-          subscriptionId: activateBody.data.recurringPayment.subscriptionId,
-          collectionDueAt: dueAt,
-        }),
-        submittedSignature,
-        now,
-        now
-      )
-      .run();
-    await getDb(env)
-      .prepare(
-        `INSERT INTO payment_subscription_collection_attempts (
+          sourceSigner.address,
+          TEST_SOLANA_ADDRESSES.wallet2,
+          DEVNET_USDC_MINT,
+          "25.00",
+          "transfer",
+          "outbound",
+          transferStatus,
+          JSON.stringify({
+            recurringPaymentId,
+            subscriptionId: activateBody.data.recurringPayment.subscriptionId,
+            collectionDueAt: dueAt,
+          }),
+          submittedSignature,
+          now,
+          now
+        )
+        .run();
+      await getDb(env)
+        .prepare(
+          `INSERT INTO payment_subscription_collection_attempts (
            id,
            organization_id,
            project_id,
@@ -3376,66 +3781,67 @@ describe("Payments routes — recurring", () => {
            created_at,
            updated_at
          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?, ?)`
-      )
-      .bind(
-        attemptId,
-        TEST_ORG.id,
-        TEST_PROJECT.id,
-        activateBody.data.recurringPayment.subscriptionId,
-        transferId,
-        DEVNET_USDC_MINT,
-        "25.00",
-        dueAt,
-        now,
-        "processing",
-        submittedSignature,
-        JSON.stringify({ recurringPaymentId }),
-        now,
-        now
-      )
-      .run();
-    confirmTransactionMock.mockRejectedValue(
-      new Error("Transaction history expired from the status cache")
-    );
-    const collectRes = await app.request(
-      `/v1/payments/recurring-payments/${recurringPaymentId}/collect`,
-      { method: "POST", headers, body: "{}" },
-      env
-    );
+        )
+        .bind(
+          attemptId,
+          TEST_ORG.id,
+          TEST_PROJECT.id,
+          activateBody.data.recurringPayment.subscriptionId,
+          transferId,
+          DEVNET_USDC_MINT,
+          "25.00",
+          dueAt,
+          now,
+          "processing",
+          submittedSignature,
+          JSON.stringify({ recurringPaymentId }),
+          now,
+          now
+        )
+        .run();
+      confirmTransactionMock.mockRejectedValue(
+        new Error("Transaction history expired from the status cache")
+      );
+      const collectRes = await app.request(
+        `/v1/payments/recurring-payments/${recurringPaymentId}/collect`,
+        { method: "POST", headers, body: "{}" },
+        env
+      );
 
-    expect(collectRes.status).toBe(200);
-    const collectBody = (await collectRes.json()) as {
-      data: {
-        recurringPayment: { nextCollectionDueAt: string };
-        collectionAttempt: { id: string; status: string; signature: string };
-        transfer: { id: string; status: string; signature: string };
+      expect(collectRes.status).toBe(200);
+      const collectBody = (await collectRes.json()) as {
+        data: {
+          recurringPayment: { nextCollectionDueAt: string };
+          collectionAttempt: { id: string; status: string; signature: string };
+          transfer: { id: string; status: string; signature: string };
+        };
       };
-    };
-    expect(collectBody.data.collectionAttempt).toMatchObject({
-      id: attemptId,
-      status: "confirmed",
-      signature: submittedSignature,
-    });
-    expect(collectBody.data.transfer).toMatchObject({
-      id: transferId,
-      status: "confirmed",
-      signature: submittedSignature,
-    });
-    expect(new Date(collectBody.data.recurringPayment.nextCollectionDueAt).getTime()).toBe(
-      new Date(dueAt).getTime() + 24 * 60 * 60 * 1000
-    );
-    expect(confirmTransactionMock).toHaveBeenCalledWith(
-      expect.anything(),
-      submittedSignature,
-      expect.objectContaining({ commitment: "confirmed" })
-    );
-    const attempt = await getDb(env)
-      .prepare("SELECT status, error FROM payment_subscription_collection_attempts WHERE id = ?")
-      .bind(attemptId)
-      .first<{ status: string; error: string | null }>();
-    expect(attempt).toMatchObject({ status: "confirmed", error: null });
-    expect(signAndSendMock).toHaveBeenCalledTimes(2);
-  });
+      expect(collectBody.data.collectionAttempt).toMatchObject({
+        id: attemptId,
+        status: "confirmed",
+        signature: submittedSignature,
+      });
+      expect(collectBody.data.transfer).toMatchObject({
+        id: transferId,
+        status: transferStatus,
+        signature: submittedSignature,
+      });
+      expect(new Date(collectBody.data.recurringPayment.nextCollectionDueAt).getTime()).toBe(
+        new Date(dueAt).getTime() + 24 * 60 * 60 * 1000
+      );
+      expect(confirmTransactionMock).toHaveBeenCalledWith(
+        expect.anything(),
+        submittedSignature,
+        expect.objectContaining({ commitment: "confirmed" })
+      );
+      const attempt = await getDb(env)
+        .prepare("SELECT status, error FROM payment_subscription_collection_attempts WHERE id = ?")
+        .bind(attemptId)
+        .first<{ status: string; error: string | null }>();
+      expect(attempt).toMatchObject({ status: "confirmed", error: null });
+      expect(signAndSendMock).toHaveBeenCalledTimes(2);
+    }
+  );
 
   it("rejects early recurring payment collection", async () => {
     const sourceSigner = await generateKeyPairSigner();
@@ -3454,7 +3860,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -3503,7 +3909,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -3587,7 +3993,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -3682,7 +4088,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -3870,7 +4276,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {
@@ -4040,7 +4446,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     confirmTransactionMock
@@ -4172,7 +4578,7 @@ describe("Payments routes — recurring", () => {
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
       getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
       signAndSend: signAndSendMock,
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     const headers = {

--- a/apps/sdp-api/src/routes/payments/handlers/transfer-batches/create.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfer-batches/create.ts
@@ -337,6 +337,7 @@ export async function createTransferBatch(c: AppContext) {
         chunk,
         recipientsByIndex,
         feePayment,
+        lastValidBlockHeight: lifetime.lastValidBlockHeight,
         preflight: body.options?.preflight !== false,
       })
     )

--- a/apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts
@@ -8,62 +8,18 @@ import type {
   PaymentTransferRecipientRow,
 } from "@/db/repositories/payment-transfer-batches.repository";
 import { createPostgresPaymentTransferBatchesRepository } from "@/db/repositories/payment-transfer-batches.repository.postgres";
-import type {
-  PaymentTransferRow,
-  PaymentTransferStatus,
-} from "@/db/repositories/payments.repository";
 import { createPostgresPaymentsRepository } from "@/db/repositories/payments.repository.postgres";
 import { internalError, transactionFailed } from "@/lib/errors";
 import { createTenantScope } from "@/lib/tenant-scope";
-import { beginApprovedWalletOperationEffect } from "@/services/policy/approved-operation-replay";
+import { logEvent } from "@/runtime/money-path-events";
 import {
-  type AppContext,
-  type getFeePayment,
-  getPaymentsRepository,
-  getPaymentTransferBatchesRepository,
-} from "../../context";
+  createTransferSignedSubmissionStore,
+  submitSignedPaymentTransaction,
+} from "@/services/payments/signed-submission";
+import { beginApprovedWalletOperationEffect } from "@/services/policy/approved-operation-replay";
+import { type AppContext, type getFeePayment, getPaymentsRepository } from "../../context";
 import type { TransactionChunk } from "./transaction";
 import type { ResolvedBatchRequest } from "./types";
-
-/**
- * Updates a chunk's payment_transfers row, failing loudly if it vanished.
- *
- * @param params.transferId - Transfer row to update.
- * @param params.status - New transfer status.
- * @param params.signature - Transaction signature, once submitted.
- * @param params.serializedTx - Base64 wire transaction for the chunk.
- * @param params.error - Failure detail, or null.
- * @returns The updated transfer row.
- */
-async function updateTransferRecord(
-  c: AppContext,
-  params: {
-    transferId: string;
-    organizationId: string;
-    projectId: string;
-    status: PaymentTransferStatus;
-    signature?: string;
-    serializedTx: string;
-    error: string | null;
-  }
-): Promise<PaymentTransferRow> {
-  const updated = await getPaymentsRepository(c).updateTransfer({
-    transferId: params.transferId,
-    organizationId: params.organizationId,
-    projectId: params.projectId,
-    status: params.status,
-    signature: params.signature,
-    serializedTx: params.serializedTx,
-    error: params.error,
-    updatedAt: new Date().toISOString(),
-  });
-
-  if (!updated) {
-    throw internalError("Payment transfer record not found for update");
-  }
-
-  return updated;
-}
 
 /**
  * Updates the recipient rows belonging to one chunk and returns the updated
@@ -143,9 +99,9 @@ export function applyRecipientRowUpdates(
  * The transfer row and its recipient links are written in ONE transaction so
  * a processing chunk transfer always has linked recipients — the invariant
  * settleTransferBatch enforces when the pending-transfers job settles it.
- * After signAndSend the signature is persisted as the sole immediate write
- * (recipients are already processing and linked), keeping the window where a
- * submitted payment lacks its recovery signature to a single database call.
+ * The exact signed bytes and signature are persisted before the durable start
+ * marker and first broadcast. Once that marker may exist, failures remain
+ * processing for reconciliation rather than falsely failing the recipients.
  *
  * @param params.resolved - Resolved batch request.
  * @param params.chunk - Chunk to sign and submit.
@@ -159,6 +115,7 @@ export async function executeChunk(params: {
   chunk: TransactionChunk;
   recipientsByIndex: Map<number, PaymentTransferRecipientRow>;
   feePayment: ReturnType<typeof getFeePayment>;
+  lastValidBlockHeight: bigint;
   preflight: boolean;
 }): Promise<void> {
   const { c, resolved, chunk } = params;
@@ -230,33 +187,16 @@ export async function executeChunk(params: {
   applyRecipientRowUpdates(params.recipientsByIndex, linkedTransfer.linked);
   const transfer = linkedTransfer.created;
 
-  const settle = async (params2: {
-    status: PaymentTransferStatus;
-    recipientStatus: PaymentTransferRecipientRow["status"];
-    signature?: string;
-    error: string | null;
-  }): Promise<PaymentTransferRow> => {
-    const updates = await updateRecipientRows({
-      repository: getPaymentTransferBatchesRepository(c),
-      recipientsByIndex: params.recipientsByIndex,
-      recipientIndexes: chunk.recipientIndexes,
-      organizationId: resolved.scope.auth.organizationId,
-      projectId: resolved.projectId,
-      transferId: transfer.id,
-      status: params2.recipientStatus,
-      error: params2.error,
-    });
-    applyRecipientRowUpdates(params.recipientsByIndex, updates);
-    return updateTransferRecord(c, {
+  const failChunk = (error: unknown) =>
+    createPostgresPaymentTransferBatchesRepository(getDb(c.env)).settleTransferBatch({
       transferId: transfer.id,
       organizationId: resolved.scope.auth.organizationId,
       projectId: resolved.projectId,
-      status: params2.status,
-      signature: params2.signature,
-      serializedTx,
-      error: params2.error,
+      transferStatus: "failed",
+      error: error instanceof Error ? error.message : String(error),
+      slot: null,
+      updatedAt: new Date().toISOString(),
     });
-  };
 
   if (params.preflight) {
     try {
@@ -268,35 +208,40 @@ export async function executeChunk(params: {
         );
       }
     } catch (error) {
-      await settle({
-        status: "failed",
-        recipientStatus: "failed",
-        error: error instanceof Error ? error.message : String(error),
-      });
+      await failChunk(error);
       return;
     }
   }
 
   await beginApprovedWalletOperationEffect(c);
-  let signature: Awaited<ReturnType<typeof params.feePayment.signAndSend>>;
+  const submissionStore = createTransferSignedSubmissionStore(getPaymentsRepository(c), transfer);
   try {
-    signature = await params.feePayment.signAndSend(txBytes);
-  } catch (error) {
-    await settle({
-      status: "failed",
-      recipientStatus: "failed",
-      error: error instanceof Error ? error.message : String(error),
+    await submitSignedPaymentTransaction({
+      feePayment: params.feePayment,
+      rpc: resolved.rpc,
+      transaction: txBytes,
+      lastValidBlockHeight: params.lastValidBlockHeight,
+      store: submissionStore,
     });
+  } catch (error) {
+    const submitted = await submissionStore.submittedRow();
+    if (submitted) {
+      logEvent("warn", {
+        event: "sdp_api_payment_submission_unresolved",
+        flow: "batch",
+        reason: "broadcast_error",
+        organization_id: transfer.organization_id,
+        project_id: transfer.project_id,
+        batch_id: firstRecipient.batch_id,
+        transfer_id: transfer.id,
+        transfer_type: transfer.type,
+        signature: submitted.signature,
+        recipient_indexes: chunk.recipientIndexes,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
+    await failChunk(error);
     return;
   }
-
-  await updateTransferRecord(c, {
-    transferId: transfer.id,
-    organizationId: resolved.scope.auth.organizationId,
-    projectId: resolved.projectId,
-    status: "processing",
-    signature,
-    serializedTx,
-    error: null,
-  });
 }

--- a/apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts
@@ -14,6 +14,7 @@ import { createTenantScope } from "@/lib/tenant-scope";
 import { logEvent } from "@/runtime/money-path-events";
 import {
   createTransferSignedSubmissionStore,
+  isDefiniteSubmissionError,
   submitSignedPaymentTransaction,
 } from "@/services/payments/signed-submission";
 import { beginApprovedWalletOperationEffect } from "@/services/policy/approved-operation-replay";
@@ -225,7 +226,7 @@ export async function executeChunk(params: {
     });
   } catch (error) {
     const submitted = await submissionStore.submittedRow();
-    if (submitted) {
+    if (submitted && !isDefiniteSubmissionError(error)) {
       logEvent("warn", {
         event: "sdp_api_payment_submission_unresolved",
         flow: "batch",

--- a/apps/sdp-api/src/routes/payments/handlers/transfer-batches/transaction.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfer-batches/transaction.ts
@@ -1,6 +1,7 @@
 import { sumDecimalAmounts } from "@sdp/payments/decimal";
 import type { Address, Instruction, TransactionSigner } from "@solana/kit";
 import {
+  address,
   addSignersToTransactionMessage,
   appendTransactionMessageInstructions,
   compileTransaction,
@@ -23,6 +24,9 @@ import { badRequest } from "@/lib/errors";
 import type { RecentBlockhash, ResolvedRecipient, TokenContext } from "./types";
 
 export const DEFAULT_MAX_RECIPIENTS_PER_TRANSACTION = 20;
+
+// biome-ignore lint/security/noSecrets: Solana Memo program id constant, not a secret.
+const MEMO_PROGRAM_ADDRESS = address("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr");
 
 export interface RecipientInstructionGroup extends ResolvedRecipient {
   instructions: Instruction[];
@@ -151,7 +155,15 @@ function buildCandidateChunk(
     lifetime: RecentBlockhash;
   }
 ): TransactionChunk {
-  const instructions = groups.flatMap((group) => group.instructions);
+  const instructions = [
+    ...groups.flatMap((group) => group.instructions),
+    // Identical chunks sharing a blockhash still need distinct transaction signatures.
+    {
+      programAddress: MEMO_PROGRAM_ADDRESS,
+      accounts: [],
+      data: new TextEncoder().encode(crypto.randomUUID()),
+    },
+  ];
   return {
     recipientIndexes: groups.map((group) => group.index),
     instructions,

--- a/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
+++ b/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
@@ -36,7 +36,11 @@ import { trackPendingTransfers } from "@/services/jobs/track-pending-transfers";
 import * as solanaServices from "@/services/solana";
 import { TEST_SOLANA_ADDRESSES } from "@/test/fixtures/tokens";
 import { env } from "@/test/helpers/env";
-import { fullySignTestTransaction, sendTransactionMock } from "@/test/helpers/payments-routes";
+import {
+  fullySignTestTransaction,
+  sendTransactionMock,
+  sendTransactionPreflightError,
+} from "@/test/helpers/payments-routes";
 import { seedTestDatabase } from "@/test/mocks/db";
 import { clearKVStores, seedCachedApiKey } from "@/test/mocks/kv";
 
@@ -920,6 +924,56 @@ describe("payment transfer batches", () => {
       "sdp_api_payment_submission_unresolved"
     );
     warn.mockRestore();
+  });
+
+  it("fails a signed batch chunk when first-attempt preflight rejects it", async () => {
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValueOnce(sourceSigner);
+    createFeePaymentAdapterMock.mockReturnValueOnce({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
+      signAndSend: vi.fn(),
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    sendTransactionMock.mockRejectedValueOnce(sendTransactionPreflightError());
+
+    const counterpartyId = await seedCounterparty("batch_preflight_rejection_counterparty");
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      walletAddress: TEST_SOLANA_ADDRESSES.wallet3,
+    });
+    const response = await app.request(
+      "/v1/payments/transfer-batches",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          source: TEST_WALLET_ID,
+          token: "SOL",
+          recipients: [{ counterpartyId, counterpartyAccountId, amount: "0.1" }],
+          options: { preflight: false },
+        }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      data: {
+        batch: { status: string };
+        recipients: Array<{ status: string }>;
+        transfers: Array<{ status: string; signature: string | null }>;
+      };
+    };
+    expect(body.data.batch.status).toBe("failed");
+    expect(body.data.recipients).toMatchObject([{ status: "failed" }]);
+    expect(body.data.transfers).toMatchObject([{ status: "failed" }]);
+    expect(body.data.transfers[0]?.signature).toBeTruthy();
   });
 
   it("dry-runs a transfer batch with zero writes", async () => {

--- a/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
+++ b/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import * as feePaymentAdapters from "@sdp/payments/fee-payment";
 import { hashString } from "@sdp/payments/hash";
 import * as solanaRpc from "@sdp/rpc/solana";
@@ -7,7 +8,18 @@ import {
   SPL_TOKEN_PROGRAMS,
   WELL_KNOWN_TOKENS,
 } from "@sdp/types";
-import { address, createNoopSigner, generateKeyPairSigner, type Signature } from "@solana/kit";
+import { getBase58Codec } from "@solana/codecs";
+import {
+  address,
+  createNoopSigner,
+  generateKeyPairSigner,
+  getCompiledTransactionMessageDecoder,
+  getSignatureFromTransaction,
+  getTransactionDecoder,
+  getTransactionEncoder,
+  type Signature,
+  type SignatureBytes,
+} from "@solana/kit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
 import {
@@ -19,10 +31,12 @@ import * as batchesRepositoryPostgres from "@/db/repositories/payment-transfer-b
 import * as paymentsRepositoryPostgres from "@/db/repositories/payments.repository.postgres";
 import app from "@/index";
 import { createTenantScope } from "@/lib/tenant-scope";
+import { rootLogger } from "@/runtime/logger";
 import { trackPendingTransfers } from "@/services/jobs/track-pending-transfers";
 import * as solanaServices from "@/services/solana";
 import { TEST_SOLANA_ADDRESSES } from "@/test/fixtures/tokens";
 import { env } from "@/test/helpers/env";
+import { fullySignTestTransaction, sendTransactionMock } from "@/test/helpers/payments-routes";
 import { seedTestDatabase } from "@/test/mocks/db";
 import { clearKVStores, seedCachedApiKey } from "@/test/mocks/kv";
 
@@ -80,6 +94,42 @@ const FIRST_SIGNATURE =
 const SECOND_SIGNATURE =
   "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV";
 const TEST_TOKEN_ACCOUNT = TEST_SOLANA_ADDRESSES.wallet3;
+
+function ownedSubmissionAdapter(
+  signingOutcome = vi.fn().mockResolvedValue(FIRST_SIGNATURE)
+): ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter> {
+  return {
+    providerId: "mock",
+    getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+    getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
+    signAsFeePayer: vi.fn(async (transactionBytes: Uint8Array) => {
+      const requestedSignature = await signingOutcome(transactionBytes);
+      const transaction = getTransactionDecoder().decode(
+        fullySignTestTransaction(transactionBytes)
+      );
+      const feePayer = Object.keys(transaction.signatures)[0];
+      let signatureBytes: Uint8Array;
+      try {
+        signatureBytes = new Uint8Array(getBase58Codec().encode(requestedSignature));
+      } catch {
+        signatureBytes = new Uint8Array();
+      }
+      if (signatureBytes.length !== 64) {
+        signatureBytes = createHash("sha512").update(requestedSignature).digest();
+      }
+      return new Uint8Array(
+        getTransactionEncoder().encode({
+          ...transaction,
+          signatures: {
+            ...transaction.signatures,
+            [feePayer]: signatureBytes as SignatureBytes,
+          },
+        })
+      );
+    }),
+    signAndSend: signingOutcome,
+  } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>;
+}
 
 function mockSourceTokenAccountRpc(params: {
   mint: string;
@@ -387,13 +437,10 @@ describe("payment transfer batches", () => {
       confirmationStatus: "confirmed",
       err: null,
     });
-    createFeePaymentAdapterMock.mockReturnValue({
-      providerId: "mock",
-      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
-      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
-      signAndSend: vi.fn().mockResolvedValue(FIRST_SIGNATURE),
-    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    createFeePaymentAdapterMock.mockReturnValue(ownedSubmissionAdapter());
+    sendTransactionMock.mockImplementation(async (_rpc, transactionBytes) =>
+      getSignatureFromTransaction(getTransactionDecoder().decode(transactionBytes))
+    );
     createOrgSignerMock.mockResolvedValue(
       createNoopSigner(address("8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ"))
     );
@@ -525,13 +572,7 @@ describe("payment transfer batches", () => {
       .fn()
       .mockResolvedValueOnce(FIRST_SIGNATURE)
       .mockResolvedValueOnce(SECOND_SIGNATURE);
-    createFeePaymentAdapterMock.mockReturnValueOnce({
-      providerId: "mock",
-      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
-      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
-      signAndSend: signAndSendMock,
-    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    createFeePaymentAdapterMock.mockReturnValueOnce(ownedSubmissionAdapter(signAndSendMock));
 
     const counterpartyId = await seedCounterparty("batch_create_counterparty");
     const firstAccountId = await seedCryptoWalletCounterpartyAccount({
@@ -723,6 +764,162 @@ describe("payment transfer batches", () => {
     expect(listRes.status).toBe(200);
     const listBody = (await listRes.json()) as { data: Array<{ id: string }> };
     expect(listBody.data.map((batch) => batch.id)).toContain(body.data.batch.id);
+  });
+
+  it("persists a batch chunk's exact signed transaction before broadcasting", async () => {
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValueOnce(sourceSigner);
+    const signAndSend = vi.fn().mockRejectedValue(new Error("legacy signAndSend was used"));
+    createFeePaymentAdapterMock.mockReturnValueOnce({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
+      signAndSend,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+
+    let persistedSignature: string | null = null;
+    sendTransactionMock.mockImplementationOnce(async (_rpc, signedBytes) => {
+      const signature = getSignatureFromTransaction(getTransactionDecoder().decode(signedBytes));
+      persistedSignature = signature;
+      const row = await getDb(env)
+        .prepare(
+          `SELECT signature, signed_transaction, last_valid_block_height, submission_started_at
+             FROM payment_transfers
+            WHERE type = 'transfer_batch'`
+        )
+        .first<{
+          signature: string | null;
+          signed_transaction: string | null;
+          last_valid_block_height: string | null;
+          submission_started_at: string | null;
+        }>();
+      expect(row).toMatchObject({
+        signature,
+        signed_transaction: Buffer.from(signedBytes).toString("base64"),
+        last_valid_block_height: "1000",
+      });
+      expect(row?.submission_started_at).not.toBeNull();
+      return signature;
+    });
+
+    const counterpartyId = await seedCounterparty("batch_signed_before_send_counterparty");
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      walletAddress: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+    const response = await app.request(
+      "/v1/payments/transfer-batches",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          source: TEST_WALLET_ID,
+          token: "SOL",
+          recipients: [{ counterpartyId, counterpartyAccountId, amount: "0.1" }],
+          options: { preflight: false },
+        }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      data: { transfers: Array<{ status: string; signature: string | null }> };
+    };
+    expect(body.data.transfers).toMatchObject([
+      { status: "processing", signature: persistedSignature },
+    ]);
+    expect(signAndSend).not.toHaveBeenCalled();
+    expect(sendTransactionMock).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a signed batch chunk processing when its first broadcast is ambiguous", async () => {
+    const warn = vi.spyOn(rootLogger, "warn").mockImplementation(() => undefined);
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValueOnce(sourceSigner);
+    const signAndSend = vi.fn().mockRejectedValue(new Error("legacy signAndSend was used"));
+    createFeePaymentAdapterMock.mockReturnValueOnce({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
+      signAsFeePayer: vi.fn().mockImplementation(fullySignTestTransaction),
+      signAndSend,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    sendTransactionMock.mockRejectedValueOnce(new Error("RPC response lost"));
+
+    const counterpartyId = await seedCounterparty("batch_ambiguous_send_counterparty");
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      walletAddress: TEST_SOLANA_ADDRESSES.wallet3,
+    });
+    const response = await app.request(
+      "/v1/payments/transfer-batches",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          source: TEST_WALLET_ID,
+          token: "SOL",
+          recipients: [{ counterpartyId, counterpartyAccountId, amount: "0.1" }],
+          options: { preflight: false },
+        }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      data: {
+        batch: { id: string };
+        recipients: Array<{ status: string }>;
+        transfers: Array<{ id: string; status: string; signature: string | null }>;
+      };
+    };
+    expect(body.data.recipients).toMatchObject([{ status: "processing" }]);
+    expect(body.data.transfers[0]).toMatchObject({ status: "processing" });
+    expect(body.data.transfers[0]?.signature).toBeTruthy();
+    const row = await getDb(env)
+      .prepare(
+        `SELECT signed_transaction, last_valid_block_height, submission_started_at
+           FROM payment_transfers WHERE id = ?`
+      )
+      .bind(body.data.transfers[0]?.id)
+      .first<{
+        signed_transaction: string | null;
+        last_valid_block_height: string | null;
+        submission_started_at: string | null;
+      }>();
+    expect(row?.signed_transaction).not.toBeNull();
+    expect(row?.last_valid_block_height).toBe("1000");
+    expect(row?.submission_started_at).not.toBeNull();
+    expect(signAndSend).not.toHaveBeenCalled();
+    expect(sendTransactionMock).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "sdp_api_payment_submission_unresolved",
+        flow: "batch",
+        reason: "broadcast_error",
+        organization_id: TEST_ORG.id,
+        project_id: TEST_PROJECT.id,
+        batch_id: body.data.batch.id,
+        transfer_id: body.data.transfers[0]?.id,
+        transfer_type: "transfer_batch",
+        signature: body.data.transfers[0]?.signature,
+        recipient_indexes: [0],
+        error: "RPC response lost",
+      }),
+      "sdp_api_payment_submission_unresolved"
+    );
+    warn.mockRestore();
   });
 
   it("dry-runs a transfer batch with zero writes", async () => {
@@ -1014,13 +1211,7 @@ describe("payment transfer batches", () => {
     createOrgSignerMock.mockResolvedValue(sourceSigner);
 
     const signAndSendMock = vi.fn().mockResolvedValue(FIRST_SIGNATURE);
-    createFeePaymentAdapterMock.mockReturnValue({
-      providerId: "mock",
-      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
-      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
-      signAndSend: signAndSendMock,
-    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    createFeePaymentAdapterMock.mockReturnValue(ownedSubmissionAdapter(signAndSendMock));
 
     const counterpartyId = await seedCounterparty("batch_idempotent_replay_counterparty");
     const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
@@ -1085,13 +1276,7 @@ describe("payment transfer batches", () => {
     createOrgSignerMock.mockResolvedValue(sourceSigner);
 
     const signAndSendMock = vi.fn().mockResolvedValue(FIRST_SIGNATURE);
-    createFeePaymentAdapterMock.mockReturnValue({
-      providerId: "mock",
-      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
-      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
-      signAndSend: signAndSendMock,
-    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    createFeePaymentAdapterMock.mockReturnValue(ownedSubmissionAdapter(signAndSendMock));
 
     const counterpartyId = await seedCounterparty("batch_idempotency_conflict_counterparty");
     const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
@@ -1159,13 +1344,7 @@ describe("payment transfer batches", () => {
     });
 
     const signAndSendMock = vi.fn().mockResolvedValue(FIRST_SIGNATURE);
-    createFeePaymentAdapterMock.mockReturnValue({
-      providerId: "mock",
-      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
-      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
-      signAndSend: signAndSendMock,
-    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    createFeePaymentAdapterMock.mockReturnValue(ownedSubmissionAdapter(signAndSendMock));
 
     const counterpartyId = await seedCounterparty("batch_idempotency_race_counterparty");
     const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
@@ -1234,13 +1413,7 @@ describe("payment transfer batches", () => {
       .fn()
       .mockResolvedValueOnce(FIRST_SIGNATURE)
       .mockResolvedValueOnce(SECOND_SIGNATURE);
-    createFeePaymentAdapterMock.mockReturnValue({
-      providerId: "mock",
-      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
-      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
-      signAndSend: signAndSendMock,
-    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    createFeePaymentAdapterMock.mockReturnValue(ownedSubmissionAdapter(signAndSendMock));
 
     const counterpartyId = await seedCounterparty("batch_without_idempotency_counterparty");
     const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
@@ -1337,13 +1510,7 @@ describe("payment transfer batches", () => {
       });
 
       const signAndSendMock = vi.fn().mockResolvedValueOnce(FIRST_SIGNATURE);
-      createFeePaymentAdapterMock.mockReturnValueOnce({
-        providerId: "mock",
-        getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
-        getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-        signAsFeePayer: vi.fn(),
-        signAndSend: signAndSendMock,
-      } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+      createFeePaymentAdapterMock.mockReturnValueOnce(ownedSubmissionAdapter(signAndSendMock));
 
       const counterpartyId = await seedCounterparty(`batch_token_counterparty_${label}`);
       const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
@@ -1431,13 +1598,7 @@ describe("payment transfer batches", () => {
     createOrgSignerMock.mockResolvedValueOnce(sourceSigner);
 
     const signAndSendMock = vi.fn().mockResolvedValueOnce(FIRST_SIGNATURE);
-    createFeePaymentAdapterMock.mockReturnValueOnce({
-      providerId: "mock",
-      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
-      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
-      signAndSend: signAndSendMock,
-    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    createFeePaymentAdapterMock.mockReturnValueOnce(ownedSubmissionAdapter(signAndSendMock));
 
     const counterpartyId = await seedCounterparty("batch_timeout_counterparty");
     const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
@@ -1486,13 +1647,7 @@ describe("payment transfer batches", () => {
     createOrgSignerMock.mockResolvedValueOnce(sourceSigner);
 
     const signAndSendMock = vi.fn().mockResolvedValueOnce(FIRST_SIGNATURE);
-    createFeePaymentAdapterMock.mockReturnValueOnce({
-      providerId: "mock",
-      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
-      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
-      signAndSend: signAndSendMock,
-    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    createFeePaymentAdapterMock.mockReturnValueOnce(ownedSubmissionAdapter(signAndSendMock));
 
     const counterpartyId = await seedCounterparty("batch_onchain_error_counterparty");
     const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
@@ -1642,13 +1797,7 @@ describe("payment transfer batches", () => {
       .fn()
       .mockResolvedValueOnce(FIRST_SIGNATURE)
       .mockResolvedValueOnce(SECOND_SIGNATURE);
-    createFeePaymentAdapterMock.mockReturnValueOnce({
-      providerId: "mock",
-      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
-      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
-      signAndSend: signAndSendMock,
-    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    createFeePaymentAdapterMock.mockReturnValueOnce(ownedSubmissionAdapter(signAndSendMock));
 
     const counterpartyId = await seedCounterparty("batch_allowlist_pass_counterparty");
     const firstAccountId = await seedCryptoWalletCounterpartyAccount({
@@ -1690,6 +1839,63 @@ describe("payment transfer batches", () => {
     expect(signAndSendMock).toHaveBeenCalledTimes(2);
   });
 
+  it("makes identical transfer chunks unique before signing", async () => {
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValueOnce(sourceSigner);
+
+    const signingMock = vi
+      .fn()
+      .mockResolvedValueOnce(FIRST_SIGNATURE)
+      .mockResolvedValueOnce(SECOND_SIGNATURE);
+    createFeePaymentAdapterMock.mockReturnValueOnce(ownedSubmissionAdapter(signingMock));
+
+    const counterpartyId = await seedCounterparty("batch_identical_chunks_counterparty");
+    const accountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      walletAddress: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+
+    const res = await app.request(
+      "/v1/payments/transfer-batches",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          source: TEST_WALLET_ID,
+          token: "SOL",
+          recipients: [
+            { counterpartyId, counterpartyAccountId: accountId, amount: "0.1" },
+            { counterpartyId, counterpartyAccountId: accountId, amount: "0.1" },
+          ],
+          options: { maxRecipientsPerTransaction: 1, preflight: false },
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+    expect(signingMock).toHaveBeenCalledTimes(2);
+    const memos = signingMock.mock.calls.map(([transactionBytes]) => {
+      const transaction = getTransactionDecoder().decode(transactionBytes);
+      const message = getCompiledTransactionMessageDecoder().decode(transaction.messageBytes);
+      if (message.version !== 0) {
+        throw new Error("Expected batch chunk v0 transaction");
+      }
+      const memoInstruction = message.instructions.at(-1);
+      if (!memoInstruction?.data) {
+        throw new Error("Expected batch chunk memo");
+      }
+      return new TextDecoder("utf-8", { fatal: true }).decode(memoInstruction.data);
+    });
+    expect(memos[0]).toMatch(/^[0-9a-f-]{36}$/);
+    expect(memos[1]).toMatch(/^[0-9a-f-]{36}$/);
+    expect(memos[0]).not.toBe(memos[1]);
+  });
+
   it("settles a mixed batch to partially_failed via the reconciliation job", async () => {
     const sourceSigner = await generateKeyPairSigner();
     await updateSeededWalletPublicKey(sourceSigner.address);
@@ -1699,13 +1905,7 @@ describe("payment transfer batches", () => {
       .fn()
       .mockResolvedValueOnce(FIRST_SIGNATURE)
       .mockResolvedValueOnce(SECOND_SIGNATURE);
-    createFeePaymentAdapterMock.mockReturnValueOnce({
-      providerId: "mock",
-      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
-      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
-      signAndSend: signAndSendMock,
-    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    createFeePaymentAdapterMock.mockReturnValueOnce(ownedSubmissionAdapter(signAndSendMock));
 
     const counterpartyId = await seedCounterparty("batch_settlement_counterparty");
     const firstAccountId = await seedCryptoWalletCounterpartyAccount({
@@ -1813,13 +2013,7 @@ describe("payment transfer batches", () => {
       const signAndSendMock = vi.fn(
         async () => `${FIRST_SIGNATURE}${signatureIndex++}` as Signature
       );
-      createFeePaymentAdapterMock.mockReturnValueOnce({
-        providerId: "mock",
-        getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
-        getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-        signAsFeePayer: vi.fn(),
-        signAndSend: signAndSendMock,
-      } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+      createFeePaymentAdapterMock.mockReturnValueOnce(ownedSubmissionAdapter(signAndSendMock));
 
       const counterpartyId = await seedCounterparty("batch_stranded_counterparty");
       const firstAccountId = await seedCryptoWalletCounterpartyAccount({
@@ -1908,13 +2102,7 @@ describe("payment transfer batches", () => {
       await updateSeededWalletPublicKey(sourceSigner.address);
       createOrgSignerMock.mockResolvedValueOnce(sourceSigner);
       const signAndSendMock = vi.fn(async () => FIRST_SIGNATURE as Signature);
-      createFeePaymentAdapterMock.mockReturnValueOnce({
-        providerId: "mock",
-        getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
-        getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-        signAsFeePayer: vi.fn(),
-        signAndSend: signAndSendMock,
-      } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+      createFeePaymentAdapterMock.mockReturnValueOnce(ownedSubmissionAdapter(signAndSendMock));
 
       const counterpartyId = await seedCounterparty("batch_link_failure_counterparty");
       const accountId = await seedCryptoWalletCounterpartyAccount({
@@ -1975,24 +2163,37 @@ describe("payment transfer batches", () => {
     }
   });
 
-  it("leaves linked recipients for reconciliation when the signature persist fails after submission", async () => {
+  it("fails a linked chunk when signed transaction persistence fails before broadcast", async () => {
     const createRepository = paymentsRepositoryPostgres.createPostgresPaymentsRepository;
-    const batchesSpy = vi.spyOn(paymentsRepositoryPostgres, "createPostgresPaymentsRepository");
+    const paymentsSpy = vi.spyOn(paymentsRepositoryPostgres, "createPostgresPaymentsRepository");
     let signaturePersistInjected = false;
-    batchesSpy.mockImplementation((db) => {
+    paymentsSpy.mockImplementation((db) => {
       const repository = createRepository(db);
       return {
         ...repository,
-        updateTransfer: async (input) => {
-          if (
-            !signaturePersistInjected &&
-            input.status === "processing" &&
-            input.signature !== undefined
-          ) {
+        persistSignedTransfer: async (input) => {
+          if (!signaturePersistInjected) {
             signaturePersistInjected = true;
             throw new Error("simulated signature persist failure");
           }
-          return repository.updateTransfer(input);
+          return repository.persistSignedTransfer(input);
+        },
+      };
+    });
+    const createBatchesRepository =
+      batchesRepositoryPostgres.createPostgresPaymentTransferBatchesRepository;
+    const settleTransferBatchMock = vi.fn();
+    const batchesSpy = vi.spyOn(
+      batchesRepositoryPostgres,
+      "createPostgresPaymentTransferBatchesRepository"
+    );
+    batchesSpy.mockImplementation((db) => {
+      const repository = createBatchesRepository(db);
+      return {
+        ...repository,
+        settleTransferBatch: async (input) => {
+          settleTransferBatchMock(input);
+          return repository.settleTransferBatch(input);
         },
       };
     });
@@ -2002,13 +2203,7 @@ describe("payment transfer batches", () => {
       await updateSeededWalletPublicKey(sourceSigner.address);
       createOrgSignerMock.mockResolvedValueOnce(sourceSigner);
       const signAndSendMock = vi.fn(async () => FIRST_SIGNATURE as Signature);
-      createFeePaymentAdapterMock.mockReturnValueOnce({
-        providerId: "mock",
-        getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
-        getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-        signAsFeePayer: vi.fn(),
-        signAndSend: signAndSendMock,
-      } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+      createFeePaymentAdapterMock.mockReturnValueOnce(ownedSubmissionAdapter(signAndSendMock));
 
       const counterpartyId = await seedCounterparty("batch_settle_failure_counterparty");
       const accountId = await seedCryptoWalletCounterpartyAccount({
@@ -2039,44 +2234,30 @@ describe("payment transfer batches", () => {
         data: { batch: { id: string; status: string } };
       };
       expect(signAndSendMock).toHaveBeenCalledTimes(1);
+      expect(sendTransactionMock).not.toHaveBeenCalled();
+      expect(body.data.batch.status).toBe("failed");
 
       const linkedRecipient = await getDb(env)
         .prepare("SELECT status, transfer_id FROM payment_transfer_recipients WHERE batch_id = ?")
         .bind(body.data.batch.id)
         .first<{ status: string; transfer_id: string | null }>();
       expect(linkedRecipient?.transfer_id).not.toBeNull();
-      expect(linkedRecipient?.status).toBe("processing");
-
-      await getDb(env)
-        .prepare(
-          `UPDATE payment_transfers
-              SET updated_at = ?
-            WHERE type = 'transfer_batch' AND status = 'processing'`
-        )
-        .bind(new Date(Date.now() - 10 * 60 * 1000).toISOString())
-        .run();
-
-      await trackPendingTransfers(env);
+      expect(linkedRecipient?.status).toBe("failed");
 
       const transferRow = await getDb(env)
-        .prepare("SELECT status FROM payment_transfers WHERE id = ?")
+        .prepare("SELECT status, signature FROM payment_transfers WHERE id = ?")
         .bind(linkedRecipient?.transfer_id)
-        .first<{ status: string }>();
-      expect(transferRow?.status).toBe("failed");
-
-      const settledRecipient = await getDb(env)
-        .prepare("SELECT status, transfer_id FROM payment_transfer_recipients WHERE batch_id = ?")
-        .bind(body.data.batch.id)
-        .first<{ status: string; transfer_id: string | null }>();
-      expect(settledRecipient?.status).toBe("failed");
-      expect(settledRecipient?.transfer_id).toBe(linkedRecipient?.transfer_id);
-
-      const batchRow = await getDb(env)
-        .prepare("SELECT status FROM payment_transfer_batches WHERE id = ?")
-        .bind(body.data.batch.id)
-        .first<{ status: string }>();
-      expect(batchRow?.status).toBe("failed");
+        .first<{ status: string; signature: string | null }>();
+      expect(transferRow).toMatchObject({ status: "failed", signature: null });
+      expect(settleTransferBatchMock).toHaveBeenCalledOnce();
+      expect(settleTransferBatchMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          transferId: linkedRecipient?.transfer_id,
+          transferStatus: "failed",
+        })
+      );
     } finally {
+      paymentsSpy.mockRestore();
       batchesSpy.mockRestore();
     }
   });
@@ -2111,13 +2292,7 @@ describe("payment transfer batches", () => {
       await updateSeededWalletPublicKey(sourceSigner.address);
       createOrgSignerMock.mockResolvedValueOnce(sourceSigner);
       const signAndSendMock = vi.fn().mockResolvedValueOnce(FIRST_SIGNATURE);
-      createFeePaymentAdapterMock.mockReturnValueOnce({
-        providerId: "mock",
-        getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
-        getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-        signAsFeePayer: vi.fn(),
-        signAndSend: signAndSendMock,
-      } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+      createFeePaymentAdapterMock.mockReturnValueOnce(ownedSubmissionAdapter(signAndSendMock));
 
       const counterpartyId = await seedCounterparty("batch_midflight_counterparty");
       const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
@@ -2168,13 +2343,7 @@ describe("payment transfer batches", () => {
       .fn()
       .mockResolvedValueOnce(FIRST_SIGNATURE)
       .mockResolvedValueOnce(SECOND_SIGNATURE);
-    createFeePaymentAdapterMock.mockReturnValueOnce({
-      providerId: "mock",
-      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
-      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
-      signAndSend: signAndSendMock,
-    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    createFeePaymentAdapterMock.mockReturnValueOnce(ownedSubmissionAdapter(signAndSendMock));
 
     const counterpartyId = await seedCounterparty("batch_concurrent_settle_counterparty");
     const firstAccountId = await seedCryptoWalletCounterpartyAccount({
@@ -2246,13 +2415,7 @@ describe("payment transfer batches", () => {
     const sourceSigner = await generateKeyPairSigner();
     await updateSeededWalletPublicKey(sourceSigner.address);
     createOrgSignerMock.mockResolvedValueOnce(sourceSigner);
-    createFeePaymentAdapterMock.mockReturnValueOnce({
-      providerId: "mock",
-      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
-      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
-      signAndSend: vi.fn(async () => FIRST_SIGNATURE as Signature),
-    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    createFeePaymentAdapterMock.mockReturnValueOnce(ownedSubmissionAdapter());
 
     const counterpartyId = await seedCounterparty("batch_stale_settle_counterparty");
     const accountId = await seedCryptoWalletCounterpartyAccount({
@@ -2349,13 +2512,7 @@ describe("payment transfer batches", () => {
     createOrgSignerMock.mockResolvedValue(sourceSigner);
     let signatureIndex = 0;
     const signAndSendMock = vi.fn(async () => `${FIRST_SIGNATURE}${signatureIndex++}` as Signature);
-    createFeePaymentAdapterMock.mockReturnValue({
-      providerId: "mock",
-      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
-      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
-      signAndSend: signAndSendMock,
-    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    createFeePaymentAdapterMock.mockReturnValue(ownedSubmissionAdapter(signAndSendMock));
     const counterpartyId = await seedCounterparty("batch_stress_counterparty");
     const destinationSigners = await Promise.all(
       Array.from({ length: 500 }, () => generateKeyPairSigner())
@@ -2432,13 +2589,7 @@ describe("payment transfer batches", () => {
     createOrgSignerMock.mockResolvedValue(sourceSigner);
     let signatureIndex = 0;
     const signAndSendMock = vi.fn(async () => `${FIRST_SIGNATURE}${signatureIndex++}` as Signature);
-    createFeePaymentAdapterMock.mockReturnValue({
-      providerId: "mock",
-      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
-      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
-      signAsFeePayer: vi.fn(),
-      signAndSend: signAndSendMock,
-    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    createFeePaymentAdapterMock.mockReturnValue(ownedSubmissionAdapter(signAndSendMock));
     const counterpartyId = await seedCounterparty("batch_burst_counterparty");
     const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
       counterpartyId,

--- a/apps/sdp-api/src/security/value-moving-conformance.node.test.ts
+++ b/apps/sdp-api/src/security/value-moving-conformance.node.test.ts
@@ -257,7 +257,6 @@ const signingSinkInventory: Record<string, string[]> = {
     "signTransactionMessageWithSigners",
   ],
   "apps/sdp-api/src/routes/pay.ts": ["signAsFeePayer"],
-  "apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts": ["signAndSend"],
   "apps/sdp-api/src/services/payments/signed-submission.ts": ["prepareOwnedSubmission"],
   "apps/sdp-api/src/services/payments/recurring-payments/shared.ts": ["signAndSend"],
   "apps/sdp-api/src/services/private-channels/deposit.ts": ["signTransactionMessageWithSigners"],

--- a/apps/sdp-api/src/services/jobs/collect-recurring-payments.node.test.ts
+++ b/apps/sdp-api/src/services/jobs/collect-recurring-payments.node.test.ts
@@ -170,6 +170,19 @@ describe("collectDueRecurringPayments", () => {
     );
   });
 
+  it("recovers a canceled payment attempt without creating a future collection", async () => {
+    const canceled = recurringRow("canceled");
+    mocks.rows.staleCollection = [canceled];
+
+    const result = await collectDueRecurringPayments({} as Env);
+
+    expect(result).toEqual({ recovered: 1, collected: 0, failed: 0, skipped: 0 });
+    expect(collectRecurringPayment).toHaveBeenCalledWith(
+      expect.objectContaining({ recurringPayment: canceled })
+    );
+    expect(collectRecurringPayment).toHaveBeenCalledTimes(1);
+  });
+
   it("uses batch-size and retry-after controls while excluding active attempts", async () => {
     await collectDueRecurringPayments(
       {
@@ -191,6 +204,12 @@ describe("collectDueRecurringPayments", () => {
     );
     expect(staleCollectionQuery?.query).toContain("ROW_NUMBER() OVER");
     expect(staleCollectionQuery?.query).toContain("PARTITION BY rp.id");
+    expect(staleCollectionQuery?.query).toContain(
+      "rp.status IN ('active', 'canceling', 'canceled')"
+    );
+    expect(staleCollectionQuery?.query).toContain(
+      "rp.status = 'active' AND a.status = 'confirmed'"
+    );
   });
 
   it("treats collection conflicts as duplicate-prevention skips", async () => {

--- a/apps/sdp-api/src/services/jobs/collect-recurring-payments.ts
+++ b/apps/sdp-api/src/services/jobs/collect-recurring-payments.ts
@@ -230,10 +230,13 @@ export async function collectDueRecurringPayments(
           AND a.project_id = rp.project_id
           AND a.subscription_id = rp.subscription_id
           AND a.due_at = rp.next_collection_due_at
-        WHERE rp.status = 'active'
+        WHERE rp.status IN ('active', 'canceling', 'canceled')
           AND rp.next_collection_due_at IS NOT NULL
           AND a.status IN ('processing', 'confirmed')
-          AND (a.status = 'confirmed' OR a.updated_at <= ?)
+          AND (
+            (a.status = 'processing' AND a.updated_at <= ?)
+            OR (rp.status = 'active' AND a.status = 'confirmed')
+          )
        ) recoverable_attempts
       WHERE attempt_rank = 1
       ORDER BY attempt_updated_at ASC

--- a/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
@@ -40,6 +40,7 @@ import { getLogger } from "@/runtime/logger";
 import { logEvent } from "@/runtime/money-path-events";
 import {
   createTransferSignedSubmissionStore,
+  isDefiniteSubmissionError,
   type TransferSignedSubmissionStore,
 } from "@/services/payments/signed-submission";
 import * as solanaServices from "@/services/solana";
@@ -659,10 +660,7 @@ async function journalRecurringPaymentCollectionError(input: {
   submittedSignature: Signature | null;
   error: unknown;
 }): Promise<void> {
-  if (
-    input.submittedSignature &&
-    !(input.error instanceof AppError && input.error.code === "TRANSACTION_FAILED")
-  ) {
+  if (input.submittedSignature && !isDefiniteSubmissionError(input.error)) {
     const updatedAt = new Date().toISOString();
     const [attemptResult, transferResult] = await Promise.allSettled([
       input.subscriptionsRepo.updateCollectionAttempt({
@@ -769,10 +767,7 @@ async function handleRecurringPaymentCollectionError(input: {
   }
 
   const submitted = await input.submissionStore?.submittedRow();
-  if (
-    submitted?.signature &&
-    !(input.error instanceof AppError && input.error.code === "TRANSACTION_FAILED")
-  ) {
+  if (submitted?.signature && !isDefiniteSubmissionError(input.error)) {
     const submittedSignature = validatedStoredCollectionSignature({
       attemptId: input.attempt.id,
       signature: submitted.signature,

--- a/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
@@ -1241,49 +1241,56 @@ export async function collectRecurringPayment(input: {
       },
     });
 
-    transfer = await paymentsRepo.createTransfer({
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-      walletId: input.sourceWallet.walletId,
-      counterpartyId: input.recurringPayment.counterparty_id,
-      sourceAddress: input.sourceWallet.publicKey,
-      destinationAddress: input.recurringPayment.destination_address,
-      token: input.recurringPayment.token,
-      amount: input.recurringPayment.amount,
-      memo: null,
-      type: "transfer",
-      direction: "outbound",
-      status: "processing",
-      provider: null,
-      providerReference: null,
-      deliveryMode: null,
-      fiatCurrency: null,
-      fiatAmount: null,
-      providerData: {
-        recurringPaymentId: input.recurringPayment.id,
-        subscriptionId: subscription.id,
-        collectionDueAt: dueAt,
-      },
-      serializedTx: null,
-      signature: null,
-      slot: null,
-      initiatedByKeyId: input.initiatedByKeyId,
+    const claimedAttempt = attempt;
+    const linkedCollection = await getDb(input.env).transaction(async (tx) => {
+      const transactionPaymentsRepo = createPostgresPaymentsRepository(tx, tenantScope(input));
+      const transactionSubscriptionsRepo = createPostgresPaymentSubscriptionsRepository(tx);
+      const createdTransfer = await transactionPaymentsRepo.createTransfer({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        walletId: input.sourceWallet.walletId,
+        counterpartyId: input.recurringPayment.counterparty_id,
+        sourceAddress: input.sourceWallet.publicKey,
+        destinationAddress: input.recurringPayment.destination_address,
+        token: input.recurringPayment.token,
+        amount: input.recurringPayment.amount,
+        memo: null,
+        type: "transfer",
+        direction: "outbound",
+        status: "processing",
+        provider: null,
+        providerReference: null,
+        deliveryMode: null,
+        fiatCurrency: null,
+        fiatAmount: null,
+        providerData: {
+          recurringPaymentId: input.recurringPayment.id,
+          subscriptionId: subscription.id,
+          collectionDueAt: dueAt,
+        },
+        serializedTx: null,
+        signature: null,
+        slot: null,
+        initiatedByKeyId: input.initiatedByKeyId,
+      });
+      if (!createdTransfer) {
+        throw new AppError("INTERNAL_ERROR", "Failed to create collection transfer");
+      }
+      const linkedAttempt = await transactionSubscriptionsRepo.updateCollectionAttempt({
+        attemptId: claimedAttempt.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        transferId: createdTransfer.id,
+        status: "processing",
+        updatedAt: new Date().toISOString(),
+      });
+      if (!linkedAttempt || linkedAttempt.transfer_id !== createdTransfer.id) {
+        throw new AppError("INTERNAL_ERROR", "Failed to link collection attempt to transfer");
+      }
+      return { attempt: linkedAttempt, transfer: createdTransfer };
     });
-    if (!transfer) {
-      throw new AppError("INTERNAL_ERROR", "Failed to create collection transfer");
-    }
-    const linkedAttempt = await subscriptionsRepo.updateCollectionAttempt({
-      attemptId: attempt.id,
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-      transferId: transfer.id,
-      status: "processing",
-      updatedAt: new Date().toISOString(),
-    });
-    if (!linkedAttempt || linkedAttempt.transfer_id !== transfer.id) {
-      throw new AppError("INTERNAL_ERROR", "Failed to link collection attempt to transfer");
-    }
-    attempt = linkedAttempt;
+    attempt = linkedCollection.attempt;
+    transfer = linkedCollection.transfer;
     submissionStore = createTransferSignedSubmissionStore(paymentsRepo, transfer);
 
     const rpc = solanaRpc.createRpc(input.env);

--- a/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
@@ -8,7 +8,7 @@ import * as solanaRpc from "@sdp/rpc/solana";
 import { assertValidAddress } from "@sdp/solana/address";
 import { parseDecimalAmount } from "@sdp/solana/amount";
 import { getBase58Codec } from "@solana/codecs";
-import { type Address, createNoopSigner, type Signature } from "@solana/kit";
+import { type Address, assertIsSignature, createNoopSigner, type Signature } from "@solana/kit";
 import * as subscriptionsProgram from "@solana/subscriptions";
 import {
   findAssociatedTokenPda,
@@ -37,6 +37,11 @@ import {
   resolveSourceTokenAccountOrAta,
 } from "@/routes/payments/token-accounts";
 import { getLogger } from "@/runtime/logger";
+import { logEvent } from "@/runtime/money-path-events";
+import {
+  createTransferSignedSubmissionStore,
+  type TransferSignedSubmissionStore,
+} from "@/services/payments/signed-submission";
 import * as solanaServices from "@/services/solana";
 import { createProjectSponsorshipFeePayment } from "@/services/sponsorship.service";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
@@ -64,6 +69,12 @@ interface VerifiedRecurringPaymentCollection {
   transferId: string;
 }
 
+interface RecurringPaymentCollectionResult {
+  recurringPayment: PaymentRecurringPaymentRow;
+  collectionAttempt: PaymentSubscriptionCollectionAttemptRow;
+  transfer: PaymentTransferRow;
+}
+
 function tenantScope(input: { organizationId: string; projectId: string }) {
   return createTenantScope({
     organizationId: input.organizationId,
@@ -84,6 +95,30 @@ function isStaleCollectionAttempt(row: PaymentSubscriptionCollectionAttemptRow):
 
 function isRecurringCollectionSource(value: unknown): value is RecurringCollectionSource {
   return value === "manual" || value === "automated";
+}
+
+function validatedStoredCollectionSignature(input: {
+  attemptId: string;
+  signature: string;
+  transferId: string;
+}): Signature {
+  try {
+    assertIsSignature(input.signature);
+    return input.signature;
+  } catch (error) {
+    getLogger().error(
+      {
+        attempt_id: input.attemptId,
+        error: activationErrorMessage(error),
+        transfer_id: input.transferId,
+      },
+      "Recurring payment collection stored signature is invalid"
+    );
+    throw new AppError(
+      "INTERNAL_ERROR",
+      "Recurring payment collection has an invalid stored signature"
+    );
+  }
 }
 
 function recurringCollectionMetadata(input: {
@@ -191,6 +226,26 @@ async function verifyRecurringPaymentCollection(input: {
   dueAt: string;
   destinationTokenAccount: Address;
 }): Promise<VerifiedRecurringPaymentCollection> {
+  const proofMismatch = (
+    reason:
+      | "persisted_evidence_mismatch"
+      | "missing_verified_addresses"
+      | "on_chain_instruction_mismatch",
+    message: string
+  ): AppError => {
+    logEvent("error", {
+      event: "sdp_api_recurring_payment_collection_proof_mismatch",
+      reason,
+      organization_id: input.transfer.organization_id,
+      project_id: input.transfer.project_id,
+      recurring_payment_id: input.recurringPayment.id,
+      subscription_id: input.subscription.id,
+      attempt_id: input.attempt.id,
+      transfer_id: input.transfer.id,
+      signature: input.signature,
+    });
+    return new AppError("CONFLICT", message);
+  };
   const providerData = input.transfer.provider_data;
   const attemptMetadata = input.attempt.metadata;
   const providerEvidenceMatches =
@@ -221,8 +276,8 @@ async function verifyRecurringPaymentCollection(input: {
     input.transfer.signature === input.signature;
 
   if (!persistedEvidenceMatches) {
-    throw new AppError(
-      "CONFLICT",
+    throw proofMismatch(
+      "persisted_evidence_mismatch",
       "Recurring payment collection evidence does not match the due payment"
     );
   }
@@ -232,7 +287,10 @@ async function verifyRecurringPaymentCollection(input: {
     !input.subscription.subscription_authority_address ||
     !input.subscription.subscriber_token_account
   ) {
-    throw new AppError("CONFLICT", "Recurring payment collection is missing verified addresses");
+    throw proofMismatch(
+      "missing_verified_addresses",
+      "Recurring payment collection is missing verified addresses"
+    );
   }
 
   const planPda = input.recurringPayment.plan_pda;
@@ -275,8 +333,8 @@ async function verifyRecurringPaymentCollection(input: {
     })
   );
   if (!hasExpectedInstruction) {
-    throw new AppError(
-      "CONFLICT",
+    throw proofMismatch(
+      "on_chain_instruction_mismatch",
       "Confirmed transaction does not prove the expected recurring payment collection"
     );
   }
@@ -369,14 +427,18 @@ async function markRecurringPaymentCollectionFailedAtomically(input: {
           throw new AppError("INTERNAL_ERROR", "Failed to mark collection transfer failed");
         }
 
-        confirmedTransferSignature = (currentTransfer.signature ??
-          input.submittedSignature) as Signature | null;
-        if (!confirmedTransferSignature) {
+        const currentSignature = currentTransfer.signature ?? input.submittedSignature;
+        if (!currentSignature) {
           throw new AppError(
             "INTERNAL_ERROR",
             "Confirmed collection transfer is missing signature"
           );
         }
+        confirmedTransferSignature = validatedStoredCollectionSignature({
+          attemptId: input.attempt.id,
+          signature: currentSignature,
+          transferId: input.transfer.id,
+        });
       }
     }
 
@@ -474,11 +536,13 @@ async function finalizeRecurringPaymentCollection(input: {
       })
     );
 
+    const expectedTransferStatus = input.transfer.status;
     const updatedTransfer = await paymentsRepo.updateTransfer({
       transferId: input.transfer.id,
       organizationId: input.organizationId,
       projectId: input.projectId,
-      status: "confirmed",
+      expectedStatus: expectedTransferStatus,
+      status: expectedTransferStatus === "finalized" ? "finalized" : "confirmed",
       signature: input.proof.signature,
       error: null,
       updatedAt: finalizedAt,
@@ -567,7 +631,7 @@ async function finalizeRecurringPaymentCollection(input: {
       finalizedAttempt.id !== input.proof.attemptId ||
       finalizedAttempt.transfer_id !== input.proof.transferId ||
       !finalizedTransfer ||
-      finalizedTransfer.status !== "confirmed" ||
+      (finalizedTransfer.status !== "confirmed" && finalizedTransfer.status !== "finalized") ||
       finalizedTransfer.signature !== input.proof.signature ||
       finalizedTransfer.id !== input.proof.transferId
     ) {
@@ -687,6 +751,83 @@ async function safeJournalRecurringPaymentCollectionError(input: {
   }
 }
 
+async function handleRecurringPaymentCollectionError(input: {
+  env: Env;
+  subscriptionsRepo: PaymentSubscriptionsRepository;
+  paymentsRepo: ReturnType<typeof createPaymentsRepository>;
+  organizationId: string;
+  projectId: string;
+  recurringPayment: PaymentRecurringPaymentRow;
+  attempt: PaymentSubscriptionCollectionAttemptRow | null;
+  transfer: PaymentTransferRow | null;
+  submissionStore: TransferSignedSubmissionStore | null;
+  submittedSignature: Signature | null;
+  error: unknown;
+}): Promise<RecurringPaymentCollectionResult> {
+  if (!input.attempt) {
+    throw input.error;
+  }
+
+  const submitted = await input.submissionStore?.submittedRow();
+  if (
+    submitted?.signature &&
+    !(input.error instanceof AppError && input.error.code === "TRANSACTION_FAILED")
+  ) {
+    const submittedSignature = validatedStoredCollectionSignature({
+      attemptId: input.attempt.id,
+      signature: submitted.signature,
+      transferId: submitted.id,
+    });
+    await safeJournalRecurringPaymentCollectionError({
+      env: input.env,
+      subscriptionsRepo: input.subscriptionsRepo,
+      paymentsRepo: input.paymentsRepo,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      recurringPaymentId: input.recurringPayment.id,
+      attempt: input.attempt,
+      transfer: submitted,
+      submittedSignature,
+      error: input.error,
+    });
+    if (input.error instanceof AppError && input.error.code === "CONFLICT") {
+      throw input.error;
+    }
+    logEvent("warn", {
+      event: "sdp_api_payment_submission_unresolved",
+      flow: "recurring",
+      reason: "submission_unconfirmed",
+      organization_id: input.organizationId,
+      project_id: input.projectId,
+      recurring_payment_id: input.recurringPayment.id,
+      attempt_id: input.attempt.id,
+      transfer_id: submitted.id,
+      transfer_type: submitted.type,
+      signature: submittedSignature,
+      error: activationErrorMessage(input.error),
+    });
+    return {
+      recurringPayment: input.recurringPayment,
+      collectionAttempt: { ...input.attempt, signature: submittedSignature },
+      transfer: submitted,
+    };
+  }
+
+  await safeJournalRecurringPaymentCollectionError({
+    env: input.env,
+    subscriptionsRepo: input.subscriptionsRepo,
+    paymentsRepo: input.paymentsRepo,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    recurringPaymentId: input.recurringPayment.id,
+    attempt: input.attempt,
+    transfer: input.transfer,
+    submittedSignature: input.submittedSignature,
+    error: input.error,
+  });
+  throw input.error;
+}
+
 async function recoverRecurringPaymentCollection(input: {
   env: Env;
   recurringRepo: PaymentRecurringPaymentsRepository;
@@ -739,10 +880,23 @@ async function recoverRecurringPaymentCollection(input: {
     throw new AppError("INTERNAL_ERROR", "Recurring payment collection transfer not found");
   }
   if (existing.signature && transfer.signature && existing.signature !== transfer.signature) {
+    logEvent("error", {
+      event: "sdp_api_recurring_payment_collection_proof_mismatch",
+      reason: "persisted_evidence_mismatch",
+      mismatch: "attempt_transfer_signature",
+      organization_id: input.organizationId,
+      project_id: input.projectId,
+      recurring_payment_id: input.recurringPayment.id,
+      subscription_id: input.subscription.id,
+      attempt_id: existing.id,
+      transfer_id: transfer.id,
+      attempt_signature: existing.signature,
+      transfer_signature: transfer.signature,
+    });
     throw new AppError("CONFLICT", "Recurring payment collection signatures do not match");
   }
-  const recoveredSignature = existing.signature ?? transfer.signature;
-  if (!recoveredSignature) {
+  const storedSignature = existing.signature ?? transfer.signature;
+  if (!storedSignature) {
     // A fresh unsigned attempt means another request is between local persistence and Kora
     // submission; wait for it to either submit or become stale instead of creating a second transfer.
     if (!isStaleCollectionAttempt(existing)) {
@@ -760,6 +914,32 @@ async function recoverRecurringPaymentCollection(input: {
     });
     return null;
   }
+  const recoveredSignature = validatedStoredCollectionSignature({
+    attemptId: existing.id,
+    signature: storedSignature,
+    transferId: transfer.id,
+  });
+  if (
+    transfer.status === "failed" &&
+    transfer.signed_transaction !== null &&
+    transfer.last_valid_block_height !== null &&
+    transfer.submission_started_at === null
+  ) {
+    if (!isStaleCollectionAttempt(existing)) {
+      throw new AppError("CONFLICT", "Recurring payment collection is already processing");
+    }
+    await markRecurringPaymentCollectionFailedAtomically({
+      env: input.env,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      recurringPaymentId: input.recurringPayment.id,
+      attempt: existing,
+      transfer,
+      submittedSignature: recoveredSignature,
+      error: new Error("Recurring payment collection was interrupted before broadcast"),
+    });
+    return null;
+  }
   const recoveredAttempt =
     existing.signature === recoveredSignature
       ? existing
@@ -772,7 +952,7 @@ async function recoverRecurringPaymentCollection(input: {
   try {
     await confirmSubscriptionSignature(
       input.env,
-      recoveredSignature as Signature,
+      recoveredSignature,
       "Recurring payment collection failed on-chain"
     );
   } catch (error) {
@@ -784,7 +964,7 @@ async function recoverRecurringPaymentCollection(input: {
         recurringPaymentId: input.recurringPayment.id,
         attempt: existing,
         transfer,
-        submittedSignature: recoveredSignature as Signature,
+        submittedSignature: recoveredSignature,
         error,
       });
       return null;
@@ -794,49 +974,78 @@ async function recoverRecurringPaymentCollection(input: {
     // still prove the completed collection without treating RPC uncertainty as failure.
   }
 
-  const currentRecurringPayment =
-    (await input.recurringRepo.getRecurringPaymentById({
-      recurringPaymentId: input.recurringPayment.id,
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-    })) ?? input.recurringPayment;
-  const currentSubscription =
-    (await input.subscriptionsRepo.getSubscriptionById({
-      subscriptionId: input.subscription.id,
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-    })) ?? input.subscription;
-  const destinationTokenAccount = currentRecurringPayment.destination_token_account
-    ? assertValidAddress(
-        currentRecurringPayment.destination_token_account,
-        "destinationTokenAccount"
-      )
-    : await resolveDestinationTokenAccount({
-        env: input.env,
-        destinationAddress: currentRecurringPayment.destination_address,
-        token: currentRecurringPayment.token,
-      });
-  const proof = await verifyRecurringPaymentCollection({
-    env: input.env,
-    recurringPayment: currentRecurringPayment,
-    subscription: currentSubscription,
-    attempt: recoveredAttempt,
-    transfer: recoveredTransfer,
-    signature: recoveredSignature as Signature,
-    dueAt: input.dueAt,
-    destinationTokenAccount,
-  });
+  try {
+    const currentRecurringPayment =
+      (await input.recurringRepo.getRecurringPaymentById({
+        recurringPaymentId: input.recurringPayment.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      })) ?? input.recurringPayment;
+    const currentSubscription =
+      (await input.subscriptionsRepo.getSubscriptionById({
+        subscriptionId: input.subscription.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      })) ?? input.subscription;
+    const destinationTokenAccount = currentRecurringPayment.destination_token_account
+      ? assertValidAddress(
+          currentRecurringPayment.destination_token_account,
+          "destinationTokenAccount"
+        )
+      : await resolveDestinationTokenAccount({
+          env: input.env,
+          destinationAddress: currentRecurringPayment.destination_address,
+          token: currentRecurringPayment.token,
+        });
+    const proof = await verifyRecurringPaymentCollection({
+      env: input.env,
+      recurringPayment: currentRecurringPayment,
+      subscription: currentSubscription,
+      attempt: recoveredAttempt,
+      transfer: recoveredTransfer,
+      signature: recoveredSignature,
+      dueAt: input.dueAt,
+      destinationTokenAccount,
+    });
 
-  return finalizeRecurringPaymentCollection({
-    env: input.env,
-    organizationId: input.organizationId,
-    projectId: input.projectId,
-    recurringPayment: currentRecurringPayment,
-    subscription: currentSubscription,
-    attempt: recoveredAttempt,
-    transfer: recoveredTransfer,
-    proof,
-  });
+    return finalizeRecurringPaymentCollection({
+      env: input.env,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      recurringPayment: currentRecurringPayment,
+      subscription: currentSubscription,
+      attempt: recoveredAttempt,
+      transfer: recoveredTransfer,
+      proof,
+    });
+  } catch (error) {
+    if (error instanceof AppError && error.code === "TRANSACTION_FAILED") {
+      await markRecurringPaymentCollectionFailedAtomically({
+        env: input.env,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        recurringPaymentId: input.recurringPayment.id,
+        attempt: existing,
+        transfer,
+        submittedSignature: recoveredSignature,
+        error,
+      });
+      return null;
+    }
+    await safeJournalRecurringPaymentCollectionError({
+      env: input.env,
+      subscriptionsRepo: input.subscriptionsRepo,
+      paymentsRepo: input.paymentsRepo,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      recurringPaymentId: input.recurringPayment.id,
+      attempt: existing,
+      transfer,
+      submittedSignature: recoveredSignature,
+      error,
+    });
+    throw error;
+  }
 }
 
 export async function recoverOrBlockLifecycleCollection(input: {
@@ -894,11 +1103,7 @@ export async function collectRecurringPayment(input: {
   recurringPayment: PaymentRecurringPaymentRow;
   initiatedByKeyId: string | null;
   collectionSource?: RecurringCollectionSource;
-}): Promise<{
-  recurringPayment: PaymentRecurringPaymentRow;
-  collectionAttempt: PaymentSubscriptionCollectionAttemptRow;
-  transfer: PaymentTransferRow;
-}> {
+}): Promise<RecurringPaymentCollectionResult> {
   if (input.recurringPayment.source_wallet_id !== input.sourceWallet.walletId) {
     throw badRequest("Recurring payment source wallet does not match request");
   }
@@ -933,6 +1138,7 @@ export async function collectRecurringPayment(input: {
   let attempt: PaymentSubscriptionCollectionAttemptRow | null = null;
   let transfer: PaymentTransferRow | null = null;
   let submittedSignature: Signature | null = null;
+  let submissionStore: TransferSignedSubmissionStore | null = null;
   try {
     const recovered = await recoverRecurringPaymentCollection({
       env: input.env,
@@ -1066,15 +1272,19 @@ export async function collectRecurringPayment(input: {
     if (!transfer) {
       throw new AppError("INTERNAL_ERROR", "Failed to create collection transfer");
     }
-    attempt =
-      (await subscriptionsRepo.updateCollectionAttempt({
-        attemptId: attempt.id,
-        organizationId: input.organizationId,
-        projectId: input.projectId,
-        transferId: transfer.id,
-        status: "processing",
-        updatedAt: new Date().toISOString(),
-      })) ?? attempt;
+    const linkedAttempt = await subscriptionsRepo.updateCollectionAttempt({
+      attemptId: attempt.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      transferId: transfer.id,
+      status: "processing",
+      updatedAt: new Date().toISOString(),
+    });
+    if (!linkedAttempt || linkedAttempt.transfer_id !== transfer.id) {
+      throw new AppError("INTERNAL_ERROR", "Failed to link collection attempt to transfer");
+    }
+    attempt = linkedAttempt;
+    submissionStore = createTransferSignedSubmissionStore(paymentsRepo, transfer);
 
     const rpc = solanaRpc.createRpc(input.env);
     const sourceOwner = assertValidAddress(input.recurringPayment.source_address, "sourceAddress");
@@ -1164,6 +1374,7 @@ export async function collectRecurringPayment(input: {
       sourceSigner,
       instructions: [createDestinationAtaInstruction, collectInstruction],
       feePayer,
+      submissionStore,
     });
     submittedSignature = signature;
     const submittedAt = new Date().toISOString();
@@ -1218,20 +1429,18 @@ export async function collectRecurringPayment(input: {
       proof,
     });
   } catch (error) {
-    if (attempt) {
-      await safeJournalRecurringPaymentCollectionError({
-        env: input.env,
-        subscriptionsRepo,
-        paymentsRepo,
-        organizationId: input.organizationId,
-        projectId: input.projectId,
-        recurringPaymentId: input.recurringPayment.id,
-        attempt,
-        transfer,
-        submittedSignature,
-        error,
-      });
-    }
-    throw error;
+    return handleRecurringPaymentCollectionError({
+      env: input.env,
+      subscriptionsRepo,
+      paymentsRepo,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      recurringPayment: input.recurringPayment,
+      attempt,
+      transfer,
+      submissionStore,
+      submittedSignature,
+      error,
+    });
   }
 }

--- a/apps/sdp-api/src/services/payments/recurring-payments/lifecycle.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/lifecycle.ts
@@ -317,31 +317,34 @@ async function runRecurringPaymentLifecycle(input: {
     return input.recurringPayment;
   }
 
-  const settled = await recoverOrBlockLifecycleCollection({
-    env: input.env,
-    recurringRepo,
-    subscriptionsRepo,
-    paymentsRepo,
-    organizationId: input.organizationId,
-    projectId: input.projectId,
-    recurringPayment: input.recurringPayment,
-  });
+  const collectionState =
+    input.operation === "cancel"
+      ? { recurringPayment: input.recurringPayment, subscription: null }
+      : await recoverOrBlockLifecycleCollection({
+          env: input.env,
+          recurringRepo,
+          subscriptionsRepo,
+          paymentsRepo,
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+          recurringPayment: input.recurringPayment,
+        });
 
   assertLifecyclePreconditions({
     operation: input.operation,
-    recurringPayment: settled.recurringPayment,
+    recurringPayment: collectionState.recurringPayment,
     sourceWallet: input.sourceWallet,
     nowIso: new Date().toISOString(),
   });
   if (
-    settled.recurringPayment.status ===
+    collectionState.recurringPayment.status ===
     getRecurringPaymentLifecycleStatuses(input.operation).finalStatus
   ) {
-    return settled.recurringPayment;
+    return collectionState.recurringPayment;
   }
 
   const claimed = await recurringRepo.claimRecurringPaymentLifecycle({
-    recurringPaymentId: settled.recurringPayment.id,
+    recurringPaymentId: collectionState.recurringPayment.id,
     organizationId: input.organizationId,
     projectId: input.projectId,
     operation: input.operation,
@@ -372,8 +375,8 @@ async function runRecurringPaymentLifecycle(input: {
     }
 
     const subscription =
-      settled.subscription?.id === claimed.subscription_id
-        ? settled.subscription
+      collectionState.subscription?.id === claimed.subscription_id
+        ? collectionState.subscription
         : await subscriptionsRepo.getSubscriptionById({
             subscriptionId: claimed.subscription_id,
             organizationId: input.organizationId,

--- a/apps/sdp-api/src/services/payments/recurring-payments/shared.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/shared.ts
@@ -20,6 +20,10 @@ import { createTokenRepository } from "@/db/repositories";
 import { AppError, badRequest } from "@/lib/errors";
 import { createTenantScope } from "@/lib/tenant-scope";
 import { isNativePaymentToken, normalizePaymentToken } from "@/services/payment-operation.service";
+import {
+  type SignedSubmissionStore,
+  submitSignedPaymentTransaction,
+} from "@/services/payments/signed-submission";
 import * as solanaServices from "@/services/solana";
 import { createProjectSponsorshipFeePayment } from "@/services/sponsorship.service";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
@@ -86,6 +90,7 @@ export async function sendSubscriptionInstructions(input: {
   sourceSigner?: TransactionSigner;
   instructions: Instruction[];
   feePayer?: Address;
+  submissionStore?: SignedSubmissionStore;
 }): Promise<Signature> {
   const signer =
     input.sourceSigner ??
@@ -117,7 +122,15 @@ export async function sendSubscriptionInstructions(input: {
   );
   const partiallySigned = await partiallySignTransactionMessageWithSigners(message);
   const txBytes = new Uint8Array(getTransactionEncoder().encode(partiallySigned));
-  return feePayment.signAndSend(txBytes);
+  return input.submissionStore
+    ? submitSignedPaymentTransaction({
+        feePayment,
+        rpc,
+        transaction: txBytes,
+        lastValidBlockHeight,
+        store: input.submissionStore,
+      })
+    : feePayment.signAndSend(txBytes);
 }
 
 export async function confirmSubscriptionSignature(

--- a/apps/sdp-api/src/services/payments/signed-submission.ts
+++ b/apps/sdp-api/src/services/payments/signed-submission.ts
@@ -22,6 +22,10 @@ export interface SignedSubmissionStore {
   hasStarted(): Promise<boolean>;
 }
 
+export type TransferSignedSubmissionStore = SignedSubmissionStore & {
+  submittedRow(): Promise<PaymentTransferRow | null>;
+};
+
 export function isDefiniteSubmissionError(error: unknown): boolean {
   return (
     error instanceof AppError &&
@@ -45,7 +49,7 @@ function mapPreflightError(error: unknown): AppError | null {
 export function createTransferSignedSubmissionStore(
   repository: PaymentsRepository,
   transfer: PaymentTransferRow
-): SignedSubmissionStore & { submittedRow(): Promise<PaymentTransferRow | null> } {
+): TransferSignedSubmissionStore {
   let row: PaymentTransferRow | null = null;
   let startState: "not_started" | "unknown" | "started" = "not_started";
   return {

--- a/apps/sdp-api/src/test/helpers/payments-routes.ts
+++ b/apps/sdp-api/src/test/helpers/payments-routes.ts
@@ -4,13 +4,17 @@ import { hashString } from "@sdp/payments/hash";
 import * as solanaRpc from "@sdp/rpc/solana";
 import { type CachedApiKey, WELL_KNOWN_TOKENS } from "@sdp/types";
 import { getBase58Codec } from "@solana/codecs";
-import type { Signature, SignatureBytes } from "@solana/kit";
 import {
   address,
   createNoopSigner,
   getSignatureFromTransaction,
   getTransactionDecoder,
   getTransactionEncoder,
+  type Signature,
+  type SignatureBytes,
+  SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM,
+  SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,
+  SolanaError,
 } from "@solana/kit";
 import * as subscriptionsProgram from "@solana/subscriptions";
 import { findAssociatedTokenPda } from "@solana-program/token-2022";
@@ -98,6 +102,25 @@ export const TEST_SPONSORSHIP_PROVIDER_CONFIG = {
   feePayerMayTransferLamports: false,
   feePayerPolicy: { test: "zero-outflow" },
 } satisfies feePaymentAdapters.SponsorshipProviderConfiguration;
+
+export function sendTransactionPreflightError(customProgramErrorCode?: number): SolanaError {
+  const cause =
+    customProgramErrorCode === undefined
+      ? undefined
+      : new SolanaError(SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM, {
+          code: customProgramErrorCode,
+          index: 0,
+        });
+  return new SolanaError(SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE, {
+    accounts: null,
+    loadedAccountsDataSize: null,
+    logs: null,
+    replacementBlockhash: null,
+    returnData: null,
+    unitsConsumed: null,
+    ...(cause === undefined ? {} : { cause }),
+  });
+}
 
 export function fullySignTestTransaction(transactionBytes: Uint8Array): Uint8Array {
   const transaction = getTransactionDecoder().decode(transactionBytes);

--- a/apps/sdp-docs/public/postman/solana-developer-platform-public.postman_collection.json
+++ b/apps/sdp-docs/public/postman/solana-developer-platform-public.postman_collection.json
@@ -1681,7 +1681,7 @@
             "method": "POST",
             "header": [],
             "url": "{{baseUrl}}/v1/payments/recurring-payments/{{id}}/cancel",
-            "description": "Cancels an active SDP-custody recurring payment by submitting the Solana subscriptions cancellation transaction and storing the resulting lifecycle state."
+            "description": "Stops future collections for an active SDP-custody recurring payment by submitting the Solana subscriptions cancellation transaction. A collection already in processing may still settle independently."
           }
         },
         {
@@ -1690,7 +1690,7 @@
             "method": "POST",
             "header": [],
             "url": "{{baseUrl}}/v1/payments/recurring-payments/{{id}}/collect",
-            "description": "Manually collects a due active SDP-custody recurring payment by submitting the Solana subscriptions collection transaction, creating a linked payment transfer, recording the collection attempt, and advancing the next due time."
+            "description": "Manually starts a due active SDP-custody recurring payment collection, creating a linked payment transfer and collection attempt. If submission cannot be confirmed immediately, a 200 response returns the same transfer as `processing` with its known signature; reconciliation settles it, and the next due time advances only after exact on-chain confirmation."
           }
         },
         {


### PR DESCRIPTION
## What changed

- Routes batch chunks and recurring collections through the durable signed-submission flow.
- Keeps ambiguous submission outcomes `processing`; definite failures settle the associated bookkeeping as `failed`.
- Atomically creates and links recurring collection attempts with their transfers.
- Verifies exact on-chain recurring collection evidence before advancing the next due period.
- Adds an SDP-generated random UUID as an on-chain Memo instruction to every batch chunk, ensuring otherwise identical chunks produce distinct signatures.
- Allows cancellation to stop future collections while an already-processing collection settles independently.
- Emits structured events for unresolved submissions and recurring proof mismatches.

## Why

An RPC or confirmation error does not prove that a transaction was never broadcast. Treating it as a definite failure could expose a payment as retryable even though funds may have moved.

Recurring attempt and transfer records also need to remain consistent, and identical batch chunks must not share the same transaction signature.

## Impact

**Before**

1. Batch and recurring transactions used `signAndSend`.
2. Bookkeeping was completed after submission.
3. An ambiguous exception could incorrectly fail the payment.
4. Recurring cancellation waited for an existing collection to resolve.

**After**

1. Create and atomically link the tracking records.
2. Persist the signed payload, signature, and expiry before broadcast.
3. Keep uncertain outcomes `processing` until reconciliation.
4. Advance the recurring due period only after exact on-chain proof.
5. Stop future collections on cancellation without changing the outcome of one already in progress.

```text
batch/recurring processing
  batch chunk / recurring collection
  → build transaction
  → add on-chain UUID Memo (batch only)
  → sign and persist bytes + signature
  → broadcast the persisted bytes
  ├─ confirmed → settle bookkeeping
  ├─ definite failure → failed
  └─ ambiguous outcome → stay processing → reconciliation
```

## Pre/post release actions

**Pre-release**

1. Merge the signed-transfer submission PR first, then retarget this PR to `main`.
2. Require green CI on the resulting stack.

**Post-release**

1. Submit a low-value multi-chunk batch with identical amounts and verify distinct signatures and final recipient states.
2. Exercise recurring collect and cancel while a collection is processing, then wait several reconciliation ticks.
3. Confirm the API and payment jobs use the same revision.
4. Monitor `sdp_api_payment_submission_unresolved` and require zero `sdp_api_recurring_payment_collection_proof_mismatch` events.

**Rollback**

Prefer fix-forward. Do not roll the recurring collection job back while a processing attempt belongs to a `canceling` or `canceled` recurring payment; the previous job does not recover those attempts.

## Result Validation

- `pnpm -C apps/sdp-api exec vitest run src/services/payments/signed-submission.test.ts src/routes/payments.transfers.test.ts src/services/jobs/track-pending-transfers.test.ts src/routes/payments/transfer-batches.test.ts src/routes/payments.recurring.test.ts` — 120 passed
- `pnpm --filter @sdp/api typecheck` — passed
- `pnpm --filter @sdp/api lint` — passed
- `pnpm check:module-boundaries` — passed
- `pnpm check:api-playground` — passed
- Full API suite — 3602 passed; 15 tests failed from parallel interference in two Redis suites, which passed 52/52 when rerun serially

## Does it affect current flows

Yes, batch submission and recurring collection/cancellation behavior.

- Successful response shapes remain unchanged.
- An uncertain recurring submission can return `200` with its transfer still `processing`.
- An uncertain batch chunk remains `processing` instead of being falsely failed.
- A recurring proof mismatch returns `409`, emits a structured event, and leaves the records unresolved for investigation.
- Cancellation no longer waits for an already-processing collection.
- Every batch chunk now contains a publicly visible on-chain Memo instruction.

## Known gaps

- The crash window after the submission-start marker but before the first RPC call is inherited from the preceding PR; automatic rebroadcast is intentionally not implemented yet.
- Structured events are logs rather than configured alerts.

## Notes

- The batch Memo contains only an SDP-generated random UUID—no customer data—and is not exposed as the transfer's API `memo`.
- Kora must allow the Solana Memo program; the batch integration smoke validates this.
- This PR contains no migration and depends on the preceding signed-outbox PR.
- Supersedes #1434 and depends on the preceding signed-transfer submission PR.