### PR TITLE
ci(web): run sdp-web unit tests, by naming the script test

### DIFF
--- a/apps/sdp-web/package.json
+++ b/apps/sdp-web/package.json
@@ -16,7 +16,7 @@
     "test:e2e:dashboard": "playwright test --config=playwright.config.ts --project=public --project=dashboard",
     "test:e2e:dashboard-transactions": "playwright test --config=playwright.config.ts --project=dashboard-transactions",
     "test:e2e:issuance": "playwright test --config=playwright.config.ts --project=issuance",
-    "test:unit": "vitest run"
+    "test": "vitest run"
   },
   "dependencies": {
     "@base-ui/react": "1.7.0",

--- a/apps/sdp-web/src/app/dashboard/markets/earn/CLAUDE.md
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/CLAUDE.md
@@ -471,8 +471,10 @@ browser pass on `/dashboard/markets/earn` and
   `document` needs a `// @vitest-environment jsdom` docblock. Mock the data-hook
   seam (`./earn-program-data`), not fetch. Run:
   `pnpm --filter sdp-web exec vitest run src/app/dashboard/markets/earn`.
-  CI does **not** run these: the root `pnpm test` is `turbo run test` and
-  sdp-web declares `test:unit`, not `test`. Run them yourself.
+  CI **does** run these, through the root `pnpm test` (`turbo run test`), since
+  sdp-web declares a `test` script like every other workspace. It did not until
+  2026-08-24: the script was named `test:unit`, so turbo skipped the package and
+  every web unit test was advisory.
 
 ## Running this locally
 


### PR DESCRIPTION
`sdp-web` declared `test:unit` while every other testing workspace declares `test`. The root `pnpm test` is `turbo run test`, so turbo skipped the package entirely and **all 1280 web unit tests were advisory**: green or red, CI never looked. One-word rename, plus the CLAUDE.md that documented the gap.

## Why a rename rather than an alias

| | |
| -- | -- |
| **Convention** | Every workspace that tests declares `test`. sdp-web was the only exception, and nothing suggests it was deliberate. |
| **Blast radius** | One reference existed anywhere in the repo, the CLAUDE.md corrected here. No workflow, script, or doc used it. |
| **Muscle memory** | `pnpm --filter sdp-web test:unit` now needs the suffix dropped. That is the only migration. |

Playwright stays on its own `test:e2e*` scripts, which the E2E jobs invoke directly and turbo still ignores.

## Reviewer notes

**This will make red web tests block merges for the first time.** Full suite is green on this commit, but any latent flake now has teeth. Worth knowing before approving.

**Cost is negligible.** `turbo run test --filter=sdp-web` runs 164 files / 1280 tests in 6.9s locally, and the task is cacheable like the rest.

The `no output files found for task sdp-web#test` warning turbo prints is pre-existing for every package whose `test` produces no coverage (verified against `@sdp/env-config`), not something this adds.

## Found while working on

[#1468](https://github.com/solana-foundation/solana-developer-platform/pull/1468), where I wrote 69 tests and then noticed CI would never run any of them. Kept separate because it changes CI for every sdp-web PR, which does not belong in a Treasury feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
