### PR TITLE
feat(api): add exact runtime execution admission

### DIFF
--- a/apps/sdp-api/src/db/repositories/earn-movements.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/earn-movements.repository.test.ts
@@ -886,6 +886,10 @@ describe("Unified earn movement ledger (postgres)", () => {
   });
 
   describe("reconciliation queue", () => {
+    beforeEach(async () => {
+      await getDb(env).prepare("DELETE FROM earn_movements").run();
+    });
+
     it("prioritizes blockhash-bound work over older confirmed rows", async () => {
       const db = getDb(env);
       const confirmed = await ledger.createSignedVaultDepositIntent(intent());

--- a/apps/sdp-api/src/services/domain/signing.service.ts
+++ b/apps/sdp-api/src/services/domain/signing.service.ts
@@ -1610,6 +1610,18 @@ export class SigningService {
     );
   }
 
+  async admitRuntimeExecution(
+    orgId: string,
+    projectId: string | undefined,
+    custodyWalletId: string
+  ): Promise<void> {
+    return this.runtimeTargets.admitRuntimeExecution({
+      organizationId: orgId,
+      projectId,
+      custodyWalletId,
+    });
+  }
+
   async getTransactionSignerForWalletRecord(
     orgId: string,
     projectId: string | undefined,
@@ -1905,6 +1917,8 @@ export function createSigningService(env: Env, scope?: TenantScope): SigningServ
     "getPublicKey",
     "getKeypairSigner",
     "getTransactionSigner",
+    "admitRuntimeExecution",
+    "getTransactionSignerForWalletRecord",
     "sign",
     "getSigningStatus",
     "configureProvider",

--- a/apps/sdp-api/src/services/domain/signing/custody-runtime-target.test.ts
+++ b/apps/sdp-api/src/services/domain/signing/custody-runtime-target.test.ts
@@ -3,6 +3,7 @@ import type { SigningPort } from "@sdp/custody/signing";
 import { PrivySigner } from "@solana/keychain-privy";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
+import { createTenantScope, TenantScopeViolationError } from "@/lib/tenant-scope";
 import type { SigningConfigRecord } from "@/services/adapters";
 import * as credentialSecretStore from "@/services/credential-secret-store";
 import { RuntimeEnvCredentialSecretStore } from "@/services/credential-secret-store";
@@ -18,6 +19,7 @@ const PROJECT_ID = "prj_runtime_targets";
 const USER_ID = "usr_runtime_targets";
 const CONFIG_PUBLIC_KEY = "Vote111111111111111111111111111111111111111";
 const CONNECTION_PUBLIC_KEY = "11111111111111111111111111111111";
+const SECOND_CONNECTION_PUBLIC_KEY = "Stake11111111111111111111111111111111111111";
 
 describe("CustodyRuntimeTargets", () => {
   const original = {
@@ -103,6 +105,312 @@ describe("CustodyRuntimeTargets", () => {
       expect.objectContaining({ requestDelayMs: 250 })
     );
     expect(read).toHaveBeenCalledTimes(2);
+  });
+
+  it("admits an exact active Config wallet without constructing a signer", async () => {
+    const config = await seedConfig({ provider: "privy" });
+    const targets = new CustodyRuntimeTargets(getDb(env), env, new Map());
+
+    await expect(
+      targets.admitRuntimeExecution({
+        organizationId: ORGANIZATION_ID,
+        projectId: PROJECT_ID,
+        custodyWalletId: `cwlt_${config.id}`,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("exposes exact admission through the tenant-scoped SigningService", async () => {
+    const config = await seedConfig({ provider: "privy" });
+    const service = createSigningService(
+      env,
+      createTenantScope({ organizationId: ORGANIZATION_ID, projectId: PROJECT_ID })
+    );
+
+    await expect(
+      service.admitRuntimeExecution(ORGANIZATION_ID, PROJECT_ID, `cwlt_${config.id}`)
+    ).resolves.toBeUndefined();
+    expect(() =>
+      service.admitRuntimeExecution("org_foreign", PROJECT_ID, `cwlt_${config.id}`)
+    ).toThrow(TenantScopeViolationError);
+    expect(() =>
+      service.getTransactionSignerForWalletRecord("org_foreign", PROJECT_ID, `cwlt_${config.id}`)
+    ).toThrow(TenantScopeViolationError);
+  });
+
+  it("admits an active non-selected Connection without reading credentials", async () => {
+    const config = await seedConfig({ provider: "privy" });
+    const connection = await seedConnection();
+    await setProjectDefault(config.id, null);
+    const read = mockStoredCredentialRead();
+    const createPrivySigner = vi.spyOn(PrivySigner, "create");
+    const targets = new CustodyRuntimeTargets(getDb(env), env, new Map());
+
+    await expect(
+      targets.admitRuntimeExecution({
+        organizationId: ORGANIZATION_ID,
+        projectId: PROJECT_ID,
+        custodyWalletId: `cwlt_${connection.id}`,
+      })
+    ).resolves.toBeUndefined();
+    expect(read).not.toHaveBeenCalled();
+    expect(createPrivySigner).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("pauses exact Connection admission before reading credentials when runtime is off", async () => {
+    const connection = await seedConnection();
+    env.PRIVY_BYOK_ENABLED = "false";
+    const read = mockStoredCredentialRead();
+    const targets = new CustodyRuntimeTargets(getDb(env), env, new Map());
+
+    await expect(
+      targets.admitRuntimeExecution({
+        organizationId: ORGANIZATION_ID,
+        projectId: PROJECT_ID,
+        custodyWalletId: `cwlt_${connection.id}`,
+      })
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      statusCode: 403,
+      details: { reason: "runtime_execution_paused" },
+    });
+    expect(read).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [PROJECT_ID, "cwlt_missing"],
+    ["prj_foreign", "cwlt_cconn_runtime_targets"],
+  ])("hides a missing or foreign exact wallet", async (projectId, custodyWalletId) => {
+    await seedConnection();
+    const read = mockStoredCredentialRead();
+    const targets = new CustodyRuntimeTargets(getDb(env), env, new Map());
+
+    await expect(
+      targets.admitRuntimeExecution({
+        organizationId: ORGANIZATION_ID,
+        projectId,
+        custodyWalletId,
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND", statusCode: 404 });
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it.each(["wallet", "connection", "credential"] as const)(
+    "reports an inactive exact Connection %s as runtime-unavailable",
+    async (inactiveOwner) => {
+      const connection = await seedConnection();
+      if (inactiveOwner === "wallet") {
+        await getDb(env)
+          .prepare("UPDATE custody_wallets SET status = 'inactive' WHERE id = ?")
+          .bind(`cwlt_${connection.id}`)
+          .run();
+      } else if (inactiveOwner === "connection") {
+        await getDb(env)
+          .prepare(
+            `UPDATE custody_connections
+             SET status = 'deactivated', deactivated_at = sdp_iso_now()
+             WHERE id = ?`
+          )
+          .bind(connection.id)
+          .run();
+      } else {
+        await getDb(env)
+          .prepare("UPDATE provider_credentials SET status = 'retired' WHERE id = ?")
+          .bind(connection.credentialId)
+          .run();
+      }
+      const read = mockStoredCredentialRead();
+      const targets = new CustodyRuntimeTargets(getDb(env), env, new Map());
+
+      await expect(
+        targets.admitRuntimeExecution({
+          organizationId: ORGANIZATION_ID,
+          projectId: PROJECT_ID,
+          custodyWalletId: `cwlt_${connection.id}`,
+        })
+      ).rejects.toMatchObject({
+        code: "CONFLICT",
+        statusCode: 409,
+        details: { reason: "runtime_execution_unavailable" },
+      });
+      expect(read).not.toHaveBeenCalled();
+    }
+  );
+
+  it("rechecks an exact Connection immediately before reading credentials", async () => {
+    const connection = await seedConnection();
+    const read = mockStoredCredentialRead();
+    const getConfigAdapter = createConfigAdapterFactory();
+    const targets = new CustodyRuntimeTargets(getDb(env), env, new Map());
+
+    await targets.admitRuntimeExecution({
+      organizationId: ORGANIZATION_ID,
+      projectId: PROJECT_ID,
+      custodyWalletId: `cwlt_${connection.id}`,
+    });
+    await getDb(env)
+      .prepare("UPDATE provider_credentials SET status = 'retired' WHERE id = ?")
+      .bind(connection.credentialId)
+      .run();
+
+    await expect(
+      targets.getTransactionSignerForWalletRecord(
+        ORGANIZATION_ID,
+        PROJECT_ID,
+        `cwlt_${connection.id}`,
+        getConfigAdapter
+      )
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      statusCode: 409,
+      details: { reason: "runtime_execution_unavailable" },
+    });
+    expect(read).not.toHaveBeenCalled();
+    expect(getConfigAdapter).not.toHaveBeenCalled();
+  });
+
+  it("signs with an exact non-default wallet under a non-selected Connection", async () => {
+    const config = await seedConfig({ provider: "privy" });
+    const connection = await seedConnection();
+    await setProjectDefault(config.id, null);
+    const custodyWalletId = `cwlt_${connection.id}_secondary`;
+    await getDb(env)
+      .prepare(
+        `INSERT INTO custody_wallets (
+           id, custody_connection_id, wallet_id, public_key, status
+         ) VALUES (?, ?, ?, ?, 'active')`
+      )
+      .bind(
+        custodyWalletId,
+        connection.id,
+        `${connection.walletId}_secondary`,
+        SECOND_CONNECTION_PUBLIC_KEY
+      )
+      .run();
+    await getDb(env)
+      .prepare("UPDATE custody_wallets SET status = 'inactive' WHERE id = ?")
+      .bind(`cwlt_${connection.id}`)
+      .run();
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({ address: SECOND_CONNECTION_PUBLIC_KEY, chain_type: "solana" }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+    const read = mockStoredCredentialRead();
+    const targets = new CustodyRuntimeTargets(getDb(env), env, new Map());
+
+    await expect(
+      targets.admitRuntimeExecution({
+        organizationId: ORGANIZATION_ID,
+        projectId: PROJECT_ID,
+        custodyWalletId,
+      })
+    ).resolves.toBeUndefined();
+    await expect(
+      targets.getTransactionSignerForWalletRecord(
+        ORGANIZATION_ID,
+        PROJECT_ID,
+        custodyWalletId,
+        createConfigAdapterFactory()
+      )
+    ).resolves.toMatchObject({ address: SECOND_CONNECTION_PUBLIC_KEY });
+    expect(read).toHaveBeenCalledOnce();
+  });
+
+  it.each(["wallet", "config"] as const)(
+    "reports an inactive exact Config %s as runtime-unavailable",
+    async (inactiveOwner) => {
+      const config = await seedConfig({ provider: "privy" });
+      await getDb(env)
+        .prepare(
+          inactiveOwner === "wallet"
+            ? "UPDATE custody_wallets SET status = 'inactive' WHERE id = ?"
+            : "UPDATE custody_configs SET status = 'inactive' WHERE id = ?"
+        )
+        .bind(inactiveOwner === "wallet" ? `cwlt_${config.id}` : config.id)
+        .run();
+      const targets = new CustodyRuntimeTargets(getDb(env), env, new Map());
+
+      await expect(
+        targets.admitRuntimeExecution({
+          organizationId: ORGANIZATION_ID,
+          projectId: PROJECT_ID,
+          custodyWalletId: `cwlt_${config.id}`,
+        })
+      ).rejects.toMatchObject({
+        code: "CONFLICT",
+        statusCode: 409,
+        details: { reason: "runtime_execution_unavailable" },
+      });
+    }
+  );
+
+  it("keeps inactive wallet rows out of the public wallet-record resolver", async () => {
+    const config = await seedConfig({ provider: "privy" });
+    await getDb(env)
+      .prepare("UPDATE custody_wallets SET status = 'inactive' WHERE id = ?")
+      .bind(`cwlt_${config.id}`)
+      .run();
+    const targets = new CustodyRuntimeTargets(getDb(env), env, new Map());
+
+    await expect(
+      targets.resolve({
+        kind: "wallet_record",
+        organizationId: ORGANIZATION_ID,
+        projectId: PROJECT_ID,
+        custodyWalletId: `cwlt_${config.id}`,
+      })
+    ).resolves.toBeNull();
+  });
+
+  it("rechecks an exact Config wallet before constructing its signer", async () => {
+    const config = await seedConfig({ provider: "privy" });
+    const getConfigAdapter = createConfigAdapterFactory();
+    const targets = new CustodyRuntimeTargets(getDb(env), env, new Map());
+
+    await targets.admitRuntimeExecution({
+      organizationId: ORGANIZATION_ID,
+      projectId: PROJECT_ID,
+      custodyWalletId: `cwlt_${config.id}`,
+    });
+    await getDb(env)
+      .prepare("UPDATE custody_wallets SET status = 'inactive' WHERE id = ?")
+      .bind(`cwlt_${config.id}`)
+      .run();
+
+    await expect(
+      targets.getTransactionSignerForWalletRecord(
+        ORGANIZATION_ID,
+        PROJECT_ID,
+        `cwlt_${config.id}`,
+        getConfigAdapter
+      )
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      details: { reason: "runtime_execution_unavailable" },
+    });
+    expect(getConfigAdapter).not.toHaveBeenCalled();
+  });
+
+  it("rejects an exact signer whose address does not match the wallet row", async () => {
+    const config = await seedConfig({ provider: "privy" });
+    const targets = new CustodyRuntimeTargets(getDb(env), env, new Map());
+
+    await expect(
+      targets.getTransactionSignerForWalletRecord(
+        ORGANIZATION_ID,
+        PROJECT_ID,
+        `cwlt_${config.id}`,
+        createConfigAdapterFactory(CONNECTION_PUBLIC_KEY)
+      )
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      statusCode: 409,
+      details: { reason: "runtime_execution_unavailable" },
+    });
   });
 
   it("rejects an exact Connection wallet while runtime is off before reading its secret", async () => {
@@ -494,10 +802,10 @@ describe("CustodyRuntimeTargets", () => {
     const targets = new CustodyRuntimeTargets(getDb(env), env, new Map());
 
     await expect(
-      targets.getTransactionSigner(
+      targets.getTransactionSignerForWalletRecord(
         ORGANIZATION_ID,
         PROJECT_ID,
-        connection.walletId,
+        `cwlt_${connection.id}`,
         createConfigAdapterFactory()
       )
     ).rejects.toMatchObject({
@@ -766,14 +1074,14 @@ function mockStoredCredentialRead() {
   return read;
 }
 
-function createConfigAdapterFactory() {
+function createConfigAdapterFactory(signerAddress = CONFIG_PUBLIC_KEY) {
   const adapter = {
     providerId: "privy",
     getPublicKey: vi.fn().mockResolvedValue(CONFIG_PUBLIC_KEY),
     sign: vi.fn().mockResolvedValue({ status: "completed", signatures: new Map() }),
     requiresApproval: vi.fn().mockReturnValue(false),
     getTransactionSigner: vi.fn().mockResolvedValue({
-      address: CONFIG_PUBLIC_KEY,
+      address: signerAddress,
       signTransactions: vi.fn(),
     }),
   } as unknown as SigningPort;

--- a/apps/sdp-api/src/services/domain/signing/custody-runtime-target.test.ts
+++ b/apps/sdp-api/src/services/domain/signing/custody-runtime-target.test.ts
@@ -4,6 +4,7 @@ import { PrivySigner } from "@solana/keychain-privy";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
 import { createTenantScope, TenantScopeViolationError } from "@/lib/tenant-scope";
+import { getLogger } from "@/runtime/logger";
 import type { SigningConfigRecord } from "@/services/adapters";
 import * as credentialSecretStore from "@/services/credential-secret-store";
 import { RuntimeEnvCredentialSecretStore } from "@/services/credential-secret-store";
@@ -120,6 +121,40 @@ describe("CustodyRuntimeTargets", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("logs an unavailable exact Config admission without Provider access", async () => {
+    const config = await seedConfig({ provider: "privy" });
+    const custodyWalletId = `cwlt_${config.id}`;
+    await getDb(env)
+      .prepare("UPDATE custody_wallets SET status = 'inactive' WHERE id = ?")
+      .bind(custodyWalletId)
+      .run();
+    const warn = vi.spyOn(getLogger(), "warn").mockImplementation(() => {});
+    const targets = new CustodyRuntimeTargets(getDb(env), env, new Map());
+
+    await expect(
+      targets.admitRuntimeExecution({
+        organizationId: ORGANIZATION_ID,
+        projectId: PROJECT_ID,
+        custodyWalletId,
+      })
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      details: { reason: "runtime_execution_unavailable" },
+    });
+    expect(warn).toHaveBeenCalledWith(
+      {
+        organizationId: ORGANIZATION_ID,
+        projectId: PROJECT_ID,
+        provider: "privy",
+        targetKind: "config",
+        targetId: config.id,
+        custodyWalletId,
+        reason: "runtime_execution_unavailable",
+      },
+      "custody_runtime_target_unavailable"
+    );
+  });
+
   it("exposes exact admission through the tenant-scoped SigningService", async () => {
     const config = await seedConfig({ provider: "privy" });
     const service = createSigningService(
@@ -185,6 +220,7 @@ describe("CustodyRuntimeTargets", () => {
   ])("hides a missing or foreign exact wallet", async (projectId, custodyWalletId) => {
     await seedConnection();
     const read = mockStoredCredentialRead();
+    const warn = vi.spyOn(getLogger(), "warn").mockImplementation(() => {});
     const targets = new CustodyRuntimeTargets(getDb(env), env, new Map());
 
     await expect(
@@ -195,6 +231,38 @@ describe("CustodyRuntimeTargets", () => {
       })
     ).rejects.toMatchObject({ code: "NOT_FOUND", statusCode: 404 });
     expect(read).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      {
+        organizationId: ORGANIZATION_ID,
+        projectId,
+        custodyWalletId,
+        reason: "exact_wallet_not_found",
+      },
+      "custody_runtime_target_unavailable"
+    );
+  });
+
+  it("preserves the exact signer's WALLET_NOT_FOUND compatibility code", async () => {
+    const warn = vi.spyOn(getLogger(), "warn").mockImplementation(() => {});
+    const targets = new CustodyRuntimeTargets(getDb(env), env, new Map());
+
+    await expect(
+      targets.getTransactionSignerForWalletRecord(
+        ORGANIZATION_ID,
+        PROJECT_ID,
+        "cwlt_missing",
+        createConfigAdapterFactory()
+      )
+    ).rejects.toMatchObject({ code: "WALLET_NOT_FOUND" });
+    expect(warn).toHaveBeenCalledWith(
+      {
+        organizationId: ORGANIZATION_ID,
+        projectId: PROJECT_ID,
+        custodyWalletId: "cwlt_missing",
+        reason: "exact_wallet_not_found",
+      },
+      "custody_runtime_target_unavailable"
+    );
   });
 
   it.each(["wallet", "connection", "credential"] as const)(
@@ -222,6 +290,7 @@ describe("CustodyRuntimeTargets", () => {
           .run();
       }
       const read = mockStoredCredentialRead();
+      const warn = vi.spyOn(getLogger(), "warn").mockImplementation(() => {});
       const targets = new CustodyRuntimeTargets(getDb(env), env, new Map());
 
       await expect(
@@ -236,6 +305,18 @@ describe("CustodyRuntimeTargets", () => {
         details: { reason: "runtime_execution_unavailable" },
       });
       expect(read).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(
+        {
+          organizationId: ORGANIZATION_ID,
+          projectId: PROJECT_ID,
+          provider: "privy",
+          targetKind: "connection",
+          targetId: connection.id,
+          custodyWalletId: `cwlt_${connection.id}`,
+          reason: "connection_unusable",
+        },
+        "custody_runtime_target_unavailable"
+      );
     }
   );
 

--- a/apps/sdp-api/src/services/domain/signing/custody-runtime-target.test.ts
+++ b/apps/sdp-api/src/services/domain/signing/custody-runtime-target.test.ts
@@ -500,6 +500,7 @@ describe("CustodyRuntimeTargets", () => {
     await setProjectDefault(config.id, null);
     env.PRIVY_BYOK_ENABLED = "false";
     const read = mockStoredCredentialRead();
+    const warn = vi.spyOn(getLogger(), "warn").mockImplementation(() => {});
     const targets = new CustodyRuntimeTargets(getDb(env), env, new Map());
 
     await expect(
@@ -520,6 +521,18 @@ describe("CustodyRuntimeTargets", () => {
       )
     ).rejects.toMatchObject({ code: "FORBIDDEN", statusCode: 403 });
     expect(read).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      {
+        organizationId: ORGANIZATION_ID,
+        projectId: PROJECT_ID,
+        provider: "privy",
+        targetKind: "connection",
+        targetId: connection.id,
+        custodyWalletId: null,
+        reason: "runtime_disabled",
+      },
+      "custody_runtime_target_unavailable"
+    );
   });
 
   it("uses the legacy Config for provider resolution while runtime is off", async () => {

--- a/apps/sdp-api/src/services/domain/signing/custody-runtime-target.ts
+++ b/apps/sdp-api/src/services/domain/signing/custody-runtime-target.ts
@@ -287,9 +287,10 @@ export class CustodyRuntimeTargets {
       params.custodyWalletId
     );
     if (!target) {
+      this.logMissingExactWallet(params);
       throw notFound("Custody wallet");
     }
-    this.assertRuntimeExecutionAllowed(target);
+    this.assertRuntimeExecutionAllowed(target, params.custodyWalletId);
   }
 
   async listWallets(params: {
@@ -547,9 +548,10 @@ export class CustodyRuntimeTargets {
       custodyWalletId
     );
     if (!target) {
-      throw notFound("Custody wallet");
+      this.logMissingExactWallet({ organizationId, projectId, custodyWalletId });
+      throw new SigningError("Custody wallet not found", "WALLET_NOT_FOUND");
     }
-    this.assertRuntimeExecutionAllowed(target);
+    this.assertRuntimeExecutionAllowed(target, custodyWalletId);
 
     if (target.kind === "config") {
       const adapter = await getConfigAdapter(organizationId, target.config);
@@ -1089,10 +1091,12 @@ export class CustodyRuntimeTargets {
   }
 
   private assertRuntimeExecutionAllowed(
-    target: CustodyRuntimeTarget
+    target: CustodyRuntimeTarget,
+    custodyWalletId: string
   ): asserts target is CustodyRuntimeTarget & { wallet: RuntimeWallet } {
     if (target.kind === "config") {
       if (!target.isRuntimeAvailable || !target.wallet) {
+        this.logUnavailable(target, RUNTIME_EXECUTION_UNAVAILABLE_REASON, custodyWalletId);
         throw conflict("Custody wallet is unavailable", {
           reason: RUNTIME_EXECUTION_UNAVAILABLE_REASON,
         });
@@ -1101,7 +1105,7 @@ export class CustodyRuntimeTargets {
     }
 
     if (!isCustodyConnectionRuntimeEnabled(this.env, target.provider)) {
-      this.logUnavailable(target, RUNTIME_EXECUTION_PAUSED_REASON);
+      this.logUnavailable(target, RUNTIME_EXECUTION_PAUSED_REASON, custodyWalletId);
       throw new AppError(
         "FORBIDDEN",
         "Wallet execution is paused. Retry after wallet execution is available.",
@@ -1109,7 +1113,7 @@ export class CustodyRuntimeTargets {
       );
     }
     if (!target.isRuntimeAvailable || !target.wallet) {
-      this.logUnavailable(target, "connection_unusable");
+      this.logUnavailable(target, "connection_unusable", custodyWalletId);
       throw conflict("Custody Connection is unavailable", {
         reason: RUNTIME_EXECUTION_UNAVAILABLE_REASON,
       });
@@ -1298,22 +1302,43 @@ export class CustodyRuntimeTargets {
     throw internalError();
   }
 
+  private logMissingExactWallet(params: {
+    organizationId: string;
+    projectId?: string;
+    custodyWalletId: string;
+  }): void {
+    getLogger().warn(
+      {
+        organizationId: params.organizationId,
+        projectId: params.projectId ?? null,
+        custodyWalletId: params.custodyWalletId,
+        reason: "exact_wallet_not_found",
+      },
+      "custody_runtime_target_unavailable"
+    );
+  }
+
   private logUnavailable(
-    target: ConnectionRuntimeTarget,
+    target: CustodyRuntimeTarget,
     reason:
       | "runtime_disabled"
       | "runtime_execution_paused"
+      | "runtime_execution_unavailable"
       | "connection_unusable"
       | "connection_changed"
       | "credential_secret_unavailable"
-      | "provider_account_mismatch"
+      | "provider_account_mismatch",
+    custodyWalletId?: string
   ): void {
     getLogger().warn(
       {
-        organizationId: target.organizationId,
-        projectId: target.projectId,
+        organizationId:
+          target.kind === "config" ? target.config.organizationId : target.organizationId,
+        projectId: target.kind === "config" ? target.config.projectId : target.projectId,
         provider: target.provider,
-        targetKind: "connection",
+        targetKind: target.kind,
+        targetId: target.kind === "config" ? target.config.id : target.connectionId,
+        ...(custodyWalletId ? { custodyWalletId } : {}),
         reason,
       },
       "custody_runtime_target_unavailable"

--- a/apps/sdp-api/src/services/domain/signing/custody-runtime-target.ts
+++ b/apps/sdp-api/src/services/domain/signing/custody-runtime-target.ts
@@ -45,7 +45,7 @@ interface ConfigRuntimeTarget {
   provider: CustodyProvider;
   config: SigningConfigRecord;
   wallet?: RuntimeWallet;
-  isRuntimeAvailable: true;
+  isRuntimeAvailable: boolean;
 }
 
 interface ConnectionRuntimeTarget {
@@ -144,6 +144,7 @@ interface ConfigRow {
 interface ConfigWalletRow extends ConfigRow {
   wallet_id: string;
   wallet_public_key: string;
+  wallet_status: string;
 }
 
 interface ConnectionTargetRow {
@@ -249,6 +250,9 @@ export interface CustodyConnectionSelectionResult {
   publicKey: string;
 }
 
+const RUNTIME_EXECUTION_PAUSED_REASON = "runtime_execution_paused";
+const RUNTIME_EXECUTION_UNAVAILABLE_REASON = "runtime_execution_unavailable";
+
 export class CustodyRuntimeTargets {
   constructor(
     private readonly db: DatabaseClient,
@@ -270,6 +274,22 @@ export class CustodyRuntimeTargets {
       return this.resolveConnection(query.organizationId, query.projectId, query.connectionId);
     }
     return this.resolveEffective(query.organizationId, query.projectId);
+  }
+
+  async admitRuntimeExecution(params: {
+    organizationId: string;
+    projectId?: string;
+    custodyWalletId: string;
+  }): Promise<void> {
+    const target = await this.resolveRetainedWalletRecord(
+      params.organizationId,
+      params.projectId,
+      params.custodyWalletId
+    );
+    if (!target) {
+      throw notFound("Custody wallet");
+    }
+    this.assertRuntimeExecutionAllowed(target);
   }
 
   async listWallets(params: {
@@ -521,27 +541,27 @@ export class CustodyRuntimeTargets {
     custodyWalletId: string,
     getConfigAdapter: ConfigAdapterResolver
   ): Promise<TransactionSigner> {
-    const target = await this.resolveWalletRecord(organizationId, projectId, custodyWalletId);
+    const target = await this.resolveRetainedWalletRecord(
+      organizationId,
+      projectId,
+      custodyWalletId
+    );
     if (!target) {
-      throw new SigningError("Custody wallet not found", "WALLET_NOT_FOUND");
+      throw notFound("Custody wallet");
     }
+    this.assertRuntimeExecutionAllowed(target);
 
     if (target.kind === "config") {
       const adapter = await getConfigAdapter(organizationId, target.config);
-      return getTransactionSigner(adapter, target.wallet);
+      const signer = await getTransactionSigner(adapter, target.wallet);
+      this.assertSignerMatchesWallet(target, signer, custodyWalletId);
+      return signer;
     }
 
-    if (!isCustodyConnectionRuntimeEnabled(this.env, target.provider)) {
-      this.logUnavailable(target, "runtime_disabled");
-      throw forbidden("Custody Connection runtime is disabled");
-    }
-    if (!target.isRuntimeAvailable || !target.wallet) {
-      this.logUnavailable(target, "connection_unusable");
-      throw conflict("Custody Connection is unavailable");
-    }
-
-    const adapter = await this.getConnectionAdapter(target);
-    return getTransactionSigner(adapter, target.wallet);
+    const adapter = await this.getConnectionAdapter(target, target.wallet);
+    const signer = await getTransactionSigner(adapter, target.wallet);
+    this.assertSignerMatchesWallet(target, signer, custodyWalletId);
+    return signer;
   }
 
   private async resolveEffective(
@@ -737,6 +757,38 @@ export class CustodyRuntimeTargets {
     return null;
   }
 
+  private async resolveRetainedWalletRecord(
+    organizationId: string,
+    projectId: string | undefined,
+    custodyWalletId: string
+  ): Promise<CustodyRuntimeTarget | null> {
+    const [connections, configs] = await Promise.all([
+      projectId
+        ? this.db.queryMany<ConnectionTargetRow>(
+            `${connectionTargetSelect()}
+             WHERE c.organization_id = ?
+               AND c.project_id = ?
+               AND w.id = ?`,
+            [organizationId, projectId, custodyWalletId]
+          )
+        : Promise.resolve([]),
+      this.db.queryMany<ConfigWalletRow>(
+        `${configWalletSelect()}
+         WHERE c.organization_id = ?
+           AND ${projectId ? "(c.project_id = ? OR c.project_id IS NULL)" : "c.project_id IS NULL"}
+           AND w.id = ?`,
+        projectId ? [organizationId, projectId, custodyWalletId] : [organizationId, custodyWalletId]
+      ),
+    ]);
+
+    if (connections.length + configs.length > 1) {
+      throw conflict("Custody wallet ownership is ambiguous");
+    }
+    if (connections[0]) return this.mapExactConnectionTarget(connections[0]);
+    if (configs[0]) return this.mapConfigWalletTarget(configs[0]);
+    return null;
+  }
+
   private async findSelectedConnection(
     organizationId: string,
     projectId: string
@@ -768,11 +820,21 @@ export class CustodyRuntimeTargets {
     return row ? this.mapConnectionTarget(row) : null;
   }
 
-  private async getConnectionAdapter(target: ConnectionRuntimeTarget): Promise<SigningPort> {
+  private async getConnectionAdapter(
+    target: ConnectionRuntimeTarget,
+    exactWallet?: RuntimeWallet
+  ): Promise<SigningPort> {
     const row = await this.loadConnectionCredential(target);
-    if (!row || !isUsableCredentialConnection(row)) {
+    const adapterDefaultWalletId = exactWallet?.walletId ?? row?.default_wallet_id;
+    if (
+      !row ||
+      !adapterDefaultWalletId ||
+      (exactWallet ? !isUsableCredentialOwner(row) : !isUsableCredentialConnection(row))
+    ) {
       this.logUnavailable(target, "connection_changed");
-      throw conflict("Custody Connection is unavailable");
+      throw conflict("Custody Connection is unavailable", {
+        reason: RUNTIME_EXECUTION_UNAVAILABLE_REASON,
+      });
     }
 
     if (row.provider !== "privy") {
@@ -795,6 +857,7 @@ export class CustodyRuntimeTargets {
       row.credential_version,
       row.secret_version_ref ?? "none",
       row.connection_id,
+      adapterDefaultWalletId,
       row.request_delay_ms ?? "env",
     ].join(":");
     if (row.storage_backend !== "runtime_env") {
@@ -807,7 +870,7 @@ export class CustodyRuntimeTargets {
     const secret = await this.readPrivyCredential(target, row);
     const adapter = createPrivyAdapterFromCredential(this.env, {
       ...secret,
-      defaultWalletId: row.default_wallet_id,
+      defaultWalletId: adapterDefaultWalletId,
       requestDelayMs: row.request_delay_ms ?? undefined,
     });
     if (row.storage_backend !== "runtime_env") {
@@ -1010,7 +1073,7 @@ export class CustodyRuntimeTargets {
       kind: "config",
       provider: config.provider,
       config,
-      isRuntimeAvailable: true,
+      isRuntimeAvailable: row.status === "active",
     };
   }
 
@@ -1021,7 +1084,63 @@ export class CustodyRuntimeTargets {
         walletId: row.wallet_id,
         publicKey: row.wallet_public_key as Address,
       },
+      isRuntimeAvailable: row.status === "active" && row.wallet_status === "active",
     };
+  }
+
+  private assertRuntimeExecutionAllowed(
+    target: CustodyRuntimeTarget
+  ): asserts target is CustodyRuntimeTarget & { wallet: RuntimeWallet } {
+    if (target.kind === "config") {
+      if (!target.isRuntimeAvailable || !target.wallet) {
+        throw conflict("Custody wallet is unavailable", {
+          reason: RUNTIME_EXECUTION_UNAVAILABLE_REASON,
+        });
+      }
+      return;
+    }
+
+    if (!isCustodyConnectionRuntimeEnabled(this.env, target.provider)) {
+      this.logUnavailable(target, RUNTIME_EXECUTION_PAUSED_REASON);
+      throw new AppError(
+        "FORBIDDEN",
+        "Wallet execution is paused. Retry after wallet execution is available.",
+        { reason: RUNTIME_EXECUTION_PAUSED_REASON }
+      );
+    }
+    if (!target.isRuntimeAvailable || !target.wallet) {
+      this.logUnavailable(target, "connection_unusable");
+      throw conflict("Custody Connection is unavailable", {
+        reason: RUNTIME_EXECUTION_UNAVAILABLE_REASON,
+      });
+    }
+  }
+
+  private assertSignerMatchesWallet(
+    target: CustodyRuntimeTarget,
+    signer: TransactionSigner,
+    custodyWalletId: string
+  ): void {
+    if (target.wallet && signer.address === target.wallet.publicKey) {
+      return;
+    }
+
+    getLogger().error(
+      {
+        organizationId:
+          target.kind === "config" ? target.config.organizationId : target.organizationId,
+        projectId: target.kind === "config" ? target.config.projectId : target.projectId,
+        provider: target.provider,
+        targetKind: target.kind,
+        targetId: target.kind === "config" ? target.config.id : target.connectionId,
+        custodyWalletId,
+        reason: "signer_address_mismatch",
+      },
+      "custody_runtime_target_unexpected"
+    );
+    throw conflict("Custody signer does not match the selected wallet", {
+      reason: RUNTIME_EXECUTION_UNAVAILABLE_REASON,
+    });
   }
 
   private mapConnectionTarget(row: ConnectionTargetRow): ConnectionRuntimeTarget {
@@ -1041,6 +1160,17 @@ export class CustodyRuntimeTargets {
       connectionId: row.connection_id,
       wallet,
       isRuntimeAvailable: this.isConnectionRuntimeAvailable(row) && wallet !== null,
+    };
+  }
+
+  private mapExactConnectionTarget(row: ConnectionTargetRow): ConnectionRuntimeTarget {
+    const target = this.mapConnectionTarget(row);
+    return {
+      ...target,
+      isRuntimeAvailable:
+        this.isConnectionOwnerRuntimeAvailable(row) &&
+        row.wallet_status === "active" &&
+        target.wallet !== null,
     };
   }
 
@@ -1136,18 +1266,23 @@ export class CustodyRuntimeTargets {
   }
 
   private isConnectionRuntimeAvailable(row: ConnectionTargetRow): boolean {
-    const provider = this.parseProvider(row.provider);
     return (
-      isCustodyConnectionRuntimeEnabled(this.env, provider) &&
-      row.connection_status === "active" &&
-      row.last_check_status === "success" &&
-      row.credential_status === "active" &&
-      row.provider_account_fingerprint !== null &&
+      this.isConnectionOwnerRuntimeAvailable(row) &&
       row.wallet_status === "active" &&
       row.default_custody_wallet_id !== null &&
       row.default_wallet_id !== null &&
       row.default_wallet_public_key !== null &&
       row.default_wallet_status === "active"
+    );
+  }
+
+  private isConnectionOwnerRuntimeAvailable(row: ConnectionTargetRow): boolean {
+    return (
+      isCustodyConnectionRuntimeEnabled(this.env, this.parseProvider(row.provider)) &&
+      row.connection_status === "active" &&
+      row.last_check_status === "success" &&
+      row.credential_status === "active" &&
+      row.provider_account_fingerprint !== null
     );
   }
 
@@ -1167,6 +1302,7 @@ export class CustodyRuntimeTargets {
     target: ConnectionRuntimeTarget,
     reason:
       | "runtime_disabled"
+      | "runtime_execution_paused"
       | "connection_unusable"
       | "connection_changed"
       | "credential_secret_unavailable"
@@ -1430,7 +1566,8 @@ function configWalletSelect(): string {
   return `SELECT c.id, c.organization_id, c.project_id, c.provider,
                  c.config_encrypted, c.encryption_version,
                  c.default_wallet_id, c.status, c.created_at, c.updated_at,
-                 w.wallet_id, w.public_key AS wallet_public_key
+                 w.wallet_id, w.public_key AS wallet_public_key,
+                 w.status AS wallet_status
           FROM custody_configs c
           JOIN custody_wallets w ON w.custody_config_id = c.id`;
 }
@@ -1552,12 +1689,18 @@ function isUsableCredentialConnection(
   default_wallet_id: string;
 } {
   return (
+    isUsableCredentialOwner(row) &&
+    row.default_wallet_id !== null &&
+    row.default_wallet_status === "active"
+  );
+}
+
+function isUsableCredentialOwner(row: ConnectionCredentialRow): boolean {
+  return (
     row.connection_status === "active" &&
     row.last_check_status === "success" &&
     row.credential_status === "active" &&
-    row.provider_account_fingerprint !== null &&
-    row.default_wallet_id !== null &&
-    row.default_wallet_status === "active"
+    row.provider_account_fingerprint !== null
   );
 }
 

--- a/apps/sdp-api/src/services/domain/signing/custody-runtime-target.ts
+++ b/apps/sdp-api/src/services/domain/signing/custody-runtime-target.ts
@@ -1338,7 +1338,7 @@ export class CustodyRuntimeTargets {
         provider: target.provider,
         targetKind: target.kind,
         targetId: target.kind === "config" ? target.config.id : target.connectionId,
-        ...(custodyWalletId ? { custodyWalletId } : {}),
+        custodyWalletId: custodyWalletId ?? null,
         reason,
       },
       "custody_runtime_target_unavailable"


### PR DESCRIPTION
## What changed

- Added `SigningService.admitRuntimeExecution(orgId, projectId, custodyWalletId)` as a shared admission boundary for an already-selected `custody_wallets.id`.
- Added an internal tenant-scoped retained-row lookup that can evaluate inactive wallet records without changing the active-only wallet inventory.
- Updated `getTransactionSignerForWalletRecord` to repeat admission immediately before credential access, construct and cache a Connection adapter for the exact Provider wallet, and verify `signer.address === wallet.publicKey`.
- Added both exact admission and the pre-existing exact signer method to the tenant-scoped `SigningService` proxy, closing a latent cross-tenant scoped-service gap.
- Added redacted telemetry and focused tests for Config and Connection lifecycle failures, missing or foreign identities, runtime disablement, exact non-default wallets, lifecycle rechecks, and signer mismatch.

The shared seam is:

```text
domain selects an exact custody_wallets.id
  -> admitRuntimeExecution()                 // DB-read-only
  -> domain-owned policy/state transition   // wired in later consumer PRs
  -> getTransactionSignerForWalletRecord()  // repeats admission
  -> exact-wallet adapter
  -> signer address assertion
  -> sign
```

## Why

Execution consumers need a shared boundary for validating an already-selected exact wallet before creating durable state or external side effects.

The boundary does not select a wallet and does not pin it for the operation lifetime. It ensures that, once a consumer supplies an exact row ID, execution does not fall back to a different wallet, Connection, or Config.

The exact signer is also hardened to:

- distinguish an unknown identity from a retained identity that is temporarily or permanently unavailable;
- stop depending on the Connection default wallet when signing with another exact wallet;
- recheck lifecycle state immediately before credential access;
- reject a signer whose address does not match the persisted wallet row.

## Impact

- No public route or OpenAPI contract is added.
- Public wallet inventory and the existing active-only wallet-record resolver remain active-only.
- Admission performs tenant-scoped database reads only; it does not read credentials, construct a signer, call the Provider/RPC, or persist state.
- An active exact wallet under an active Connection can execute without requiring that Connection’s default wallet to remain usable.
- Adapter construction and caching are scoped to the exact Provider wallet ID.
- No database schema, migration, dependency, consumer state machine, pin, binding, backfill, or persistent execution state is added.

For the new admission and hardened exact-signer paths:

| Condition | Result |
|---|---|
| Missing or foreign admission identity | `404 NOT_FOUND` |
| Missing exact signer identity | `404 WALLET_NOT_FOUND` |
| Connection runtime disabled | `403` with `runtime_execution_paused` |
| Inactive or unusable exact wallet, Config, Connection, or Credential | `409` with `runtime_execution_unavailable` |
| Connection or Credential changes before adapter construction | `409` with `runtime_execution_unavailable` |
| Secret backend unavailable before Provider access | `503` |
| Signer address differs from the persisted wallet address | `409` with unexpected-target telemetry |

## Pre/post-release actions

### Pre-release

- No migration, backfill, data repair, dependency installation, or environment change is required.

### Post-release

- Monitor `custody_runtime_target_unavailable` by `reason` and tenant.
- Use `provider`, `targetKind`, and `targetId` only for events where a Config or Connection was successfully resolved.
- Alert on `custody_runtime_target_unexpected` with `reason=signer_address_mismatch`.
- Watch Earn vault execution failure rates for unexpected `403` or `409` responses.
- No schema or data rollback is required. Application rollback cannot reverse external transactions that were already signed or broadcast.

## Result validation

- `pnpm -C apps/sdp-api exec vitest run src/services/domain/signing/custody-runtime-target.test.ts` — 42/42 tests passed.
- `pnpm --filter @sdp/api typecheck` — passed.
- `pnpm exec biome check apps/sdp-api/src/services/domain/signing.service.ts apps/sdp-api/src/services/domain/signing/custody-runtime-target.ts apps/sdp-api/src/services/domain/signing/custody-runtime-target.test.ts` — passed.
- `git diff --check main...HEAD` — passed.

## Does it affect current flows and how

**Before**

1. The exact signer used the active-only wallet-record resolver.
2. Inactive wallet, Config, or Connection rows appeared missing.
3. Exact Connection signer eligibility and adapter construction still depended on a usable Connection default wallet, even though the explicit wallet ID was passed to the adapter.
4. `getTransactionSignerForWalletRecord` did not centrally assert that the returned signer matched the persisted wallet address.
5. The tenant-scoped proxy did not enforce tenant claims for the pre-existing exact signer method.

**After**

1. Admission and exact signing resolve the exact retained row within organization/project scope without fallback.
2. Known but unavailable lifecycle state fails explicitly as `409 runtime_execution_unavailable`.
3. Exact Connection signing validates the owner and exact wallet independently of the Connection default wallet.
4. Adapter construction and caching use the exact Provider wallet ID.
5. Exact signer resolution repeats the lifecycle guard and centrally verifies the signer address.
6. Scoped-service calls to both exact methods enforce organization/project tenant claims.

`admitRuntimeExecution` has no committed production domain consumer yet, so it does not change domain orchestration by itself.

The existing exact signer is currently used by Earn vault execution through `createOrgSignerForCustodyWallet`:

- If a wallet is already inactive during Earn’s initial active-only resolution, the request still returns `404`.
- If the retained row becomes unavailable after that resolution but before signing, the exact signer now returns `409 runtime_execution_unavailable`.
- Direct exact-signer calls receive the same retained-row behavior.
- Normal active/default-aligned execution remains unchanged.
- Active exact non-default Connection wallets no longer depend on the default wallet remaining usable.
- Earn already performed a caller-level signer-address comparison; this PR centralizes that invariant inside the shared exact signer.

## Known gaps

- Transfers and batches, recurring payments, issuance and workflows, Private Channels, Approval execution, and Rings are not wired to admission in this PR.
- Operation snapshots, resource pins, retry identity lifetimes, and consumer-specific pause/release behavior remain decisions for their respective domain PRs.
- Admission is DB-read-only and non-locking. The signer repeats the lifecycle check, but identity fixation for the full operation lifetime remains consumer-specific.
- The full API suite remains pending in an environment with a working container runtime.

## Notes

- Missing or foreign identity telemetry intentionally contains only the requested organization/project scope, `custodyWalletId`, and `reason=exact_wallet_not_found`; it does not expose resolved owner metadata.
- Resolved-target denials include Provider and target metadata.
- Existing generic Connection failures that have no exact row context emit `custodyWalletId: null`.
- Status-only reconciliation remains unchanged and does not perform new signing, submission, or Provider mutation.
- This PR intentionally adds only the shared exact identity/admission/signer seam; it does not introduce consumer pinning or a generic execution framework.