### PR TITLE
test(web): consolidate e2e bootstrap into managed session helpers

### DIFF
--- a/apps/sdp-web/playwright/support/auth-session.ts
+++ b/apps/sdp-web/playwright/support/auth-session.ts
@@ -11,6 +11,13 @@ type ClerkWindow = {
   };
 };
 
+export interface PlaywrightAdminSession {
+  identity: ClerkTestIdentity;
+  page: Page;
+  bearerToken: string;
+  getBearerToken: () => Promise<string>;
+}
+
 async function readClerkBearerToken(page: Page): Promise<string | null> {
   return page.evaluate(async () => {
     const clerkClient = (window as unknown as ClerkWindow).Clerk;
@@ -55,12 +62,7 @@ export function createClerkBearerTokenProvider(page: Page): () => Promise<string
   };
 }
 
-export async function getPlaywrightAdminSession(browser: Browser): Promise<{
-  identity: ClerkTestIdentity;
-  page: Page;
-  bearerToken: string;
-  getBearerToken: () => Promise<string>;
-}> {
+export async function getPlaywrightAdminSession(browser: Browser): Promise<PlaywrightAdminSession> {
   const identity = await resolveClerkTestIdentity();
   const page = await openAuthenticatedBootstrapPage(browser);
   const bearerToken = await getClerkBearerToken(page);

--- a/apps/sdp-web/playwright/support/issuance-fixtures.ts
+++ b/apps/sdp-web/playwright/support/issuance-fixtures.ts
@@ -48,10 +48,6 @@ export function writeIssuanceFixtures(fixtures: IssuanceFixtures): void {
   fs.writeFileSync(issuanceFixturesPath, JSON.stringify(fixtures, null, 2));
 }
 
-export function readIssuanceFixtures(): IssuanceFixtures {
-  return JSON.parse(fs.readFileSync(issuanceFixturesPath, "utf8")) as IssuanceFixtures;
-}
-
 export function clearIssuanceFixtures(): void {
   fs.rmSync(issuanceFixturesPath, { force: true });
 }

--- a/apps/sdp-web/playwright/support/local-dashboard-bootstrap.ts
+++ b/apps/sdp-web/playwright/support/local-dashboard-bootstrap.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import type { Page } from "@playwright/test";
+import type { Browser, Page } from "@playwright/test";
 import type {
   CounterpartyAccountResponse,
   CounterpartyResponse,
@@ -24,6 +24,7 @@ import { KoraClient } from "@solana/kora";
 import { getTransferSolInstruction } from "@solana-program/system";
 import { Client } from "pg";
 import { getE2EEnv } from "../env";
+import { getPlaywrightAdminSession, type PlaywrightAdminSession } from "./auth-session";
 import { type ClerkTestIdentity, setClerkOrganizationTier } from "./clerk-admin";
 import {
   type BearerTokenProvider,
@@ -98,6 +99,8 @@ export interface WalletBootstrapResult {
     slug: string;
     name: string;
   };
+  /** The freshly provisioned project, for seedProjectCookie. */
+  projectId: string;
   wallets: PlaywrightWalletFixture[];
 }
 
@@ -342,6 +345,45 @@ async function listWallets(api: LocalApiClient): Promise<PaymentsDashboardWallet
   return data.wallets;
 }
 
+/**
+ * Runs a provision callback inside an admin session that is always closed.
+ *
+ * `session.getBearerToken` depends on the session page and is only valid inside
+ * `provision`. Callers that need a token after this function returns must return
+ * the static `session.bearerToken` snapshot from the callback.
+ *
+ * @param browser - The Playwright browser to open the admin session in.
+ * @param provision - Provisions data while the admin session is open.
+ * @returns The provision result after the admin page is closed.
+ */
+export async function provisionWithAdminSession<T>(
+  browser: Browser,
+  provision: (session: PlaywrightAdminSession) => Promise<T>
+): Promise<T> {
+  const session = await getPlaywrightAdminSession(browser);
+
+  try {
+    return await provision(session);
+  } finally {
+    await session.page.close();
+  }
+}
+
+/**
+ * Points the test page at the project a bootstrap just provisioned.
+ *
+ * Every bootstrap helper here recreates the Playwright org — and with it the
+ * project — out-of-band, so whatever project cookie the page's context already
+ * holds now names a deleted project. Until the dashboard's cookie repair runs,
+ * project-scoped requests 403 ("Requested project is not accessible") and pages
+ * render their empty states. Any test that bootstraps fixtures must call this
+ * before its first navigation; skipping it is what the intermittent
+ * empty-page-then-timeout failures look like.
+ *
+ * @param page - The test page whose browser context gets the cookie.
+ * @param projectId - The project the bootstrap provisioned.
+ * @returns Resolves once the cookie is set.
+ */
 export async function seedProjectCookie(page: Page, projectId: string): Promise<void> {
   await page.context().addCookies([
     {
@@ -351,6 +393,30 @@ export async function seedProjectCookie(page: Page, projectId: string): Promise<
       sameSite: "Lax",
     },
   ]);
+}
+
+/**
+ * Runs `provision` inside a managed admin session, then points `page` at the
+ * project it provisioned. Owns the whole bootstrap ceremony: opens the admin
+ * session, closes it even when provisioning throws, and seeds the test page's
+ * project cookie before the caller can navigate — see seedProjectCookie for why
+ * seeding is mandatory.
+ *
+ * @param browser - The Playwright browser to open the admin session in.
+ * @param page - The test page whose context receives the project cookie.
+ * @param provision - Provisions fixtures with the admin session; must return the projectId to seed.
+ * @returns The provision result, after the cookie is seeded.
+ */
+export async function bootstrapProjectForPage<T extends { projectId: string }>(
+  browser: Browser,
+  page: Page,
+  provision: (session: PlaywrightAdminSession) => Promise<T>
+): Promise<T> {
+  return provisionWithAdminSession(browser, async (session) => {
+    const result = await provision(session);
+    await seedProjectCookie(page, result.projectId);
+    return result;
+  });
 }
 
 export async function resolvePlaywrightProjectId(
@@ -796,6 +862,7 @@ export async function bootstrapLocalWalletFixtures(input: {
       slug: organization.slug,
       name: organization.name,
     },
+    projectId,
     wallets,
   };
 }

--- a/apps/sdp-web/playwright/support/local-issuance-bootstrap.ts
+++ b/apps/sdp-web/playwright/support/local-issuance-bootstrap.ts
@@ -17,7 +17,6 @@ import {
   getBootstrapApiBaseUrl,
   getPlaywrightCustodyProvider,
   type PlaywrightWalletFixture,
-  resolvePlaywrightProjectId,
   seedLocalClerkOrganizationMapping,
 } from "./local-dashboard-bootstrap";
 
@@ -162,7 +161,7 @@ export async function bootstrapLocalIssuanceFixtures({
     fundSourceWallet: true,
     fundSourceAmountSol: 0.05,
   });
-  const projectId = await resolvePlaywrightProjectId(getBootstrapApiBaseUrl(), bearerToken);
+  const projectId = walletBootstrap.projectId;
   const api = createLocalApiClient(getBootstrapApiBaseUrl(), bearerToken, projectId);
 
   const treasuryWallet = requireWallet(
@@ -255,7 +254,7 @@ export async function bootstrapLocalPaymentFixtures({
     fundSourceWallet: true,
     fundSourceAmountSol: 0.05,
   });
-  const projectId = await resolvePlaywrightProjectId(getBootstrapApiBaseUrl(), bearerToken);
+  const projectId = walletBootstrap.projectId;
   const api = createLocalApiClient(getBootstrapApiBaseUrl(), bearerToken, projectId);
   const treasuryWallet = requireWallet(
     walletBootstrap.wallets,

--- a/apps/sdp-web/playwright/tests/api-keys.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/api-keys.e2e.spec.ts
@@ -1,17 +1,27 @@
 import { expect, test } from "@playwright/test";
-import { getPlaywrightAdminSession } from "../support/auth-session";
-import { bootstrapLocalWalletFixtures } from "../support/local-dashboard-bootstrap";
+import {
+  bootstrapLocalWalletFixtures,
+  provisionWithAdminSession,
+  seedProjectCookie,
+} from "../support/local-dashboard-bootstrap";
 
 test.describe
   .serial("dashboard api keys e2e", () => {
+    let projectId = "";
+
     test.beforeAll(async ({ browser }) => {
-      const session = await getPlaywrightAdminSession(browser);
-      await bootstrapLocalWalletFixtures({
-        identity: session.identity,
-        bearerToken: session.getBearerToken,
-        walletCount: 1,
-      });
-      await session.page.close();
+      const fixtures = await provisionWithAdminSession(browser, (session) =>
+        bootstrapLocalWalletFixtures({
+          identity: session.identity,
+          bearerToken: session.getBearerToken,
+          walletCount: 1,
+        })
+      );
+      projectId = fixtures.projectId;
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await seedProjectCookie(page, projectId);
     });
 
     test("user can create a selected-wallet API key and the secret is only shown once", async ({

--- a/apps/sdp-web/playwright/tests/gcp-read-only-smoke.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/gcp-read-only-smoke.e2e.spec.ts
@@ -11,9 +11,8 @@ import {
   resolveTotalBalance,
 } from "../../src/app/dashboard/payments/payments-overview.utils";
 import { getE2EEnv } from "../env";
-import { getPlaywrightAdminSession } from "../support/auth-session";
 import { createLocalApiClient } from "../support/local-api-client";
-import { seedProjectCookie } from "../support/local-dashboard-bootstrap";
+import { provisionWithAdminSession, seedProjectCookie } from "../support/local-dashboard-bootstrap";
 
 interface ReadOnlyFixture {
   issuanceTransactions: TokenTransactionListItem[];
@@ -28,6 +27,25 @@ interface ReadOnlyFixture {
 interface PageFailureCapture {
   failures: string[];
   assertClean: () => void;
+}
+
+/**
+ * Resolves the required total balance returned by the read-only smoke API.
+ *
+ * @param wallet - The wallet whose populated balance is required.
+ * @returns The wallet's resolved total balance.
+ */
+function resolveRequiredTotalBalance(wallet: PaymentsDashboardWallet): number {
+  if (!wallet.balances) {
+    throw new Error(`Wallet ${wallet.walletId} did not return balances`);
+  }
+
+  const totalBalance = resolveTotalBalance(wallet.balances);
+  if (totalBalance === null) {
+    throw new Error(`Wallet ${wallet.walletId} did not return a resolvable balance`);
+  }
+
+  return totalBalance;
 }
 
 function capturePageFailures(page: Page): PageFailureCapture {
@@ -87,85 +105,102 @@ test.describe("GCP dev dashboard read-only smoke", () => {
     }
     expect(env.sdpApiBaseUrl).toBe("https://api-dev.solana.com");
 
-    const session = await getPlaywrightAdminSession(browser);
-    expect(session.identity.email).toBe(env.clerkTestEmail);
-    expect(session.identity.organizationId).toBe(env.clerkOrgId);
+    fixture = await provisionWithAdminSession(browser, async (session) => {
+      expect(session.identity.email).toBe(env.clerkTestEmail);
+      expect(session.identity.organizationId).toBe(env.clerkOrgId);
 
-    const orgApi = createLocalApiClient(env.sdpApiBaseUrl, session.getBearerToken);
-    const { projects } = await orgApi.get<ListProjectsResponse>("/v1/projects");
-    expect(projects.length, "the explicit test organization must have projects").toBeGreaterThan(0);
+      const orgApi = createLocalApiClient(env.sdpApiBaseUrl, session.getBearerToken);
+      const { projects } = await orgApi.get<ListProjectsResponse>("/v1/projects");
+      expect(projects.length, "the explicit test organization must have projects").toBeGreaterThan(
+        0
+      );
 
-    const project = projects.find((candidate) => candidate.id === env.expectedProjectId);
-    expect(project, "the exact GCP smoke project must belong to the test org").toBeDefined();
-    if (!project) throw new Error("Exact GCP smoke project was not returned by the API");
+      const project = projects.find((candidate) => candidate.id === env.expectedProjectId);
+      expect(project, "the exact GCP smoke project must belong to the test org").toBeDefined();
+      if (!project) throw new Error("Exact GCP smoke project was not returned by the API");
 
-    const api = createLocalApiClient(env.sdpApiBaseUrl, session.getBearerToken, project.id);
-    const walletsPath = `/v1/wallets?${new URLSearchParams({
-      includeBalances: "true",
-      includeAllProviders: "true",
-      view: "summary",
-    })}`;
-    const issuancePath = `/v1/issuance/transactions?${new URLSearchParams({
-      page: "1",
-      pageSize: "20",
-    })}`;
-    const transfersPath = `/v1/payments/transfers?${new URLSearchParams({
-      page: "1",
-      pageSize: "20",
-    })}`;
-    const [walletData, issuanceTransactions, transfers] = await Promise.all([
-      api.get<{ wallets: PaymentsDashboardWallet[] }>(walletsPath),
-      api.get<TokenTransactionListItem[]>(issuancePath),
-      api.get<PaymentTransferSummary[]>(transfersPath),
-    ]);
-    const transferMarker = transfers[0]?.token ?? transfers[0]?.amount;
-    if (!transferMarker) throw new Error("The known transfer needs a rendered token or amount");
-    const populatedWallet = walletData.wallets.find(
-      (wallet) => (resolveTotalBalance(wallet.balances ?? []) ?? 0) > 0
-    );
-    if (!populatedWallet) throw new Error("The exact test project needs a populated wallet");
-    const populatedWalletBalanceLabel = formatCurrencyAmount(
-      resolveTotalBalance(populatedWallet.balances ?? []),
-      "en-US"
-    );
-    expect(populatedWalletBalanceLabel, "the known populated wallet fixture changed").toBe(
-      "$10.00"
-    );
+      const api = createLocalApiClient(env.sdpApiBaseUrl, session.getBearerToken, project.id);
+      const walletsPath = `/v1/wallets?${new URLSearchParams({
+        includeBalances: "true",
+        includeAllProviders: "true",
+        view: "summary",
+      })}`;
+      const issuancePath = `/v1/issuance/transactions?${new URLSearchParams({
+        page: "1",
+        pageSize: "20",
+      })}`;
+      const transfersPath = `/v1/payments/transfers?${new URLSearchParams({
+        page: "1",
+        pageSize: "20",
+      })}`;
+      const [walletData, issuanceTransactions, transfers] = await Promise.all([
+        api.get<{ wallets: PaymentsDashboardWallet[] }>(walletsPath),
+        api.get<TokenTransactionListItem[]>(issuancePath),
+        api.get<PaymentTransferSummary[]>(transfersPath),
+      ]);
+      const firstTransfer = transfers[0];
+      if (!firstTransfer) throw new Error("The exact test project needs a known transfer");
+      // Either display field marks the row; the transfer only fails the smoke
+      // when it would render neither.
+      const transferMarker = firstTransfer.token ?? firstTransfer.amount;
+      if (!transferMarker) throw new Error("The known transfer needs a rendered token or amount");
+      // Candidates without a resolvable balance are skipped, not fatal — only the
+      // selected fixture wallet must resolve.
+      const populatedWallet = walletData.wallets.find((wallet) => {
+        if (!wallet.balances) return false;
+        const totalBalance = resolveTotalBalance(wallet.balances);
+        return totalBalance !== null && totalBalance > 0;
+      });
+      if (!populatedWallet) throw new Error("The exact test project needs a populated wallet");
+      const populatedWalletBalanceLabel = formatCurrencyAmount(
+        resolveRequiredTotalBalance(populatedWallet),
+        "en-US"
+      );
+      expect(populatedWalletBalanceLabel, "the known populated wallet fixture changed").toBe(
+        "$10.00"
+      );
 
-    fixture = {
-      issuanceTransactions,
-      populatedWallet,
-      populatedWalletBalanceLabel,
-      project,
-      transferMarker,
-      transfers,
-      wallets: walletData.wallets,
-    };
-    const knownRecordCount =
-      fixture.wallets.length + fixture.issuanceTransactions.length + fixture.transfers.length;
-    expect(knownRecordCount, "the exact test project must contain known records").toBeGreaterThan(
-      0
-    );
-    expect(fixture.wallets.length, "wallet hydration needs a real wallet fixture").toBeGreaterThan(
-      0
-    );
-    expect(
-      fixture.issuanceTransactions.length,
-      "home activity needs a real issuance transaction"
-    ).toBeGreaterThan(0);
-    expect(fixture.transfers.length, "payments needs a real transfer fixture").toBeGreaterThan(0);
+      const resolvedFixture = {
+        issuanceTransactions,
+        populatedWallet,
+        populatedWalletBalanceLabel,
+        project,
+        transferMarker,
+        transfers,
+        wallets: walletData.wallets,
+      } satisfies ReadOnlyFixture;
+      const knownRecordCount =
+        resolvedFixture.wallets.length +
+        resolvedFixture.issuanceTransactions.length +
+        resolvedFixture.transfers.length;
+      expect(knownRecordCount, "the exact test project must contain known records").toBeGreaterThan(
+        0
+      );
+      expect(
+        resolvedFixture.wallets.length,
+        "wallet hydration needs a real wallet fixture"
+      ).toBeGreaterThan(0);
+      expect(
+        resolvedFixture.issuanceTransactions.length,
+        "home activity needs a real issuance transaction"
+      ).toBeGreaterThan(0);
+      expect(
+        resolvedFixture.transfers.length,
+        "payments needs a real transfer fixture"
+      ).toBeGreaterThan(0);
 
-    console.info(
-      JSON.stringify({
-        event: "gcp_read_only_fixture",
-        projectId: fixture.project.id,
-        projectName: fixture.project.name,
-        wallets: fixture.wallets.length,
-        issuanceTransactions: fixture.issuanceTransactions.length,
-        transfers: fixture.transfers.length,
-      })
-    );
-    await session.page.close();
+      console.info(
+        JSON.stringify({
+          event: "gcp_read_only_fixture",
+          projectId: resolvedFixture.project.id,
+          projectName: resolvedFixture.project.name,
+          wallets: resolvedFixture.wallets.length,
+          issuanceTransactions: resolvedFixture.issuanceTransactions.length,
+          transfers: resolvedFixture.transfers.length,
+        })
+      );
+      return resolvedFixture;
+    });
   });
 
   test.beforeEach(async ({ page }) => {

--- a/apps/sdp-web/playwright/tests/issuance.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/issuance.e2e.spec.ts
@@ -1,13 +1,8 @@
 import { expect, type Page, test } from "@playwright/test";
 import { address, getAddressEncoder, getProgramDerivedAddress } from "@solana/kit";
 import { formatDisplayLabel } from "@/lib/utils";
-import { getPlaywrightAdminSession } from "../support/auth-session";
-import {
-  clearIssuanceFixtures,
-  type IssuanceFixtures,
-  readIssuanceFixtures,
-} from "../support/issuance-fixtures";
-import { seedProjectCookie } from "../support/local-dashboard-bootstrap";
+import { clearIssuanceFixtures, type IssuanceFixtures } from "../support/issuance-fixtures";
+import { provisionWithAdminSession, seedProjectCookie } from "../support/local-dashboard-bootstrap";
 import { bootstrapLocalIssuanceFixtures } from "../support/local-issuance-bootstrap";
 
 // biome-ignore lint/security/noSecrets: Solana associated token program ID, not a secret.
@@ -322,13 +317,12 @@ test.describe
 
     test.beforeAll(async ({ browser }) => {
       clearIssuanceFixtures();
-      const session = await getPlaywrightAdminSession(browser);
-      await bootstrapLocalIssuanceFixtures({
-        identity: session.identity,
-        bearerToken: session.getBearerToken,
-      });
-      fixtures = readIssuanceFixtures();
-      await session.page.close();
+      fixtures = await provisionWithAdminSession(browser, (session) =>
+        bootstrapLocalIssuanceFixtures({
+          identity: session.identity,
+          bearerToken: session.getBearerToken,
+        })
+      );
     });
 
     test.beforeEach(async ({ page }) => {

--- a/apps/sdp-web/playwright/tests/payments-command-center.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/payments-command-center.e2e.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "@playwright/test";
-import { getPlaywrightAdminSession } from "../support/auth-session";
 import {
   ensureLinkedOrg,
   getBootstrapApiBaseUrl,
+  provisionWithAdminSession,
   resolvePlaywrightProjectId,
   seedProjectCookie,
 } from "../support/local-dashboard-bootstrap";
@@ -11,10 +11,10 @@ test.describe("payments command center and transaction ledger", () => {
   let projectId = "";
 
   test.beforeAll(async ({ browser }) => {
-    const session = await getPlaywrightAdminSession(browser);
-    await ensureLinkedOrg(session.identity, { tier: "enterprise" });
-    projectId = await resolvePlaywrightProjectId(getBootstrapApiBaseUrl(), session.getBearerToken);
-    await session.page.close();
+    projectId = await provisionWithAdminSession(browser, async (session) => {
+      await ensureLinkedOrg(session.identity, { tier: "enterprise" });
+      return resolvePlaywrightProjectId(getBootstrapApiBaseUrl(), session.getBearerToken);
+    });
   });
 
   test.beforeEach(async ({ page }) => {

--- a/apps/sdp-web/playwright/tests/payments-recurring.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/payments-recurring.e2e.spec.ts
@@ -1,16 +1,13 @@
 import { randomUUID } from "node:crypto";
 import { expect, test } from "@playwright/test";
-import { getPlaywrightAdminSession } from "../support/auth-session";
 import { createLocalApiClient } from "../support/local-api-client";
 import {
-  ensureLinkedOrg,
+  getBootstrapApiBaseUrl,
+  provisionWithAdminSession,
   seedCounterpartyWithSolanaAccount,
   seedProjectCookie,
 } from "../support/local-dashboard-bootstrap";
-import {
-  bootstrapLocalPaymentFixtures,
-  getBootstrapApiBaseUrl,
-} from "../support/local-issuance-bootstrap";
+import { bootstrapLocalPaymentFixtures } from "../support/local-issuance-bootstrap";
 
 test.describe
   .serial("dashboard recurring payments", () => {
@@ -22,40 +19,43 @@ test.describe
     let recurringTokenSymbol = "";
 
     test.beforeAll(async ({ browser }) => {
-      const session = await getPlaywrightAdminSession(browser);
-      await ensureLinkedOrg(session.identity, { tier: "enterprise" });
-      const fixtures = await bootstrapLocalPaymentFixtures({
-        identity: session.identity,
-        bearerToken: session.getBearerToken,
-        tier: "enterprise",
-      });
-      const api = createLocalApiClient(
-        getBootstrapApiBaseUrl(),
-        session.getBearerToken,
-        fixtures.projectId
-      );
+      bootstrapProjectId = await provisionWithAdminSession(browser, async (session) => {
+        const fixtures = await bootstrapLocalPaymentFixtures({
+          identity: session.identity,
+          bearerToken: session.getBearerToken,
+          tier: "enterprise",
+        });
+        const api = createLocalApiClient(
+          getBootstrapApiBaseUrl(),
+          session.getBearerToken,
+          fixtures.projectId
+        );
 
-      await api.post(`/v1/issuance/tokens/${fixtures.token.id}/mint`, {
-        mint: {
-          destination: fixtures.wallets.treasury.publicKey,
-          amount: "25",
-        },
-      });
+        await api.post(`/v1/issuance/tokens/${fixtures.token.id}/mint`, {
+          mint: {
+            destination: fixtures.wallets.treasury.publicKey,
+            amount: "25",
+          },
+        });
 
-      const suffix = randomUUID().slice(0, 8);
-      recurringAccountLabel = `E2E Subscription ${suffix}`;
-      const seededCounterparty = await seedCounterpartyWithSolanaAccount(api, {
-        displayName: `E2E Recurring ${suffix}`,
-        email: `e2e-recurring-${suffix}@example.com`,
-        accountLabel: recurringAccountLabel,
-        destinationAddress: fixtures.wallets.treasury.publicKey,
-      });
+        const suffix = randomUUID().slice(0, 8);
+        recurringAccountLabel = `E2E Subscription ${suffix}`;
+        const seededCounterparty = await seedCounterpartyWithSolanaAccount(api, {
+          displayName: `E2E Recurring ${suffix}`,
+          email: `e2e-recurring-${suffix}@example.com`,
+          accountLabel: recurringAccountLabel,
+          destinationAddress: fixtures.wallets.treasury.publicKey,
+        });
 
-      bootstrapProjectId = fixtures.projectId;
-      recurringCounterpartyName = seededCounterparty.displayName;
-      recurringWalletLabel = fixtures.wallets.treasury.label ?? fixtures.wallets.treasury.publicKey;
-      recurringTokenSymbol = fixtures.token.symbol;
-      await session.page.close();
+        recurringCounterpartyName = seededCounterparty.displayName;
+        const treasuryLabel = fixtures.wallets.treasury.label;
+        if (!treasuryLabel) {
+          throw new Error("Recurring payment treasury wallet did not return its seeded label");
+        }
+        recurringWalletLabel = treasuryLabel;
+        recurringTokenSymbol = fixtures.token.symbol;
+        return fixtures.projectId;
+      });
     });
 
     test.beforeEach(async ({ page }) => {

--- a/apps/sdp-web/playwright/tests/payments-transfer.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/payments-transfer.e2e.spec.ts
@@ -1,16 +1,15 @@
 import { randomUUID } from "node:crypto";
 import { expect, test } from "@playwright/test";
-import { getPlaywrightAdminSession } from "../support/auth-session";
 import { createLocalApiClient } from "../support/local-api-client";
 import {
   bootstrapLocalWalletFixtures,
   createExternalSolanaAddress,
+  getBootstrapApiBaseUrl,
   getPlaywrightCustodyProvider,
-  resolvePlaywrightProjectId,
+  provisionWithAdminSession,
   seedCounterpartyWithSolanaAccount,
   seedProjectCookie,
 } from "../support/local-dashboard-bootstrap";
-import { getBootstrapApiBaseUrl } from "../support/local-issuance-bootstrap";
 
 test.describe
   .serial("dashboard payments e2e", () => {
@@ -26,65 +25,68 @@ test.describe
     let bootstrapProjectId = "";
 
     test.beforeAll(async ({ browser }) => {
-      const session = await getPlaywrightAdminSession(browser);
-      const walletBootstrap = await bootstrapLocalWalletFixtures({
-        identity: session.identity,
-        bearerToken: session.getBearerToken,
-        provider: getPlaywrightCustodyProvider(),
-        walletCount: 1,
-        fundSourceWallet: true,
-        fundSourceAmountSol: 0.05,
-        tier: "enterprise",
-      });
-      const projectId = await resolvePlaywrightProjectId(
-        getBootstrapApiBaseUrl(),
-        session.getBearerToken
-      );
-      const api = createLocalApiClient(getBootstrapApiBaseUrl(), session.getBearerToken, projectId);
-      const sourceWallet = walletBootstrap.wallets[0];
-      if (!sourceWallet) {
-        throw new Error("Payment bootstrap did not create a source wallet");
-      }
+      bootstrapProjectId = await provisionWithAdminSession(browser, async (session) => {
+        const walletBootstrap = await bootstrapLocalWalletFixtures({
+          identity: session.identity,
+          bearerToken: session.getBearerToken,
+          provider: getPlaywrightCustodyProvider(),
+          walletCount: 1,
+          fundSourceWallet: true,
+          fundSourceAmountSol: 0.05,
+          tier: "enterprise",
+        });
+        const api = createLocalApiClient(
+          getBootstrapApiBaseUrl(),
+          session.getBearerToken,
+          walletBootstrap.projectId
+        );
+        const sourceWallet = walletBootstrap.wallets[0];
+        if (!sourceWallet) {
+          throw new Error("Payment bootstrap did not create a source wallet");
+        }
 
-      sourceWalletLabel = sourceWallet.label ?? sourceWallet.publicKey;
-      sourceWalletId = sourceWallet.walletId;
-      transferTokenSymbol = "SOL";
-      bootstrapProjectId = projectId;
+        if (!sourceWallet.label) {
+          throw new Error("Payment bootstrap source wallet did not return its seeded label");
+        }
+        sourceWalletLabel = sourceWallet.label;
+        sourceWalletId = sourceWallet.walletId;
+        transferTokenSymbol = "SOL";
 
-      destinationAddress = await createExternalSolanaAddress();
-      const suffix = randomUUID().slice(0, 8);
-      counterpartyName = `E2E Payee ${suffix}`;
-      accountLabel = `E2E Solana ${suffix}`;
-      await seedCounterpartyWithSolanaAccount(api, {
-        displayName: counterpartyName,
-        email: `e2e-payee-${suffix}@example.com`,
-        accountLabel,
-        destinationAddress,
-      });
+        destinationAddress = await createExternalSolanaAddress();
+        const suffix = randomUUID().slice(0, 8);
+        counterpartyName = `E2E Payee ${suffix}`;
+        accountLabel = `E2E Solana ${suffix}`;
+        await seedCounterpartyWithSolanaAccount(api, {
+          displayName: counterpartyName,
+          email: `e2e-payee-${suffix}@example.com`,
+          accountLabel,
+          destinationAddress,
+        });
 
-      deniedDestinationAddress = await createExternalSolanaAddress();
-      deniedCounterpartyName = `E2E Blocked Payee ${suffix}`;
-      deniedAccountLabel = `E2E Blocked Solana ${suffix}`;
-      await seedCounterpartyWithSolanaAccount(api, {
-        displayName: deniedCounterpartyName,
-        email: `e2e-blocked-payee-${suffix}@example.com`,
-        accountLabel: deniedAccountLabel,
-        destinationAddress: deniedDestinationAddress,
-      });
+        deniedDestinationAddress = await createExternalSolanaAddress();
+        deniedCounterpartyName = `E2E Blocked Payee ${suffix}`;
+        deniedAccountLabel = `E2E Blocked Solana ${suffix}`;
+        await seedCounterpartyWithSolanaAccount(api, {
+          displayName: deniedCounterpartyName,
+          email: `e2e-blocked-payee-${suffix}@example.com`,
+          accountLabel: deniedAccountLabel,
+          destinationAddress: deniedDestinationAddress,
+        });
 
-      await api.put(`/v1/payments/wallets/${sourceWalletId}/policies`, {
-        defaultAction: "allow",
-        rules: [
-          {
-            id: "allowlist-destinations",
-            kind: "destination",
-            allowlist: [destinationAddress],
-            action: "allow",
-            name: "Allowed destinations",
-          },
-        ],
+        await api.put(`/v1/payments/wallets/${sourceWalletId}/policies`, {
+          defaultAction: "allow",
+          rules: [
+            {
+              id: "allowlist-destinations",
+              kind: "destination",
+              allowlist: [destinationAddress],
+              action: "allow",
+              name: "Allowed destinations",
+            },
+          ],
+        });
+        return walletBootstrap.projectId;
       });
-      await session.page.close();
     });
 
     test.beforeEach(async ({ page }) => {

--- a/apps/sdp-web/playwright/tests/policies.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/policies.e2e.spec.ts
@@ -1,12 +1,10 @@
 import { expect, test } from "@playwright/test";
 import { SOL_MINT } from "@sdp/types";
-import { getPlaywrightAdminSession } from "../support/auth-session";
 import { createLocalApiClient } from "../support/local-api-client";
 import {
   bootstrapLocalWalletFixtures,
-  ensureLinkedOrg,
   getBootstrapApiBaseUrl,
-  resolvePlaywrightProjectId,
+  provisionWithAdminSession,
   seedProjectCookie,
 } from "../support/local-dashboard-bootstrap";
 
@@ -16,10 +14,7 @@ test.describe("policies responsive table", () => {
   let projectId = "";
 
   test.beforeAll(async ({ browser }) => {
-    const session = await getPlaywrightAdminSession(browser);
-
-    try {
-      await ensureLinkedOrg(session.identity, { tier: "enterprise" });
+    projectId = await provisionWithAdminSession(browser, async (session) => {
       const fixtures = await bootstrapLocalWalletFixtures({
         identity: session.identity,
         bearerToken: session.getBearerToken,
@@ -33,11 +28,11 @@ test.describe("policies responsive table", () => {
         throw new Error("Failed to create a wallet for Policies responsive coverage");
       }
 
-      projectId = await resolvePlaywrightProjectId(
+      const api = createLocalApiClient(
         getBootstrapApiBaseUrl(),
-        session.getBearerToken
+        session.getBearerToken,
+        fixtures.projectId
       );
-      const api = createLocalApiClient(getBootstrapApiBaseUrl(), session.getBearerToken, projectId);
       await api.put(`/v1/payments/wallets/${encodeURIComponent(wallet.walletId)}/policies`, {
         defaultAction: "allow",
         rules: [
@@ -51,9 +46,8 @@ test.describe("policies responsive table", () => {
           },
         ],
       });
-    } finally {
-      await session.page.close();
-    }
+      return fixtures.projectId;
+    });
   });
 
   test.beforeEach(async ({ page }) => {

--- a/apps/sdp-web/playwright/tests/private-channels.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/private-channels.e2e.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "@playwright/test";
-import { getPlaywrightAdminSession } from "../support/auth-session";
 import {
   ensureLinkedOrg,
+  getBootstrapApiBaseUrl,
+  provisionWithAdminSession,
   resolvePlaywrightProjectId,
   seedProjectCookie,
 } from "../support/local-dashboard-bootstrap";
-import { getBootstrapApiBaseUrl } from "../support/local-issuance-bootstrap";
 
 // The dashboard gates on the `private-channels` Vercel flag, whose default falls
 // back to PRIVATE_CHANNELS_ENABLED. Local Playwright runs have no Vercel provider,
@@ -20,13 +20,10 @@ test.describe
     let bootstrapProjectId = "";
 
     test.beforeAll(async ({ browser }) => {
-      const session = await getPlaywrightAdminSession(browser);
-      await ensureLinkedOrg(session.identity, { tier: "enterprise" });
-      bootstrapProjectId = await resolvePlaywrightProjectId(
-        getBootstrapApiBaseUrl(),
-        session.getBearerToken
-      );
-      await session.page.close();
+      bootstrapProjectId = await provisionWithAdminSession(browser, async (session) => {
+        await ensureLinkedOrg(session.identity, { tier: "enterprise" });
+        return resolvePlaywrightProjectId(getBootstrapApiBaseUrl(), session.getBearerToken);
+      });
     });
 
     test.beforeEach(async ({ page }) => {

--- a/apps/sdp-web/playwright/tests/theme.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/theme.e2e.spec.ts
@@ -1,6 +1,8 @@
 import { type Browser, expect, type Page, test } from "@playwright/test";
-import { getPlaywrightAdminSession } from "../support/auth-session";
-import { bootstrapLocalWalletFixtures } from "../support/local-dashboard-bootstrap";
+import {
+  bootstrapLocalWalletFixtures,
+  bootstrapProjectForPage,
+} from "../support/local-dashboard-bootstrap";
 
 const THEME_STORAGE_KEY = "sdp-theme";
 const THEME_TEST_INITIALIZED_KEY = "sdp-theme-test-initialized";
@@ -44,17 +46,20 @@ async function setThemePreference(page: Page, preference: ThemePreference) {
 }
 
 /** Only the toast test needs a wallet to copy an address from. Bootstrapping it for the
- *  whole suite meant one custody-provider hiccup failed every theme test with it. */
-async function bootstrapWalletForToasts(browser: Browser) {
-  const session = await getPlaywrightAdminSession(browser);
-  await bootstrapLocalWalletFixtures({
-    identity: session.identity,
-    bearerToken: session.getBearerToken,
-    provider: "privy",
-    walletCount: 1,
-    walletLabel: `Theme Toast ${Date.now().toString(36).toUpperCase()}`,
-    tier: "enterprise",
-  });
+ *  whole suite meant one custody-provider hiccup failed every theme test with it.
+ *  Bootstrapping replaces the org, so the page's project cookie must be reseeded
+ *  before it navigates — see seedProjectCookie. */
+async function bootstrapWalletForToasts(browser: Browser, page: Page) {
+  return bootstrapProjectForPage(browser, page, (session) =>
+    bootstrapLocalWalletFixtures({
+      identity: session.identity,
+      bearerToken: session.getBearerToken,
+      provider: "privy",
+      walletCount: 1,
+      walletLabel: `Theme Toast ${Date.now().toString(36).toUpperCase()}`,
+      tier: "enterprise",
+    })
+  );
 }
 
 test.describe("dashboard theme e2e", () => {
@@ -146,7 +151,7 @@ test.describe("dashboard theme e2e", () => {
   });
 
   test("themes rendered toasts in both modes", async ({ browser, page }) => {
-    await bootstrapWalletForToasts(browser);
+    await bootstrapWalletForToasts(browser, page);
     await clearThemePreferenceBeforeNavigation(page);
     await page.emulateMedia({ colorScheme: "light" });
     await page.goto("/dashboard/wallets");

--- a/apps/sdp-web/playwright/tests/wallets.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/wallets.e2e.spec.ts
@@ -5,14 +5,13 @@ import {
   type Token,
   type TokenTransaction,
 } from "@sdp/types";
-import { getPlaywrightAdminSession } from "../support/auth-session";
 import { createLocalApiClient, type LocalApiClient } from "../support/local-api-client";
 import {
   bootstrapLocalWalletFixtures,
+  bootstrapProjectForPage,
   ensureLinkedOrg,
   getBootstrapApiBaseUrl,
   resolvePlaywrightProjectId,
-  seedProjectCookie,
 } from "../support/local-dashboard-bootstrap";
 
 interface TokenResponse {
@@ -145,11 +144,10 @@ function getActivityRow(
 
 async function bootstrapWalletRouteFixture(
   browser: Browser,
+  page: Page,
   input: { labelPrefix: string; withPolicy?: boolean }
 ) {
-  const session = await getPlaywrightAdminSession(browser);
-
-  try {
+  return bootstrapProjectForPage(browser, page, async (session) => {
     const walletLabel = `${input.labelPrefix} ${Date.now().toString(36).toUpperCase()}`;
     const fixtures = await bootstrapLocalWalletFixtures({
       identity: session.identity,
@@ -159,17 +157,17 @@ async function bootstrapWalletRouteFixture(
       walletLabel,
       tier: "enterprise",
     });
-    const projectId = await resolvePlaywrightProjectId(
-      getBootstrapApiBaseUrl(),
-      session.getBearerToken
-    );
     const wallet = fixtures.wallets[0];
     if (!wallet) {
       throw new Error("Failed to bootstrap wallet route fixture");
     }
 
     if (input.withPolicy) {
-      const api = createLocalApiClient(getBootstrapApiBaseUrl(), session.getBearerToken, projectId);
+      const api = createLocalApiClient(
+        getBootstrapApiBaseUrl(),
+        session.getBearerToken,
+        fixtures.projectId
+      );
       await api.put(`/v1/payments/wallets/${encodeURIComponent(wallet.walletId)}/policies`, {
         defaultAction: "allow",
         rules: [
@@ -185,47 +183,24 @@ async function bootstrapWalletRouteFixture(
       });
     }
 
-    return { projectId, wallet, walletLabel };
-  } finally {
-    await session.page.close();
-  }
+    return { projectId: fixtures.projectId, wallet, walletLabel };
+  });
 }
 
 test.describe
   .serial("dashboard wallets e2e", () => {
-    let walletsProjectId = "";
-
-    test.beforeAll(async ({ browser }) => {
-      const session = await getPlaywrightAdminSession(browser);
-      await ensureLinkedOrg(session.identity);
-      walletsProjectId = await resolvePlaywrightProjectId(
-        getBootstrapApiBaseUrl(),
-        session.getBearerToken
-      );
-      await session.page.close();
-    });
-
-    test.beforeEach(async ({ page }) => {
-      await seedProjectCookie(page, walletsProjectId);
-    });
-
     test("bootstrapped Privy wallet appears in the wallets overview", async ({ browser, page }) => {
-      const session = await getPlaywrightAdminSession(browser);
       const walletLabel = `Wallet Detail ${Date.now().toString(36).toUpperCase()}`;
-      const fixtures = await bootstrapLocalWalletFixtures({
-        identity: session.identity,
-        bearerToken: session.getBearerToken,
-        provider: "privy",
-        walletCount: 1,
-        walletLabel,
-        tier: "enterprise",
-      });
-      const projectId = await resolvePlaywrightProjectId(
-        getBootstrapApiBaseUrl(),
-        session.getBearerToken
+      const fixtures = await bootstrapProjectForPage(browser, page, (session) =>
+        bootstrapLocalWalletFixtures({
+          identity: session.identity,
+          bearerToken: session.getBearerToken,
+          provider: "privy",
+          walletCount: 1,
+          walletLabel,
+          tier: "enterprise",
+        })
       );
-      await session.page.close();
-      await seedProjectCookie(page, projectId);
 
       const wallet = fixtures.wallets[0];
       if (!wallet) {
@@ -244,10 +219,9 @@ test.describe
     });
 
     test("wallet workspace and detail aliases preserve navigation", async ({ browser, page }) => {
-      const { projectId, wallet, walletLabel } = await bootstrapWalletRouteFixture(browser, {
+      const { wallet, walletLabel } = await bootstrapWalletRouteFixture(browser, page, {
         labelPrefix: "Wallet Routes",
       });
-      await seedProjectCookie(page, projectId);
 
       const encodedWalletId = encodeURIComponent(wallet.walletId);
       const walletHref = `/dashboard/wallets/${encodedWalletId}`;
@@ -318,10 +292,9 @@ test.describe
     });
 
     test("wallet actions menu preserves page geometry", async ({ browser, page }) => {
-      const { projectId, wallet, walletLabel } = await bootstrapWalletRouteFixture(browser, {
+      const { wallet, walletLabel } = await bootstrapWalletRouteFixture(browser, page, {
         labelPrefix: "Wallet Action Geometry",
       });
-      await seedProjectCookie(page, projectId);
       await page.setViewportSize({ width: 1280, height: 500 });
       await page.goto(`/dashboard/wallets/${encodeURIComponent(wallet.walletId)}`, {
         waitUntil: "domcontentloaded",
@@ -389,11 +362,10 @@ test.describe
     });
 
     test("wallet policy history opens the revision drawer", async ({ browser, page }) => {
-      const { projectId, wallet } = await bootstrapWalletRouteFixture(browser, {
+      const { wallet } = await bootstrapWalletRouteFixture(browser, page, {
         labelPrefix: "Wallet Policy Routes",
         withPolicy: true,
       });
-      await seedProjectCookie(page, projectId);
 
       const walletHref = `/dashboard/wallets/${encodeURIComponent(wallet.walletId)}`;
       const policyHref = `${walletHref}/policy`;
@@ -433,14 +405,14 @@ test.describe
       browser,
       page,
     }, testInfo) => {
-      const session = await getPlaywrightAdminSession(browser);
-      const projectId = await resolvePlaywrightProjectId(
-        getBootstrapApiBaseUrl(),
-        session.getBearerToken
-      );
-      await ensureLinkedOrg(session.identity, { tier: "enterprise" });
-      await session.page.close();
-      await seedProjectCookie(page, projectId);
+      await bootstrapProjectForPage(browser, page, async (session) => {
+        await ensureLinkedOrg(session.identity, { tier: "enterprise" });
+        const projectId = await resolvePlaywrightProjectId(
+          getBootstrapApiBaseUrl(),
+          session.getBearerToken
+        );
+        return { projectId };
+      });
 
       await page.goto("/dashboard/wallets/setup", { waitUntil: "domcontentloaded" });
       await expect(page.getByText("Step 1 of 2", { exact: true })).toBeVisible({
@@ -557,26 +529,26 @@ test.describe
       browser,
       page,
     }) => {
-      const session = await getPlaywrightAdminSession(browser);
-      let projectId = "";
-      try {
-        await bootstrapLocalWalletFixtures({
-          identity: session.identity,
-          bearerToken: session.getBearerToken,
-          provider: "privy",
-          walletCount: 1,
-          walletLabel: `Wallet Enter Prerequisite ${Date.now().toString(36).toUpperCase()}`,
-          tier: "enterprise",
-        });
-        projectId = await resolvePlaywrightProjectId(
-          getBootstrapApiBaseUrl(),
-          session.getBearerToken
-        );
-      } finally {
-        await session.page.close();
-      }
+      const { bearerToken, projectId } = await bootstrapProjectForPage(
+        browser,
+        page,
+        async (session) => {
+          const fixtures = await bootstrapLocalWalletFixtures({
+            identity: session.identity,
+            bearerToken: session.getBearerToken,
+            provider: "privy",
+            walletCount: 1,
+            walletLabel: `Wallet Enter Prerequisite ${Date.now().toString(36).toUpperCase()}`,
+            tier: "enterprise",
+          });
+          return {
+            bearerToken: session.bearerToken,
+            projectId: fixtures.projectId,
+          };
+        }
+      );
 
-      const api = createLocalApiClient(getBootstrapApiBaseUrl(), session.bearerToken, projectId);
+      const api = createLocalApiClient(getBootstrapApiBaseUrl(), bearerToken, projectId);
       const walletLabel = `Wallet Enter ${Date.now().toString(36).toUpperCase()}`;
       const countMatchingWallets = async () => {
         // biome-ignore lint/security/noSecrets: Local API path with query params for wallet listing.
@@ -603,7 +575,6 @@ test.describe
       };
 
       await page.setViewportSize({ width: 390, height: 844 });
-      await seedProjectCookie(page, projectId);
       await page.goto("/dashboard/wallets/setup", { waitUntil: "domcontentloaded" });
       await expect(page.getByText("Step 1 of 2", { exact: true })).toBeVisible({
         timeout: E2E_POLL_TIMEOUT_MS,
@@ -637,68 +608,75 @@ test.describe
     }) => {
       test.setTimeout(420_000);
 
-      const session = await getPlaywrightAdminSession(browser);
-      const fixtures = await bootstrapLocalWalletFixtures({
-        identity: session.identity,
-        bearerToken: session.getBearerToken,
-        provider: "privy",
-        walletCount: 1,
-        tier: "enterprise",
-      });
-      const projectId = await resolvePlaywrightProjectId(
-        getBootstrapApiBaseUrl(),
-        session.getBearerToken
-      );
-      const api = createLocalApiClient(getBootstrapApiBaseUrl(), session.getBearerToken, projectId);
-      await seedProjectCookie(page, projectId);
+      const { deployedToken, wallet } = await bootstrapProjectForPage(
+        browser,
+        page,
+        async (session) => {
+          const fixtures = await bootstrapLocalWalletFixtures({
+            identity: session.identity,
+            bearerToken: session.getBearerToken,
+            provider: "privy",
+            walletCount: 1,
+            tier: "enterprise",
+          });
+          const api = createLocalApiClient(
+            getBootstrapApiBaseUrl(),
+            session.getBearerToken,
+            fixtures.projectId
+          );
+          const wallet = fixtures.wallets[0];
+          if (!wallet) {
+            throw new Error("Failed to bootstrap wallet burn activity fixture");
+          }
 
-      const wallet = fixtures.wallets[0];
-      if (!wallet) {
-        throw new Error("Failed to bootstrap wallet burn activity fixture");
-      }
+          const deployedToken = await createAndDeployWalletActivityToken(api, wallet.walletId);
+          const mintAddress = deployedToken.mintAddress;
+          if (!mintAddress) {
+            throw new Error("Failed to deploy wallet activity token with a mint address");
+          }
 
-      const deployedToken = await createAndDeployWalletActivityToken(api, wallet.walletId);
-      const mintAddress = deployedToken.mintAddress;
-      if (!mintAddress) {
-        throw new Error("Failed to deploy wallet activity token with a mint address");
-      }
+          const minted = await postWithSigningProviderRetry<MintResponse>(
+            api,
+            `/v1/issuance/tokens/${encodeURIComponent(deployedToken.id)}/mint`,
+            {
+              signingWalletId: wallet.walletId,
+              mint: {
+                destination: wallet.publicKey,
+                amount: "6",
+              },
+            }
+          );
+          expect(minted.transaction.status).toBe("confirmed");
+          expect(minted.tokenAccount).toBeTruthy();
 
-      const minted = await postWithSigningProviderRetry<MintResponse>(
-        api,
-        `/v1/issuance/tokens/${encodeURIComponent(deployedToken.id)}/mint`,
-        {
-          signingWalletId: wallet.walletId,
-          mint: {
-            destination: wallet.publicKey,
-            amount: "6",
-          },
+          const burned = await postWithSigningProviderRetry<TransactionResponse>(
+            api,
+            `/v1/issuance/tokens/${encodeURIComponent(deployedToken.id)}/burn`,
+            {
+              signingWalletId: wallet.walletId,
+              burn: {
+                source: minted.tokenAccount,
+                amount: "2",
+              },
+            }
+          );
+          expect(burned.transaction.type).toBe("burn");
+          expect(burned.transaction.status).toBe("confirmed");
+          expect(burned.transaction.signature).toBeTruthy();
+
+          await waitForToken(
+            api,
+            deployedToken.id,
+            (token) => token.totalSupply === "4",
+            "have total supply 4"
+          );
+          return {
+            deployedToken,
+            projectId: fixtures.projectId,
+            wallet,
+          };
         }
       );
-      expect(minted.transaction.status).toBe("confirmed");
-      expect(minted.tokenAccount).toBeTruthy();
-
-      const burned = await postWithSigningProviderRetry<TransactionResponse>(
-        api,
-        `/v1/issuance/tokens/${encodeURIComponent(deployedToken.id)}/burn`,
-        {
-          signingWalletId: wallet.walletId,
-          burn: {
-            source: minted.tokenAccount,
-            amount: "2",
-          },
-        }
-      );
-      expect(burned.transaction.type).toBe("burn");
-      expect(burned.transaction.status).toBe("confirmed");
-      expect(burned.transaction.signature).toBeTruthy();
-
-      await waitForToken(
-        api,
-        deployedToken.id,
-        (token) => token.totalSupply === "4",
-        "have total supply 4"
-      );
-      await session.page.close();
 
       await page.goto(`/dashboard/wallets/${wallet.walletId}`, { waitUntil: "domcontentloaded" });
       await page.getByRole("heading", { name: "Recent activity" }).scrollIntoViewIfNeeded();
@@ -724,20 +702,15 @@ test.describe
     }) => {
       test.setTimeout(420_000);
 
-      const session = await getPlaywrightAdminSession(browser);
-      const fixtures = await bootstrapLocalWalletFixtures({
-        identity: session.identity,
-        bearerToken: session.getBearerToken,
-        provider: "privy",
-        walletCount: 1,
-        tier: "enterprise",
-      });
-      const projectId = await resolvePlaywrightProjectId(
-        getBootstrapApiBaseUrl(),
-        session.getBearerToken
+      const fixtures = await bootstrapProjectForPage(browser, page, (session) =>
+        bootstrapLocalWalletFixtures({
+          identity: session.identity,
+          bearerToken: session.getBearerToken,
+          provider: "privy",
+          walletCount: 1,
+          tier: "enterprise",
+        })
       );
-      await session.page.close();
-      await seedProjectCookie(page, projectId);
 
       const wallet = fixtures.wallets[0];
       if (!wallet) {


### PR DESCRIPTION
- Add `provisionWithAdminSession` (admin session with try/finally close) and `bootstrapProjectForPage` (provision + seed the test page's project cookie) to `local-dashboard-bootstrap.ts`; every bootstrap now returns `projectId`
- Migrate all 13 hand-rolled bootstrap ceremonies across 10 spec files onto the helpers; `seedProjectCookie` now documents the stale-cookie contract (out-of-band bootstrap deletes the project the page's cookie names → 403 "Requested project is not accessible" → empty states)
- Fix `api-keys.e2e` never seeding the project cookie (both tests navigated on a stale cookie)
- Fix `wallets.e2e` resolve-before-provision inversion that seeded a deleted project id
- Fix `theme.e2e` toast bootstrap leaking its admin browser context, plus 8 specs leaking the session on any failure before their bare `close()`
- Drop redundant double org-provisioning in `policies.e2e` and `payments-recurring.e2e`, the duplicate `resolvePlaywrightProjectId` calls, and `issuance.e2e`'s JSON file round-trip for a value the bootstrap already returns
- `onboarding.e2e` (asserts the app's own cookie-repair path) and the non-toast theme tests are intentionally untouched
- Verified: `tsc --noEmit`, `biome check playwright`, `playwright test --list` (57 tests / 13 files) all pass;
