### PR TITLE
fix(cron): give managed monitors a check-in margin covering job startup

### DIFF
--- a/apps/sdp-api/src/cron/runner.node.test.ts
+++ b/apps/sdp-api/src/cron/runner.node.test.ts
@@ -172,7 +172,35 @@ describe("startCron", () => {
     startCron({ env, bg, observability });
 
     (scheduleMock.mock.calls[3][1] as () => void)();
-    expect(runWorkflowExecutions).toHaveBeenCalledWith({ env, bg, observability });
+    expect(runWorkflowExecutions).toHaveBeenCalledWith({
+      env,
+      bg,
+      observability: expect.anything(),
+    });
+  });
+
+  it("gives every tick monitor a check-in margin surviving instance restarts", async () => {
+    const bg = makeBg();
+    const env = {} as Env;
+    const observability = makeObservability();
+    startCron({ env, bg, observability });
+
+    (scheduleMock.mock.calls[3][1] as () => void)();
+    const passed = vi.mocked(runWorkflowExecutions).mock.calls[0][0].observability;
+    expect(passed).toBeDefined();
+    expect(passed).not.toBe(observability);
+
+    await passed?.withMonitor("sdp-api-run-workflow-executions", async () => undefined, {
+      schedule: { type: "crontab", value: "*/5 * * * *" },
+    });
+    expect(observability.withMonitor).toHaveBeenCalledExactlyOnceWith(
+      "sdp-api-run-workflow-executions",
+      expect.any(Function),
+      {
+        schedule: { type: "crontab", value: "*/5 * * * *" },
+        checkinMargin: 3,
+      }
+    );
   });
 
   // The engine is the one scheduled task behind a feature flag that defaults ON (asset
@@ -206,7 +234,7 @@ describe("startCron", () => {
     expect(runWorkflowSecretRetirements).toHaveBeenCalledWith({
       env: SELF_HOSTED_NO_PROFILES,
       bg,
-      observability,
+      observability: expect.anything(),
     });
   });
 
@@ -296,7 +324,11 @@ describe("startCron", () => {
     startCron({ env, bg, observability });
     const tick = scheduleMock.mock.calls[1][1] as () => void;
     tick();
-    expect(runPendingTransfersReconciliation).toHaveBeenCalledWith({ env, bg, observability });
+    expect(runPendingTransfersReconciliation).toHaveBeenCalledWith({
+      env,
+      bg,
+      observability: expect.anything(),
+    });
   });
 
   it("tick invokes approved wallet-operation recovery with the supplied deps", () => {
@@ -306,7 +338,11 @@ describe("startCron", () => {
     startCron({ env, bg, observability });
     const tick = scheduleMock.mock.calls[0][1] as () => void;
     tick();
-    expect(runApprovedWalletOperationRecovery).toHaveBeenCalledWith({ env, bg, observability });
+    expect(runApprovedWalletOperationRecovery).toHaveBeenCalledWith({
+      env,
+      bg,
+      observability: expect.anything(),
+    });
   });
 
   it("tick invokes vault-movement recovery outside the Earn feature gate", () => {
@@ -319,7 +355,7 @@ describe("startCron", () => {
     expect(runEarnVaultMovementsReconciliation).toHaveBeenCalledWith({
       env,
       bg,
-      observability,
+      observability: expect.anything(),
     });
   });
 
@@ -331,7 +367,11 @@ describe("startCron", () => {
     // recovery, transfers, recurring, workflow executions — recurring is third.
     const tick = scheduleMock.mock.calls[2][1] as () => void;
     tick();
-    expect(runRecurringPaymentsCollection).toHaveBeenCalledWith({ env, bg, observability });
+    expect(runRecurringPaymentsCollection).toHaveBeenCalledWith({
+      env,
+      bg,
+      observability: expect.anything(),
+    });
   });
 
   it("tick passes observability=undefined through when caller did not supply one", () => {
@@ -379,6 +419,10 @@ describe("startCron", () => {
     startCron({ env, bg, observability });
     const tick = scheduleMock.mock.calls[4][1] as () => void;
     tick();
-    expect(runRingsIndexingPoll).toHaveBeenCalledWith({ env, bg, observability });
+    expect(runRingsIndexingPoll).toHaveBeenCalledWith({
+      env,
+      bg,
+      observability: expect.anything(),
+    });
   });
 });

--- a/apps/sdp-api/src/cron/runner.ts
+++ b/apps/sdp-api/src/cron/runner.ts
@@ -77,10 +77,28 @@ function isCronDisabled(env: Env): boolean {
   );
 }
 
+const IN_PROCESS_CHECKIN_MARGIN_MINUTES = 3;
+
+function withCheckinMargin(observability: Observability): Observability {
+  return {
+    captureException: (error) => observability.captureException(error),
+    withScope: (callback) => observability.withScope(callback),
+    withMonitor: (slug, work, options) =>
+      observability.withMonitor(slug, work, {
+        checkinMargin: IN_PROCESS_CHECKIN_MARGIN_MINUTES,
+        ...options,
+      }),
+  };
+}
+
 export function startCron(deps: CronDeps): CronHandle | null {
   if (isCronDisabled(deps.env)) {
     return null;
   }
+  deps = {
+    ...deps,
+    observability: deps.observability ? withCheckinMargin(deps.observability) : undefined,
+  };
 
   // node-cron's `task.stop()` halts future scheduling but doesn't promise
   // to interrupt a tick already mid-flight. A `stopping` flag short-circuits

--- a/apps/sdp-api/src/job.node.test.ts
+++ b/apps/sdp-api/src/job.node.test.ts
@@ -379,6 +379,7 @@ describe("runCronJob", () => {
     for (const [, config] of starts) {
       expect(config).toEqual({
         schedule: { type: "crontab", value: "*/3 * * * *" },
+        checkinMargin: 4,
         maxRuntime: 2,
       });
     }
@@ -559,11 +560,14 @@ describe("runCronJob", () => {
 
     await runCronJob();
 
-    const startedSlugs = vi
+    const startedCalls = vi
       .mocked(nodeObservability.captureCheckIn)
-      .mock.calls.filter(([checkIn]) => checkIn.status === "in_progress")
-      .map(([checkIn]) => checkIn.monitorSlug);
+      .mock.calls.filter(([checkIn]) => checkIn.status === "in_progress");
+    const startedSlugs = startedCalls.map(([checkIn]) => checkIn.monitorSlug);
     expect(startedSlugs).toContain("sdp-api-managed-refresh-earn-metrics");
+    for (const [, monitorConfig] of startedCalls) {
+      expect(monitorConfig).toMatchObject({ checkinMargin: 4 });
+    }
     expect(runEarnMetricsRefreshTick).toHaveBeenCalledExactlyOnceWith(env, undefined);
 
     const catalogueObservability = vi.mocked(runEarnCatalogueSyncIfDue).mock.calls[0][1];

--- a/apps/sdp-api/src/job.ts
+++ b/apps/sdp-api/src/job.ts
@@ -49,6 +49,7 @@ import type { Env } from "@/types/env";
 
 const MAX_MANAGED_SCHEDULER_GAP_MINUTES = 5;
 const MANAGED_CATALOGUE_CHECKIN_MARGIN_MINUTES = 10;
+const MANAGED_CHECKIN_MARGIN_MINUTES = 4;
 
 /**
  * One-shot reconciliation entrypoint for the managed Cloud Run Job — the only
@@ -273,7 +274,11 @@ function createManagedTickRunner({
       const monitorSlug = getManagedMonitorSlug(monitor);
       const checkInId = observability.captureCheckIn(
         { monitorSlug, status: "in_progress" },
-        { schedule: { type: "crontab", value: cadence }, maxRuntime: maxRuntimeMinutes }
+        {
+          schedule: { type: "crontab", value: cadence },
+          checkinMargin: MANAGED_CHECKIN_MARGIN_MINUTES,
+          maxRuntime: maxRuntimeMinutes,
+        }
       );
       checkIns.set(monitor, { checkInId, monitorSlug });
     }
@@ -325,7 +330,11 @@ function createManagedTaskObservability(
               checkinMargin: MANAGED_CATALOGUE_CHECKIN_MARGIN_MINUTES,
               maxRuntime: maxRuntimeMinutes,
             }
-          : { ...options, maxRuntime: maxRuntimeMinutes };
+          : {
+              ...options,
+              checkinMargin: MANAGED_CHECKIN_MARGIN_MINUTES,
+              maxRuntime: maxRuntimeMinutes,
+            };
       return observability.withMonitor(getManagedMonitorSlug(monitor), work, managedOptions);
     },
   };

--- a/apps/sdp-api/src/job.ts
+++ b/apps/sdp-api/src/job.ts
@@ -141,7 +141,7 @@ export async function runCronJob(): Promise<void> {
     const rpc = probeRpc;
     const egress = await waitForEgress({
       probe: () => rpc.getBlockHeight({ commitment: "confirmed" }).send(),
-      deadlineMs: 180_000,
+      deadlineMs: 120_000,
       intervalMs: 5_000,
     });
     if (egress.ready) {


### PR DESCRIPTION
## Problem

Since this morning every managed cron monitor fires "missed check-in" each cycle while all job executions actually succeed. Cause: #1453 registers the `in_progress` check-ins at job start, but a managed execution now begins 1.5–4 minutes after its scheduled minute — 30–60s Cloud Run job provisioning plus the egress warmup from #1474 — and the monitors ride Sentry's default one-minute margin. The same failure mode is waiting for the always-on worker (sdp-infra#73): in-process tick monitors pass only a schedule, so any worker restart or deploy (a 1–2 minute gap on per-minute crontabs) would reproduce the wall on the in-process slugs.

## What changed

Explicit, startup/restart-tolerant check-in margins for both execution models:

1. **Managed monitors (`sdp-api-managed-*`)** — `checkinMargin: 4` minutes on the pre-registered check-ins in `createManagedTickRunner` and on the wrapped options in `createManagedTaskObservability`. Four minutes covers provisioning plus the full warmup budget and stays inside the 5-minute dev cadence, so a genuinely missed execution still alerts. Deliberately not 5: with the prod `*/3` cadence a margin ≥ cadence starts attributing late check-ins to neighboring slots and can mask a real miss.
2. **Egress warmup deadline 180s → 120s** — the driver's side of the review finding that 60s provisioning + 180s warmup sat exactly on the margin; observed warmup maxima are 10–50s, so the budget stays generous while worst case lands at ~3 minutes against the 4-minute margin.
3. **In-process monitors (`sdp-api-*`)** — `startCron` wraps the supplied observability so every tick monitor gets `checkinMargin: 3` (explicit caller options still win). Covers worker/self-hosted instance restarts and deploys.
4. The hourly catalogue monitor keeps its existing 10-minute margin.

The managed and in-process slug sets are disjoint, so the Cloud Run job and the worker can coexist during the dev soak without touching each other's monitors.

## Why not other options

- Registering check-ins before the warmup: the check-in itself is an outbound call and would land in the same egress window the warmup exists to wait out.
- Editing margins in the Sentry UI: the code upserts `monitorConfig` with every check-in, overwriting UI changes each cycle.

## Validation

- `job.node.test.ts` — 36 passed (new: every managed `in_progress` registration carries the margin; exact-options pin updated).
- `runner.node.test.ts` — 24 passed (new: the wrapped observability injects the margin and is not the caller's instance; identity assertions relaxed to `expect.anything()`).
- `egress-warmup.test.ts` — 3 passed; typecheck and lint clean.

cc @GuiBibeau — your #1453 monitor model; flagging the interplay rather than silently changing it.
