### PR TITLE
feat(private-channels): use project RPC configuration

### DIFF
--- a/apps/sdp-api/src/db/migrations/postgres/0040_private_channels.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0040_private_channels.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS private_channel_instances (
     project_id TEXT NOT NULL,
 
     gateway_url TEXT NOT NULL,
-    chain_rpc_url TEXT NOT NULL,
+    chain_rpc_url TEXT NOT NULL DEFAULT '',
     escrow_program_id TEXT NOT NULL,
     withdraw_program_id TEXT NOT NULL,
     escrow_instance_addr TEXT NOT NULL,

--- a/apps/sdp-api/src/db/migrations/postgres/0069_private_channels_legacy_rpc_default.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0069_private_channels_legacy_rpc_default.sql
@@ -1,0 +1,5 @@
+-- The API now resolves Private Channels traffic through the project's RPC
+-- integration. Keep the legacy column during the compatibility window, but
+-- allow new writers to omit a value that is no longer used for execution.
+ALTER TABLE private_channel_instances
+    ALTER COLUMN chain_rpc_url SET DEFAULT '';

--- a/apps/sdp-api/src/db/migrations/postgres/0069_private_channels_project_rpc.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0069_private_channels_project_rpc.sql
@@ -1,0 +1,7 @@
+-- Private Channels uses the project's effective RPC connection for all Solana
+-- L1 traffic. Keeping a second endpoint on the instance duplicated credentials,
+-- became stale when the project changed provider, and could not represent
+-- providers whose credentials travel in headers.
+
+ALTER TABLE private_channel_instances
+    DROP COLUMN IF EXISTS chain_rpc_url;

--- a/apps/sdp-api/src/db/migrations/postgres/0069_private_channels_project_rpc.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0069_private_channels_project_rpc.sql
@@ -1,7 +1,0 @@
--- Private Channels uses the project's effective RPC connection for all Solana
--- L1 traffic. Keeping a second endpoint on the instance duplicated credentials,
--- became stale when the project changed provider, and could not represent
--- providers whose credentials travel in headers.
-
-ALTER TABLE private_channel_instances
-    DROP COLUMN IF EXISTS chain_rpc_url;

--- a/apps/sdp-api/src/db/repositories/private-channel-deposit.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/private-channel-deposit.repository.test.ts
@@ -26,7 +26,6 @@ function makeInput(overrides: Partial<CreateDepositInput> = {}): CreateDepositIn
     amount: "1.5",
     context: {
       gatewayUrl: "https://gw.example",
-      chainRpcUrl: "https://devnet.example",
       escrowProgramId: "EscrowProg1111111111111111111111111111111",
       escrowInstanceAddr: "EscrowInst1111111111111111111111111111111",
       actingUserId: TEST_USER.id,
@@ -87,7 +86,6 @@ describe("PrivateChannelDepositRepository (postgres)", () => {
     // Context is opaque JSONB round-tripped as-is; the oracle never reads it.
     expect(row?.context).toMatchObject({
       gatewayUrl: "https://gw.example",
-      chainRpcUrl: "https://devnet.example",
       escrowProgramId: "EscrowProg1111111111111111111111111111111",
       escrowInstanceAddr: "EscrowInst1111111111111111111111111111111",
     });

--- a/apps/sdp-api/src/db/repositories/private-channel-event.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/private-channel-event.repository.test.ts
@@ -72,9 +72,9 @@ describe("PrivateChannelEventRepository (postgres)", () => {
     await db
       .prepare(
         `INSERT INTO private_channel_instances
-           (id, organization_id, project_id, gateway_url, chain_rpc_url,
+           (id, organization_id, project_id, gateway_url,
             escrow_program_id, withdraw_program_id, escrow_instance_addr, auth_url, is_active)
-         VALUES (?, ?, ?, 'http://gw', 'http://rpc', 'prog1', 'prog2', 'escrow1', 'http://auth', true)`
+         VALUES (?, ?, ?, 'http://gw', 'prog1', 'prog2', 'escrow1', 'http://auth', true)`
       )
       .bind(TEST_INSTANCE_ID, TEST_ORG.id, TEST_PROJECT_ID)
       .run();

--- a/apps/sdp-api/src/db/repositories/private-channel-instance.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/private-channel-instance.repository.postgres.ts
@@ -15,7 +15,6 @@ function mapRow(row: Record<string, unknown>): PrivateChannelInstanceRow {
     organization_id: row.organization_id as string,
     project_id: row.project_id as string,
     gateway_url: row.gateway_url as string,
-    chain_rpc_url: row.chain_rpc_url as string,
     escrow_program_id: row.escrow_program_id as string,
     withdraw_program_id: row.withdraw_program_id as string,
     escrow_instance_addr: row.escrow_instance_addr as string,
@@ -77,11 +76,11 @@ export function createPostgresPrivateChannelInstanceRepository(
         .prepare(
           `INSERT INTO private_channel_instances (
                id, organization_id, project_id,
-               gateway_url, chain_rpc_url,
+               gateway_url,
                escrow_program_id, withdraw_program_id, escrow_instance_addr,
                auth_url,
                is_active, created_by
-             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, TRUE, ?)
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, TRUE, ?)
           RETURNING *`
         )
         .bind(
@@ -89,7 +88,6 @@ export function createPostgresPrivateChannelInstanceRepository(
           input.organizationId,
           input.projectId,
           input.gatewayUrl,
-          input.chainRpcUrl,
           input.escrowProgramId,
           input.withdrawProgramId,
           input.escrowInstanceAddr,
@@ -104,8 +102,7 @@ export function createPostgresPrivateChannelInstanceRepository(
       const row = await db
         .prepare(
           `UPDATE private_channel_instances
-              SET chain_rpc_url = ?,
-                  escrow_program_id = ?,
+              SET escrow_program_id = ?,
                   withdraw_program_id = ?,
                   escrow_instance_addr = ?,
                   auth_url = ?,
@@ -115,7 +112,6 @@ export function createPostgresPrivateChannelInstanceRepository(
           RETURNING *`
         )
         .bind(
-          input.chainRpcUrl,
           input.escrowProgramId,
           input.withdrawProgramId,
           input.escrowInstanceAddr,

--- a/apps/sdp-api/src/db/repositories/private-channel-instance.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/private-channel-instance.repository.postgres.ts
@@ -15,6 +15,7 @@ function mapRow(row: Record<string, unknown>): PrivateChannelInstanceRow {
     organization_id: row.organization_id as string,
     project_id: row.project_id as string,
     gateway_url: row.gateway_url as string,
+    chain_rpc_url: row.chain_rpc_url as string,
     escrow_program_id: row.escrow_program_id as string,
     withdraw_program_id: row.withdraw_program_id as string,
     escrow_instance_addr: row.escrow_instance_addr as string,
@@ -76,11 +77,11 @@ export function createPostgresPrivateChannelInstanceRepository(
         .prepare(
           `INSERT INTO private_channel_instances (
                id, organization_id, project_id,
-               gateway_url,
+               gateway_url, chain_rpc_url,
                escrow_program_id, withdraw_program_id, escrow_instance_addr,
                auth_url,
                is_active, created_by
-             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, TRUE, ?)
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, TRUE, ?)
           RETURNING *`
         )
         .bind(
@@ -88,6 +89,7 @@ export function createPostgresPrivateChannelInstanceRepository(
           input.organizationId,
           input.projectId,
           input.gatewayUrl,
+          input.chainRpcUrl,
           input.escrowProgramId,
           input.withdrawProgramId,
           input.escrowInstanceAddr,
@@ -102,7 +104,8 @@ export function createPostgresPrivateChannelInstanceRepository(
       const row = await db
         .prepare(
           `UPDATE private_channel_instances
-              SET escrow_program_id = ?,
+              SET chain_rpc_url = ?,
+                  escrow_program_id = ?,
                   withdraw_program_id = ?,
                   escrow_instance_addr = ?,
                   auth_url = ?,
@@ -112,6 +115,7 @@ export function createPostgresPrivateChannelInstanceRepository(
           RETURNING *`
         )
         .bind(
+          input.chainRpcUrl,
           input.escrowProgramId,
           input.withdrawProgramId,
           input.escrowInstanceAddr,

--- a/apps/sdp-api/src/db/repositories/private-channel-instance.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/private-channel-instance.repository.test.ts
@@ -140,12 +140,10 @@ describe("PrivateChannelInstanceRepository (postgres)", () => {
     const reactivated = await repo.reactivateAndUpdate({
       id: created.id,
       ...SANDBOX_DEFAULTS,
-      chainRpcUrl: "https://mainnet.helius-rpc.com/?api-key=NEW",
       authUrl: "http://auth.example:8903",
     });
     expect(reactivated?.id).toBe(created.id);
     expect(reactivated?.is_active).toBe(true);
-    expect(reactivated?.chain_rpc_url).toBe("https://mainnet.helius-rpc.com/?api-key=NEW");
     expect(reactivated?.auth_url).toBe("http://auth.example:8903");
     // gateway_url is the identity key and must not change on reactivation.
     expect(reactivated?.gateway_url).toBe(created.gateway_url);

--- a/apps/sdp-api/src/db/repositories/private-channel-instance.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/private-channel-instance.repository.test.ts
@@ -140,10 +140,12 @@ describe("PrivateChannelInstanceRepository (postgres)", () => {
     const reactivated = await repo.reactivateAndUpdate({
       id: created.id,
       ...SANDBOX_DEFAULTS,
+      chainRpcUrl: "https://mainnet.helius-rpc.com/?api-key=NEW",
       authUrl: "http://auth.example:8903",
     });
     expect(reactivated?.id).toBe(created.id);
     expect(reactivated?.is_active).toBe(true);
+    expect(reactivated?.chain_rpc_url).toBe("https://mainnet.helius-rpc.com/?api-key=NEW");
     expect(reactivated?.auth_url).toBe("http://auth.example:8903");
     // gateway_url is the identity key and must not change on reactivation.
     expect(reactivated?.gateway_url).toBe(created.gateway_url);

--- a/apps/sdp-api/src/db/repositories/private-channel-instance.repository.ts
+++ b/apps/sdp-api/src/db/repositories/private-channel-instance.repository.ts
@@ -10,7 +10,6 @@ export interface PrivateChannelInstanceRow {
   organization_id: string;
   project_id: string;
   gateway_url: string;
-  chain_rpc_url: string;
   escrow_program_id: string;
   withdraw_program_id: string;
   escrow_instance_addr: string;
@@ -68,7 +67,6 @@ export function mapPrivateChannelInstanceRow(
     organizationId: row.organization_id,
     projectId: row.project_id,
     gatewayUrl: row.gateway_url,
-    chainRpcUrl: row.chain_rpc_url,
     escrowProgramId: row.escrow_program_id,
     withdrawProgramId: row.withdraw_program_id,
     escrowInstanceAddr: row.escrow_instance_addr,

--- a/apps/sdp-api/src/db/repositories/private-channel-instance.repository.ts
+++ b/apps/sdp-api/src/db/repositories/private-channel-instance.repository.ts
@@ -10,6 +10,8 @@ export interface PrivateChannelInstanceRow {
   organization_id: string;
   project_id: string;
   gateway_url: string;
+  /** Legacy response compatibility only; never used for RPC execution. */
+  chain_rpc_url: string;
   escrow_program_id: string;
   withdraw_program_id: string;
   escrow_instance_addr: string;
@@ -67,6 +69,7 @@ export function mapPrivateChannelInstanceRow(
     organizationId: row.organization_id,
     projectId: row.project_id,
     gatewayUrl: row.gateway_url,
+    chainRpcUrl: row.chain_rpc_url,
     escrowProgramId: row.escrow_program_id,
     withdrawProgramId: row.withdraw_program_id,
     escrowInstanceAddr: row.escrow_instance_addr,

--- a/apps/sdp-api/src/db/repositories/private-channel-reference.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/private-channel-reference.repository.test.ts
@@ -64,9 +64,9 @@ describe("PrivateChannelReferenceRepository (postgres)", () => {
     await db
       .prepare(
         `INSERT INTO private_channel_instances
-           (id, organization_id, project_id, gateway_url, chain_rpc_url,
+           (id, organization_id, project_id, gateway_url,
             escrow_program_id, withdraw_program_id, escrow_instance_addr, auth_url, is_active)
-         VALUES (?, ?, ?, 'http://gw', 'http://rpc', 'prog1', 'prog2', 'escrow1', 'http://auth', true)`
+         VALUES (?, ?, ?, 'http://gw', 'prog1', 'prog2', 'escrow1', 'http://auth', true)`
       )
       .bind(TEST_INSTANCE_ID, TEST_ORG.id, TEST_PROJECT_ID)
       .run();

--- a/apps/sdp-api/src/db/repositories/private-channel-transfer.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/private-channel-transfer.repository.test.ts
@@ -131,12 +131,12 @@ describe("PrivateChannelTransferRepository (postgres)", () => {
     await db
       .prepare(
         `INSERT INTO private_channel_instances (
-           id, organization_id, project_id, gateway_url, chain_rpc_url,
+           id, organization_id, project_id, gateway_url,
            escrow_program_id, withdraw_program_id, escrow_instance_addr, auth_url, is_active
          ) VALUES
-           (?, ?, ?, 'https://gateway.example', 'https://rpc.example',
+           (?, ?, ?, 'https://gateway.example',
             'escrow_program', 'withdraw_program', 'escrow_instance', 'https://auth.example', TRUE),
-           (?, ?, ?, 'https://other-gateway.example', 'https://other-rpc.example',
+           (?, ?, ?, 'https://other-gateway.example',
             'other_escrow_program', 'other_withdraw_program', 'other_escrow_instance',
             'https://other-auth.example', TRUE)`
       )

--- a/apps/sdp-api/src/db/repositories/private-channel-withdrawal.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/private-channel-withdrawal.repository.test.ts
@@ -24,7 +24,6 @@ function makeInput(overrides: Partial<CreateWithdrawalInput> = {}): CreateWithdr
     amount: "1.5",
     context: {
       gatewayUrl: "https://gw.example",
-      chainRpcUrl: "https://devnet.example",
       escrowProgramId: "EscrowProg1111111111111111111111111111111",
       escrowInstanceAddr: "EscrowInst1111111111111111111111111111111",
       actingUserId: TEST_USER.id,
@@ -90,7 +89,6 @@ describe("PrivateChannelWithdrawalRepository (postgres)", () => {
     expect(row?.settlement_ref).toBeNull();
     expect(row?.context).toMatchObject({
       gatewayUrl: "https://gw.example",
-      chainRpcUrl: "https://devnet.example",
     });
   });
 

--- a/apps/sdp-api/src/db/repositories/private-channel.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/private-channel.repository.test.ts
@@ -20,9 +20,9 @@ async function seedInstance(db: ReturnType<typeof getDb>, id: string): Promise<v
   await db
     .prepare(
       `INSERT INTO private_channel_instances
-         (id, organization_id, project_id, gateway_url, chain_rpc_url,
+         (id, organization_id, project_id, gateway_url,
           escrow_program_id, withdraw_program_id, escrow_instance_addr, auth_url, is_active)
-       VALUES (?, ?, ?, ?, 'http://rpc', 'prog1', 'prog2', 'escrow1', 'http://auth', ?)`
+       VALUES (?, ?, ?, ?, 'prog1', 'prog2', 'escrow1', 'http://auth', ?)`
     )
     // gateway_url is unique per (project, gateway); each instance needs its own.
     .bind(id, TEST_ORG_ID, TEST_PROJECT_ID, `http://gw/${id}`, id === TEST_INSTANCE_ID ? 1 : 0)

--- a/apps/sdp-api/src/openapi/schemas/private-channels.ts
+++ b/apps/sdp-api/src/openapi/schemas/private-channels.ts
@@ -13,7 +13,6 @@ export const privateChannelInstanceSchema = z
     organizationId: z.string(),
     projectId: z.string(),
     gatewayUrl: z.string().openapi({ example: "http://34.71.147.163:8899" }),
-    chainRpcUrl: z.string().openapi({ example: "https://devnet.helius-rpc.com/?api-key=…" }),
     escrowProgramId: solanaAddressSchema,
     withdrawProgramId: solanaAddressSchema,
     escrowInstanceAddr: solanaAddressSchema,
@@ -28,7 +27,6 @@ export const privateChannelInstanceSchema = z
 export const privateChannelInstanceInputSchema = z
   .object({
     gatewayUrl: z.string(),
-    chainRpcUrl: z.string(),
     escrowProgramId: solanaAddressSchema,
     withdrawProgramId: solanaAddressSchema,
     escrowInstanceAddr: solanaAddressSchema,
@@ -62,10 +60,12 @@ export const privateChannelHealthQuerySchema = z.object({
 export const privateChannelProbeBodySchema = z
   .object({
     gatewayUrl: z.string().min(1),
-    chainRpcUrl: z.string().min(1),
     authUrl: z.string().min(1),
   })
-  .openapi({ description: "Probe request body: the three URLs the connect flow re-probes." });
+  .openapi({
+    description:
+      "Probe request body. The selected project's configured RPC is probed automatically.",
+  });
 
 const gatewayProbeResponseSchema = z.object({
   status: z.number(),

--- a/apps/sdp-api/src/openapi/schemas/private-channels.ts
+++ b/apps/sdp-api/src/openapi/schemas/private-channels.ts
@@ -13,6 +13,11 @@ export const privateChannelInstanceSchema = z
     organizationId: z.string(),
     projectId: z.string(),
     gatewayUrl: z.string().openapi({ example: "http://34.71.147.163:8899" }),
+    chainRpcUrl: z.string().openapi({
+      description:
+        "Deprecated compatibility field. Private Channels execution uses the project's RPC integration.",
+      example: "https://devnet.helius-rpc.com/?api-key=…",
+    }),
     escrowProgramId: solanaAddressSchema,
     withdrawProgramId: solanaAddressSchema,
     escrowInstanceAddr: solanaAddressSchema,
@@ -27,6 +32,10 @@ export const privateChannelInstanceSchema = z
 export const privateChannelInstanceInputSchema = z
   .object({
     gatewayUrl: z.string(),
+    chainRpcUrl: z.string().optional().openapi({
+      description:
+        "Deprecated and ignored for execution. Configure RPC on the SDP project instead.",
+    }),
     escrowProgramId: solanaAddressSchema,
     withdrawProgramId: solanaAddressSchema,
     escrowInstanceAddr: solanaAddressSchema,

--- a/apps/sdp-api/src/routes/private-channels.channels.test.ts
+++ b/apps/sdp-api/src/routes/private-channels.channels.test.ts
@@ -74,9 +74,9 @@ async function seedAuth(): Promise<void> {
     getDb(env)
       .prepare(
         `INSERT INTO private_channel_instances
-           (id, organization_id, project_id, gateway_url, chain_rpc_url,
+           (id, organization_id, project_id, gateway_url,
             escrow_program_id, withdraw_program_id, escrow_instance_addr, auth_url, is_active)
-         VALUES (?, ?, ?, 'http://gw', 'http://rpc', 'prog1', 'prog2', 'escrow1', 'http://auth', true)`
+         VALUES (?, ?, ?, 'http://gw', 'prog1', 'prog2', 'escrow1', 'http://auth', true)`
       )
       .bind(TEST_INSTANCE_ID, TEST_ORG.id, TEST_PROJECT.id),
     // Connecting an instance auto-provisions its default channel (instance connect →

--- a/apps/sdp-api/src/routes/private-channels.events.test.ts
+++ b/apps/sdp-api/src/routes/private-channels.events.test.ts
@@ -127,7 +127,6 @@ async function connectInstance(): Promise<void> {
       headers: authHeaders(),
       body: JSON.stringify({
         gatewayUrl: SANDBOX_DEFAULTS.gatewayUrl,
-        chainRpcUrl: SANDBOX_DEFAULTS.chainRpcUrl,
         escrowProgramId: SANDBOX_DEFAULTS.escrowProgramId,
         withdrawProgramId: SANDBOX_DEFAULTS.withdrawProgramId,
         escrowInstanceAddr: SANDBOX_DEFAULTS.escrowInstanceAddr,

--- a/apps/sdp-api/src/routes/private-channels.transfers.test.ts
+++ b/apps/sdp-api/src/routes/private-channels.transfers.test.ts
@@ -195,9 +195,9 @@ async function seedRouteState(): Promise<void> {
     db
       .prepare(
         `INSERT INTO private_channel_instances
-           (id, organization_id, project_id, gateway_url, chain_rpc_url,
+           (id, organization_id, project_id, gateway_url,
             escrow_program_id, withdraw_program_id, escrow_instance_addr, auth_url, is_active)
-         VALUES (?, ?, ?, 'https://gateway.example', 'https://api.devnet.solana.com',
+         VALUES (?, ?, ?, 'https://gateway.example',
                  ?, ?, ?, 'https://auth.example', true)`
       )
       .bind(

--- a/apps/sdp-api/src/routes/private-channels/context.ts
+++ b/apps/sdp-api/src/routes/private-channels/context.ts
@@ -11,7 +11,9 @@ import {
   createPrivateChannelWithdrawalRepository,
   createProjectUserRepository,
 } from "@/db/repositories";
+import { getAuth, requireProjectId } from "@/lib/auth";
 import { createPrivateChannelEventService } from "@/services/private-channels/event.service";
+import { loadProjectRpcClient } from "@/services/private-channels/project-rpc";
 import type { Env } from "@/types/env";
 
 /** Hono request context bound to the app `Env`. */
@@ -59,4 +61,16 @@ export function getPrivateChannelUserRepository(c: AppContext) {
 
 export function getProjectUserRepository(c: AppContext) {
   return createProjectUserRepository(c.env);
+}
+
+/** Resolve this request's selected project RPC without exposing its endpoint. */
+export function loadPrivateChannelProjectRpcClient(c: AppContext) {
+  const auth = getAuth(c);
+  return loadProjectRpcClient({
+    env: c.env,
+    kv: c.var.kv,
+    organizationId: auth.organizationId,
+    projectId: requireProjectId(c),
+    environment: c.get("projectEnvironment"),
+  });
 }

--- a/apps/sdp-api/src/routes/private-channels/handlers/balance.ts
+++ b/apps/sdp-api/src/routes/private-channels/handlers/balance.ts
@@ -6,7 +6,10 @@ import { resolveScope, resolveWalletAddress } from "@/routes/payments/wallets";
 import { getChannelBalance, mapPrivateChannelError } from "@/services/private-channels";
 import { resolveGatewayAuth } from "@/services/private-channels/auth/gateway-auth";
 import type { AppContext } from "../context";
-import { getPrivateChannelInstanceRepository } from "../context";
+import {
+  getPrivateChannelInstanceRepository,
+  loadPrivateChannelProjectRpcClient,
+} from "../context";
 import { balanceQuerySchema } from "../schemas";
 
 /**
@@ -58,12 +61,14 @@ export async function getPrivateChannelBalance(c: AppContext) {
       projectId,
       userId: auth.userId,
     });
+    const projectRpc = await loadPrivateChannelProjectRpcClient(c);
 
     const balance = await getChannelBalance(c.env, {
       instance,
       owner,
       mint: parsed.data.mint,
       auth: gatewayAuth,
+      cluster: projectRpc.cluster,
     });
     return success(c, balance);
   } catch (error) {

--- a/apps/sdp-api/src/routes/private-channels/handlers/deposits.ts
+++ b/apps/sdp-api/src/routes/private-channels/handlers/deposits.ts
@@ -12,7 +12,10 @@ import {
 } from "@/services/private-channels";
 import { resolveGatewayAuth } from "@/services/private-channels/auth/gateway-auth";
 import type { AppContext } from "../context";
-import { getPrivateChannelInstanceRepository } from "../context";
+import {
+  getPrivateChannelInstanceRepository,
+  loadPrivateChannelProjectRpcClient,
+} from "../context";
 import { type createDepositBodySchema, depositIdParamSchema } from "../schemas";
 
 async function loadActiveInstance(c: AppContext, organizationId: string, projectId: string) {
@@ -50,6 +53,7 @@ export async function createPrivateChannelDeposit(
     }
     const projectId = requireProjectId(c);
     const instance = await loadActiveInstance(c, auth.organizationId, projectId);
+    const projectRpc = await loadPrivateChannelProjectRpcClient(c);
 
     // Source wallet must be a custody wallet we can sign for.
     const depositorPubkey = resolveWalletAddress(wallets, body.walletId, "walletId", auth, [
@@ -83,6 +87,7 @@ export async function createPrivateChannelDeposit(
       mint: body.mint,
       recipient,
       gatewayAuth,
+      projectRpc,
     });
     return success(c, deposit);
   } catch (error) {

--- a/apps/sdp-api/src/routes/private-channels/handlers/event-references.test.ts
+++ b/apps/sdp-api/src/routes/private-channels/handlers/event-references.test.ts
@@ -114,9 +114,9 @@ describe("Private Channels event references handler", () => {
     await db
       .prepare(
         `INSERT INTO private_channel_instances
-           (id, organization_id, project_id, gateway_url, chain_rpc_url,
+           (id, organization_id, project_id, gateway_url,
             escrow_program_id, withdraw_program_id, escrow_instance_addr, auth_url, is_active)
-         VALUES (?, ?, ?, 'http://gw', 'http://rpc', 'prog1', 'prog2', 'escrow1', 'http://auth', true)`
+         VALUES (?, ?, ?, 'http://gw', 'prog1', 'prog2', 'escrow1', 'http://auth', true)`
       )
       .bind(INSTANCE_ID, ORGANIZATION_ID, PROJECT_ID)
       .run();

--- a/apps/sdp-api/src/routes/private-channels/handlers/events.test.ts
+++ b/apps/sdp-api/src/routes/private-channels/handlers/events.test.ts
@@ -93,9 +93,9 @@ describe("Private Channels event handlers", () => {
     await db
       .prepare(
         `INSERT INTO private_channel_instances
-           (id, organization_id, project_id, gateway_url, chain_rpc_url,
+           (id, organization_id, project_id, gateway_url,
             escrow_program_id, withdraw_program_id, escrow_instance_addr, auth_url, is_active)
-         VALUES (?, ?, ?, 'http://gw', 'http://rpc', 'prog1', 'prog2', 'escrow1', 'http://auth', true)`
+         VALUES (?, ?, ?, 'http://gw', 'prog1', 'prog2', 'escrow1', 'http://auth', true)`
       )
       .bind(INSTANCE_ID, ORGANIZATION_ID, PROJECT_ID)
       .run();

--- a/apps/sdp-api/src/routes/private-channels/handlers/instance.ts
+++ b/apps/sdp-api/src/routes/private-channels/handlers/instance.ts
@@ -19,6 +19,7 @@ import {
   getPrivateChannelUserRepository,
   getPrivateChannelWithdrawalRepository,
   getProjectUserRepository,
+  loadPrivateChannelProjectRpcClient,
 } from "../context";
 import { emitLifecycle, emitMember } from "../helpers";
 import type { connectPrivateChannelInstanceSchema } from "../schemas";
@@ -47,6 +48,7 @@ export const connectPrivateChannelInstance = async (
 
   const body = c.req.valid("json");
   const { confirmReactivate, ...input } = body;
+  const projectRpc = await loadPrivateChannelProjectRpcClient(c);
 
   const repo = getPrivateChannelInstanceRepository(c);
   const scope = { organizationId: auth.organizationId, projectId };
@@ -64,20 +66,22 @@ export const connectPrivateChannelInstance = async (
   // Re-probe server-side: a tampered client could otherwise POST unreachable config.
   const probe = await verifyInstanceConnection({
     gatewayUrl: input.gatewayUrl,
-    chainRpcUrl: input.chainRpcUrl,
     authUrl: input.authUrl,
+    rpcTarget: {
+      endpoint: projectRpc.target.endpoint,
+      headers: projectRpc.target.headers,
+    },
   });
   if (!probe.ok) {
     // AppError responses are returned silently by app.onError; log diagnostics here.
-    // Redacted: chainRpcUrl carries the operator's provider API key as a query
-    // parameter (see SANDBOX_DEFAULTS), so the raw URLs must not reach the log.
+    // The resolved RPC endpoint and credentials never reach logs or persistence.
     getLogger().warn(
       redactCredentialSecrets({
         organizationId: auth.organizationId,
         projectId,
         gatewayUrl: input.gatewayUrl,
-        chainRpcUrl: input.chainRpcUrl,
         authUrl: input.authUrl,
+        rpcProvider: projectRpc.target.providerId,
         gateway: probe.gateway,
         rpc: probe.rpc,
         auth: probe.auth,
@@ -144,52 +148,67 @@ export const connectPrivateChannelInstance = async (
   // Auto-onboard the human connector as the workspace's founding SPC member and
   // add them to the default channel. Skipped for API-key auth (no user identity
   // to attribute — the API key's owner can still invite themselves via /users).
+  // This is follow-up provisioning after the instance and channel are durable;
+  // it must not turn a successful connection into a false 500 response.
   if (auth.userId) {
-    const projectUser = await getProjectUserRepository(c).getByProjectAndUserId(
-      projectId,
-      auth.userId
-    );
-    if (projectUser) {
-      const userRepo = getPrivateChannelUserRepository(c);
-      const existingOwner = await userRepo.findByProjectAndUser(scope, auth.userId);
-      const owner =
-        existingOwner ??
-        (
-          await inviteMember(c.env, userRepo, {
-            ...scope,
-            authUrl: row.auth_url,
-            targetUserId: auth.userId,
-            targetUserEmail: projectUser.email,
-            invitedBy: auth.userId,
-          })
-        ).member;
+    try {
+      const projectUser = await getProjectUserRepository(c).getByProjectAndUserId(
+        projectId,
+        auth.userId
+      );
+      if (projectUser) {
+        const userRepo = getPrivateChannelUserRepository(c);
+        const existingOwner = await userRepo.findByProjectAndUser(scope, auth.userId);
+        const owner =
+          existingOwner ??
+          (
+            await inviteMember(c.env, userRepo, {
+              ...scope,
+              authUrl: row.auth_url,
+              targetUserId: auth.userId,
+              targetUserEmail: projectUser.email,
+              invitedBy: auth.userId,
+            })
+          ).member;
 
-      const memberships = await userRepo.listMembershipsForUser(owner.id);
-      const alreadyMember = memberships.some((m) => m.channel_id === defaultChannel.id);
-      const membership = await userRepo.addMembership({
-        channelId: defaultChannel.id,
-        privateChannelUserId: owner.id,
-        addedBy: auth.userId,
-      });
-      if (!alreadyMember) {
-        await emitMember(
-          c,
-          {
-            organizationId: row.organization_id,
-            projectId: row.project_id,
-            instanceId: row.id,
-          },
-          PRIVATE_CHANNEL_EVENT_TYPES.MEMBER_ADDED,
-          {
-            channelId: defaultChannel.id,
-            payload: {
-              privateChannelUserId: owner.id,
-              targetUserId: owner.user_id,
-              membershipId: membership.id,
+        const memberships = await userRepo.listMembershipsForUser(owner.id);
+        const alreadyMember = memberships.some((m) => m.channel_id === defaultChannel.id);
+        const membership = await userRepo.addMembership({
+          channelId: defaultChannel.id,
+          privateChannelUserId: owner.id,
+          addedBy: auth.userId,
+        });
+        if (!alreadyMember) {
+          await emitMember(
+            c,
+            {
+              organizationId: row.organization_id,
+              projectId: row.project_id,
+              instanceId: row.id,
             },
-          }
-        );
+            PRIVATE_CHANNEL_EVENT_TYPES.MEMBER_ADDED,
+            {
+              channelId: defaultChannel.id,
+              payload: {
+                privateChannelUserId: owner.id,
+                targetUserId: owner.user_id,
+                membershipId: membership.id,
+              },
+            }
+          );
+        }
       }
+    } catch (error) {
+      getLogger().error(
+        {
+          organizationId: row.organization_id,
+          projectId: row.project_id,
+          instanceId: row.id,
+          userId: auth.userId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "connectPrivateChannelInstance: connected but owner bootstrap failed"
+      );
     }
   }
 

--- a/apps/sdp-api/src/routes/private-channels/handlers/instance.ts
+++ b/apps/sdp-api/src/routes/private-channels/handlers/instance.ts
@@ -67,10 +67,7 @@ export const connectPrivateChannelInstance = async (
   const probe = await verifyInstanceConnection({
     gatewayUrl: input.gatewayUrl,
     authUrl: input.authUrl,
-    rpcTarget: {
-      endpoint: projectRpc.target.endpoint,
-      headers: projectRpc.target.headers,
-    },
+    probeRpc: projectRpc.probe,
   });
   if (!probe.ok) {
     // AppError responses are returned silently by app.onError; log diagnostics here.

--- a/apps/sdp-api/src/routes/private-channels/handlers/overview.ts
+++ b/apps/sdp-api/src/routes/private-channels/handlers/overview.ts
@@ -29,10 +29,7 @@ export async function getPrivateChannelOverview(c: AppContext) {
 
   const instance = mapPrivateChannelInstanceRow(row);
   const projectRpc = await loadPrivateChannelProjectRpcClient(c);
-  const overview = await getInstanceOverview(instance, {
-    endpoint: projectRpc.target.endpoint,
-    headers: projectRpc.target.headers,
-  });
+  const overview = await getInstanceOverview(instance, projectRpc.rpc);
 
   const health = overview.gateway.health;
   if (health.status === "unreachable") {

--- a/apps/sdp-api/src/routes/private-channels/handlers/overview.ts
+++ b/apps/sdp-api/src/routes/private-channels/handlers/overview.ts
@@ -5,7 +5,10 @@ import { notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { getInstanceOverview } from "@/services/private-channels";
 import type { AppContext } from "../context";
-import { getPrivateChannelInstanceRepository } from "../context";
+import {
+  getPrivateChannelInstanceRepository,
+  loadPrivateChannelProjectRpcClient,
+} from "../context";
 import { recordInstanceError } from "../helpers";
 
 // GET /instance/overview — active instance snapshot: gateway health + a few
@@ -25,7 +28,11 @@ export async function getPrivateChannelOverview(c: AppContext) {
   }
 
   const instance = mapPrivateChannelInstanceRow(row);
-  const overview = await getInstanceOverview(instance);
+  const projectRpc = await loadPrivateChannelProjectRpcClient(c);
+  const overview = await getInstanceOverview(instance, {
+    endpoint: projectRpc.target.endpoint,
+    headers: projectRpc.target.headers,
+  });
 
   const health = overview.gateway.health;
   if (health.status === "unreachable") {

--- a/apps/sdp-api/src/routes/private-channels/handlers/probe.ts
+++ b/apps/sdp-api/src/routes/private-channels/handlers/probe.ts
@@ -15,10 +15,7 @@ export async function probePrivateChannelConnection(
     c,
     await verifyInstanceConnection({
       ...body,
-      rpcTarget: {
-        endpoint: projectRpc.target.endpoint,
-        headers: projectRpc.target.headers,
-      },
+      probeRpc: projectRpc.probe,
     })
   );
 }

--- a/apps/sdp-api/src/routes/private-channels/handlers/probe.ts
+++ b/apps/sdp-api/src/routes/private-channels/handlers/probe.ts
@@ -1,6 +1,7 @@
 import { success } from "@/lib/response";
 import type { ValidatedBodyContext } from "@/middleware/validate";
 import { verifyInstanceConnection } from "@/services/private-channels";
+import { loadPrivateChannelProjectRpcClient } from "../context";
 import type { probeConnectionSchema } from "../schemas";
 
 // Same probe the Connect handler runs internally — `probe.ok === true` here
@@ -9,5 +10,15 @@ export async function probePrivateChannelConnection(
   c: ValidatedBodyContext<typeof probeConnectionSchema>
 ) {
   const body = c.req.valid("json");
-  return success(c, await verifyInstanceConnection(body));
+  const projectRpc = await loadPrivateChannelProjectRpcClient(c);
+  return success(
+    c,
+    await verifyInstanceConnection({
+      ...body,
+      rpcTarget: {
+        endpoint: projectRpc.target.endpoint,
+        headers: projectRpc.target.headers,
+      },
+    })
+  );
 }

--- a/apps/sdp-api/src/routes/private-channels/handlers/transfers.ts
+++ b/apps/sdp-api/src/routes/private-channels/handlers/transfers.ts
@@ -6,7 +6,10 @@ import type { ValidatedBodyContext } from "@/middleware/validate";
 import { createChannelTransfer, mapPrivateChannelError } from "@/services/private-channels";
 import { resolveGatewayAuth } from "@/services/private-channels/auth/gateway-auth";
 import type { AppContext } from "../context";
-import { getPrivateChannelTransferRepository } from "../context";
+import {
+  getPrivateChannelTransferRepository,
+  loadPrivateChannelProjectRpcClient,
+} from "../context";
 import {
   type createTransferBodySchema,
   transferChannelIdParamSchema,
@@ -50,6 +53,7 @@ export async function createPrivateChannelTransfer(
       projectId: context.projectId,
       userId: context.auth.userId,
     });
+    const projectRpc = await loadPrivateChannelProjectRpcClient(c);
     const transfer = await createChannelTransfer(c.env, {
       instance: context.instance,
       organizationId: context.auth.organizationId,
@@ -62,6 +66,7 @@ export async function createPrivateChannelTransfer(
       amount: body.amount,
       mint: body.mint,
       gatewayAuth,
+      cluster: projectRpc.cluster,
     });
     return success(c, transfer);
   } catch (error) {

--- a/apps/sdp-api/src/routes/private-channels/handlers/withdrawals.ts
+++ b/apps/sdp-api/src/routes/private-channels/handlers/withdrawals.ts
@@ -12,7 +12,10 @@ import {
 } from "@/services/private-channels";
 import { resolveGatewayAuth } from "@/services/private-channels/auth/gateway-auth";
 import type { AppContext } from "../context";
-import { getPrivateChannelInstanceRepository } from "../context";
+import {
+  getPrivateChannelInstanceRepository,
+  loadPrivateChannelProjectRpcClient,
+} from "../context";
 import { type createWithdrawalBodySchema, withdrawalIdParamSchema } from "../schemas";
 
 async function loadActiveInstance(c: AppContext, organizationId: string, projectId: string) {
@@ -47,6 +50,7 @@ export async function createPrivateChannelWithdrawal(
     }
     const projectId = requireProjectId(c);
     const instance = await loadActiveInstance(c, auth.organizationId, projectId);
+    const projectRpc = await loadPrivateChannelProjectRpcClient(c);
 
     // Source wallet must be a custody wallet we can sign for (the burn owner).
     const ownerPubkey = resolveWalletAddress(wallets, body.walletId, "walletId", auth, [
@@ -80,6 +84,7 @@ export async function createPrivateChannelWithdrawal(
       mint: body.mint,
       destination,
       gatewayAuth,
+      cluster: projectRpc.cluster,
     });
     return success(c, withdrawal);
   } catch (error) {

--- a/apps/sdp-api/src/routes/private-channels/schemas.ts
+++ b/apps/sdp-api/src/routes/private-channels/schemas.ts
@@ -17,10 +17,9 @@ export type ConnectPrivateChannelInstanceInput = z.infer<
   typeof connectPrivateChannelInstanceSchema
 >;
 
-/** Body for `POST /probe`: the three URLs the connect flow re-probes. */
+/** Body for `POST /probe`: SPC-owned URLs; Solana RPC comes from the project. */
 export const probeConnectionSchema = z.object({
   gatewayUrl: z.string().min(1),
-  chainRpcUrl: z.string().min(1),
   authUrl: z.string().min(1),
 });
 

--- a/apps/sdp-api/src/services/guarded-egress.test.ts
+++ b/apps/sdp-api/src/services/guarded-egress.test.ts
@@ -5,6 +5,7 @@ import {
   EgressBlockedError,
   guardedFetch,
   guardedLookup,
+  headersForRedirect,
   isBlockedAddress,
   nextRedirectStep,
 } from "@/services/guarded-egress";
@@ -99,6 +100,36 @@ describe("nextRedirectStep", () => {
 
   it("is not a redirect without a location", () => {
     expect(nextRedirectStep(302, null, "https://rpc.example/", init)).toBeNull();
+  });
+});
+
+describe("headersForRedirect", () => {
+  const headers = {
+    Accept: "application/json",
+    "Content-Type": "application/json; charset=utf-8",
+    Authorization: "Bearer secret",
+    "x-api-key": "secret",
+  };
+
+  it("preserves provider headers within the same origin", () => {
+    expect(headersForRedirect("https://rpc.example/v1", "https://rpc.example/v2", headers)).toBe(
+      headers
+    );
+  });
+
+  it("drops tenant credentials when a redirect changes origin", () => {
+    expect(
+      headersForRedirect("https://rpc.example/v1", "https://regional.example/v2", headers)
+    ).toEqual({
+      Accept: "application/json",
+      "Content-Type": "application/json; charset=utf-8",
+    });
+  });
+
+  it("treats a port change as a different origin", () => {
+    expect(
+      headersForRedirect("https://rpc.example/v1", "https://rpc.example:8443/v2", headers)
+    ).not.toHaveProperty("Authorization");
   });
 });
 

--- a/apps/sdp-api/src/services/guarded-egress.ts
+++ b/apps/sdp-api/src/services/guarded-egress.ts
@@ -136,6 +136,30 @@ export interface RedirectStep {
   body: string;
 }
 
+const CROSS_ORIGIN_REDIRECT_HEADERS = new Set(["accept", "content-type"]);
+
+/**
+ * Tenant RPC headers may use provider-specific names, so there is no complete
+ * denylist for credentials. Preserve them only within the same origin. A
+ * cross-origin redirect receives the protocol headers SDP owns, never the
+ * tenant-supplied authentication material.
+ */
+export function headersForRedirect(
+  from: string,
+  to: string,
+  headers: Record<string, string>
+): Record<string, string> {
+  if (new URL(from).origin === new URL(to).origin) {
+    return headers;
+  }
+
+  return Object.fromEntries(
+    Object.entries(headers).filter(([name]) =>
+      CROSS_ORIGIN_REDIRECT_HEADERS.has(name.toLowerCase())
+    )
+  );
+}
+
 /**
  * The next request a redirect asks for, or null when it is not a redirect we
  * follow. Method handling matches what `fetch` did before the guard existed:
@@ -178,6 +202,7 @@ export async function guardedFetch(url: string, init: GuardedFetchInit): Promise
 
   return guardedFetch(step.url, {
     ...init,
+    headers: headersForRedirect(url, step.url, init.headers),
     method: step.method,
     body: step.body,
     maxRedirects: init.maxRedirects - 1,

--- a/apps/sdp-api/src/services/guarded-egress.ts
+++ b/apps/sdp-api/src/services/guarded-egress.ts
@@ -117,6 +117,8 @@ export interface GuardedFetchInit {
   method: string;
   headers: Record<string, string>;
   body: string;
+  /** Propagates the caller's transport timeout/cancellation to the socket. */
+  signal?: AbortSignal;
   /**
    * How many redirects to follow. Zero is the probe's existing `redirect:
    * "manual"`. The relay follows a few, because a provider answering on a
@@ -186,7 +188,7 @@ async function guardedRequest(target: URL, init: GuardedFetchInit): Promise<Resp
   return new Promise<Response>((resolve, reject) => {
     const req = httpsRequest(
       target,
-      { method: init.method, headers: init.headers, lookup: guardedLookup },
+      { method: init.method, headers: init.headers, lookup: guardedLookup, signal: init.signal },
       (res) => {
         const chunks: Buffer[] = [];
         res.on("data", (chunk: Buffer) => chunks.push(chunk));

--- a/apps/sdp-api/src/services/jobs/track-pending-deposits.node.test.ts
+++ b/apps/sdp-api/src/services/jobs/track-pending-deposits.node.test.ts
@@ -33,6 +33,19 @@ const { createRpc, getSignatureStatuses } = vi.hoisted(() => ({
 }));
 vi.mock("@sdp/rpc/solana", () => ({ createRpc, getSignatureStatuses }));
 
+const { loadProjectRpcClient, PROJECT_RPC } = vi.hoisted(() => {
+  const PROJECT_RPC = { __projectRpc: true };
+  return {
+    PROJECT_RPC,
+    loadProjectRpcClient: vi.fn(async () => ({
+      cluster: "devnet",
+      rpc: PROJECT_RPC,
+      target: { endpoint: "https://project-rpc.example" },
+    })),
+  };
+});
+vi.mock("@/services/private-channels/project-rpc", () => ({ loadProjectRpcClient }));
+
 import { trackPendingDeposits } from "./track-pending-deposits";
 
 const NOW_ISO = "2026-07-17T00:00:00.000Z";
@@ -66,7 +79,6 @@ function instanceRow(overrides: Record<string, unknown> = {}) {
     organization_id: "org",
     project_id: "proj",
     gateway_url: "http://gw",
-    chain_rpc_url: "https://api.devnet.solana.com",
     escrow_program_id: "esc",
     withdraw_program_id: "wdp",
     escrow_instance_addr: "instAddr",
@@ -95,24 +107,23 @@ describe("trackPendingDeposits", () => {
     depositRepo.listNonTerminal.mockResolvedValueOnce([]);
     await trackPendingDeposits({} as Env);
     expect(depositRepo.updateDeposit).not.toHaveBeenCalled();
-    expect(createRpc).not.toHaveBeenCalled();
+    expect(loadProjectRpcClient).not.toHaveBeenCalled();
   });
 
-  it("advances submitted → confirmed via the CURRENT instance's chain RPC", async () => {
+  it("advances submitted → confirmed via the project's configured RPC", async () => {
     depositRepo.listNonTerminal.mockResolvedValueOnce([
       depositRow({ id: "d1", status: "submitted", signature: "sig1" }),
     ]);
-    // Instance may have been reconfigured; the reconciler reads the live row.
-    instanceRepo.getById.mockResolvedValueOnce(
-      instanceRow({ chain_rpc_url: "https://api.devnet.solana.com/new" })
-    );
     getSignatureStatuses.mockResolvedValueOnce([{ confirmationStatus: "confirmed" }]);
 
     await trackPendingDeposits({} as Env);
 
-    expect(createRpc).toHaveBeenCalledWith(expect.anything(), {
-      rpcUrl: "https://api.devnet.solana.com/new",
+    expect(loadProjectRpcClient).toHaveBeenCalledWith({
+      env: expect.anything(),
+      organizationId: "org",
+      projectId: "proj",
     });
+    expect(getSignatureStatuses).toHaveBeenCalledWith(PROJECT_RPC, ["sig1"]);
     expect(depositRepo.updateDeposit).toHaveBeenCalledWith(
       expect.objectContaining({ id: "d1", status: "confirmed", expectedStatus: "submitted" })
     );

--- a/apps/sdp-api/src/services/jobs/track-pending-deposits.ts
+++ b/apps/sdp-api/src/services/jobs/track-pending-deposits.ts
@@ -6,16 +6,16 @@
  * Reconciles non-terminal deposits each cron tick:
  *  1. `pending` with no signature, stuck > 5 min → failed (never broadcast).
  *  2. `submitted` with a signature → getSignatureStatuses on the deposit's
- *     instance chain RPC → `confirmed` / `failed`; signature not found + stale
+ *     project's configured RPC → `confirmed` / `failed`; signature not found + stale
  *     → failed.
  *
  * `confirmed → settled` is not driven: the operator's channel-side credit is
  * off-chain and gateway `getTransaction` is Operator-only, so we can't observe
  * it. The UI surfaces the credit via the channel-balance read.
  *
- * The reconciler always reads the CURRENT instance row (via `instance_id`) for
- * RPC endpoints, so an operator repointing a stale endpoint doesn't strand
- * in-flight intents. The audit context on each deposit is never consulted here.
+ * The reconciler resolves the project's CURRENT RPC connection each tick, so
+ * provider changes and credential rotations apply to in-flight intents. The
+ * audit context on each deposit is never consulted here.
  * All status transitions are compare-and-swap (`expectedStatus`) so a concurrent
  * worker can't regress state.
  */
@@ -31,6 +31,10 @@ import {
 } from "@/db/repositories";
 import { getLogger } from "@/runtime/logger";
 import { emitDepositEvent } from "@/services/private-channels/deposit-events";
+import {
+  loadProjectRpcClient,
+  type PrivateChannelProjectRpcClient,
+} from "@/services/private-channels/project-rpc";
 import type { Env } from "@/types/env";
 
 const STUCK_AFTER_MS = 5 * 60 * 1000;
@@ -47,6 +51,7 @@ export async function trackPendingDeposits(env: Env): Promise<void> {
   // Cache instance rows across the tick — a busy project's deposits share one row
   // and we don't want to hit Postgres once per deposit.
   const instances = new Map<string, PrivateChannelInstanceRow | null>();
+  const projectRpcs = new Map<string, Promise<PrivateChannelProjectRpcClient>>();
   const loadInstance = async (id: string) => {
     if (instances.has(id)) {
       return instances.get(id) ?? null;
@@ -54,6 +59,18 @@ export async function trackPendingDeposits(env: Env): Promise<void> {
     const row = await instanceRepo.getById(id);
     instances.set(id, row);
     return row;
+  };
+  const loadProjectRpc = (instance: PrivateChannelInstanceRow) => {
+    const key = `${instance.organization_id}:${instance.project_id}`;
+    const cached = projectRpcs.get(key);
+    if (cached) return cached;
+    const loaded = loadProjectRpcClient({
+      env,
+      organizationId: instance.organization_id,
+      projectId: instance.project_id,
+    });
+    projectRpcs.set(key, loaded);
+    return loaded;
   };
 
   const now = Date.now();
@@ -73,7 +90,7 @@ export async function trackPendingDeposits(env: Env): Promise<void> {
           await failStale(env, repo, deposit, now, "Deposit instance no longer connected.");
           continue;
         }
-        await reconcileSubmitted(env, repo, deposit, instance, now);
+        await reconcileSubmitted(env, repo, deposit, await loadProjectRpc(instance), now);
       }
       // `confirmed` intentionally has no transition here — see module docstring.
     } catch (err) {
@@ -136,7 +153,7 @@ async function reconcileSubmitted(
   env: Env,
   repo: PrivateChannelDepositRepository,
   deposit: PrivateChannelDepositRow,
-  instance: PrivateChannelInstanceRow,
+  projectRpc: PrivateChannelProjectRpcClient,
   now: number
 ): Promise<void> {
   if (!deposit.signature) {
@@ -144,8 +161,9 @@ async function reconcileSubmitted(
     return;
   }
 
-  const rpc = solanaRpc.createRpc(env, { rpcUrl: instance.chain_rpc_url });
-  const [status] = await solanaRpc.getSignatureStatuses(rpc, [deposit.signature as Signature]);
+  const [status] = await solanaRpc.getSignatureStatuses(projectRpc.rpc, [
+    deposit.signature as Signature,
+  ]);
 
   if (!status) {
     // Not found on chain; if it's been a while, treat the tx as dropped.

--- a/apps/sdp-api/src/services/jobs/track-pending-withdrawals.node.test.ts
+++ b/apps/sdp-api/src/services/jobs/track-pending-withdrawals.node.test.ts
@@ -48,6 +48,18 @@ vi.mock("@sdp/rpc/solana", () => ({
   getTransaction,
 }));
 
+const { loadProjectRpcClient } = vi.hoisted(() => {
+  const PROJECT_RPC = { __projectRpc: true };
+  return {
+    loadProjectRpcClient: vi.fn(async () => ({
+      cluster: "devnet",
+      rpc: PROJECT_RPC,
+      target: { endpoint: "https://project-rpc.example" },
+    })),
+  };
+});
+vi.mock("@/services/private-channels/project-rpc", () => ({ loadProjectRpcClient }));
+
 // Deterministic ATA derivation: an owner's ATA is `ata:<owner>`.
 const { findAssociatedTokenPda } = vi.hoisted(() => ({
   findAssociatedTokenPda: vi.fn(async ({ owner }: { owner: string }) => [`ata:${owner}`, 255]),
@@ -98,7 +110,6 @@ function instanceRow(overrides: Record<string, unknown> = {}) {
     organization_id: "org",
     project_id: "proj",
     gateway_url: "http://gw",
-    chain_rpc_url: "https://api.devnet.solana.com",
     escrow_program_id: "esc",
     withdraw_program_id: "wdp",
     escrow_instance_addr: ESCROW_INSTANCE,

--- a/apps/sdp-api/src/services/jobs/track-pending-withdrawals.ts
+++ b/apps/sdp-api/src/services/jobs/track-pending-withdrawals.ts
@@ -18,9 +18,9 @@
  *     `TRANSFER_STUCK_WARNING` (debounced via `context.lastStuckWarningAt`),
  *     never auto-`failed` — the balance is already burned.
  *
- * The reconciler always reads the CURRENT instance row for RPC endpoints, so an
- * operator repointing a stale endpoint doesn't strand in-flight intents. The
- * audit context on each withdrawal is never consulted here.
+ * The release reconciler resolves the project's CURRENT RPC connection each
+ * tick, so provider changes and credential rotations apply to in-flight intents.
+ * The audit context on each withdrawal is never consulted here.
  *
  * All status transitions are compare-and-swap (`expectedStatus`) so a concurrent
  * worker can't regress state. Release attribution is by content
@@ -44,7 +44,11 @@ import {
   type PrivateChannelWithdrawalRow,
 } from "@/db/repositories";
 import { getLogger } from "@/runtime/logger";
-import { inferCluster, knownMintToken } from "@/services/private-channels/mint";
+import { knownMintToken } from "@/services/private-channels/mint";
+import {
+  loadProjectRpcClient,
+  type PrivateChannelProjectRpcClient,
+} from "@/services/private-channels/project-rpc";
 import { emitWithdrawalEvent } from "@/services/private-channels/withdraw-events";
 import type { Env } from "@/types/env";
 
@@ -67,6 +71,7 @@ export async function trackPendingWithdrawals(env: Env): Promise<void> {
   }
 
   const instances = new Map<string, PrivateChannelInstanceRow | null>();
+  const projectRpcs = new Map<string, Promise<PrivateChannelProjectRpcClient>>();
   const loadInstance = async (id: string) => {
     if (instances.has(id)) {
       return instances.get(id) ?? null;
@@ -74,6 +79,18 @@ export async function trackPendingWithdrawals(env: Env): Promise<void> {
     const row = await instanceRepo.getById(id);
     instances.set(id, row);
     return row;
+  };
+  const loadProjectRpc = (instance: PrivateChannelInstanceRow) => {
+    const key = `${instance.organization_id}:${instance.project_id}`;
+    const cached = projectRpcs.get(key);
+    if (cached) return cached;
+    const loaded = loadProjectRpcClient({
+      env,
+      organizationId: instance.organization_id,
+      projectId: instance.project_id,
+    });
+    projectRpcs.set(key, loaded);
+    return loaded;
   };
 
   const now = Date.now();
@@ -121,20 +138,29 @@ export async function trackPendingWithdrawals(env: Env): Promise<void> {
     }
   }
 
-  for (const group of groups.values()) {
-    try {
-      await reconcileReleaseGroup(env, repo, observationRepo, group, now);
-    } catch (err) {
-      getLogger().error(
-        {
-          instanceId: group.instance.id,
-          mint: group.mint,
-          error: err instanceof Error ? err.message : String(err),
-        },
-        "trackPendingWithdrawals: failed to reconcile release group"
-      );
-    }
-  }
+  await Promise.all(
+    [...groups.values()].map(async (group) => {
+      try {
+        await reconcileReleaseGroup(
+          env,
+          repo,
+          observationRepo,
+          group,
+          await loadProjectRpc(group.instance),
+          now
+        );
+      } catch (err) {
+        getLogger().error(
+          {
+            instanceId: group.instance.id,
+            mint: group.mint,
+            error: err instanceof Error ? err.message : String(err),
+          },
+          "trackPendingWithdrawals: failed to reconcile release group"
+        );
+      }
+    })
+  );
 }
 
 interface ReleaseGroup {
@@ -295,6 +321,7 @@ async function reconcileReleaseGroup(
   repo: PrivateChannelWithdrawalRepository,
   observationRepo: PrivateChannelSettlementObservationRepository,
   group: ReleaseGroup,
+  projectRpc: PrivateChannelProjectRpcClient,
   now: number
 ): Promise<void> {
   const withdrawals = group.withdrawals;
@@ -302,7 +329,7 @@ async function reconcileReleaseGroup(
     return;
   }
 
-  const cluster = inferCluster(group.instance.chain_rpc_url);
+  const cluster = projectRpc.cluster;
   const mint = address(group.mint);
 
   // Content matching needs this mint's own scale AND its owning token program: the
@@ -322,8 +349,7 @@ async function reconcileReleaseGroup(
     tokenProgram,
   });
 
-  const rpc = solanaRpc.createRpc(env, { rpcUrl: group.instance.chain_rpc_url });
-  const sigInfos = await solanaRpc.getSignaturesForAddress(rpc, vaultAta, {
+  const sigInfos = await solanaRpc.getSignaturesForAddress(projectRpc.rpc, vaultAta, {
     limit: RELEASE_SCAN_LIMIT,
   });
 
@@ -331,7 +357,7 @@ async function reconcileReleaseGroup(
   // transfers keep their index so batched releases don't collide on the
   // settlement_observations PK.
   const releases = await collectReleases(
-    rpc,
+    projectRpc.rpc,
     sigInfos.filter((s) => !s.err).map((s) => ({ signature: s.signature, blockTime: s.blockTime }))
   );
 

--- a/apps/sdp-api/src/services/private-channels/balance.ts
+++ b/apps/sdp-api/src/services/private-channels/balance.ts
@@ -14,14 +14,14 @@
 
 import { getChannelTokenBalance } from "@sdp/private-channels";
 import { assertValidAddress } from "@sdp/solana/address";
-import type { PrivateChannelBalance, PrivateChannelInstance } from "@sdp/types";
+import type { PrivateChannelBalance, PrivateChannelInstance, SolanaCluster } from "@sdp/types";
 import { SPL_TOKEN_PROGRAMS } from "@sdp/types";
 import type { Env } from "@/types/env";
 import { type SpcAuthContext, withGatewayRpc } from "./auth/gateway-auth";
-import { inferCluster, knownMintToken, resolveChannelToken } from "./mint";
+import { knownMintToken, resolveChannelToken } from "./mint";
 
-/** The instance fields the balance read needs: gateway URL + a cluster hint. */
-type BalanceInstance = Pick<PrivateChannelInstance, "gatewayUrl" | "chainRpcUrl">;
+/** The instance fields the balance read needs. */
+type BalanceInstance = Pick<PrivateChannelInstance, "gatewayUrl">;
 
 /**
  * Read an owner's channel token balance through the gateway → wire DTO.
@@ -36,9 +36,15 @@ export async function getChannelBalance(
     owner,
     mint,
     auth,
-  }: { instance: BalanceInstance; owner: string; mint?: string; auth: SpcAuthContext }
+    cluster,
+  }: {
+    instance: BalanceInstance;
+    owner: string;
+    mint?: string;
+    auth: SpcAuthContext;
+    cluster: SolanaCluster;
+  }
 ): Promise<PrivateChannelBalance> {
-  const cluster = inferCluster(instance.chainRpcUrl);
   const ownerAddress = assertValidAddress(owner, "owner");
   const mintAddress = assertValidAddress(mint ?? resolveChannelToken(cluster).mint, "mint");
 

--- a/apps/sdp-api/src/services/private-channels/deposit-confirm.node.test.ts
+++ b/apps/sdp-api/src/services/private-channels/deposit-confirm.node.test.ts
@@ -1,7 +1,7 @@
+import type { SolanaRpc } from "@sdp/rpc/solana";
 import type { Signature } from "@solana/kit";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PrivateChannelDepositRepository, PrivateChannelDepositRow } from "@/db/repositories";
-import type { Env } from "@/types/env";
 
 // Mock the RPC transport so we can simulate confirm outcomes + transport errors.
 const { createRpc, confirmTransaction } = vi.hoisted(() => ({
@@ -12,8 +12,8 @@ vi.mock("@sdp/rpc/solana", () => ({ createRpc, confirmTransaction }));
 
 import { confirmAndPersistDeposit } from "./deposit-confirm";
 
-const env = {} as Env;
 const SIGNATURE = "sig-123" as Signature;
+const RPC = {} as SolanaRpc;
 
 function makeRepo() {
   const updateDeposit = vi.fn(
@@ -35,9 +35,9 @@ describe("confirmAndPersistDeposit", () => {
     const repo = makeRepo();
     confirmTransaction.mockRejectedValueOnce(new Error("network timeout"));
 
-    const result = await confirmAndPersistDeposit(env, repo, {
+    const result = await confirmAndPersistDeposit(repo, {
       depositId: "dep_1",
-      chainRpcUrl: "https://devnet",
+      rpc: RPC,
       signature: SIGNATURE,
     });
 
@@ -50,9 +50,9 @@ describe("confirmAndPersistDeposit", () => {
     const repo = makeRepo();
     confirmTransaction.mockResolvedValueOnce({ err: null });
 
-    await confirmAndPersistDeposit(env, repo, {
+    await confirmAndPersistDeposit(repo, {
       depositId: "dep_1",
-      chainRpcUrl: "https://devnet",
+      rpc: RPC,
       signature: SIGNATURE,
     });
 
@@ -65,9 +65,9 @@ describe("confirmAndPersistDeposit", () => {
     const repo = makeRepo();
     confirmTransaction.mockResolvedValueOnce({ err: { InstructionError: [0, "Custom"] } });
 
-    await confirmAndPersistDeposit(env, repo, {
+    await confirmAndPersistDeposit(repo, {
       depositId: "dep_1",
-      chainRpcUrl: "https://devnet",
+      rpc: RPC,
       signature: SIGNATURE,
     });
 

--- a/apps/sdp-api/src/services/private-channels/deposit-confirm.ts
+++ b/apps/sdp-api/src/services/private-channels/deposit-confirm.ts
@@ -8,10 +8,9 @@
  * (`confirmation.err`) is a terminal failure.
  */
 
-import * as solanaRpc from "@sdp/rpc/solana";
+import { confirmTransaction, type SolanaRpc } from "@sdp/rpc/solana";
 import type { Signature } from "@solana/kit";
 import type { PrivateChannelDepositRepository, PrivateChannelDepositRow } from "@/db/repositories";
-import type { Env } from "@/types/env";
 
 /**
  * Confirm a broadcast deposit on its chain and persist the outcome:
@@ -24,13 +23,11 @@ import type { Env } from "@/types/env";
  * observable. `settled` becomes reachable when SPC ships events.
  */
 export async function confirmAndPersistDeposit(
-  env: Env,
   repo: PrivateChannelDepositRepository,
-  input: { depositId: string; chainRpcUrl: string; signature: Signature }
+  input: { depositId: string; rpc: SolanaRpc; signature: Signature }
 ): Promise<PrivateChannelDepositRow | null> {
   try {
-    const chainRpc = solanaRpc.createRpc(env, { rpcUrl: input.chainRpcUrl });
-    const confirmation = await solanaRpc.confirmTransaction(chainRpc, input.signature, {
+    const confirmation = await confirmTransaction(input.rpc, input.signature, {
       commitment: "confirmed",
     });
     if (confirmation.err) {

--- a/apps/sdp-api/src/services/private-channels/deposit.ts
+++ b/apps/sdp-api/src/services/private-channels/deposit.ts
@@ -4,7 +4,7 @@
  * Moves USDC from a custody wallet into the instance escrow on the instance's
  * chain (devnet). The tx is server-signed by the custody wallet, which is BOTH
  * the escrow `user` (moves the tokens) and the escrow `payer` / tx fee payer
- * (pays rent + the SOL fee). Broadcast targets `instance.chainRpcUrl`, NOT the
+ * (pays rent + the SOL fee). Broadcast uses the project's configured RPC, NOT the
  * default RPC or the gateway.
  *
  * TODO(gasless): switch to the Kora/native sponsored fee-payer model (the
@@ -53,13 +53,14 @@ import type { Env } from "@/types/env";
 import type { SpcAuthContext } from "./auth/gateway-auth";
 import { confirmAndPersistDeposit } from "./deposit-confirm";
 import { emitDepositEvent } from "./deposit-events";
-import { inferCluster, resolveChannelToken } from "./mint";
+import { resolveChannelToken } from "./mint";
+import type { PrivateChannelProjectRpcClient } from "./project-rpc";
 import { describeTxError } from "./tx-error";
 
 /** The instance fields the deposit needs. */
 type DepositInstance = Pick<
   PrivateChannelInstance,
-  "id" | "gatewayUrl" | "chainRpcUrl" | "escrowProgramId" | "escrowInstanceAddr"
+  "id" | "gatewayUrl" | "escrowProgramId" | "escrowInstanceAddr"
 >;
 
 export interface CreateChannelDepositInput {
@@ -82,6 +83,7 @@ export interface CreateChannelDepositInput {
    * `pcUserId` is recorded on the audit context.
    */
   gatewayAuth: SpcAuthContext;
+  projectRpc: PrivateChannelProjectRpcClient;
 }
 
 /**
@@ -100,6 +102,7 @@ async function broadcastDeposit(
     tokenProgram: Address;
     recipient: Address;
     amountBaseUnits: bigint;
+    projectRpc: PrivateChannelProjectRpcClient;
   }
 ): Promise<Signature> {
   const signer = await solanaServices.createOrgSigner(
@@ -118,22 +121,18 @@ async function broadcastDeposit(
   // `tokenProgram` is passed explicitly rather than left to the generated client's
   // classic-SPL default: it is an ATA seed, so the default would derive the wrong
   // `userAta`/`instanceAta` for a token-2022 mint.
-  const depositIx = await getDepositInstructionAsync({
-    payer: signer,
-    user: signer,
-    instance: address(input.instance.escrowInstanceAddr),
-    mint: input.mint,
-    tokenProgram: input.tokenProgram,
-    amount: input.amountBaseUnits,
-    recipient: input.recipient,
-  });
-
-  // Blockhash + broadcast + confirm all target the instance chain (devnet).
-  const chainRpc = solanaRpc.createRpc(env, { rpcUrl: input.instance.chainRpcUrl });
-  const { blockhash, lastValidBlockHeight } = await solanaRpc.getRecentBlockhash(
-    chainRpc,
-    "confirmed"
-  );
+  const [depositIx, { blockhash, lastValidBlockHeight }] = await Promise.all([
+    getDepositInstructionAsync({
+      payer: signer,
+      user: signer,
+      instance: address(input.instance.escrowInstanceAddr),
+      mint: input.mint,
+      tokenProgram: input.tokenProgram,
+      amount: input.amountBaseUnits,
+      recipient: input.recipient,
+    }),
+    solanaRpc.getRecentBlockhash(input.projectRpc.rpc, "confirmed"),
+  ]);
 
   const message = pipe(
     createTransactionMessage({ version: 0 }),
@@ -145,7 +144,7 @@ async function broadcastDeposit(
   // The custody wallet is the only signer (payer + user); fully sign and broadcast.
   const signed = await signTransactionMessageWithSigners(message);
   const signedBytes = new Uint8Array(getTransactionEncoder().encode(signed));
-  return solanaRpc.sendTransaction(chainRpc, signedBytes);
+  return solanaRpc.sendTransaction(input.projectRpc.rpc, signedBytes);
 }
 
 /** Create a deposit intent: persist, broadcast to devnet, confirm on-chain. */
@@ -164,8 +163,10 @@ export async function createChannelDeposit(
     );
   }
 
-  const cluster = inferCluster(instance.chainRpcUrl);
-  const { mint, decimals, tokenProgram } = resolveChannelToken(cluster, input.mint);
+  const { mint, decimals, tokenProgram } = resolveChannelToken(
+    input.projectRpc.cluster,
+    input.mint
+  );
   const depositor = wallet.publicKey;
   const recipient = input.recipient ?? depositor;
 
@@ -187,7 +188,6 @@ export async function createChannelDeposit(
     // Audit-only snapshot; the oracle always reads the current instance row.
     context: {
       gatewayUrl: instance.gatewayUrl,
-      chainRpcUrl: instance.chainRpcUrl,
       escrowProgramId: instance.escrowProgramId,
       escrowInstanceAddr: instance.escrowInstanceAddr,
       actingUserId: input.userId,
@@ -212,6 +212,7 @@ export async function createChannelDeposit(
       tokenProgram: address(tokenProgram),
       recipient: address(recipient),
       amountBaseUnits,
+      projectRpc: input.projectRpc,
     });
   } catch (error) {
     const failureReason = describeTxError(error, "Deposit submission failed.");
@@ -242,9 +243,9 @@ export async function createChannelDeposit(
   // Confirm on the instance chain and persist the outcome. A transport/timeout
   // error here leaves the deposit `submitted` (the reconciler finalizes it); only
   // a real on-chain error marks it `failed`. See `confirmAndPersistDeposit`.
-  const settled = await confirmAndPersistDeposit(env, repo, {
+  const settled = await confirmAndPersistDeposit(repo, {
     depositId: created.id,
-    chainRpcUrl: instance.chainRpcUrl,
+    rpc: input.projectRpc.rpc,
     signature,
   });
   if (settled) {

--- a/apps/sdp-api/src/services/private-channels/mint.ts
+++ b/apps/sdp-api/src/services/private-channels/mint.ts
@@ -1,20 +1,15 @@
 /**
  * Instance token resolution.
  *
- * The persisted `PrivateChannelInstance` stores no explicit cluster or mint, so
- * both are derived: the cluster from the chain RPC URL, and the token from the
- * project's allowlist (`PRIVATE_CHANNEL_TOKEN_SYMBOLS` in `@sdp/types`, which is
- * also what the dashboard's token selector renders). Shared by the balance read
- * and the deposit/withdraw/transfer flows.
+ * Private Channels uses the selected project's cluster and the product allowlist
+ * (`PRIVATE_CHANNEL_TOKEN_SYMBOLS` in `@sdp/types`), which is also what the
+ * dashboard token selector renders. Shared by the balance read and the
+ * deposit/withdraw/transfer flows.
  */
 
 import type { PrivateChannelToken, SolanaCluster } from "@sdp/types";
 import { privateChannelTokens, SPL_TOKEN_PROGRAMS, WELL_KNOWN_TOKENS } from "@sdp/types";
 import { badRequest } from "@/lib/errors";
-
-// Re-exported so the API and the dashboard derive the cluster identically; a
-// disagreement would mean one of them resolves the wrong cluster's mint.
-export { inferCluster } from "@sdp/types";
 
 /**
  * The channel token for a request: the caller's `mint` when the instance accepts

--- a/apps/sdp-api/src/services/private-channels/project-rpc.ts
+++ b/apps/sdp-api/src/services/private-channels/project-rpc.ts
@@ -1,0 +1,70 @@
+import { type ResolvedRpcTarget, resolveRpcTarget } from "@sdp/rpc/relay";
+import { createRpc, type SolanaRpc } from "@sdp/rpc/solana";
+import { CLUSTER_BY_SDP_ENVIRONMENT, type SdpEnvironment, type SolanaCluster } from "@sdp/types";
+import { getDb } from "@/db";
+import type { KVStoreSet } from "@/runtime/kv";
+import { createKVStoreSet } from "@/runtime/kv-redis";
+import { createTenantRpcConnectionLookup } from "@/services/rpc-connection-lookup";
+import type { Env } from "@/types/env";
+
+export interface PrivateChannelProjectRpcClient {
+  cluster: SolanaCluster;
+  rpc: SolanaRpc;
+  target: ResolvedRpcTarget;
+}
+
+export interface LoadProjectRpcClientInput {
+  env: Env;
+  organizationId: string;
+  projectId: string;
+  /** Already known on authenticated requests; jobs resolve it from the project row. */
+  environment?: SdpEnvironment;
+  /** Reuse the request's stores when available; jobs construct the same Redis-backed set. */
+  kv?: KVStoreSet;
+}
+
+/**
+ * Load a client for the same effective RPC target used by the SDP relay.
+ *
+ * Resolution happens for every request/job pass so provider switches and BYOK
+ * credential rotation take effect immediately. The returned endpoint and
+ * headers are execution-only: Private Channels never persists or serializes
+ * them on its instance records.
+ */
+export async function loadProjectRpcClient(
+  input: LoadProjectRpcClientInput
+): Promise<PrivateChannelProjectRpcClient> {
+  const db = getDb(input.env);
+  const environment =
+    input.environment ??
+    (
+      await db
+        .prepare(
+          `SELECT environment
+           FROM projects
+          WHERE id = ? AND organization_id = ? AND status = 'active'`
+        )
+        .bind(input.projectId, input.organizationId)
+        .first<{ environment: SdpEnvironment }>()
+    )?.environment;
+
+  if (!environment) {
+    throw new Error(`Active project ${input.projectId} was not found while resolving its RPC`);
+  }
+
+  const target = await resolveRpcTarget({
+    env: input.env,
+    kv: input.kv ?? createKVStoreSet(input.env),
+    db,
+    organizationId: input.organizationId,
+    authProjectId: input.projectId,
+    requestedProjectId: null,
+    connections: createTenantRpcConnectionLookup(input.env, db),
+  });
+
+  return {
+    cluster: CLUSTER_BY_SDP_ENVIRONMENT[environment],
+    rpc: createRpc(input.env, { rpcUrl: target.endpoint, headers: target.headers }),
+    target,
+  };
+}

--- a/apps/sdp-api/src/services/private-channels/project-rpc.ts
+++ b/apps/sdp-api/src/services/private-channels/project-rpc.ts
@@ -1,16 +1,19 @@
+import type { SolanaRpcProbeResult } from "@sdp/private-channels";
 import { type ResolvedRpcTarget, resolveRpcTarget } from "@sdp/rpc/relay";
-import { createRpc, type SolanaRpc } from "@sdp/rpc/solana";
+import { createRpcFromTransport, type SolanaRpc } from "@sdp/rpc/solana";
 import { CLUSTER_BY_SDP_ENVIRONMENT, type SdpEnvironment, type SolanaCluster } from "@sdp/types";
 import { getDb } from "@/db";
 import type { KVStoreSet } from "@/runtime/kv";
 import { createKVStoreSet } from "@/runtime/kv-redis";
 import { createTenantRpcConnectionLookup } from "@/services/rpc-connection-lookup";
+import { createRpcTransportForTarget } from "@/services/rpc-egress";
 import type { Env } from "@/types/env";
 
 export interface PrivateChannelProjectRpcClient {
   cluster: SolanaCluster;
   rpc: SolanaRpc;
   target: ResolvedRpcTarget;
+  probe: () => Promise<SolanaRpcProbeResult>;
 }
 
 export interface LoadProjectRpcClientInput {
@@ -61,10 +64,34 @@ export async function loadProjectRpcClient(
     requestedProjectId: null,
     connections: createTenantRpcConnectionLookup(input.env, db),
   });
+  const rpc = createRpcFromTransport(createRpcTransportForTarget(target));
 
   return {
     cluster: CLUSTER_BY_SDP_ENVIRONMENT[environment],
-    rpc: createRpc(input.env, { rpcUrl: target.endpoint, headers: target.headers }),
+    rpc,
     target,
+    probe: () => probeProjectRpc(rpc),
   };
+}
+
+async function probeProjectRpc(rpc: SolanaRpc): Promise<SolanaRpcProbeResult> {
+  const startedAt = Date.now();
+  try {
+    const response = await rpc.getVersion().send();
+    const version = response["solana-core"];
+    if (!version) {
+      return {
+        ok: false,
+        latencyMs: Date.now() - startedAt,
+        error: "Response missing solana-core version.",
+      };
+    }
+    return { ok: true, latencyMs: Date.now() - startedAt, version };
+  } catch (error) {
+    return {
+      ok: false,
+      latencyMs: Date.now() - startedAt,
+      error: error instanceof Error ? error.message || "RPC probe failed." : "RPC probe failed.",
+    };
+  }
 }

--- a/apps/sdp-api/src/services/private-channels/service.ts
+++ b/apps/sdp-api/src/services/private-channels/service.ts
@@ -4,6 +4,7 @@ import {
   type GatewayHealthResult,
   probeConnection,
   probeGatewayHealth,
+  type SolanaRpcProbeTarget,
 } from "@sdp/private-channels";
 import type {
   PrivateChannelHealth,
@@ -48,7 +49,12 @@ interface JsonRpcResponse<T> {
 }
 
 // Minimal JSON-RPC POST to the gateway. Throws on network / non-2xx / error.
-async function jsonRpc<T>(url: string, method: string, params: unknown[] = []): Promise<T> {
+async function jsonRpc<T>(
+  url: string,
+  method: string,
+  params: unknown[] = [],
+  headers: Record<string, string> = {}
+): Promise<T> {
   const res = await fetch(url, {
     method: "POST",
     signal: AbortSignal.timeout(RPC_TIMEOUT_MS),
@@ -56,6 +62,7 @@ async function jsonRpc<T>(url: string, method: string, params: unknown[] = []): 
       "Content-Type": "application/json",
       Accept: "application/json",
       "User-Agent": "sdp-private-channels/0.1",
+      ...headers,
     },
     body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
   });
@@ -90,17 +97,18 @@ interface AccountInfoResult {
 
 type OverviewInput = Pick<
   PrivateChannelInstance,
-  "gatewayUrl" | "chainRpcUrl" | "escrowProgramId" | "escrowInstanceAddr" | "authUrl"
+  "gatewayUrl" | "escrowProgramId" | "escrowInstanceAddr" | "authUrl"
 >;
 
 function settledOrNull<T, U>(p: Promise<T>, map: (v: T) => U): Promise<U | null> {
   return Promise.allSettled([p]).then(([r]) => (r.status === "fulfilled" ? map(r.value) : null));
 }
 
-// Post-connect overview. Gateway JSON-RPC = SPC channel chain; chainRpcUrl =
+// Post-connect overview. Gateway JSON-RPC = SPC channel chain; projectRpc =
 // Solana L1 (where the escrow program + instance actually live).
 export async function getInstanceOverview(
-  input: OverviewInput
+  input: OverviewInput,
+  projectRpc: SolanaRpcProbeTarget
 ): Promise<PrivateChannelInstanceOverview> {
   const authBase = input.authUrl;
 
@@ -122,17 +130,25 @@ export async function getInstanceOverview(
       ),
       (v) => v.value.blockhash
     ),
-    Promise.allSettled([jsonRpc<{ "solana-core"?: string }>(input.chainRpcUrl, "getVersion")]).then(
-      ([r]): PrivateChannelInstanceOverview["chainRpc"] =>
-        r.status === "fulfilled"
-          ? { ok: true, solanaVersion: r.value["solana-core"] ?? null }
-          : { ok: false, error: toError(r.reason) }
+    Promise.allSettled([
+      jsonRpc<{ "solana-core"?: string }>(
+        projectRpc.endpoint,
+        "getVersion",
+        [],
+        projectRpc.headers
+      ),
+    ]).then(([r]): PrivateChannelInstanceOverview["chainRpc"] =>
+      r.status === "fulfilled"
+        ? { ok: true, solanaVersion: r.value["solana-core"] ?? null }
+        : { ok: false, error: toError(r.reason) }
     ),
     Promise.allSettled([
-      jsonRpc<AccountInfoResult>(input.chainRpcUrl, "getAccountInfo", [
-        input.escrowInstanceAddr,
-        { encoding: "base64", dataSlice: { offset: 0, length: 0 } },
-      ]),
+      jsonRpc<AccountInfoResult>(
+        projectRpc.endpoint,
+        "getAccountInfo",
+        [input.escrowInstanceAddr, { encoding: "base64", dataSlice: { offset: 0, length: 0 } }],
+        projectRpc.headers
+      ),
     ]).then(([r]): PrivateChannelInstanceOverview["escrowInstance"] => {
       if (r.status === "rejected") return { present: false, error: toError(r.reason) };
       if (r.value.value === null) return { present: false, error: "Account not found on-chain." };
@@ -144,10 +160,12 @@ export async function getInstanceOverview(
       };
     }),
     Promise.allSettled([
-      jsonRpc<AccountInfoResult>(input.chainRpcUrl, "getAccountInfo", [
-        input.escrowProgramId,
-        { encoding: "base64", dataSlice: { offset: 0, length: 0 } },
-      ]),
+      jsonRpc<AccountInfoResult>(
+        projectRpc.endpoint,
+        "getAccountInfo",
+        [input.escrowProgramId, { encoding: "base64", dataSlice: { offset: 0, length: 0 } }],
+        projectRpc.headers
+      ),
     ]).then(([r]): PrivateChannelInstanceOverview["escrowProgram"] => {
       if (r.status === "rejected") return { present: false, error: toError(r.reason) };
       if (r.value.value === null)

--- a/apps/sdp-api/src/services/private-channels/service.ts
+++ b/apps/sdp-api/src/services/private-channels/service.ts
@@ -4,8 +4,9 @@ import {
   type GatewayHealthResult,
   probeConnection,
   probeGatewayHealth,
-  type SolanaRpcProbeTarget,
 } from "@sdp/private-channels";
+import type { SolanaRpc } from "@sdp/rpc/solana";
+import { assertValidAddress } from "@sdp/solana/address";
 import type {
   PrivateChannelHealth,
   PrivateChannelInstance,
@@ -83,18 +84,6 @@ function toError(reason: unknown): string {
   return "Request failed.";
 }
 
-interface AccountInfoResult {
-  context: { slot: number };
-  value: {
-    lamports: number;
-    owner: string;
-    executable: boolean;
-    data: [string, string];
-    rentEpoch: number;
-    space?: number;
-  } | null;
-}
-
 type OverviewInput = Pick<
   PrivateChannelInstance,
   "gatewayUrl" | "escrowProgramId" | "escrowInstanceAddr" | "authUrl"
@@ -108,9 +97,11 @@ function settledOrNull<T, U>(p: Promise<T>, map: (v: T) => U): Promise<U | null>
 // Solana L1 (where the escrow program + instance actually live).
 export async function getInstanceOverview(
   input: OverviewInput,
-  projectRpc: SolanaRpcProbeTarget
+  projectRpc: SolanaRpc
 ): Promise<PrivateChannelInstanceOverview> {
   const authBase = input.authUrl;
+  const escrowInstanceAddress = assertValidAddress(input.escrowInstanceAddr, "escrowInstanceAddr");
+  const escrowProgramAddress = assertValidAddress(input.escrowProgramId, "escrowProgramId");
 
   const [
     gatewayHealth,
@@ -130,25 +121,19 @@ export async function getInstanceOverview(
       ),
       (v) => v.value.blockhash
     ),
-    Promise.allSettled([
-      jsonRpc<{ "solana-core"?: string }>(
-        projectRpc.endpoint,
-        "getVersion",
-        [],
-        projectRpc.headers
-      ),
-    ]).then(([r]): PrivateChannelInstanceOverview["chainRpc"] =>
-      r.status === "fulfilled"
-        ? { ok: true, solanaVersion: r.value["solana-core"] ?? null }
-        : { ok: false, error: toError(r.reason) }
+    Promise.allSettled([projectRpc.getVersion().send()]).then(
+      ([r]): PrivateChannelInstanceOverview["chainRpc"] =>
+        r.status === "fulfilled"
+          ? { ok: true, solanaVersion: r.value["solana-core"] ?? null }
+          : { ok: false, error: toError(r.reason) }
     ),
     Promise.allSettled([
-      jsonRpc<AccountInfoResult>(
-        projectRpc.endpoint,
-        "getAccountInfo",
-        [input.escrowInstanceAddr, { encoding: "base64", dataSlice: { offset: 0, length: 0 } }],
-        projectRpc.headers
-      ),
+      projectRpc
+        .getAccountInfo(escrowInstanceAddress, {
+          encoding: "base64",
+          dataSlice: { offset: 0, length: 0 },
+        })
+        .send(),
     ]).then(([r]): PrivateChannelInstanceOverview["escrowInstance"] => {
       if (r.status === "rejected") return { present: false, error: toError(r.reason) };
       if (r.value.value === null) return { present: false, error: "Account not found on-chain." };
@@ -156,16 +141,16 @@ export async function getInstanceOverview(
         present: true,
         owner: r.value.value.owner,
         ownerMatchesProgram: r.value.value.owner === input.escrowProgramId,
-        lamports: r.value.value.lamports,
+        lamports: Number(r.value.value.lamports),
       };
     }),
     Promise.allSettled([
-      jsonRpc<AccountInfoResult>(
-        projectRpc.endpoint,
-        "getAccountInfo",
-        [input.escrowProgramId, { encoding: "base64", dataSlice: { offset: 0, length: 0 } }],
-        projectRpc.headers
-      ),
+      projectRpc
+        .getAccountInfo(escrowProgramAddress, {
+          encoding: "base64",
+          dataSlice: { offset: 0, length: 0 },
+        })
+        .send(),
     ]).then(([r]): PrivateChannelInstanceOverview["escrowProgram"] => {
       if (r.status === "rejected") return { present: false, error: toError(r.reason) };
       if (r.value.value === null)

--- a/apps/sdp-api/src/services/private-channels/transfer.node.test.ts
+++ b/apps/sdp-api/src/services/private-channels/transfer.node.test.ts
@@ -45,7 +45,6 @@ const CHANNEL_ID = "pch_transfer_test";
 const RECIPIENT_PC_USER_ID = "pcu_transfer_recipient";
 const RECIPIENT_VERIFIED_WALLET_ID = "pcvw_transfer_recipient";
 const GATEWAY_URL = "https://gateway.example";
-const CHAIN_RPC_URL = "https://api.devnet.solana.com";
 const MINT = address("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU");
 const SIGNATURE = "1".repeat(64) as Signature;
 const GATEWAY_RPC = { kind: "gateway-rpc" };
@@ -88,7 +87,6 @@ function makeInput(overrides: Partial<Parameters<typeof createChannelTransfer>[1
     instance: {
       id: INSTANCE_ID,
       gatewayUrl: GATEWAY_URL,
-      chainRpcUrl: CHAIN_RPC_URL,
     },
     organizationId: ORGANIZATION_ID,
     projectId: PROJECT_ID,
@@ -104,6 +102,7 @@ function makeInput(overrides: Partial<Parameters<typeof createChannelTransfer>[1
     },
     amount: "1.25",
     gatewayAuth: auth,
+    cluster: "devnet" as const,
     ...overrides,
   };
 }

--- a/apps/sdp-api/src/services/private-channels/transfer.ts
+++ b/apps/sdp-api/src/services/private-channels/transfer.ts
@@ -34,12 +34,12 @@ import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import type { Env } from "@/types/env";
 import { type SpcAuthContext, withGatewayRpc } from "./auth/gateway-auth";
 import { getChannelBalance } from "./balance";
-import { inferCluster, resolveChannelToken } from "./mint";
+import { resolveChannelToken } from "./mint";
 import { confirmAndPersistTransfer } from "./transfer-confirm";
 import { emitTransferEvent } from "./transfer-events";
 import { describeTxError, isNodeAtCapacityError } from "./tx-error";
 
-type TransferInstance = Pick<PrivateChannelInstance, "id" | "gatewayUrl" | "chainRpcUrl">;
+type TransferInstance = Pick<PrivateChannelInstance, "id" | "gatewayUrl">;
 
 export interface CreateChannelTransferInput {
   instance: TransferInstance;
@@ -66,6 +66,7 @@ export interface CreateChannelTransferInput {
   /** Mint to transfer; must be on the instance's allowlist. Defaults to its first entry. */
   mint?: string;
   gatewayAuth: SpcAuthContext;
+  cluster: import("@sdp/types").SolanaCluster;
 }
 
 /**
@@ -249,8 +250,7 @@ export async function createChannelTransfer(
   env: Env,
   input: CreateChannelTransferInput
 ): Promise<PrivateChannelTransfer> {
-  const cluster = inferCluster(input.instance.chainRpcUrl);
-  const token = resolveChannelToken(cluster, input.mint);
+  const token = resolveChannelToken(input.cluster, input.mint);
   const mint = address(token.mint);
   const tokenProgram = address(token.tokenProgram);
   const { decimals } = token;
@@ -274,6 +274,7 @@ export async function createChannelTransfer(
     owner: sender,
     mint,
     auth: input.gatewayAuth,
+    cluster: input.cluster,
   });
   if (amountBaseUnits > BigInt(balance.amount)) {
     throw new AppError("INSUFFICIENT_TOKEN_BALANCE");

--- a/apps/sdp-api/src/services/private-channels/withdraw.ts
+++ b/apps/sdp-api/src/services/private-channels/withdraw.ts
@@ -52,7 +52,7 @@ import * as solanaServices from "@/services/solana";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import type { Env } from "@/types/env";
 import { type SpcAuthContext, withGatewayRpc } from "./auth/gateway-auth";
-import { inferCluster, resolveChannelToken } from "./mint";
+import { resolveChannelToken } from "./mint";
 import { describeTxError } from "./tx-error";
 import { confirmAndPersistWithdrawal } from "./withdraw-confirm";
 import { emitWithdrawalEvent } from "./withdraw-events";
@@ -60,7 +60,7 @@ import { emitWithdrawalEvent } from "./withdraw-events";
 /** The instance fields the withdrawal needs. */
 type WithdrawalInstance = Pick<
   PrivateChannelInstance,
-  "id" | "gatewayUrl" | "chainRpcUrl" | "escrowProgramId" | "escrowInstanceAddr"
+  "id" | "gatewayUrl" | "escrowProgramId" | "escrowInstanceAddr"
 >;
 
 export interface CreateChannelWithdrawalInput {
@@ -84,6 +84,7 @@ export interface CreateChannelWithdrawalInput {
    * refreshed.
    */
   gatewayAuth: SpcAuthContext;
+  cluster: import("@sdp/types").SolanaCluster;
 }
 
 /**
@@ -156,8 +157,7 @@ export async function createChannelWithdrawal(
 ): Promise<PrivateChannelWithdrawal> {
   const { instance, organizationId, projectId, wallet } = input;
 
-  const cluster = inferCluster(instance.chainRpcUrl);
-  const { mint, decimals, tokenProgram } = resolveChannelToken(cluster, input.mint);
+  const { mint, decimals, tokenProgram } = resolveChannelToken(input.cluster, input.mint);
   const owner = wallet.publicKey;
   const destination = input.destination ?? owner;
 
@@ -179,7 +179,6 @@ export async function createChannelWithdrawal(
     // Audit-only snapshot; the oracle always reads the current instance row.
     context: {
       gatewayUrl: instance.gatewayUrl,
-      chainRpcUrl: instance.chainRpcUrl,
       escrowProgramId: instance.escrowProgramId,
       escrowInstanceAddr: instance.escrowInstanceAddr,
       actingUserId: input.userId,

--- a/apps/sdp-api/src/services/rpc-egress.test.ts
+++ b/apps/sdp-api/src/services/rpc-egress.test.ts
@@ -3,7 +3,7 @@ import type { AddressInfo } from "node:net";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { EgressBlockedError } from "@/services/guarded-egress";
 import { checkResolvedRpcTargetConnection } from "@/services/provider-setup-registry";
-import { fetchRpcRelayTarget } from "@/services/rpc-egress";
+import { createRpcTransportForTarget, fetchRpcRelayTarget } from "@/services/rpc-egress";
 
 /**
  * Both directions matter. A guard that refused everything would pass a
@@ -66,6 +66,27 @@ describe("fetchRpcRelayTarget", () => {
         { headers: { "Content-Type": "application/json" }, body: "{}" }
       )
     ).rejects.toBeInstanceOf(EgressBlockedError);
+  });
+});
+
+describe("createRpcTransportForTarget", () => {
+  const payload = { jsonrpc: "2.0", id: "probe", method: "getVersion", params: [] };
+
+  it("runs a platform Solana transport through the relay executor", async () => {
+    const transport = createRpcTransportForTarget({ endpoint: origin });
+
+    const response = await transport<{ result: { "solana-core": string } }>({ payload });
+
+    expect(response.result["solana-core"]).toBe("0.0.0");
+  });
+
+  it("guards customer endpoints used by the Solana transport", async () => {
+    const transport = createRpcTransportForTarget({
+      endpoint: `https://localhost:${(server.address() as AddressInfo).port}/`,
+      connectionId: "rconn_test",
+    });
+
+    await expect(transport({ payload })).rejects.toBeInstanceOf(EgressBlockedError);
   });
 });
 

--- a/apps/sdp-api/src/services/rpc-egress.ts
+++ b/apps/sdp-api/src/services/rpc-egress.ts
@@ -12,6 +12,7 @@
  * Platform targets keep the ordinary fetch: they come from deployment config
  * and are legitimately private in local development and in the Surfpool suites.
  */
+import type { RpcTransport } from "@solana/kit";
 import { guardedFetch } from "@/services/guarded-egress";
 
 /**
@@ -32,6 +33,7 @@ export interface RpcEgressTarget {
 export interface RpcEgressInit {
   headers: Record<string, string>;
   body: string;
+  signal?: AbortSignal;
 }
 
 /** Whether the endpoint came from a customer and so has to be address-checked. */
@@ -53,6 +55,7 @@ export async function fetchRpcRelayTarget(
       method: "POST",
       headers: init.headers,
       body: init.body,
+      signal: init.signal,
       maxRedirects: RELAY_MAX_REDIRECTS,
     });
   }
@@ -61,5 +64,36 @@ export async function fetchRpcRelayTarget(
     method: "POST",
     headers: init.headers,
     body: init.body,
+    signal: init.signal,
   });
+}
+
+/**
+ * Adapt the canonical relay egress executor to a Solana Kit transport.
+ * Customer/BYOK targets therefore receive the same DNS and redirect guards as
+ * `/v1/rpc`, while managed platform targets keep their existing direct path.
+ */
+export function createRpcTransportForTarget(
+  target: RpcEgressTarget & { headers?: Record<string, string> }
+): RpcTransport {
+  return async function rpcTransport<TResponse>({
+    payload,
+    signal,
+  }: Parameters<RpcTransport>[0]): Promise<TResponse> {
+    const upstream = await fetchRpcRelayTarget(target, {
+      headers: {
+        ...target.headers,
+        Accept: "application/json",
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify(payload),
+      signal,
+    });
+
+    if (!upstream.ok) {
+      throw new Error(`RPC request failed with HTTP ${upstream.status}`);
+    }
+
+    return (await upstream.json()) as TResponse;
+  };
 }

--- a/apps/sdp-web/src/app/dashboard/payments/private-channels/instance/actions.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/private-channels/instance/actions.ts
@@ -112,6 +112,10 @@ export async function connectPrivateChannelAction(
     return { ok: false, kind: "validation", fieldErrors: flattenFieldErrors(parsed.error) };
   }
   const confirmReactivate = readConfirmReactivate(input);
+  // The shared compatibility schema defaults an omitted legacy RPC URL to an
+  // empty string for persistence. Do not turn that default back into a request
+  // field: the API accepts omission while an explicitly empty URL is invalid.
+  const { chainRpcUrl: _legacyChainRpcUrl, ...connectInput } = parsed.data;
 
   try {
     const client = await createSdpApiClient();
@@ -119,7 +123,7 @@ export async function connectPrivateChannelAction(
       "/v1/private-channels/instance",
       {
         method: "POST",
-        body: JSON.stringify({ ...parsed.data, confirmReactivate }),
+        body: JSON.stringify({ ...connectInput, confirmReactivate }),
       }
     );
     // Connecting flips the active instance, which changes the Overview, the header

--- a/apps/sdp-web/src/app/dashboard/payments/private-channels/instance/actions.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/private-channels/instance/actions.ts
@@ -70,7 +70,6 @@ export type TestConnectionResult = ConnectionProbeResult;
 // re-probe — a success here means Connect will not fail on the probe.
 export async function testConnectionAction(input: {
   gatewayUrl: string;
-  chainRpcUrl: string;
   authUrl: string;
 }): Promise<TestConnectionResult> {
   try {

--- a/apps/sdp-web/src/app/dashboard/payments/private-channels/instance/private-channels-connect-form.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/private-channels/instance/private-channels-connect-form.tsx
@@ -26,15 +26,15 @@ import {
   testConnectionAction,
 } from "./actions";
 
-type FormValues = PrivateChannelInstanceInput;
+type FormValues = Omit<PrivateChannelInstanceInput, "chainRpcUrl">;
 
-/**
- * Sandbox prefill for the connect form. `chainRpcUrl` is deliberately blank:
- * SANDBOX_DEFAULTS carries a documented placeholder (`?api-key=XXXXXXX`) rather than
- * a working endpoint, so prefilling it guarantees a failed probe on first Connect and
- * hides the field's own placeholder. The operator supplies their own keyed RPC URL.
- */
-const FORM_PREFILL: FormValues = { ...SANDBOX_DEFAULTS, chainRpcUrl: "" };
+const FORM_PREFILL: FormValues = {
+  gatewayUrl: SANDBOX_DEFAULTS.gatewayUrl,
+  escrowProgramId: SANDBOX_DEFAULTS.escrowProgramId,
+  withdrawProgramId: SANDBOX_DEFAULTS.withdrawProgramId,
+  escrowInstanceAddr: SANDBOX_DEFAULTS.escrowInstanceAddr,
+  authUrl: SANDBOX_DEFAULTS.authUrl,
+};
 
 interface Props {
   initialInstance: PrivateChannelInstance | null;
@@ -55,7 +55,6 @@ function toValues(instance: PrivateChannelInstance | null): FormValues {
   if (!instance) return { ...FORM_PREFILL };
   return {
     gatewayUrl: instance.gatewayUrl,
-    chainRpcUrl: instance.chainRpcUrl,
     escrowProgramId: instance.escrowProgramId,
     withdrawProgramId: instance.withdrawProgramId,
     escrowInstanceAddr: instance.escrowInstanceAddr,
@@ -68,7 +67,6 @@ export function PrivateChannelsConnectForm({ initialInstance }: Props) {
   const [values, setValues] = useState<FormValues>(() => toValues(initialInstance));
   const [errors, setErrors] = useState<FieldErrors>({});
   const [gatewayResult, setGatewayResult] = useState<ConnectionProbeResult["gateway"] | null>(null);
-  const [rpcResult, setRpcResult] = useState<ConnectionProbeResult["rpc"] | null>(null);
   const [authResult, setAuthResult] = useState<ConnectionProbeResult["auth"] | null>(null);
   const [isTesting, startTesting] = useTransition();
   const [isConnecting, startConnecting] = useTransition();
@@ -94,7 +92,6 @@ export function PrivateChannelsConnectForm({ initialInstance }: Props) {
     setErrors((prev) => ({ ...prev, [key]: undefined }));
     // Any edit invalidates the last probe result.
     setGatewayResult(null);
-    setRpcResult(null);
     setAuthResult(null);
   };
 
@@ -104,7 +101,6 @@ export function PrivateChannelsConnectForm({ initialInstance }: Props) {
       setValues(toValues(result.instance));
       setErrors({});
       setGatewayResult(null);
-      setRpcResult(null);
       setAuthResult(null);
       toast.success(t("DashboardPrivateChannels.instance.connectSuccess"));
       // The instance is live now — take the operator to the Overview.
@@ -117,7 +113,6 @@ export function PrivateChannelsConnectForm({ initialInstance }: Props) {
     }
     if (result.kind === "probe") {
       setGatewayResult(result.probe.gateway);
-      setRpcResult(result.probe.rpc);
       setAuthResult(result.probe.auth);
       toast.error(result.message);
       return;
@@ -140,11 +135,9 @@ export function PrivateChannelsConnectForm({ initialInstance }: Props) {
     startTesting(async () => {
       const result = await testConnectionAction({
         gatewayUrl: values.gatewayUrl,
-        chainRpcUrl: values.chainRpcUrl,
         authUrl: values.authUrl,
       });
       setGatewayResult(result.gateway);
-      setRpcResult(result.rpc);
       setAuthResult(result.auth);
     });
   };
@@ -176,7 +169,6 @@ export function PrivateChannelsConnectForm({ initialInstance }: Props) {
         setInstance(null);
         setValues({ ...FORM_PREFILL });
         setGatewayResult(null);
-        setRpcResult(null);
         setAuthResult(null);
         setShowDelete(false);
         toast.success(t("DashboardPrivateChannels.instance.deleteSuccess"));
@@ -197,17 +189,6 @@ export function PrivateChannelsConnectForm({ initialInstance }: Props) {
         disabled={isLocked}
         onChange={(v) => update("gatewayUrl", v)}
         status={gatewayStatus(t, gatewayResult)}
-      />
-
-      <UrlField
-        id="chain-rpc-url"
-        label={t("DashboardPrivateChannels.instance.chainRpcUrl")}
-        placeholder={t("DashboardPrivateChannels.instance.chainRpcPlaceholder")}
-        value={values.chainRpcUrl}
-        error={errors.chainRpcUrl}
-        disabled={isLocked}
-        onChange={(v) => update("chainRpcUrl", v)}
-        status={rpcStatus(t, rpcResult)}
       />
 
       <UrlField
@@ -323,30 +304,6 @@ function gatewayStatus(
         : gatewayResult.status === "degraded"
           ? gatewayResult.reason
           : gatewayResult.error,
-  };
-}
-
-function rpcStatus(
-  t: Translate,
-  rpcResult: ConnectionProbeResult["rpc"] | null
-): StatusIndicator | null {
-  if (!rpcResult) return null;
-  if (rpcResult.ok) {
-    return {
-      label: t("DashboardPrivateChannels.instance.statusReady"),
-      dotClass: GATEWAY_DOT.ready,
-      textClass: GATEWAY_TEXT.ready,
-      detail: t("DashboardPrivateChannels.instance.latencyWithVersion", {
-        ms: rpcResult.latencyMs,
-        version: rpcResult.version,
-      }),
-    };
-  }
-  return {
-    label: t("DashboardPrivateChannels.instance.statusFailed"),
-    dotClass: GATEWAY_DOT.unreachable,
-    textClass: GATEWAY_TEXT.unreachable,
-    detail: rpcResult.error,
   };
 }
 

--- a/apps/sdp-web/src/lib/api-playground-catalog.generated.json
+++ b/apps/sdp-web/src/lib/api-playground-catalog.generated.json
@@ -1164,7 +1164,7 @@
             "description": "Generated from this operation's public OpenAPI request schema.",
             "kind": "textarea",
             "valueType": "json",
-            "defaultValue": "{\n  \"commitMessage\": \"Require approval for transfers above 10,000 USDC.\",\n  \"defaultAction\": \"allow\",\n  \"rules\": [\n    {\n      \"id\": \"approve-vault-deposits\",\n      \"kind\": \"operation_type\",\n      \"operationTypes\": [\n        \"earn_vault_deposit\"\n      ],\n      \"action\": \"approval_required\"\n    }\n  ]\n}",
+            "defaultValue": "{\n  \"commitMessage\": \"Require approval for transfers above 10,000 USDC.\",\n  \"defaultAction\": \"allow\",\n  \"rules\": [\n    {\n      \"id\": \"approve-vault-deposits\",\n      \"kind\": \"operation_type\",\n      \"operationTypes\": [\n        \"earn_vault_deposit\"\n      ],\n      \"action\": \"approval_required\"\n    }\n  ],\n  \"expectedRevisionId\": \"wcpr_example\"\n}",
             "required": true
           }
         ],

--- a/packages/sdp-private-channels/src/constants.ts
+++ b/packages/sdp-private-channels/src/constants.ts
@@ -4,13 +4,11 @@ import type { PrivateChannelInstanceConfig } from "./types";
  * Public sandbox instance operated by the Solana Private Channels project. All identifiers
  * are on-chain public keys, not secrets.
  *
- * `chainRpcUrl` is a template, not a working endpoint: devnet's public RPC is
- * heavily rate-limited and the escrow deposit/withdraw path submits real
- * transactions, so operators supply their own API key.
+ * Solana L1 traffic uses the SDP project's configured RPC provider; it is not
+ * part of this instance-specific configuration.
  */
 export const SANDBOX_DEFAULTS: PrivateChannelInstanceConfig = {
   gatewayUrl: "http://34.71.147.163:8899",
-  chainRpcUrl: "https://devnet.helius-rpc.com/?api-key=XXXXXXX",
   // biome-ignore lint/security/noSecrets: Public Solana program ID.
   escrowProgramId: "9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU",
   // biome-ignore lint/security/noSecrets: Public Solana program ID.

--- a/packages/sdp-private-channels/src/constants.ts
+++ b/packages/sdp-private-channels/src/constants.ts
@@ -4,11 +4,12 @@ import type { PrivateChannelInstanceConfig } from "./types";
  * Public sandbox instance operated by the Solana Private Channels project. All identifiers
  * are on-chain public keys, not secrets.
  *
- * Solana L1 traffic uses the SDP project's configured RPC provider; it is not
- * part of this instance-specific configuration.
+ * `chainRpcUrl` remains only for compatibility with the dashboard currently on
+ * `main`; the API ignores it for execution and uses the project's RPC provider.
  */
 export const SANDBOX_DEFAULTS: PrivateChannelInstanceConfig = {
   gatewayUrl: "http://34.71.147.163:8899",
+  chainRpcUrl: "https://devnet.helius-rpc.com/?api-key=XXXXXXX",
   // biome-ignore lint/security/noSecrets: Public Solana program ID.
   escrowProgramId: "9tgHa1DcnaSSUtmMsst8ovKTe1Gfxzezn27KnH9xXYeU",
   // biome-ignore lint/security/noSecrets: Public Solana program ID.

--- a/packages/sdp-private-channels/src/index.ts
+++ b/packages/sdp-private-channels/src/index.ts
@@ -36,7 +36,11 @@ export {
   type ConnectionProbeResult,
   probeConnection,
 } from "./probe";
-export { probeSolanaRpc, type SolanaRpcProbeResult } from "./rpc";
+export {
+  probeSolanaRpc,
+  type SolanaRpcProbeResult,
+  type SolanaRpcProbeTarget,
+} from "./rpc";
 export {
   type PrivateChannelInstanceInputSchema,
   privateChannelInstanceInputSchema,

--- a/packages/sdp-private-channels/src/index.ts
+++ b/packages/sdp-private-channels/src/index.ts
@@ -36,11 +36,7 @@ export {
   type ConnectionProbeResult,
   probeConnection,
 } from "./probe";
-export {
-  probeSolanaRpc,
-  type SolanaRpcProbeResult,
-  type SolanaRpcProbeTarget,
-} from "./rpc";
+export { probeSolanaRpc, type SolanaRpcProbeResult } from "./rpc";
 export {
   type PrivateChannelInstanceInputSchema,
   privateChannelInstanceInputSchema,

--- a/packages/sdp-private-channels/src/probe.test.ts
+++ b/packages/sdp-private-channels/src/probe.test.ts
@@ -23,7 +23,7 @@ const CHAIN_RPC_URL = "https://api.devnet.solana.com";
 const AUTH_URL = "http://auth.test:8903";
 
 function baseInput() {
-  return { gatewayUrl: GATEWAY_URL, chainRpcUrl: CHAIN_RPC_URL, authUrl: AUTH_URL };
+  return { gatewayUrl: GATEWAY_URL, rpcTarget: { endpoint: CHAIN_RPC_URL }, authUrl: AUTH_URL };
 }
 
 afterEach(() => {

--- a/packages/sdp-private-channels/src/probe.test.ts
+++ b/packages/sdp-private-channels/src/probe.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { probeConnection } from "./probe";
+import { probeSolanaRpc } from "./rpc";
 
 function stubFetch(impl: (url: string, init?: RequestInit) => Promise<Response>): void {
   vi.stubGlobal(
@@ -23,7 +24,11 @@ const CHAIN_RPC_URL = "https://api.devnet.solana.com";
 const AUTH_URL = "http://auth.test:8903";
 
 function baseInput() {
-  return { gatewayUrl: GATEWAY_URL, rpcTarget: { endpoint: CHAIN_RPC_URL }, authUrl: AUTH_URL };
+  return {
+    gatewayUrl: GATEWAY_URL,
+    probeRpc: () => probeSolanaRpc(CHAIN_RPC_URL),
+    authUrl: AUTH_URL,
+  };
 }
 
 afterEach(() => {

--- a/packages/sdp-private-channels/src/probe.ts
+++ b/packages/sdp-private-channels/src/probe.ts
@@ -1,13 +1,13 @@
 import { type GatewayHealthResult, probeGatewayHealth } from "./health";
-import { probeSolanaRpc, type SolanaRpcProbeResult } from "./rpc";
+import { probeSolanaRpc, type SolanaRpcProbeResult, type SolanaRpcProbeTarget } from "./rpc";
 
 /** Timeout for the auth `/health` probe. Matches the rest of the connect probes. */
 const AUTH_PROBE_TIMEOUT_MS = 5000;
 
 export interface ConnectionProbeInput {
   gatewayUrl: string;
-  chainRpcUrl: string;
   authUrl: string;
+  rpcTarget: SolanaRpcProbeTarget;
 }
 
 export type AuthProbeResult =
@@ -54,7 +54,7 @@ async function probeAuth(authUrl: string): Promise<AuthProbeResult> {
 export async function probeConnection(input: ConnectionProbeInput): Promise<ConnectionProbeResult> {
   const [gateway, rpc, auth] = await Promise.all([
     probeGatewayHealth(input.gatewayUrl),
-    probeSolanaRpc(input.chainRpcUrl),
+    probeSolanaRpc(input.rpcTarget),
     probeAuth(input.authUrl),
   ]);
   return { gateway, rpc, auth, ok: gateway.status === "ready" && rpc.ok && auth.ok };

--- a/packages/sdp-private-channels/src/probe.ts
+++ b/packages/sdp-private-channels/src/probe.ts
@@ -1,5 +1,5 @@
 import { type GatewayHealthResult, probeGatewayHealth } from "./health";
-import { probeSolanaRpc, type SolanaRpcProbeResult, type SolanaRpcProbeTarget } from "./rpc";
+import type { SolanaRpcProbeResult } from "./rpc";
 
 /** Timeout for the auth `/health` probe. Matches the rest of the connect probes. */
 const AUTH_PROBE_TIMEOUT_MS = 5000;
@@ -7,7 +7,8 @@ const AUTH_PROBE_TIMEOUT_MS = 5000;
 export interface ConnectionProbeInput {
   gatewayUrl: string;
   authUrl: string;
-  rpcTarget: SolanaRpcProbeTarget;
+  /** Supplied by the API so project RPC traffic uses its guarded egress transport. */
+  probeRpc: () => Promise<SolanaRpcProbeResult>;
 }
 
 export type AuthProbeResult =
@@ -54,7 +55,7 @@ async function probeAuth(authUrl: string): Promise<AuthProbeResult> {
 export async function probeConnection(input: ConnectionProbeInput): Promise<ConnectionProbeResult> {
   const [gateway, rpc, auth] = await Promise.all([
     probeGatewayHealth(input.gatewayUrl),
-    probeSolanaRpc(input.rpcTarget),
+    input.probeRpc(),
     probeAuth(input.authUrl),
   ]);
   return { gateway, rpc, auth, ok: gateway.status === "ready" && rpc.ok && auth.ok };

--- a/packages/sdp-private-channels/src/rpc.ts
+++ b/packages/sdp-private-channels/src/rpc.ts
@@ -6,11 +6,6 @@ export type SolanaRpcProbeResult =
   | { ok: true; latencyMs: number; version: string }
   | { ok: false; latencyMs: number; error: string };
 
-export interface SolanaRpcProbeTarget {
-  endpoint: string;
-  headers?: Record<string, string>;
-}
-
 interface SolanaRpcVersionResponse {
   jsonrpc?: "2.0";
   id?: string | number;
@@ -35,12 +30,9 @@ function toErrorMessage(error: unknown): string {
  * Non-JSON, non-2xx, JSON-RPC errors, and network timeouts all resolve as
  * `{ ok: false }`; never throws.
  */
-export async function probeSolanaRpc(
-  input: string | SolanaRpcProbeTarget
-): Promise<SolanaRpcProbeResult> {
+export async function probeSolanaRpc(url: string): Promise<SolanaRpcProbeResult> {
   const startedAt = Date.now();
-  const endpoint = typeof input === "string" ? input : input.endpoint;
-  const parsed = parseHttpUrl(endpoint, "Project RPC URL");
+  const parsed = parseHttpUrl(url, "Chain RPC URL");
   if ("error" in parsed) {
     return { ok: false, latencyMs: 0, error: parsed.error };
   }
@@ -57,7 +49,6 @@ export async function probeSolanaRpc(
         Accept: "application/json",
         "Cache-Control": "no-store",
         "User-Agent": "sdp-private-channels/0.1",
-        ...(typeof input === "string" ? {} : input.headers),
       },
       body: JSON.stringify({
         jsonrpc: "2.0",

--- a/packages/sdp-private-channels/src/rpc.ts
+++ b/packages/sdp-private-channels/src/rpc.ts
@@ -6,6 +6,11 @@ export type SolanaRpcProbeResult =
   | { ok: true; latencyMs: number; version: string }
   | { ok: false; latencyMs: number; error: string };
 
+export interface SolanaRpcProbeTarget {
+  endpoint: string;
+  headers?: Record<string, string>;
+}
+
 interface SolanaRpcVersionResponse {
   jsonrpc?: "2.0";
   id?: string | number;
@@ -30,9 +35,12 @@ function toErrorMessage(error: unknown): string {
  * Non-JSON, non-2xx, JSON-RPC errors, and network timeouts all resolve as
  * `{ ok: false }`; never throws.
  */
-export async function probeSolanaRpc(url: string): Promise<SolanaRpcProbeResult> {
+export async function probeSolanaRpc(
+  input: string | SolanaRpcProbeTarget
+): Promise<SolanaRpcProbeResult> {
   const startedAt = Date.now();
-  const parsed = parseHttpUrl(url, "Chain RPC URL");
+  const endpoint = typeof input === "string" ? input : input.endpoint;
+  const parsed = parseHttpUrl(endpoint, "Project RPC URL");
   if ("error" in parsed) {
     return { ok: false, latencyMs: 0, error: parsed.error };
   }
@@ -49,6 +57,7 @@ export async function probeSolanaRpc(url: string): Promise<SolanaRpcProbeResult>
         Accept: "application/json",
         "Cache-Control": "no-store",
         "User-Agent": "sdp-private-channels/0.1",
+        ...(typeof input === "string" ? {} : input.headers),
       },
       body: JSON.stringify({
         jsonrpc: "2.0",

--- a/packages/sdp-private-channels/src/schema.test.ts
+++ b/packages/sdp-private-channels/src/schema.test.ts
@@ -22,6 +22,24 @@ describe("privateChannelInstanceInputSchema", () => {
     expect(fieldErrors.gatewayUrl?.[0]).toMatch(/required/i);
   });
 
+  it("accepts an omitted legacy chain RPC URL", () => {
+    const { chainRpcUrl: _legacyChainRpcUrl, ...input } = SANDBOX_DEFAULTS;
+    const result = privateChannelInstanceInputSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.chainRpcUrl).toBe("");
+  });
+
+  it("rejects a non-http legacy chain RPC URL", () => {
+    const result = privateChannelInstanceInputSchema.safeParse({
+      ...SANDBOX_DEFAULTS,
+      chainRpcUrl: "ftp://example.com",
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.flatten().fieldErrors.chainRpcUrl?.[0]).toMatch(/http\/https/i);
+  });
+
   it("rejects an escrow program ID that is not base58", () => {
     const result = privateChannelInstanceInputSchema.safeParse({
       ...SANDBOX_DEFAULTS,

--- a/packages/sdp-private-channels/src/schema.test.ts
+++ b/packages/sdp-private-channels/src/schema.test.ts
@@ -22,16 +22,6 @@ describe("privateChannelInstanceInputSchema", () => {
     expect(fieldErrors.gatewayUrl?.[0]).toMatch(/required/i);
   });
 
-  it("rejects a non-http protocol for the devnet RPC URL", () => {
-    const result = privateChannelInstanceInputSchema.safeParse({
-      ...SANDBOX_DEFAULTS,
-      chainRpcUrl: "ftp://example.com",
-    });
-    expect(result.success).toBe(false);
-    if (result.success) return;
-    expect(result.error.flatten().fieldErrors.chainRpcUrl?.[0]).toMatch(/http\/https/i);
-  });
-
   it("rejects an escrow program ID that is not base58", () => {
     const result = privateChannelInstanceInputSchema.safeParse({
       ...SANDBOX_DEFAULTS,

--- a/packages/sdp-private-channels/src/schema.ts
+++ b/packages/sdp-private-channels/src/schema.ts
@@ -37,6 +37,10 @@ const base58Address = (label: string) =>
  */
 export const privateChannelInstanceInputSchema = z.object({
   gatewayUrl: httpUrl("Gateway URL"),
+  // Transitional expand/contract compatibility: current `main` still sends
+  // this field, while the migrated UI omits it. It is persisted only so the old
+  // response contract remains intact and is never used for RPC execution.
+  chainRpcUrl: httpUrl("Chain RPC URL").optional().default(""),
   escrowProgramId: base58Address("Escrow program ID"),
   withdrawProgramId: base58Address("Withdraw program ID"),
   escrowInstanceAddr: base58Address("Escrow instance address"),

--- a/packages/sdp-private-channels/src/schema.ts
+++ b/packages/sdp-private-channels/src/schema.ts
@@ -37,7 +37,6 @@ const base58Address = (label: string) =>
  */
 export const privateChannelInstanceInputSchema = z.object({
   gatewayUrl: httpUrl("Gateway URL"),
-  chainRpcUrl: httpUrl("Chain RPC URL"),
   escrowProgramId: base58Address("Escrow program ID"),
   withdrawProgramId: base58Address("Withdraw program ID"),
   escrowInstanceAddr: base58Address("Escrow instance address"),

--- a/packages/sdp-rpc/src/solana.ts
+++ b/packages/sdp-rpc/src/solana.ts
@@ -167,6 +167,15 @@ export function createRpc(env: RpcEnv, options?: RpcClientOptions): SolanaRpc {
     transport = createDefaultRpcTransport({ url: rpcUrl });
   }
 
+  return createRpcFromTransport(transport, { requestTimeoutMs: timeoutMs });
+}
+
+/** Build the standard SDP Solana client around a caller-owned egress transport. */
+export function createRpcFromTransport(
+  transport: RpcTransport,
+  options: Pick<RpcClientOptions, "requestTimeoutMs"> = {}
+): SolanaRpc {
+  const timeoutMs = options.requestTimeoutMs ?? DEFAULT_RPC_REQUEST_TIMEOUT_MS;
   return createSolanaRpcFromTransport(withRequestTimeout(transport, timeoutMs));
 }
 

--- a/packages/sdp-types/src/private-channels.ts
+++ b/packages/sdp-types/src/private-channels.ts
@@ -42,19 +42,6 @@ export interface PrivateChannelToken {
 }
 
 /**
- * Infer the Solana cluster from an instance's chain RPC URL. The persisted
- * instance stores no explicit cluster, and the sandbox is devnet, so an
- * unrecognized URL is treated as devnet.
- *
- * Lives here rather than in the API so the web derives the cluster the SAME way
- * the API does. `useSolanaCluster()` resolves from the selected project's
- * environment instead, which can disagree with the instance's own RPC URL.
- */
-export function inferCluster(chainRpcUrl: string): SolanaCluster {
-  return /mainnet/i.test(chainRpcUrl) ? "mainnet-beta" : "devnet";
-}
-
-/**
  * The allowed tokens for one cluster, in allowlist order. Symbols not deployed
  * on the cluster are skipped rather than guessed at from the other cluster.
  */
@@ -83,7 +70,6 @@ export function privateChannelTokens(cluster: SolanaCluster): PrivateChannelToke
  */
 export interface PrivateChannelInstanceInput {
   gatewayUrl: string;
-  chainRpcUrl: string;
   escrowProgramId: string;
   withdrawProgramId: string;
   escrowInstanceAddr: string;
@@ -193,7 +179,6 @@ export type PrivateChannelTransferStatus =
  */
 export interface PrivateChannelTransferContext {
   gatewayUrl?: string;
-  chainRpcUrl?: string;
   escrowProgramId?: string;
   escrowInstanceAddr?: string;
   /** SDP user that created the intent. */

--- a/packages/sdp-types/src/private-channels.ts
+++ b/packages/sdp-types/src/private-channels.ts
@@ -42,6 +42,16 @@ export interface PrivateChannelToken {
 }
 
 /**
+ * Legacy cluster inference used by the currently deployed Private Channels UI.
+ *
+ * @deprecated Private Channels now derives the cluster from the SDP project.
+ * Keep this helper until the UI migration no longer imports it.
+ */
+export function inferCluster(chainRpcUrl: string): SolanaCluster {
+  return /mainnet/i.test(chainRpcUrl) ? "mainnet-beta" : "devnet";
+}
+
+/**
  * The allowed tokens for one cluster, in allowlist order. Symbols not deployed
  * on the cluster are skipped rather than guessed at from the other cluster.
  */
@@ -70,6 +80,14 @@ export function privateChannelTokens(cluster: SolanaCluster): PrivateChannelToke
  */
 export interface PrivateChannelInstanceInput {
   gatewayUrl: string;
+  /**
+   * Legacy compatibility field. The API accepts and returns it while the
+   * existing dashboard is being migrated, but Private Channels operations use
+   * the project's configured RPC instead.
+   *
+   * @deprecated Configure RPC on the SDP project.
+   */
+  chainRpcUrl: string;
   escrowProgramId: string;
   withdrawProgramId: string;
   escrowInstanceAddr: string;
@@ -179,6 +197,8 @@ export type PrivateChannelTransferStatus =
  */
 export interface PrivateChannelTransferContext {
   gatewayUrl?: string;
+  /** @deprecated Private Channels uses the project's configured RPC. */
+  chainRpcUrl?: string;
   escrowProgramId?: string;
   escrowInstanceAddr?: string;
   /** SDP user that created the intent. */


### PR DESCRIPTION
- Private Channels now uses the RPC that is already set up for the project, so teams only need to configure it once.
- We removed the duplicate RPC field from setup, making the connection flow shorter and less confusing.
- The existing API stays in place for now, while Private Channels automatically follows the project's RPC settings behind the scenes.
