### PR TITLE
fix(security): resolve GitHub dependency and CodeQL alerts

### DIFF
--- a/.github/scripts/translate-missing.mjs
+++ b/.github/scripts/translate-missing.mjs
@@ -37,6 +37,8 @@ function git(args) {
 
 function writeStepSummary(markdown) {
   if (process.env.GITHUB_STEP_SUMMARY) {
+    // The runner owns this fixed diagnostic path; remote text cannot select a file or execute.
+    // codeql[js/http-to-file-access]
     fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${markdown}\n`);
   }
 }
@@ -185,6 +187,8 @@ async function githubRequest(method, resourcePath, body) {
     return null;
   }
 
+  // Catalog diagnostics are posted back to the same repository through this fixed API host.
+  // codeql[js/file-access-to-http]
   const response = await fetch(`https://api.github.com${resourcePath}`, {
     method,
     headers: {

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,9 +19,4 @@ jobs:
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
-          # The preceding check confines this path to API -> @sdp/kamino ->
-          # klend-sdk, and build-node.mjs replaces bigint-buffer with its pure-JS
-          # browser entry before scanning every shipped API bundle for the native
-          # loader. No patched bigint-buffer release exists today.
-          allow-ghsas: GHSA-3gc7-fjrx-p6mg
           comment-summary-in-pr: on-failure

--- a/apps/sdp-api/Dockerfile
+++ b/apps/sdp-api/Dockerfile
@@ -33,6 +33,7 @@ COPY packages/sdp-spc-escrow/package.json ./packages/sdp-spc-escrow/
 COPY packages/sdp-spc-withdraw/package.json ./packages/sdp-spc-withdraw/
 COPY packages/kit-augment/package.json ./packages/kit-augment/
 COPY packages/sdp-kamino/package.json ./packages/sdp-kamino/
+COPY packages/bigint-buffer/package.json ./packages/bigint-buffer/
 COPY patches ./patches
 
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
@@ -59,6 +60,7 @@ COPY packages/sdp-spc-escrow ./packages/sdp-spc-escrow
 COPY packages/sdp-spc-withdraw ./packages/sdp-spc-withdraw
 COPY packages/kit-augment ./packages/kit-augment
 COPY packages/sdp-kamino ./packages/sdp-kamino
+COPY packages/bigint-buffer ./packages/bigint-buffer
 
 WORKDIR /repo/apps/sdp-api
 RUN node scripts/build-node.mjs

--- a/apps/sdp-api/Dockerfile.dockerignore
+++ b/apps/sdp-api/Dockerfile.dockerignore
@@ -32,6 +32,7 @@ packages/*
 !packages/sdp-spc-withdraw
 !packages/kit-augment
 !packages/sdp-kamino
+!packages/bigint-buffer
 docs
 infra
 scripts

--- a/apps/sdp-api/scripts/build-node.mjs
+++ b/apps/sdp-api/scripts/build-node.mjs
@@ -32,22 +32,6 @@ function resolveOrcaWasm() {
   return path.join(path.dirname(orca), "orca_whirlpools_core_js_bindings_bg.wasm");
 }
 
-/**
- * Resolve bigint-buffer's browser build, which is its pure-JavaScript
- * implementation and never attempts to load the vulnerable native binding.
- *
- * The package is transitive, so walk the real klend -> Raydium -> buffer-layout
- * dependency path instead of relying on pnpm hoisting. If that graph moves, the
- * build fails here and the dependency-boundary check must be reviewed too.
- */
-function resolveSafeBigintBuffer() {
-  const kaminoAnchor = path.resolve("../../packages/sdp-kamino/package.json");
-  const klend = createRequire(kaminoAnchor).resolve("@kamino-finance/klend-sdk");
-  const raydium = createRequire(klend).resolve("@raydium-io/raydium-sdk-v2");
-  const bufferLayoutUtils = createRequire(raydium).resolve("@solana/buffer-layout-utils");
-  return createRequire(bufferLayoutUtils).resolve("bigint-buffer/dist/browser.js");
-}
-
 // CJS interop banner for ESM output: pg and other native-backed deps still
 // reach for require/__filename/__dirname even when bundled as ESM.
 const banner =
@@ -77,18 +61,12 @@ await esbuild.build({
   format: "esm",
   outdir: "dist",
   external: ["pg-native", "@sentry/profiling-node"],
-  // bigint-buffer@1.1.5 has no patched release. Its browser entry is the
-  // package's pure-JS implementation, so execution can be registered without
-  // placing the vulnerable native loader in any API artifact.
-  alias: { "bigint-buffer": resolveSafeBigintBuffer() },
   banner: { js: banner },
 });
 
-// klend-sdk's dependency graph declares bigint-buffer@1.1.5, whose native
-// binding has GHSA-3gc7-fjrx-p6mg and no patched release. The alias above forces
-// its pure-JS browser implementation. Keep that replacement honest: fail the
-// build if a future graph change pulls the native loader into ANY shipped
-// JavaScript entry point.
+// The workspace override for bigint-buffer is pure JavaScript and has no native
+// loader. Keep that replacement honest: fail the build if a future graph change
+// pulls the vulnerable loader from GHSA-3gc7-fjrx-p6mg into any shipped entry.
 for (const entryPoint of Object.keys(entryPoints)) {
   const output = path.join("dist", `${entryPoint}.js`);
   // The safe browser implementation can retain a harmless generated variable

--- a/apps/sdp-web/playwright/support/issuance-fixtures.ts
+++ b/apps/sdp-web/playwright/support/issuance-fixtures.ts
@@ -45,6 +45,8 @@ export const issuanceFixturesPath = path.join(__dirname, "../.fixtures/issuance.
 
 export function writeIssuanceFixtures(fixtures: IssuanceFixtures): void {
   fs.mkdirSync(path.dirname(issuanceFixturesPath), { recursive: true });
+  // This gitignored Playwright path is fixed; local API data cannot choose an arbitrary file.
+  // codeql[js/http-to-file-access]
   fs.writeFileSync(issuanceFixturesPath, JSON.stringify(fixtures, null, 2));
 }
 

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -33,6 +33,7 @@ This map is generated from the module-boundary check. It records the permitted w
 | `@sdp/spc-escrow` | Generated @solana/kit client for the Private Channels escrow program. | `@sdp/kit-augment` |
 | `@sdp/spc-withdraw` | Generated @solana/kit client for the Private Channels withdraw program. | `@sdp/kit-augment` |
 | `@sdp/types` | Shared runtime types, constants, and product contracts. | None |
+| `bigint-buffer` | Private pure-JavaScript compatibility package replacing bigint-buffer's vulnerable native binding. | None |
 | `sdp-docs` | Public documentation site and generated API reference. | `@sdp/env-config`, `@sdp/types` |
 | `sdp-web` | Dashboard application. | `@sdp/issuance`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/solana`, `@sdp/types` |
 
@@ -57,5 +58,6 @@ This map is generated from the module-boundary check. It records the permitted w
 - `@sdp/spc-escrow` -> `@sdp/kit-augment`
 - `@sdp/spc-withdraw` -> `@sdp/kit-augment`
 - `@sdp/types` -> None
+- `bigint-buffer` -> None
 - `sdp-docs` -> `@sdp/env-config`, `@sdp/types`
 - `sdp-web` -> `@sdp/issuance`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/solana`, `@sdp/types`

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
       "@babel/core": "7.29.7",
       "axios": "1.18.1",
       "brace-expansion": "5.0.9",
+      "bigint-buffer": "workspace:*",
       "esbuild": "0.28.1",
       "fast-uri": "3.1.5",
       "js-yaml": "4.3.0",
@@ -27,6 +28,7 @@
       "sharp": "0.35.3",
       "undici": "7.29.0",
       "vite": "7.3.6",
+      "jayson>uuid": "11.1.1",
       "ws": "8.21.0"
     },
     "patchedDependencies": {

--- a/packages/bigint-buffer/browser.js
+++ b/packages/bigint-buffer/browser.js
@@ -1,0 +1,48 @@
+function asBuffer(value) {
+  if (!Buffer.isBuffer(value) && !(value instanceof Uint8Array)) {
+    throw new TypeError("Expected a Buffer or Uint8Array");
+  }
+  return Buffer.from(value);
+}
+
+function assertBigInt(value) {
+  if (typeof value !== "bigint") {
+    throw new TypeError("Expected a bigint");
+  }
+  if (value < 0n) {
+    throw new RangeError("Expected a non-negative bigint");
+  }
+}
+
+function assertWidth(width) {
+  if (!Number.isSafeInteger(width) || width < 0) {
+    throw new RangeError("Expected width to be a non-negative safe integer");
+  }
+}
+
+function toBigIntLE(value) {
+  const buffer = asBuffer(value);
+  buffer.reverse();
+  const hex = buffer.toString("hex");
+  return hex.length === 0 ? 0n : BigInt(`0x${hex}`);
+}
+
+function toBigIntBE(value) {
+  const hex = asBuffer(value).toString("hex");
+  return hex.length === 0 ? 0n : BigInt(`0x${hex}`);
+}
+
+function toBufferLE(value, width) {
+  const buffer = toBufferBE(value, width);
+  buffer.reverse();
+  return buffer;
+}
+
+function toBufferBE(value, width) {
+  assertBigInt(value);
+  assertWidth(width);
+  const hex = value.toString(16);
+  return Buffer.from(hex.padStart(width * 2, "0").slice(0, width * 2), "hex");
+}
+
+module.exports = { toBigIntBE, toBigIntLE, toBufferBE, toBufferLE };

--- a/packages/bigint-buffer/index.d.ts
+++ b/packages/bigint-buffer/index.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="node" />
+
+export declare function toBigIntLE(value: Buffer | Uint8Array): bigint;
+export declare function toBigIntBE(value: Buffer | Uint8Array): bigint;
+export declare function toBufferLE(value: bigint, width: number): Buffer;
+export declare function toBufferBE(value: bigint, width: number): Buffer;

--- a/packages/bigint-buffer/node.js
+++ b/packages/bigint-buffer/node.js
@@ -1,0 +1,1 @@
+module.exports = require("./browser.js");

--- a/packages/bigint-buffer/package.json
+++ b/packages/bigint-buffer/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "bigint-buffer",
+  "version": "1.1.6",
+  "private": true,
+  "description": "SDP-owned pure-JavaScript bigint-buffer compatibility package",
+  "license": "Apache-2.0",
+  "main": "node.js",
+  "browser": {
+    "./node.js": "./browser.js"
+  },
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./node.js"
+    }
+  },
+  "sideEffects": false,
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  }
+}

--- a/packages/bigint-buffer/test/conversion.test.js
+++ b/packages/bigint-buffer/test/conversion.test.js
@@ -1,0 +1,25 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const { toBigIntBE, toBigIntLE, toBufferBE, toBufferLE } = require("../node.js");
+
+test("converts valid buffers without native bindings", () => {
+  assert.equal(toBigIntBE(Buffer.from("deadbeef", "hex")), 0xdeadbeefn);
+  assert.equal(toBigIntLE(Buffer.from("deadbeef", "hex")), 0xefbeadden);
+  assert.deepEqual(toBufferBE(0xdeadbeefn, 8), Buffer.from("00000000deadbeef", "hex"));
+  assert.deepEqual(toBufferLE(0xdeadbeefn, 8), Buffer.from("efbeadde00000000", "hex"));
+  assert.equal(toBigIntBE(Buffer.alloc(0)), 0n);
+  assert.equal(toBigIntLE(Buffer.alloc(0)), 0n);
+});
+
+test("rejects the invalid inputs that reach the vulnerable native boundary", () => {
+  for (const value of [null, undefined, {}, "deadbeef"]) {
+    assert.throws(() => toBigIntLE(value), TypeError);
+    assert.throws(() => toBigIntBE(value), TypeError);
+  }
+});
+
+test("rejects invalid output sizes and signed values", () => {
+  assert.throws(() => toBufferBE(-1n, 8), RangeError);
+  assert.throws(() => toBufferLE(1n, -1), RangeError);
+  assert.throws(() => toBufferBE(1n, 1.5), RangeError);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,7 @@ overrides:
   '@babel/core': 7.29.7
   axios: 1.18.1
   brace-expansion: 5.0.9
+  bigint-buffer: workspace:*
   esbuild: 0.28.1
   fast-uri: 3.1.5
   js-yaml: 4.3.0
@@ -48,6 +49,7 @@ overrides:
   sharp: 0.35.3
   undici: 7.29.0
   vite: 7.3.6
+  jayson>uuid: 11.1.1
   ws: 8.21.0
 
 packageExtensionsChecksum: sha256-Hq4aG11euVLISXl/NBcyj4016UlEcDZd8BZXkelHdyM=
@@ -495,6 +497,8 @@ importers:
       vitest:
         specifier: 4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-istanbul@4.1.10)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.50.0)(tsx@4.23.5)(yaml@2.9.0))
+
+  packages/bigint-buffer: {}
 
   packages/kit-augment:
     dependencies:
@@ -5990,15 +5994,8 @@ packages:
   big.js@6.2.2:
     resolution: {integrity: sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==}
 
-  bigint-buffer@1.1.5:
-    resolution: {integrity: sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==}
-    engines: {node: '>= 10.0.0'}
-
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
-
-  bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -6724,9 +6721,6 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
-
-  file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -9127,13 +9121,12 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@14.0.1:
-    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
   vfile-location@5.0.3:
@@ -12153,7 +12146,7 @@ snapshots:
     dependencies:
       '@solana/buffer-layout': 4.0.1
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
-      bigint-buffer: 1.1.5
+      bigint-buffer: link:packages/bigint-buffer
       bignumber.js: 9.3.1
     transitivePeerDependencies:
       - bufferutil
@@ -12165,7 +12158,7 @@ snapshots:
     dependencies:
       '@solana/buffer-layout': 4.0.1
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
-      bigint-buffer: 1.1.5
+      bigint-buffer: link:packages/bigint-buffer
       bignumber.js: 9.3.1
     transitivePeerDependencies:
       - bufferutil
@@ -15149,15 +15142,7 @@ snapshots:
 
   big.js@6.2.2: {}
 
-  bigint-buffer@1.1.5:
-    dependencies:
-      bindings: 1.5.0
-
   bignumber.js@9.3.1: {}
-
-  bindings@1.5.0:
-    dependencies:
-      file-uri-to-path: 1.0.0
 
   bl@4.1.0:
     dependencies:
@@ -16037,8 +16022,6 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-uri-to-path@1.0.0: {}
-
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -16717,7 +16700,7 @@ snapshots:
       isomorphic-ws: 4.0.1(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       json-stringify-safe: 5.0.1
       stream-json: 1.9.1
-      uuid: 8.3.2
+      uuid: 11.1.1
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
@@ -19016,9 +18999,9 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@14.0.1: {}
+  uuid@11.1.1: {}
 
-  uuid@8.3.2: {}
+  uuid@14.0.1: {}
 
   vfile-location@5.0.3:
     dependencies:

--- a/scripts/check-kamino-dependency-boundary.mjs
+++ b/scripts/check-kamino-dependency-boundary.mjs
@@ -5,6 +5,10 @@ const ROOT = process.cwd();
 const LOCKFILE = "pnpm-lock.yaml";
 const KAMINO_PACKAGE = "packages/sdp-kamino/package.json";
 const API_PACKAGE = "apps/sdp-api/package.json";
+const API_DOCKERFILE = "apps/sdp-api/Dockerfile";
+const API_DOCKERIGNORE = "apps/sdp-api/Dockerfile.dockerignore";
+const SAFE_BIGINT_PACKAGE = "packages/bigint-buffer/package.json";
+const SAFE_BIGINT_RESOLUTION = "link:packages/bigint-buffer";
 
 function packageJsonFiles(parent) {
   return readdirSync(path.join(ROOT, parent), { withFileTypes: true })
@@ -44,10 +48,35 @@ function assertExactConsumers(dependency, expected) {
 }
 
 // Only the private Kamino package may own klend-sdk, and only the API may ship
-// that package. A new web/docs/package consumer would create an artifact not
-// protected by the API bundle's pure-JS bigint-buffer replacement.
+// that package. bigint-buffer itself is replaced workspace-wide so unbundled
+// tools and tests cannot reach the abandoned package's native binding either.
 assertExactConsumers("@kamino-finance/klend-sdk", [KAMINO_PACKAGE]);
 assertExactConsumers("@sdp/kamino", [API_PACKAGE]);
+
+const safeBigintManifest = JSON.parse(readFileSync(path.join(ROOT, SAFE_BIGINT_PACKAGE), "utf8"));
+if (
+  safeBigintManifest.name !== "bigint-buffer" ||
+  safeBigintManifest.version !== "1.1.6" ||
+  safeBigintManifest.private !== true
+) {
+  throw new Error(
+    `${SAFE_BIGINT_PACKAGE} must remain the private bigint-buffer@1.1.6 compatibility package.`
+  );
+}
+
+const dockerfile = readFileSync(path.join(ROOT, API_DOCKERFILE), "utf8");
+for (const requiredCopy of [
+  "COPY packages/bigint-buffer/package.json ./packages/bigint-buffer/",
+  "COPY packages/bigint-buffer ./packages/bigint-buffer",
+]) {
+  if (!dockerfile.includes(requiredCopy)) {
+    throw new Error(`${API_DOCKERFILE} must include: ${requiredCopy}`);
+  }
+}
+const dockerignore = readFileSync(path.join(ROOT, API_DOCKERIGNORE), "utf8");
+if (!dockerignore.includes("!packages/bigint-buffer")) {
+  throw new Error(`${API_DOCKERIGNORE} must include packages/bigint-buffer in the build context.`);
+}
 
 const lines = readFileSync(path.join(ROOT, LOCKFILE), "utf8").split(/\r?\n/);
 const bigintVersions = new Set();
@@ -75,11 +104,9 @@ for (const line of lines) {
   if (bigintDependency) directParents.set(snapshot, bigintDependency[1]);
 }
 
-if (bigintVersions.size !== 1 || !bigintVersions.has("1.1.5")) {
+if (bigintVersions.size !== 0) {
   throw new Error(
-    `Expected only bigint-buffer@1.1.5 in ${LOCKFILE}; found ${
-      [...bigintVersions].join(", ") || "none"
-    }.`
+    `Registry bigint-buffer versions re-entered ${LOCKFILE}: ${[...bigintVersions].join(", ")}.`
   );
 }
 
@@ -89,8 +116,10 @@ const allowedParents = new Set([
 ]);
 const normalizedParents = new Set();
 for (const [parent, version] of directParents) {
-  if (version !== "1.1.5") {
-    throw new Error(`${parent} resolves bigint-buffer to unexpected version ${version}.`);
+  if (version !== SAFE_BIGINT_RESOLUTION) {
+    throw new Error(
+      `${parent} resolves bigint-buffer to ${version}; expected ${SAFE_BIGINT_RESOLUTION}.`
+    );
   }
   const normalized = parent.replace(/\(.+$/, "");
   normalizedParents.add(normalized);
@@ -112,5 +141,5 @@ if (
 
 console.log(
   "Kamino dependency boundary OK: API -> @sdp/kamino -> klend-sdk -> " +
-    "@solana/buffer-layout-utils -> bigint-buffer@1.1.5"
+    "@solana/buffer-layout-utils -> workspace bigint-buffer@1.1.6 (pure JS)"
 );

--- a/scripts/check-module-boundaries.mjs
+++ b/scripts/check-module-boundaries.mjs
@@ -83,6 +83,13 @@ const MODULE_METADATA = [
     ],
   },
   {
+    name: "bigint-buffer",
+    directory: "packages/bigint-buffer",
+    purpose:
+      "Private pure-JavaScript compatibility package replacing bigint-buffer's vulnerable native binding.",
+    allowedDependencies: [],
+  },
+  {
     name: "@sdp/custody",
     directory: "packages/sdp-custody",
     purpose: "Custody provider abstractions and keychain adapters.",


### PR DESCRIPTION
- Replace vulnerable `bigint-buffer@1.1.5` with a private, pure-JavaScript workspace compatibility package and remove the native binding from the lockfile.
- Override Jayson’s CommonJS `uuid` dependency to patched `11.1.1` while leaving `uuid@14.0.1` consumers unchanged.
- Document and suppress three bounded CodeQL data flows: the Playwright fixture, GitHub step summary, and release-PR diagnostics.
- Remove the dependency-review exception for GHSA-3gc7-fjrx-p6mg and extend the Kamino boundary check to enforce the safe package and Docker build context.
- Keep invalid bigint inputs fail-closed with regression coverage; preserve valid endian conversion and Jayson UUID generation.

**before** — vulnerable transitive dependencies and unclassified automation flows:

1. Kamino dependencies resolved `bigint-buffer@1.1.5`; the API bundle aliased its browser entry, but the vulnerable package and native loader remained installed and Dependabot stayed open.
2. Jayson resolved vulnerable `uuid@8.3.2`, despite using only the compatible `v4()` CommonJS API.
3. CodeQL reported intentional network/file flows without source-level boundary documentation.

**after** — workspace-enforced safe dependencies and explicit scanner boundaries:

1. Every `@solana/buffer-layout-utils` edge resolves the private `bigint-buffer@1.1.6` pure-JavaScript workspace package; the registry package and native binding dependencies leave the lockfile.
2. Only `jayson>uuid` resolves `11.1.1`; RPC WebSocket consumers continue using `14.0.1`.
3. Targeted `codeql[...]` comments suppress the three reviewed sinks, while CI boundary checks fail if the unsafe package or an incomplete API Docker context returns.

## How the dependency boundary works

```text
@sdp/api -> @sdp/kamino -> @solana/buffer-layout-utils
                               |
                               +-> workspace bigint-buffer@1.1.6 (pure JS)
                                      |
                                      +-> invalid Buffer input throws TypeError

jayson@4.3.0 -> uuid@11.1.1 (CommonJS v4)
rpc-websockets -> uuid@14.0.1
```

**Verification**

- `pnpm --filter bigint-buffer test` — 3 passed, including invalid-input and valid conversion controls.
- `node scripts/check-kamino-dependency-boundary.mjs` — passed; safe lockfile resolution and Docker context enforced.
- `pnpm --filter @sdp/api build` — passed; all API entries contain no `bigint-buffer` native loader.
- `pnpm --filter @sdp/api typecheck` and `pnpm --filter sdp-web typecheck` — passed.
- `node --test scripts/release-translations.test.mjs` — 26 passed.
- `pnpm --filter @sdp/kamino test` — 97 passed, 3 skipped; `pnpm --filter sdp-web test` — 1,456 passed.
- Jayson CommonJS UUID smoke — resolved `uuid@11.1.1` and generated a valid v4 identifier.
- `pnpm exec biome check <changed files>` — passed with no errors.

Known gaps

- CodeQL suppression behavior and the API Docker build are delegated to this PR’s GitHub Actions run.
- `pnpm --filter @sdp/api test` could not start locally because no container runtime is available; CI owns the containerized API suite.
