### PR TITLE
fix(release): re-arm auto-merge when the release PR is recreated

### DIFF
--- a/.github/scripts/release-automerge.mjs
+++ b/.github/scripts/release-automerge.mjs
@@ -1,0 +1,28 @@
+/**
+ * GitHub freezes the commit headline an auto-merge request was armed with.
+ * `enablePullRequestAutoMerge` refuses a second call on an already-armed pull
+ * request, so a headline armed at one version survives every later update to
+ * the pull request itself, including its title.
+ *
+ * That matters here because release-please recreates the release pull request
+ * on every push to `main`. A pull request armed while it was `0.67.2` still
+ * squash-merges as `chore(main): release 0.67.2` after it has been recreated as
+ * `0.68.0`, and `release-flow.mjs publish` reads the version out of the release
+ * commit subject and refuses a mismatch against `package.json`. The refusal is
+ * correct, but it costs the release: `publish-release` fails and
+ * `deploy-api-production`, which needs it, is skipped.
+ *
+ * @param {string | null | undefined} armedHeadline Headline currently armed on
+ *   the pull request, or null when auto-merge is not armed.
+ * @param {string} desiredHeadline Headline the current release version needs.
+ * @returns {boolean} True when auto-merge must be disarmed and re-armed.
+ */
+export function autoMergeNeedsRearm(armedHeadline, desiredHeadline) {
+  if (!desiredHeadline) {
+    throw new Error("desiredHeadline is required to evaluate auto-merge drift");
+  }
+  if (!armedHeadline) {
+    return false;
+  }
+  return armedHeadline !== desiredHeadline;
+}

--- a/.github/scripts/release-flow.mjs
+++ b/.github/scripts/release-flow.mjs
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { createCommitOnBranch, githubGraphqlRequest } from "./github-commit-on-branch.mjs";
+import { autoMergeNeedsRearm } from "./release-automerge.mjs";
 import { nextReleaseVersion, releaseCommitSemantics } from "./release-version.mjs";
 
 const mode = process.argv[2];
@@ -397,7 +398,39 @@ async function createReleaseBranchCommit(version) {
   return commit.oid;
 }
 
+async function armedAutoMergeHeadline(pullRequestId) {
+  const query = `
+    query ReleaseAutoMergeState($pullRequestId: ID!) {
+      node(id: $pullRequestId) {
+        ... on PullRequest {
+          autoMergeRequest {
+            commitHeadline
+          }
+        }
+      }
+    }
+  `;
+
+  const data = await githubGraphqlRequest({ query, variables: { pullRequestId }, token });
+  return data?.node?.autoMergeRequest?.commitHeadline ?? null;
+}
+
+async function disableAutoMerge(pullRequestId) {
+  const query = `
+    mutation DisableReleaseAutoMerge($pullRequestId: ID!) {
+      disablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId }) {
+        pullRequest {
+          number
+        }
+      }
+    }
+  `;
+
+  await githubGraphqlRequest({ query, variables: { pullRequestId }, token });
+}
+
 async function enableAutoMerge(pullRequestId, version) {
+  const commitHeadline = `chore(main): release ${version}`;
   const query = `
     mutation EnableReleaseAutoMerge($pullRequestId: ID!, $commitHeadline: String!) {
       enablePullRequestAutoMerge(input: {
@@ -415,21 +448,34 @@ async function enableAutoMerge(pullRequestId, version) {
     }
   `;
 
+  const arm = () =>
+    githubGraphqlRequest({ query, variables: { pullRequestId, commitHeadline }, token });
+
   try {
-    await githubGraphqlRequest({
-      query,
-      variables: {
-        pullRequestId,
-        commitHeadline: `chore(main): release ${version}`,
-      },
-      token,
-    });
+    await arm();
+    return;
   } catch (error) {
-    if (error.message.includes("Auto merge is already enabled")) {
-      return;
+    if (!error.message.includes("Auto merge is already enabled")) {
+      throw error;
     }
-    throw error;
   }
+
+  // Already armed, which on this repository usually means armed at an earlier
+  // version: this pull request is recreated on every push to main, and the
+  // headline GitHub squash-merges with is frozen at arming time even though the
+  // title is updated. Left alone, the release commit lands on main naming the
+  // wrong version and `publish` refuses it, taking the production deploy with
+  // it. See release-automerge.mjs for the full reasoning.
+  const armedHeadline = await armedAutoMergeHeadline(pullRequestId);
+  if (!autoMergeNeedsRearm(armedHeadline, commitHeadline)) {
+    return;
+  }
+
+  console.log(
+    `Re-arming auto-merge: headline was ${JSON.stringify(armedHeadline)}, expected ${JSON.stringify(commitHeadline)}`
+  );
+  await disableAutoMerge(pullRequestId);
+  await arm();
 }
 
 async function ensureReleasePrSettings() {

--- a/scripts/release-automerge.test.mjs
+++ b/scripts/release-automerge.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { autoMergeNeedsRearm } from "../.github/scripts/release-automerge.mjs";
+
+const desired = "chore(main): release 0.68.0";
+
+test("re-arms when the frozen headline names an earlier version", () => {
+  // The 0.68.0 release: armed while the pull request was still 0.67.2, merged
+  // as 0.67.2, and `publish` refused it against package.json 0.68.0.
+  assert.equal(autoMergeNeedsRearm("chore(main): release 0.67.2", desired), true);
+  // The same shape one release earlier, armed as 0.66.1 and merged as 0.66.1.
+  assert.equal(autoMergeNeedsRearm("chore(main): release 0.66.1", desired), true);
+});
+
+test("leaves a headline that already matches alone", () => {
+  assert.equal(autoMergeNeedsRearm(desired, desired), false);
+});
+
+test("does not re-arm when auto-merge is not armed at all", () => {
+  for (const armed of [null, undefined, ""]) {
+    assert.equal(autoMergeNeedsRearm(armed, desired), false);
+  }
+});
+
+test("refuses to evaluate drift without a target headline", () => {
+  assert.throws(() => autoMergeNeedsRearm("chore(main): release 0.67.2", ""), /desiredHeadline/);
+});


### PR DESCRIPTION
## What

`enablePullRequestAutoMerge` refuses a second call on a pull request that is already armed, and GitHub freezes the commit headline from the first call. `upsertReleasePullRequest` swallowed that refusal, so the headline outlived every later update to the release pull request, including its title.

Because release-please recreates the release pull request on every push to `main`, that drift is the normal case here, not an edge one.

- Read the armed headline back when arming is refused, and disarm and re-arm only when it has drifted. An already-correct headline stays a no-op.
- The drift decision lives in `release-automerge.mjs` with the reasoning attached, covered by the two headlines that actually shipped wrong.
- The version check in `publish` is deliberately unchanged. Refusing to tag a commit whose subject disagrees with `package.json` is what kept a mislabelled release out of production twice. The frozen headline is the defect.

## Why now

#1475 was armed on 2026-08-25 as `0.67.2`, recreated four times as release-please absorbed new commits, and merged this morning as `chore(main): release 0.67.2` while `package.json` said `0.68.0`. `publish` refused the mismatch:

```
Error: Release commit version 0.67.2 does not match package.json 0.68.0
  at publishApprovedRelease (.github/scripts/release-flow.mjs:600:13)
```

`deploy-api-production` needs `publish-release`, so v0.68.0 got no tag, no GitHub release and no production deploy. The same shape cost 0.67.0 on 2026-08-24, merged as `chore(main): release 0.66.1` by run 32779676835.

Left alone, the recovery is worse than the failure. `prepareRelease` publishes the pending tag from its ahead-of-tag branch, but it runs inside `prepare-release-pr`, so the next ordinary merge to `main` creates the tag with no production deploy behind it. That is what happened to v0.67.0, whose tag was published by run 32780897261 with `publish-release` and `deploy-api-production` both skipped.

## Merging this one

**Squash-merge it with the subject `chore(main): release 0.68.0`.** `package.json` on `main` is already `0.68.0`, so that subject makes `publish-release` parse and match, cut the tag at this commit, and hand `deploy-api-production` a `release_sha` that resolves. The dev smoke gate from #1494 stays in the path.

The tag will then sit on this commit rather than on `060457d8`, so it carries one commit that is not in its own changelog. That artifact is already familiar on this repo, it is CI-only, and it is the cost of getting 0.68.0 deployed through the normal path rather than by dispatching around the smoke gate.

## Verified

- `node --test scripts/release-automerge.test.mjs`, 4 passed.
- `pnpm test:scripts`, 107 passed.
- `pnpm exec biome check` clean on the three changed files. The four remaining warnings are pre-existing `GITHUB_OUTPUT` turbo env notices in `writePlan`.
- Not verified here: the re-arm path itself needs a live release pull request that is already armed. It cannot be exercised from CI, and the next release exercises it.
