### PR TITLE
feat(ci): ephemeral per-PR API environments on dev (PRO-1767)

### DIFF
--- a/.github/scripts/ephemeral-env.sh
+++ b/.github/scripts/ephemeral-env.sh
@@ -24,9 +24,49 @@ api_service="sdp-dev-api-pr-${pr}"
 worker_service="sdp-dev-worker-pr-${pr}"
 db_job="sdp-dev-api-pr-${pr}-db"
 db_name="sdp_api_pr_${pr}"
-redis_db=$(((pr % 15) + 1))
 
 run() { gcloud run "$@" --project "${PROJECT}" --region "${REGION}"; }
+
+list_redis_claims() { # prints "<pr> <db>" for every labeled job and service
+  local kind
+  for kind in jobs services; do
+    run "${kind}" list --filter 'metadata.labels.sdp-ephemeral-redis-db:*' \
+      --format 'value(metadata.labels.sdp-ephemeral-pr,metadata.labels.sdp-ephemeral-redis-db)'
+  done
+}
+
+# On a same-second race two PRs could pick the same slot; the offset scan makes
+# that need pr1 ≡ pr2 (mod 15), and verify_redis_claim (lower PR wins) turns the
+# residue into a loud failure whose rerun converges on a free slot.
+redis_db_taken() { # <claims> <db> — taken by a PR that outranks us?
+  awk -v pr="${pr}" -v db="$2" '$2 == db && $1 != pr && $1 < pr { found = 1 } END { exit !found }' <<<"$1"
+}
+
+allocate_redis_db() {
+  local claims own db i
+  claims="$(list_redis_claims)"
+  own="$(run jobs describe "${db_job}" \
+    --format 'value(metadata.labels.sdp-ephemeral-redis-db)' 2>/dev/null || true)"
+  if [[ -n "${own}" ]] && ! redis_db_taken "${claims}" "${own}"; then
+    echo "${own}"; return
+  fi
+  for i in $(seq 0 14); do
+    db=$(((pr + i) % 15 + 1))
+    if ! awk -v db="${db}" '$2 == db { found = 1 } END { exit !found }' <<<"${claims}"; then
+      echo "${db}"; return
+    fi
+  done
+  echo "all 15 redis logical dbs are claimed by live ephemeral environments; tear one down first" >&2
+  return 1
+}
+
+verify_redis_claim() { # after claiming: fail if a lower-numbered PR holds our db
+  local db="$1"
+  if redis_db_taken "$(list_redis_claims)" "${db}"; then
+    echo "redis db ${db} is claimed by an older ephemeral environment; rerun the deploy to pick a new slot" >&2
+    return 1
+  fi
+}
 
 yaml_to_json() {
   python3 -c 'import yaml, json, sys; json.dump(yaml.safe_load(sys.stdin), sys.stdout)'
@@ -45,6 +85,8 @@ deploy() {
   local image="${1:?image is required}"
   local tmp; tmp="$(mktemp -d)"
 
+  redis_db="$(allocate_redis_db)"
+
   export_json services "${BASE_API_SERVICE}" >"${tmp}/api.json"
 
   # Per-PR database job: the migrate-job clone re-pointed at the bundled
@@ -52,10 +94,12 @@ deploy() {
   # the job can flush the PR's redis db.
   export_json jobs "${BASE_MIGRATE_JOB}" | jq \
     --arg name "${db_job}" --arg pr "${pr}" --arg image "${image}" \
+    --arg redisdb "${redis_db}" \
     --argjson extra "$(ephemeral_env_json)" \
     --argjson redis "$(jq '[.spec.template.spec.containers[0].env[] | select(.name == "REDIS_URL")]' "${tmp}/api.json")" \
     '.metadata.name = $name
      | .metadata.labels["sdp-ephemeral-pr"] = $pr
+     | .metadata.labels["sdp-ephemeral-redis-db"] = $redisdb
      | .spec.template.spec.template.spec.containers[0].image = $image
      | .spec.template.spec.template.spec.containers[0].command = ["node", "ephemeral-db.js"]
      | .spec.template.spec.template.spec.containers[0].args = ["ensure"]
@@ -63,12 +107,15 @@ deploy() {
          ((.spec.template.spec.template.spec.containers[0].env // []) + $redis + $extra)
     ' >"${tmp}/${db_job}.json"
   run jobs replace "${tmp}/${db_job}.json" >/dev/null
+  verify_redis_claim "${redis_db}"
   run jobs execute "${db_job}" --wait
 
   jq --arg name "${api_service}" --arg pr "${pr}" --arg image "${image}" \
+    --arg redisdb "${redis_db}" \
     --argjson extra "$(ephemeral_env_json)" \
     '.metadata.name = $name
      | .metadata.labels["sdp-ephemeral-pr"] = $pr
+     | .metadata.labels["sdp-ephemeral-redis-db"] = $redisdb
      | .metadata.annotations["run.googleapis.com/ingress"] = "all"
      | del(.spec.traffic, .spec.template.metadata.name, .status)
      | .spec.template.metadata.annotations["autoscaling.knative.dev/minScale"] = "0"

--- a/.github/scripts/ephemeral-env.sh
+++ b/.github/scripts/ephemeral-env.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Ephemeral per-PR API environments on dev (PRO-1767).
+#
+#   ephemeral-env.sh deploy <pr-number> <image>
+#   ephemeral-env.sh teardown <pr-number>
+#
+# deploy clones the dev migrate job and the dev API/worker services into
+# per-PR copies that share dev's secrets but land on their own database
+# (EPHEMERAL_DB_NAME) and redis keyspace (EPHEMERAL_REDIS_DB). teardown
+# drops the database, flushes the redis db, and deletes the clones.
+set -euo pipefail
+
+PROJECT="${PROJECT_ID:-solana-developer-platform-dev}"
+REGION="${REGION:-us-central1}"
+BASE_API_SERVICE="sdp-dev-api-public"
+BASE_WORKER_SERVICE="sdp-dev-worker"
+BASE_MIGRATE_JOB="sdp-dev-api-public-migrate"
+
+cmd="${1:?usage: ephemeral-env.sh <deploy|teardown> <pr-number> [image]}"
+pr="${2:?pr number is required}"
+[[ "${pr}" =~ ^[0-9]+$ ]] || { echo "pr number must be numeric" >&2; exit 1; }
+
+api_service="sdp-dev-api-pr-${pr}"
+worker_service="sdp-dev-worker-pr-${pr}"
+db_job="sdp-dev-api-pr-${pr}-db"
+db_name="sdp_api_pr_${pr}"
+redis_db=$(((pr % 15) + 1))
+
+run() { gcloud run "$@" --project "${PROJECT}" --region "${REGION}"; }
+
+yaml_to_json() {
+  python3 -c 'import yaml, json, sys; json.dump(yaml.safe_load(sys.stdin), sys.stdout)'
+}
+
+export_json() { # <services|jobs> <name>
+  run "$1" describe "$2" --format=export | yaml_to_json
+}
+
+ephemeral_env_json() {
+  jq -n --arg db "${db_name}" --arg redis "${redis_db}" \
+    '[{name: "EPHEMERAL_DB_NAME", value: $db}, {name: "EPHEMERAL_REDIS_DB", value: $redis}]'
+}
+
+deploy() {
+  local image="${1:?image is required}"
+  local tmp; tmp="$(mktemp -d)"
+
+  export_json services "${BASE_API_SERVICE}" >"${tmp}/api.json"
+
+  # Per-PR database job: the migrate-job clone re-pointed at the bundled
+  # ephemeral-db.js entrypoint. REDIS_URL is copied from the API service so
+  # the job can flush the PR's redis db.
+  export_json jobs "${BASE_MIGRATE_JOB}" | jq \
+    --arg name "${db_job}" --arg pr "${pr}" --arg image "${image}" \
+    --argjson extra "$(ephemeral_env_json)" \
+    --argjson redis "$(jq '[.spec.template.spec.containers[0].env[] | select(.name == "REDIS_URL")]' "${tmp}/api.json")" \
+    '.metadata.name = $name
+     | .metadata.labels["sdp-ephemeral-pr"] = $pr
+     | .spec.template.spec.template.spec.containers[0].image = $image
+     | .spec.template.spec.template.spec.containers[0].command = ["node", "ephemeral-db.js"]
+     | .spec.template.spec.template.spec.containers[0].args = ["ensure"]
+     | .spec.template.spec.template.spec.containers[0].env =
+         ((.spec.template.spec.template.spec.containers[0].env // []) + $redis + $extra)
+    ' >"${tmp}/${db_job}.json"
+  run jobs replace "${tmp}/${db_job}.json" >/dev/null
+  run jobs execute "${db_job}" --wait
+
+  jq --arg name "${api_service}" --arg pr "${pr}" --arg image "${image}" \
+    --argjson extra "$(ephemeral_env_json)" \
+    '.metadata.name = $name
+     | .metadata.labels["sdp-ephemeral-pr"] = $pr
+     | .metadata.annotations["run.googleapis.com/ingress"] = "all"
+     | del(.spec.traffic, .spec.template.metadata.name, .status)
+     | .spec.template.metadata.annotations["autoscaling.knative.dev/minScale"] = "0"
+     | .spec.template.metadata.annotations["autoscaling.knative.dev/maxScale"] = "2"
+     | .spec.template.spec.containers[0].image = $image
+     | .spec.template.spec.containers[0].env =
+         ((.spec.template.spec.containers[0].env // []) + $extra)
+    ' "${tmp}/api.json" >"${tmp}/${api_service}.json"
+  run services replace "${tmp}/${api_service}.json" >/dev/null
+  run services add-iam-policy-binding "${api_service}" \
+    --member allUsers --role roles/run.invoker >/dev/null
+
+  export_json services "${BASE_WORKER_SERVICE}" | jq \
+    --arg name "${worker_service}" --arg pr "${pr}" --arg image "${image}" \
+    --argjson extra "$(ephemeral_env_json)" \
+    '.metadata.name = $name
+     | .metadata.labels["sdp-ephemeral-pr"] = $pr
+     | del(.spec.traffic, .spec.template.metadata.name, .status)
+     | .spec.template.spec.containers[0].image = $image
+     | .spec.template.spec.containers[0].env =
+         ((.spec.template.spec.containers[0].env // []) + $extra)
+    ' >"${tmp}/${worker_service}.json"
+  run services replace "${tmp}/${worker_service}.json" >/dev/null
+
+  run services describe "${api_service}" --format='value(status.url)'
+}
+
+teardown() {
+  if run jobs describe "${db_job}" >/dev/null 2>&1; then
+    run jobs execute "${db_job}" --args drop --wait || echo "database drop failed; dropping resources anyway" >&2
+    run jobs delete "${db_job}" --quiet
+  fi
+  for service in "${api_service}" "${worker_service}"; do
+    if run services describe "${service}" >/dev/null 2>&1; then
+      run services delete "${service}" --quiet
+    fi
+  done
+}
+
+case "${cmd}" in
+  deploy) deploy "${3:?image is required}" ;;
+  teardown) teardown ;;
+  *) echo "unknown command: ${cmd}" >&2; exit 1 ;;
+esac

--- a/.github/scripts/ephemeral-env.sh
+++ b/.github/scripts/ephemeral-env.sh
@@ -107,7 +107,10 @@ deploy() {
          ((.spec.template.spec.template.spec.containers[0].env // []) + $redis + $extra)
     ' >"${tmp}/${db_job}.json"
   run jobs replace "${tmp}/${db_job}.json" >/dev/null
-  verify_redis_claim "${redis_db}"
+  if ! verify_redis_claim "${redis_db}"; then
+    run jobs delete "${db_job}" --quiet
+    exit 1
+  fi
   run jobs execute "${db_job}" --wait
 
   jq --arg name "${api_service}" --arg pr "${pr}" --arg image "${image}" \
@@ -145,7 +148,14 @@ deploy() {
 
 teardown() {
   if run jobs describe "${db_job}" >/dev/null 2>&1; then
-    run jobs execute "${db_job}" --args drop --wait || echo "database drop failed; dropping resources anyway" >&2
+    local drop_args="drop" own_db
+    own_db="$(run jobs describe "${db_job}" \
+      --format 'value(metadata.labels.sdp-ephemeral-redis-db)' 2>/dev/null || true)"
+    if [[ -n "${own_db}" ]] && redis_db_taken "$(list_redis_claims)" "${own_db}"; then
+      echo "redis db ${own_db} belongs to an older PR; dropping database only" >&2
+      drop_args="drop,skip-redis"
+    fi
+    run jobs execute "${db_job}" --args "${drop_args}" --wait || echo "database drop failed; dropping resources anyway" >&2
     run jobs delete "${db_job}" --quiet
   fi
   for service in "${api_service}" "${worker_service}"; do

--- a/.github/workflows/sdp-api-ephemeral.yml
+++ b/.github/workflows/sdp-api-ephemeral.yml
@@ -75,11 +75,17 @@ jobs:
           docker push "${IMAGE}"
           echo "IMAGE=${IMAGE}" >> "${GITHUB_ENV}"
 
+      - name: Checkout trusted deploy scripts
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: main
+          path: trusted
+
       - name: Deploy ephemeral environment
         id: deploy
         run: |
           set -euo pipefail
-          URL="$(.github/scripts/ephemeral-env.sh deploy "${PR_NUMBER}" "${IMAGE}" | tail -1)"
+          URL="$(trusted/.github/scripts/ephemeral-env.sh deploy "${PR_NUMBER}" "${IMAGE}" | tail -1)"
           echo "url=${URL}" >> "${GITHUB_OUTPUT}"
           echo "Ephemeral API for PR #${PR_NUMBER}: ${URL}" >> "${GITHUB_STEP_SUMMARY}"
 
@@ -96,7 +102,7 @@ jobs:
           |---|---|
           | API | ${URL} |
           | Database | \`sdp_api_pr_${PR_NUMBER}\` (dev Cloud SQL, branch migrations applied) |
-          | Redis | dev Memorystore, logical db $((PR_NUMBER % 15 + 1)) |
+          | Redis | dev Memorystore, dedicated logical db |
           | Worker | \`sdp-dev-worker-pr-${PR_NUMBER}\` (internal, crons enabled) |
 
           Redeploys on every push while the \`ephemeral-api\` label is set; torn down when the PR closes. Point the web app at it with \`NEXT_PUBLIC_SDP_API_BASE_URL\`.
@@ -126,6 +132,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: main
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
@@ -164,10 +172,16 @@ jobs:
       - name: Tear down environments whose PR is closed
         run: |
           set -euo pipefail
-          mapfile -t prs < <(gcloud run services list \
-            --project "${PROJECT_ID}" --region "${REGION}" \
-            --filter 'metadata.labels.sdp-ephemeral-pr:*' \
-            --format 'value(metadata.labels.sdp-ephemeral-pr)' | sort -u)
+          mapfile -t prs < <({
+            gcloud run services list \
+              --project "${PROJECT_ID}" --region "${REGION}" \
+              --filter 'metadata.labels.sdp-ephemeral-pr:*' \
+              --format 'value(metadata.labels.sdp-ephemeral-pr)'
+            gcloud run jobs list \
+              --project "${PROJECT_ID}" --region "${REGION}" \
+              --filter 'metadata.labels.sdp-ephemeral-pr:*' \
+              --format 'value(metadata.labels.sdp-ephemeral-pr)'
+          } | sort -u)
           for pr in "${prs[@]:-}"; do
             [ -n "${pr}" ] || continue
             state="$(gh pr view "${pr}" --json state --jq .state 2>/dev/null || echo UNKNOWN)"

--- a/.github/workflows/sdp-api-ephemeral.yml
+++ b/.github/workflows/sdp-api-ephemeral.yml
@@ -1,0 +1,178 @@
+name: Ephemeral PR API environment
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened, closed, unlabeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to deploy or tear down"
+        type: string
+        required: true
+      action:
+        description: "deploy or teardown"
+        type: choice
+        options: [deploy, teardown]
+        default: deploy
+  schedule:
+    - cron: "17 4 * * *"
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: sdp-api-ephemeral-${{ github.event.pull_request.number || inputs.pr_number || 'reaper' }}
+  cancel-in-progress: false
+
+env:
+  PROJECT_ID: solana-developer-platform-dev
+  REGION: us-central1
+  REPO: sdp-dev
+  LABEL: ephemeral-api
+
+jobs:
+  deploy:
+    name: Deploy ephemeral environment
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    if: >-
+      github.repository == 'solana-foundation/solana-developer-platform' &&
+      ((github.event_name == 'pull_request' &&
+        github.event.action != 'closed' && github.event.action != 'unlabeled' &&
+        github.event.pull_request.state == 'open' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        contains(github.event.pull_request.labels.*.name, 'ephemeral-api')) ||
+       (github.event_name == 'workflow_dispatch' && inputs.action == 'deploy'))
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/head', inputs.pr_number) }}
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.DEPLOY_WIF_PROVIDER }}
+          service_account: ${{ vars.DEPLOY_SA }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+
+      - name: Build and push image
+        run: |
+          set -euo pipefail
+          SHA="$(git rev-parse HEAD)"
+          IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/sdp-api-public:pr-${PR_NUMBER}-${SHA}"
+          docker build -f apps/sdp-api/Dockerfile --build-arg GIT_SHA="${SHA}" -t "${IMAGE}" .
+          docker push "${IMAGE}"
+          echo "IMAGE=${IMAGE}" >> "${GITHUB_ENV}"
+
+      - name: Deploy ephemeral environment
+        id: deploy
+        run: |
+          set -euo pipefail
+          URL="$(.github/scripts/ephemeral-env.sh deploy "${PR_NUMBER}" "${IMAGE}" | tail -1)"
+          echo "url=${URL}" >> "${GITHUB_OUTPUT}"
+          echo "Ephemeral API for PR #${PR_NUMBER}: ${URL}" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Comment URL on PR
+        env:
+          URL: ${{ steps.deploy.outputs.url }}
+        run: |
+          set -euo pipefail
+          marker="<!-- sdp-ephemeral-api -->"
+          body="$(cat <<EOF
+          ${marker}
+          ### Ephemeral API environment
+          | | |
+          |---|---|
+          | API | ${URL} |
+          | Database | \`sdp_api_pr_${PR_NUMBER}\` (dev Cloud SQL, branch migrations applied) |
+          | Redis | dev Memorystore, logical db $((PR_NUMBER % 15 + 1)) |
+          | Worker | \`sdp-dev-worker-pr-${PR_NUMBER}\` (internal, crons enabled) |
+
+          Redeploys on every push while the \`ephemeral-api\` label is set; torn down when the PR closes. Point the web app at it with \`NEXT_PUBLIC_SDP_API_BASE_URL\`.
+          EOF
+          )"
+          existing="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --jq "[.[] | select(.body | startswith(\"${marker}\"))][0].id // empty")"
+          if [ -n "${existing}" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" -f body="${body}" >/dev/null
+          else
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" -f body="${body}" >/dev/null
+          fi
+
+  teardown:
+    name: Tear down ephemeral environment
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: >-
+      github.repository == 'solana-foundation/solana-developer-platform' &&
+      ((github.event_name == 'pull_request' &&
+        ((github.event.action == 'closed' &&
+          contains(github.event.pull_request.labels.*.name, 'ephemeral-api')) ||
+         (github.event.action == 'unlabeled' && github.event.label.name == 'ephemeral-api'))) ||
+       (github.event_name == 'workflow_dispatch' && inputs.action == 'teardown'))
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.DEPLOY_WIF_PROVIDER }}
+          service_account: ${{ vars.DEPLOY_SA }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+
+      - name: Tear down ephemeral environment
+        run: .github/scripts/ephemeral-env.sh teardown "${PR_NUMBER}"
+
+  reaper:
+    name: Reap environments for closed PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: >-
+      github.repository == 'solana-foundation/solana-developer-platform' &&
+      github.event_name == 'schedule'
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.DEPLOY_WIF_PROVIDER }}
+          service_account: ${{ vars.DEPLOY_SA }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+
+      - name: Tear down environments whose PR is closed
+        run: |
+          set -euo pipefail
+          mapfile -t prs < <(gcloud run services list \
+            --project "${PROJECT_ID}" --region "${REGION}" \
+            --filter 'metadata.labels.sdp-ephemeral-pr:*' \
+            --format 'value(metadata.labels.sdp-ephemeral-pr)' | sort -u)
+          for pr in "${prs[@]:-}"; do
+            [ -n "${pr}" ] || continue
+            state="$(gh pr view "${pr}" --json state --jq .state 2>/dev/null || echo UNKNOWN)"
+            if [ "${state}" = "CLOSED" ] || [ "${state}" = "MERGED" ]; then
+              echo "reaping ephemeral environment for closed PR #${pr}"
+              .github/scripts/ephemeral-env.sh teardown "${pr}"
+            fi
+          done

--- a/apps/sdp-api/scripts/build-node.mjs
+++ b/apps/sdp-api/scripts/build-node.mjs
@@ -77,6 +77,8 @@ const entryPoints = {
   "custody-backfill": "scripts/migrate-custody-encryption.ts",
   // configure.js generates a self-hosted .env in the terminal from the prebuilt image.
   configure: "scripts/configure.ts",
+  // ephemeral-db.js creates/drops per-PR databases from the prebuilt image (PRO-1767).
+  "ephemeral-db": "scripts/ephemeral-db.mjs",
 };
 
 const zkSdkNodeEntries = new Set();

--- a/apps/sdp-api/scripts/ephemeral-db.mjs
+++ b/apps/sdp-api/scripts/ephemeral-db.mjs
@@ -75,7 +75,11 @@ if (mode === "ensure") {
 } else {
   const redisUrl = process.env.REDIS_URL?.trim();
   const redisDb = process.env.EPHEMERAL_REDIS_DB?.trim();
-  if (redisUrl && redisDb) {
+  const skipRedis = process.argv.includes("skip-redis");
+  if (skipRedis) {
+    console.log("skip-redis: this environment lost its redis claim; not flushing");
+  }
+  if (!skipRedis && redisUrl && redisDb) {
     const url = new URL(redisUrl);
     url.pathname = `/${redisDb}`;
     const redis = new Redis(url.toString(), { maxRetriesPerRequest: 3, lazyConnect: true });

--- a/apps/sdp-api/scripts/ephemeral-db.mjs
+++ b/apps/sdp-api/scripts/ephemeral-db.mjs
@@ -1,0 +1,90 @@
+/**
+ * Lifecycle for an ephemeral per-PR database (PRO-1767). Bundled into the
+ * image as ephemeral-db.js and run inside the VPC as a Cloud Run job
+ * execution, because the dev Cloud SQL instance is unreachable from Actions.
+ *
+ *   node ephemeral-db.js ensure   create EPHEMERAL_DB_NAME if missing, then
+ *                                 run migrations against it
+ *   node ephemeral-db.js drop     terminate connections, drop the database,
+ *                                 flush the PR's redis db
+ *
+ * DATABASE_URL stays the shared dev URL and serves as the admin connection;
+ * the PR database name comes from EPHEMERAL_DB_NAME.
+ */
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Redis from "ioredis";
+import pg from "pg";
+import { runPostgresMigrations } from "./lib/run-postgres-migrations.mjs";
+
+const { Client } = pg;
+
+const mode = process.argv[2];
+const dbName = process.env.EPHEMERAL_DB_NAME?.trim();
+const baseUrl = process.env.DATABASE_URL?.trim();
+
+if (mode !== "ensure" && mode !== "drop") {
+  console.error("usage: ephemeral-db.mjs <ensure|drop>");
+  process.exit(1);
+}
+if (!dbName || !/^[a-z][a-z0-9_]{0,62}$/.test(dbName)) {
+  console.error("EPHEMERAL_DB_NAME is required and must match [a-z][a-z0-9_]*");
+  process.exit(1);
+}
+if (!baseUrl) {
+  console.error("DATABASE_URL is required");
+  process.exit(1);
+}
+
+const prUrl = new URL(baseUrl);
+prUrl.pathname = `/${dbName}`;
+if (new URL(baseUrl).pathname === prUrl.pathname) {
+  console.error(`refusing to manage the shared database "${dbName}"`);
+  process.exit(1);
+}
+
+const admin = new Client({ connectionString: baseUrl });
+await admin.connect();
+try {
+  if (mode === "ensure") {
+    try {
+      await admin.query(`CREATE DATABASE "${dbName}"`);
+      console.log(`created database ${dbName}`);
+    } catch (error) {
+      if (error.code !== "42P04") throw error;
+      console.log(`database ${dbName} already exists`);
+    }
+  } else {
+    await admin.query(
+      "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()",
+      [dbName]
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    console.log(`dropped database ${dbName}`);
+  }
+} finally {
+  await admin.end();
+}
+
+if (mode === "ensure") {
+  const appDir = path.dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+  const migrationsDir =
+    process.env.MIGRATIONS_DIR?.trim() || path.join(appDir, "src/db/migrations/postgres");
+  await runPostgresMigrations({ databaseUrl: prUrl.toString(), migrationsDir });
+  console.log(`migrations applied to ${dbName}`);
+} else {
+  const redisUrl = process.env.REDIS_URL?.trim();
+  const redisDb = process.env.EPHEMERAL_REDIS_DB?.trim();
+  if (redisUrl && redisDb) {
+    const url = new URL(redisUrl);
+    url.pathname = `/${redisDb}`;
+    const redis = new Redis(url.toString(), { maxRetriesPerRequest: 3, lazyConnect: true });
+    try {
+      await redis.connect();
+      await redis.flushdb();
+      console.log(`flushed redis db ${redisDb}`);
+    } finally {
+      redis.disconnect();
+    }
+  }
+}

--- a/apps/sdp-api/src/lib/runtime-env.test.ts
+++ b/apps/sdp-api/src/lib/runtime-env.test.ts
@@ -1,45 +1,44 @@
 import { describe, expect, it } from "vitest";
-import type { Env } from "@/types/env";
-import { getDeploymentMode, isSelfHostedDeployment } from "./runtime-env";
+import { applyEphemeralOverrides } from "./runtime-env";
 
-const envWith = (mode: string | undefined): Pick<Env, "SDP_DEPLOYMENT_MODE"> =>
-  ({ SDP_DEPLOYMENT_MODE: mode }) as Pick<Env, "SDP_DEPLOYMENT_MODE">;
+describe("applyEphemeralOverrides", () => {
+  it("rewrites the database name and redis db index when overrides are set", () => {
+    const env: NodeJS.ProcessEnv = {
+      DATABASE_URL: "postgresql://sdp:s3cret@10.0.0.5:5432/sdp_api?sslmode=require",
+      REDIS_URL: "redis://:authtoken@10.0.0.6:6379",
+      EPHEMERAL_DB_NAME: "sdp_api_pr_123",
+      EPHEMERAL_REDIS_DB: "4",
+    };
 
-describe("getDeploymentMode", () => {
-  it("defaults to managed when SDP_DEPLOYMENT_MODE is unset", () => {
-    expect(getDeploymentMode(envWith(undefined))).toBe("managed");
-  });
+    applyEphemeralOverrides(env);
 
-  it("accepts the documented values", () => {
-    expect(getDeploymentMode(envWith("managed"))).toBe("managed");
-    expect(getDeploymentMode(envWith("self_hosted"))).toBe("self_hosted");
-  });
-
-  it("throws on a typo'd value (selfhosted, no underscore)", () => {
-    expect(() => getDeploymentMode(envWith("selfhosted"))).toThrow(
-      /Invalid SDP_DEPLOYMENT_MODE.*selfhosted/
+    expect(env.DATABASE_URL).toBe(
+      "postgresql://sdp:s3cret@10.0.0.5:5432/sdp_api_pr_123?sslmode=require"
     );
+    expect(env.REDIS_URL).toBe("redis://:authtoken@10.0.0.6:6379/4");
   });
 
-  it("throws on any other unknown value", () => {
-    expect(() => getDeploymentMode(envWith("hosted"))).toThrow(/Invalid SDP_DEPLOYMENT_MODE/);
-    expect(() => getDeploymentMode(envWith(""))).toThrow(/Invalid SDP_DEPLOYMENT_MODE/);
-  });
-});
+  it("is idempotent", () => {
+    const env: NodeJS.ProcessEnv = {
+      DATABASE_URL: "postgresql://sdp@db:5432/sdp_api",
+      EPHEMERAL_DB_NAME: "sdp_api_pr_7",
+    };
 
-describe("isSelfHostedDeployment", () => {
-  it("returns false for managed (default)", () => {
-    expect(isSelfHostedDeployment(envWith(undefined))).toBe(false);
-    expect(isSelfHostedDeployment(envWith("managed"))).toBe(false);
-  });
+    applyEphemeralOverrides(env);
+    applyEphemeralOverrides(env);
 
-  it("returns true for self_hosted", () => {
-    expect(isSelfHostedDeployment(envWith("self_hosted"))).toBe(true);
+    expect(env.DATABASE_URL).toBe("postgresql://sdp@db:5432/sdp_api_pr_7");
   });
 
-  it("propagates the validation error for invalid values", () => {
-    expect(() => isSelfHostedDeployment(envWith("selfhosted"))).toThrow(
-      /Invalid SDP_DEPLOYMENT_MODE/
-    );
+  it("leaves URLs untouched without overrides", () => {
+    const env: NodeJS.ProcessEnv = {
+      DATABASE_URL: "postgresql://sdp@db:5432/sdp_api",
+      REDIS_URL: "redis://cache:6379",
+    };
+
+    applyEphemeralOverrides(env);
+
+    expect(env.DATABASE_URL).toBe("postgresql://sdp@db:5432/sdp_api");
+    expect(env.REDIS_URL).toBe("redis://cache:6379");
   });
 });

--- a/apps/sdp-api/src/lib/runtime-env.test.ts
+++ b/apps/sdp-api/src/lib/runtime-env.test.ts
@@ -1,5 +1,48 @@
 import { describe, expect, it } from "vitest";
-import { applyEphemeralOverrides } from "./runtime-env";
+import type { Env } from "@/types/env";
+import { applyEphemeralOverrides, getDeploymentMode, isSelfHostedDeployment } from "./runtime-env";
+
+const envWith = (mode: string | undefined): Pick<Env, "SDP_DEPLOYMENT_MODE"> =>
+  ({ SDP_DEPLOYMENT_MODE: mode }) as Pick<Env, "SDP_DEPLOYMENT_MODE">;
+
+describe("getDeploymentMode", () => {
+  it("defaults to managed when SDP_DEPLOYMENT_MODE is unset", () => {
+    expect(getDeploymentMode(envWith(undefined))).toBe("managed");
+  });
+
+  it("accepts the documented values", () => {
+    expect(getDeploymentMode(envWith("managed"))).toBe("managed");
+    expect(getDeploymentMode(envWith("self_hosted"))).toBe("self_hosted");
+  });
+
+  it("throws on a typo'd value (selfhosted, no underscore)", () => {
+    expect(() => getDeploymentMode(envWith("selfhosted"))).toThrow(
+      /Invalid SDP_DEPLOYMENT_MODE.*selfhosted/
+    );
+  });
+
+  it("throws on any other unknown value", () => {
+    expect(() => getDeploymentMode(envWith("hosted"))).toThrow(/Invalid SDP_DEPLOYMENT_MODE/);
+    expect(() => getDeploymentMode(envWith(""))).toThrow(/Invalid SDP_DEPLOYMENT_MODE/);
+  });
+});
+
+describe("isSelfHostedDeployment", () => {
+  it("returns false for managed (default)", () => {
+    expect(isSelfHostedDeployment(envWith(undefined))).toBe(false);
+    expect(isSelfHostedDeployment(envWith("managed"))).toBe(false);
+  });
+
+  it("returns true for self_hosted", () => {
+    expect(isSelfHostedDeployment(envWith("self_hosted"))).toBe(true);
+  });
+
+  it("propagates the validation error for invalid values", () => {
+    expect(() => isSelfHostedDeployment(envWith("selfhosted"))).toThrow(
+      /Invalid SDP_DEPLOYMENT_MODE/
+    );
+  });
+});
 
 describe("applyEphemeralOverrides", () => {
   it("rewrites the database name and redis db index when overrides are set", () => {

--- a/apps/sdp-api/src/lib/runtime-env.ts
+++ b/apps/sdp-api/src/lib/runtime-env.ts
@@ -42,6 +42,33 @@ export function isSelfHostedDeployment(env: Pick<Env, "SDP_DEPLOYMENT_MODE">): b
  * remains responsible for required values; feature-specific readers handle
  * their optional values where they are consumed.
  */
+/**
+ * Ephemeral per-PR environments mount the same dev secrets but must land on
+ * their own database and Redis keyspace. EPHEMERAL_DB_NAME and
+ * EPHEMERAL_REDIS_DB rewrite the secret-provided URLs in place so every
+ * downstream reader (API, worker, cron) sees the per-PR endpoints.
+ */
+export function applyEphemeralOverrides(env: NodeJS.ProcessEnv): void {
+  const dbName = env.EPHEMERAL_DB_NAME?.trim();
+  if (dbName && env.DATABASE_URL) {
+    const url = new URL(env.DATABASE_URL);
+    url.pathname = `/${dbName}`;
+    env.DATABASE_URL = url.toString();
+  }
+  const redisDb = env.EPHEMERAL_REDIS_DB?.trim();
+  if (redisDb && env.REDIS_URL) {
+    const url = new URL(env.REDIS_URL);
+    url.pathname = `/${redisDb}`;
+    env.REDIS_URL = url.toString();
+  }
+}
+
+let ephemeralOverridesApplied = false;
+
 export function getProcessEnv(): Env {
+  if (!ephemeralOverridesApplied) {
+    applyEphemeralOverrides(process.env);
+    ephemeralOverridesApplied = true;
+  }
   return process.env as unknown as Env;
 }


### PR DESCRIPTION
Implements the ephemeral per-PR dev API design locked today (see PRO-1767 comment).

**How it works**
- Label a PR `ephemeral-api` → builds the branch image and stands up `sdp-dev-api-pr-<n>` (public run.app URL, scale 0–2) + `sdp-dev-worker-pr-<n>` (internal, crons enabled), cloned live from the real dev service manifests so config never drifts from terraform.
- Isolation is two env overrides applied at boot (`getProcessEnv`): `EPHEMERAL_DB_NAME` re-points `DATABASE_URL` at `sdp_api_pr_<n>` on the dev Cloud SQL instance; `EPHEMERAL_REDIS_DB` re-points `REDIS_URL` at a logical db (1–15) claimed collision-free via a `sdp-ephemeral-redis-db` label on the PR's resources — offset scan for a free slot, then a post-claim verify where the lower-numbered PR wins, so no two live environments ever share a db (hard cap: 15 concurrent). Index 0 stays dev/main.
- A per-PR clone of the migrate job runs the new bundled `ephemeral-db.js` in-VPC: `ensure` creates the database and applies the branch's migrations from zero; `drop` (args override at teardown) terminates connections, drops it, and flushes the redis db.
- The URL is commented on the PR (updated in place per push). Teardown on close/unlabel; a nightly reaper sweeps environments whose PR closed while the event was missed.

**Coexistence with dev/main**: `sdp-dev-api-public`/`api-dev.solana.com`, its database, and redis db 0 are untouched; ephemerals share only instance-level capacity. Not behind the LB → no Cloud Armor; app-level Clerk auth still applies (dev-tier tradeoff).

**Depends on** sdp-infra#94 (project-level `run.admin` for the dev deployer — dev terraform auto-applies on merge).

**Rollout note**: first `ensure` run requires the dev app DB role to have `CREATEDB`; if it doesn't, one-time `ALTER ROLE <app_user> CREATEDB` on the dev instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


**Security posture** (Greptile round): the privileged orchestration script (`ephemeral-env.sh`) always runs from a trusted `main` checkout — the PR checkout is used only as the Docker build context; teardown checks out `main` explicitly. The nightly reaper discovers environments by label on both services *and* jobs, so a deploy that dies between the db job and the API service still gets reaped once the PR closes.
