### PR TITLE
ci(slack): prod-only deploy notifications with commit context

### DIFF
--- a/.github/workflows/deploy-sdp-api-gcp-prod.yml
+++ b/.github/workflows/deploy-sdp-api-gcp-prod.yml
@@ -30,6 +30,39 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  notify-start:
+    name: Notify Slack — release started
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    continue-on-error: true
+    if: github.repository == 'solana-foundation/solana-developer-platform'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4.0.1
+
+      - name: Notify Slack — deploy started
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
+          DOPPLER_PROJECT: solana-developer-platform
+          DOPPLER_CONFIG: dev_ci
+          SERVICE: sdp-api
+          ENV: production
+          STATUS: started
+          VERSION: ${{ inputs.release_tag != '' && inputs.release_tag || inputs.image_sha }}
+          DEPLOY_SHA: ${{ inputs.release_sha != '' && inputs.release_sha || inputs.image_sha }}
+          ACTOR: ${{ github.actor }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          COMMIT="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${DEPLOY_SHA}" \
+            --jq '(.sha[0:7]) + " — " + (.commit.message | split("\n")[0])' 2>/dev/null || true)"
+          export COMMIT
+          ./scripts/notify-slack.sh
+
   smoke:
     name: Gate on dev smoke
     if: >-
@@ -84,20 +117,8 @@ jobs:
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4.0.1
 
-      - name: Notify Slack — deploy started
-        continue-on-error: true
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
-          DOPPLER_PROJECT: solana-developer-platform
-          DOPPLER_CONFIG: dev_ci
-          SERVICE: sdp-api
-          ENV: production
-          STATUS: started
-          VERSION: ${{ inputs.release_tag != '' && inputs.release_tag || inputs.image_sha }}
-          ACTOR: ${{ github.actor }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          RUN_ID: ${{ github.run_id }}
-        run: ./scripts/notify-slack.sh
+      - name: Resolve commit summary
+        run: echo "COMMIT_LINE=$(git log -1 --format='%h — %s' "${DEPLOY_IMAGE_SHA}" 2>/dev/null || true)" >> "${GITHUB_ENV}"
 
       - name: Verify release identity
         if: ${{ inputs.release_sha != '' }}
@@ -376,6 +397,7 @@ jobs:
           SERVICE: sdp-api
           ENV: production
           STATUS: ${{ job.status }}
+          COMMIT: ${{ env.COMMIT_LINE }}
           VERSION: ${{ inputs.release_tag != '' && inputs.release_tag || inputs.image_sha }}
           ACTOR: ${{ github.actor }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/deploy-sdp-api-gcp-prod.yml
+++ b/.github/workflows/deploy-sdp-api-gcp-prod.yml
@@ -387,19 +387,40 @@ jobs:
             --region "${REGION}" --project "${PROJECT_ID}" \
             --remove-tags "${CANDIDATE_TAG}"
 
+
+  notify-result:
+    name: Notify Slack — release result
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    continue-on-error: true
+    needs: [smoke, deploy]
+    if: >-
+      always() &&
+      github.repository == 'solana-foundation/solana-developer-platform' &&
+      needs.deploy.result != 'cancelled'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4.0.1
+
       - name: Notify Slack — deploy result
-        if: ${{ always() }}
-        continue-on-error: true
         env:
+          GH_TOKEN: ${{ github.token }}
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
           DOPPLER_PROJECT: solana-developer-platform
           DOPPLER_CONFIG: dev_ci
           SERVICE: sdp-api
           ENV: production
-          STATUS: ${{ job.status }}
-          COMMIT: ${{ env.COMMIT_LINE }}
+          STATUS: ${{ needs.deploy.result == 'success' && 'success' || 'failure' }}
           VERSION: ${{ inputs.release_tag != '' && inputs.release_tag || inputs.image_sha }}
+          DEPLOY_SHA: ${{ inputs.release_sha != '' && inputs.release_sha || inputs.image_sha }}
           ACTOR: ${{ github.actor }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           RUN_ID: ${{ github.run_id }}
-        run: ./scripts/notify-slack.sh
+        run: |
+          COMMIT="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${DEPLOY_SHA}" \
+            --jq '(.sha[0:7]) + " — " + (.commit.message | split("\n")[0])' 2>/dev/null || true)"
+          export COMMIT
+          ./scripts/notify-slack.sh

--- a/.github/workflows/deploy-sdp-api-gcp-prod.yml
+++ b/.github/workflows/deploy-sdp-api-gcp-prod.yml
@@ -396,8 +396,7 @@ jobs:
     needs: [smoke, deploy]
     if: >-
       always() &&
-      github.repository == 'solana-foundation/solana-developer-platform' &&
-      needs.deploy.result != 'cancelled'
+      github.repository == 'solana-foundation/solana-developer-platform'
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
@@ -413,7 +412,10 @@ jobs:
           DOPPLER_CONFIG: dev_ci
           SERVICE: sdp-api
           ENV: production
-          STATUS: ${{ needs.deploy.result == 'success' && 'success' || 'failure' }}
+          STATUS: >-
+            ${{ needs.deploy.result == 'success' && 'success' ||
+                (needs.deploy.result == 'cancelled' || needs.smoke.result == 'cancelled') && 'cancelled' ||
+                'failure' }}
           VERSION: ${{ inputs.release_tag != '' && inputs.release_tag || inputs.image_sha }}
           DEPLOY_SHA: ${{ inputs.release_sha != '' && inputs.release_sha || inputs.image_sha }}
           ACTOR: ${{ github.actor }}

--- a/.github/workflows/deploy-sdp-api-gcp.yml
+++ b/.github/workflows/deploy-sdp-api-gcp.yml
@@ -40,21 +40,6 @@ jobs:
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4.0.1
 
-      - name: Notify Slack — deploy started
-        continue-on-error: true
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
-          DOPPLER_PROJECT: solana-developer-platform
-          DOPPLER_CONFIG: dev_ci
-          SERVICE: sdp-api
-          ENV: dev
-          STATUS: started
-          VERSION: ${{ github.sha }}
-          ACTOR: ${{ github.actor }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          RUN_ID: ${{ github.run_id }}
-        run: ./scripts/notify-slack.sh
-
       - name: Authenticate to GCP
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
@@ -107,22 +92,6 @@ jobs:
             cat "${describe_err}" >&2
             exit 1
           fi
-
-      - name: Notify Slack — deploy result
-        if: always()
-        continue-on-error: true
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
-          DOPPLER_PROJECT: solana-developer-platform
-          DOPPLER_CONFIG: dev_ci
-          SERVICE: sdp-api
-          ENV: dev
-          STATUS: ${{ job.status }}
-          VERSION: ${{ github.sha }}
-          ACTOR: ${{ github.actor }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          RUN_ID: ${{ github.run_id }}
-        run: ./scripts/notify-slack.sh
 
   smoke:
     name: Post-deploy dev smoke

--- a/scripts/notify-slack.sh
+++ b/scripts/notify-slack.sh
@@ -17,9 +17,10 @@ echo "::add-mask::$SLACK"
 
 LABEL="$SERVICE"; [ -n "$ENV" ] && LABEL="$SERVICE ($ENV)"
 case "$STATUS" in
-  started) MARKER="[STARTED] Deploy $LABEL"; COLOR="#dbab09" ;;
-  success) MARKER="[SUCCESS] Deploy $LABEL"; COLOR="#36a64f" ;;
-  *)       MARKER="[FAILED] Deploy $LABEL";  COLOR="#cc0000" ;;
+  started)   MARKER="[STARTED] Deploy $LABEL";   COLOR="#dbab09" ;;
+  success)   MARKER="[SUCCESS] Deploy $LABEL";   COLOR="#36a64f" ;;
+  cancelled) MARKER="[CANCELLED] Deploy $LABEL"; COLOR="#808080" ;;
+  *)         MARKER="[FAILED] Deploy $LABEL";    COLOR="#cc0000" ;;
 esac
 
 FIELDS=$(jq -n --arg label "$LABEL" --arg ver "$VERSION" --arg commit "$COMMIT" --arg actor "$ACTOR" --arg run "$RUN_URL" --arg rid "$RUN_ID" \

--- a/scripts/notify-slack.sh
+++ b/scripts/notify-slack.sh
@@ -3,13 +3,13 @@
 # Reads the webhook from Doppler (SLACK_DEPLOY_WEBHOOK_URL).
 #
 # Required env: SERVICE, STATUS (started|success|failure/<other>), DOPPLER_PROJECT, DOPPLER_CONFIG, DOPPLER_TOKEN
-# Optional env: ENV (e.g. mainnet/devnet), VERSION (tag/sha), ACTOR, RUN_URL, RUN_ID
+# Optional env: ENV (e.g. mainnet/devnet), VERSION (tag/sha), COMMIT ("<sha> — <subject>"), ACTOR, RUN_URL, RUN_ID
 set -euo pipefail
 
 SERVICE="${SERVICE:?SERVICE required}"
 STATUS="${STATUS:?STATUS required}"
 ENV="${ENV:-}"; VERSION="${VERSION:-}"; ACTOR="${ACTOR:-unknown}"
-RUN_URL="${RUN_URL:-}"; RUN_ID="${RUN_ID:-}"
+COMMIT="${COMMIT:-}"; RUN_URL="${RUN_URL:-}"; RUN_ID="${RUN_ID:-}"
 
 SLACK=$(doppler secrets get SLACK_DEPLOY_WEBHOOK_URL --plain --project "$DOPPLER_PROJECT" --config "$DOPPLER_CONFIG" 2>/dev/null || true)
 if [ -z "$SLACK" ]; then echo "::warning::SLACK_DEPLOY_WEBHOOK_URL missing — skipping notification"; exit 0; fi
@@ -22,9 +22,10 @@ case "$STATUS" in
   *)       MARKER="[FAILED] Deploy $LABEL";  COLOR="#cc0000" ;;
 esac
 
-FIELDS=$(jq -n --arg label "$LABEL" --arg ver "$VERSION" --arg actor "$ACTOR" --arg run "$RUN_URL" --arg rid "$RUN_ID" \
+FIELDS=$(jq -n --arg label "$LABEL" --arg ver "$VERSION" --arg commit "$COMMIT" --arg actor "$ACTOR" --arg run "$RUN_URL" --arg rid "$RUN_ID" \
   '[ {type:"mrkdwn",text:("*Service:*\n`"+$label+"`")} ]
     + (if $ver != "" then [ {type:"mrkdwn",text:("*Version:*\n`"+$ver+"`")} ] else [] end)
+    + (if $commit != "" then [ {type:"mrkdwn",text:("*Commit:*\n"+$commit)} ] else [] end)
     + [ {type:"mrkdwn",text:("*Triggered by:*\n"+$actor)} ]
     + (if $run != "" then [ {type:"mrkdwn",text:("*Run:*\n<"+$run+"|workflow #"+$rid+">")} ] else [] end)')
 PAYLOAD=$(jq -n --arg marker "$MARKER" --arg color "$COLOR" --argjson fields "$FIELDS" \


### PR DESCRIPTION
Per Nikhil: deploy Slack notifications should cover only the prod release flow — [STARTED] when the release begins (before the dev smoke gate) and the result after prod promotion. Dev deploys stop posting entirely.

- `deploy-sdp-api-gcp.yml`: both notify steps removed.
- `deploy-sdp-api-gcp-prod.yml`: new first job posts [STARTED] (parallel to the smoke gate); the result notification gains the commit line.
- `notify-slack.sh`: optional `COMMIT` field — `<short-sha> — <subject>`, matching the breeze deploy notifications' format.

Root cause of the silence until today, for the record: `SLACK_DEPLOY_WEBHOOK_URL` existed only in Doppler `prd` while the notify steps read `dev_ci`; the value is now copied to `dev_ci` (no code change needed for that part).

🤖 Generated with [Claude Code](https://claude.com/claude-code)