### PR TITLE
feat(earn): wisdomtree catalogue client + deposit-eligibility capability

### DIFF
--- a/packages/sdp-earn/src/capabilities.ts
+++ b/packages/sdp-earn/src/capabilities.ts
@@ -1,4 +1,5 @@
 import type {
+  EarnDepositEligibilityProvider,
   EarnLiveMetricsProvider,
   EarnPortfolioWalletProvider,
   EarnVaultDepositQuoteProvider,
@@ -158,6 +159,26 @@ export function supportsVaultWithdrawQuote(
     Record<(typeof VAULT_WITHDRAW_QUOTE_METHODS)[number], unknown>
   >;
   return VAULT_WITHDRAW_QUOTE_METHODS.every((method) => typeof candidate[method] === "function");
+}
+
+const DEPOSIT_ELIGIBILITY_METHODS = ["checkDepositEligibility"] as const satisfies readonly Exclude<
+  keyof EarnDepositEligibilityProvider,
+  keyof EarnVaultProvider
+>[];
+
+/**
+ * Capability discovery for the optional deposit-eligibility contract — same
+ * method-presence rule as the guards above. Consulted by MONEY-IN paths only
+ * (ADR 0002: an exit must never inherit this gate); a provider without the
+ * capability is simply not eligibility-gated.
+ */
+export function supportsDepositEligibility(
+  client: EarnVaultProvider
+): client is EarnDepositEligibilityProvider {
+  const candidate = client as Partial<
+    Record<(typeof DEPOSIT_ELIGIBILITY_METHODS)[number], unknown>
+  >;
+  return DEPOSIT_ELIGIBILITY_METHODS.every((method) => typeof candidate[method] === "function");
 }
 
 const LIVE_METRICS_METHODS = ["listStrategyMetrics"] as const satisfies readonly Exclude<

--- a/packages/sdp-earn/src/index.ts
+++ b/packages/sdp-earn/src/index.ts
@@ -9,6 +9,7 @@ import { WisdomTreeEarnClient } from "./providers/wisdomtree/client";
 import type { EarnVaultProvider } from "./types";
 
 export {
+  supportsDepositEligibility,
   supportsLiveMetrics,
   supportsPortfolioWallets,
   supportsWithdrawalApprovals,
@@ -32,6 +33,9 @@ export { WisdomTreeEarnClient } from "./providers/wisdomtree/client";
 export { isClusterFundableInEnvironment, isStrategyWithinDeclaredSupport } from "./support";
 export type {
   EarnDeclaredStrategySupport,
+  EarnDepositEligibility,
+  EarnDepositEligibilityInput,
+  EarnDepositEligibilityProvider,
   EarnLiveMetricsProvider,
   EarnPendingWithdrawalApproval,
   EarnPortfolioAddressBookEntryInput,

--- a/packages/sdp-earn/src/providers/wisdomtree/client.test.ts
+++ b/packages/sdp-earn/src/providers/wisdomtree/client.test.ts
@@ -1,0 +1,360 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it, mock } from "node:test";
+import { wellKnownMint } from "@sdp/types";
+import { WISDOMTREE_FUNDS } from "@sdp/types/wisdomtree-programs";
+import { supportsDepositEligibility, supportsPortfolioWallets } from "../../capabilities";
+import { SdpEarnError, type SdpEarnErrorCode } from "../../errors";
+import type { EarnRuntimeContext } from "../../types";
+import { WisdomTreeEarnClient } from "./client";
+import { resetWisdomTreeTokenCache } from "./connect";
+
+/**
+ * Canonical no-network harness (see src/fetch.test.ts): `globalThis.fetch` is
+ * stubbed per test and restored in `afterEach` — no test may ever reach the
+ * real WisdomTree Connect API.
+ */
+
+const client = new WisdomTreeEarnClient();
+
+const WTGXX = WISDOMTREE_FUNDS[0];
+const MAINNET_USDC = wellKnownMint("USDC", "mainnet-beta");
+
+const credential = JSON.stringify({
+  clientId: "client-id",
+  clientSecret: "client-secret",
+  username: "api-user",
+  password: "api-pass",
+});
+
+const productionCtx: EarnRuntimeContext = {
+  env: { WISDOMTREE_API_KEY: credential },
+  environment: "production",
+};
+const sandboxCtx: EarnRuntimeContext = {
+  env: { WISDOMTREE_SANDBOX_API_KEY: credential },
+  environment: "sandbox",
+};
+
+const jsonResponse = (status: number, body: unknown): Response =>
+  new Response(JSON.stringify(body), { status });
+
+const tokenReply = { access_token: "bearer-token", expires_in: 600 };
+
+/** Queue JSON replies; extra calls replay the last reply. */
+function stubConnectFetch(...replies: Array<{ status?: number; body: unknown }>) {
+  let index = 0;
+  return mock.method(globalThis, "fetch", async () => {
+    const reply = replies[Math.min(index, replies.length - 1)];
+    index += 1;
+    return jsonResponse(reply.status ?? 200, reply.body);
+  });
+}
+
+type FetchMock = ReturnType<typeof stubConnectFetch>;
+
+const requestUrl = (fetchMock: FetchMock, call = 0): string =>
+  String(fetchMock.mock.calls[call].arguments[0]);
+
+const earnError =
+  (code: SdpEarnErrorCode, message?: RegExp) =>
+  (error: unknown): boolean =>
+    error instanceof SdpEarnError &&
+    error.code === code &&
+    (message === undefined || message.test(error.message));
+
+beforeEach(() => {
+  resetWisdomTreeTokenCache();
+});
+
+afterEach(() => {
+  mock.restoreAll();
+});
+
+describe("capability shape", () => {
+  it("reports deposit eligibility and nothing custodial", () => {
+    assert.equal(supportsDepositEligibility(client), true);
+    assert.equal(supportsPortfolioWallets(client), false);
+  });
+});
+
+describe("listStrategies", () => {
+  it("answers an empty shelf outside production without any network call", async () => {
+    const fetchMock = stubConnectFetch({ body: {} });
+    assert.deepEqual(await client.listStrategies(sandboxCtx), []);
+    assert.equal(fetchMock.mock.callCount(), 0);
+  });
+
+  it("throws PROVIDER_NOT_CONFIGURED before any network call without a credential", async () => {
+    const fetchMock = stubConnectFetch({ body: {} });
+    await assert.rejects(
+      client.listStrategies({ env: {}, environment: "production" }),
+      earnError("PROVIDER_NOT_CONFIGURED", /WISDOMTREE_API_KEY/)
+    );
+    assert.equal(fetchMock.mock.callCount(), 0);
+  });
+
+  it("throws PROVIDER_NOT_CONFIGURED on a malformed packed credential", async () => {
+    await assert.rejects(
+      client.listStrategies({
+        env: { WISDOMTREE_API_KEY: "not-json" },
+        environment: "production",
+      }),
+      earnError("PROVIDER_NOT_CONFIGURED", /not valid JSON/)
+    );
+    await assert.rejects(
+      client.listStrategies({
+        env: { WISDOMTREE_API_KEY: JSON.stringify({ clientId: "only" }) },
+        environment: "production",
+      }),
+      earnError("PROVIDER_NOT_CONFIGURED", /clientSecret/)
+    );
+    await assert.rejects(
+      client.listStrategies({
+        env: { WISDOMTREE_API_KEY: "null" },
+        environment: "production",
+      }),
+      earnError("PROVIDER_NOT_CONFIGURED", /must be a JSON object/)
+    );
+  });
+
+  it("maps a tradable registry fund onto a catalogue snapshot", async () => {
+    const fetchMock = stubConnectFetch(
+      { body: tokenReply },
+      {
+        body: {
+          products: [
+            { exchange_code: WTGXX.exchangeCode, can_trade: true, issuer: "WisdomTree" },
+            { exchange_code: "SPXUX", can_trade: true },
+          ],
+        },
+      }
+    );
+
+    const snapshots = await client.listStrategies(productionCtx);
+    assert.equal(snapshots.length, 1);
+    const snapshot = snapshots[0];
+    assert.deepEqual(snapshot, {
+      providerReference: WTGXX.mint,
+      name: WTGXX.name,
+      sourceKind: "rwa",
+      underlyingSource: "wtgxx",
+      depositMints: [MAINNET_USDC],
+      shareMint: WTGXX.mint,
+      hostCluster: "mainnet-beta",
+      apyType: "variable",
+      liquidityTerm: "delayed",
+      redemptionDelayDays: 1,
+      riskMetadata: { curator: "wisdomtree" },
+    });
+
+    // OAuth password grant first, then the products read with the bearer token.
+    assert.equal(fetchMock.mock.callCount(), 2);
+    assert.match(requestUrl(fetchMock, 0), /\/o\/token\/$/);
+    assert.match(requestUrl(fetchMock, 1), /\/api\/orders\/products$/);
+    const productsInit = fetchMock.mock.calls[1].arguments[1] as RequestInit;
+    assert.equal(new Headers(productsInit.headers).get("authorization"), "Bearer bearer-token");
+  });
+
+  it("skips a fund the organization cannot trade — absent OR can_trade unstated", async () => {
+    stubConnectFetch(
+      { body: tokenReply },
+      { body: { products: [{ exchange_code: WTGXX.exchangeCode }] } }
+    );
+    assert.deepEqual(await client.listStrategies(productionCtx), []);
+
+    resetWisdomTreeTokenCache();
+    mock.restoreAll();
+    stubConnectFetch({ body: tokenReply }, { body: { products: [] } });
+    assert.deepEqual(await client.listStrategies(productionCtx), []);
+  });
+
+  it("throws PROVIDER_UNAVAILABLE on a products response with no products array", async () => {
+    stubConnectFetch({ body: tokenReply }, { body: {} });
+    await assert.rejects(
+      client.listStrategies(productionCtx),
+      earnError("PROVIDER_UNAVAILABLE", /no products array/)
+    );
+  });
+
+  it("classifies malformed product entries as PROVIDER_UNAVAILABLE", async () => {
+    stubConnectFetch({ body: tokenReply }, { body: { products: [null] } });
+    await assert.rejects(
+      client.listStrategies(productionCtx),
+      earnError("PROVIDER_UNAVAILABLE", /malformed product entry/)
+    );
+  });
+
+  it("throws PROVIDER_UNAVAILABLE when the token endpoint returns no access_token", async () => {
+    stubConnectFetch({ body: { token_type: "Bearer" } });
+    await assert.rejects(
+      client.listStrategies(productionCtx),
+      earnError("PROVIDER_UNAVAILABLE", /no access_token/)
+    );
+  });
+
+  it("surfaces the provider's own message on a refused token exchange", async () => {
+    stubConnectFetch({ status: 401, body: { error: "invalid_grant" } });
+    await assert.rejects(
+      client.listStrategies(productionCtx),
+      earnError("BAD_REQUEST", /invalid_grant/)
+    );
+  });
+
+  it("caches the bearer token across calls in one environment", async () => {
+    const fetchMock = stubConnectFetch(
+      { body: tokenReply },
+      { body: { products: [{ exchange_code: WTGXX.exchangeCode, can_trade: true }] } }
+    );
+    await client.listStrategies(productionCtx);
+    await client.listStrategies(productionCtx);
+    // 1 token call + 2 product reads: the second pass reuses the cached token.
+    assert.equal(fetchMock.mock.callCount(), 3);
+    assert.match(requestUrl(fetchMock, 2), /\/api\/orders\/products$/);
+  });
+
+  it("does not reuse a bearer token after any credential field rotates", async () => {
+    const rotatedCtx: EarnRuntimeContext = {
+      ...productionCtx,
+      env: {
+        WISDOMTREE_API_KEY: JSON.stringify({
+          ...JSON.parse(credential),
+          clientSecret: "rotated-client-secret",
+        }),
+      },
+    };
+    const fetchMock = stubConnectFetch(
+      { body: { access_token: "first-token", expires_in: 600 } },
+      { body: { products: [] } },
+      { body: { access_token: "rotated-token", expires_in: 600 } },
+      { body: { products: [] } }
+    );
+
+    await client.listStrategies(productionCtx);
+    await client.listStrategies(rotatedCtx);
+
+    assert.equal(fetchMock.mock.callCount(), 4);
+    assert.match(requestUrl(fetchMock, 2), /\/o\/token\/$/);
+  });
+
+  it("refreshes a rejected bearer token and retries the request once", async () => {
+    const fetchMock = stubConnectFetch(
+      { body: { access_token: "stale-token", expires_in: 600 } },
+      { status: 401, body: { error: "invalid_token" } },
+      { body: { access_token: "fresh-token", expires_in: 600 } },
+      { body: { products: [] } }
+    );
+
+    await client.listStrategies(productionCtx);
+
+    assert.equal(fetchMock.mock.callCount(), 4);
+    assert.equal(
+      new Headers((fetchMock.mock.calls[3].arguments[1] as RequestInit).headers).get(
+        "authorization"
+      ),
+      "Bearer fresh-token"
+    );
+  });
+});
+
+describe("checkDepositEligibility", () => {
+  const owner = "OwnerWa11etAddre55555555555555555555555555555";
+
+  const walletsReply = (records: unknown) => ({
+    body: { data: { Solana: records } },
+  });
+
+  it("approves a registered, approved Solana wallet", async () => {
+    stubConnectFetch(
+      { body: tokenReply },
+      { body: { guid: "org-guid" } },
+      walletsReply([{ public_key: owner, status: "approved" }])
+    );
+    const verdict = await client.checkDepositEligibility(productionCtx, {
+      providerReference: WTGXX.mint,
+      owner,
+    });
+    assert.deepEqual(verdict, { eligible: true });
+  });
+
+  it("refuses an unregistered wallet with a customer-renderable reason", async () => {
+    stubConnectFetch(
+      { body: tokenReply },
+      { body: { guid: "org-guid" } },
+      walletsReply([{ public_key: "SomeOtherWallet", status: "approved" }])
+    );
+    const verdict = await client.checkDepositEligibility(productionCtx, {
+      providerReference: WTGXX.mint,
+      owner,
+    });
+    assert.equal(verdict.eligible, false);
+    assert.match(verdict.reason ?? "", /not registered with WisdomTree Connect/);
+  });
+
+  it("fails closed on a registered wallet that is not approved", async () => {
+    stubConnectFetch(
+      { body: tokenReply },
+      { body: { guid: "org-guid" } },
+      walletsReply([{ public_key: owner, status: "pending" }])
+    );
+    const verdict = await client.checkDepositEligibility(productionCtx, {
+      providerReference: WTGXX.mint,
+      owner,
+    });
+    assert.equal(verdict.eligible, false);
+    assert.match(verdict.reason ?? "", /status is "pending"/);
+  });
+
+  it("fails closed when the wallets response has no Solana lane", async () => {
+    stubConnectFetch(
+      { body: tokenReply },
+      { body: { guid: "org-guid" } },
+      { body: { data: { Ethereum: [{ public_key: owner, status: "approved" }] } } }
+    );
+    const verdict = await client.checkDepositEligibility(productionCtx, {
+      providerReference: WTGXX.mint,
+      owner,
+    });
+    assert.equal(verdict.eligible, false);
+  });
+
+  it("accepts the organisation_guid spelling and throws when every guid field is absent", async () => {
+    stubConnectFetch(
+      { body: tokenReply },
+      { body: { organisation_guid: "org-guid" } },
+      walletsReply([{ public_key: owner, status: "approved" }])
+    );
+    const verdict = await client.checkDepositEligibility(productionCtx, {
+      providerReference: WTGXX.mint,
+      owner,
+    });
+    assert.equal(verdict.eligible, true);
+
+    resetWisdomTreeTokenCache();
+    mock.restoreAll();
+    stubConnectFetch({ body: tokenReply }, { body: { name: "Org with no guid" } });
+    await assert.rejects(
+      client.checkDepositEligibility(productionCtx, { providerReference: WTGXX.mint, owner }),
+      earnError("PROVIDER_UNAVAILABLE", /no guid/)
+    );
+  });
+
+  it("throws PROVIDER_UNAVAILABLE on a wallets response with no data map", async () => {
+    stubConnectFetch({ body: tokenReply }, { body: { guid: "org-guid" } }, { body: {} });
+    await assert.rejects(
+      client.checkDepositEligibility(productionCtx, { providerReference: WTGXX.mint, owner }),
+      earnError("PROVIDER_UNAVAILABLE", /no data map/)
+    );
+  });
+
+  it("classifies malformed wallet entries as PROVIDER_UNAVAILABLE", async () => {
+    stubConnectFetch(
+      { body: tokenReply },
+      { body: { guid: "org-guid" } },
+      walletsReply([{ public_key: 42, status: "approved" }])
+    );
+    await assert.rejects(
+      client.checkDepositEligibility(productionCtx, { providerReference: WTGXX.mint, owner }),
+      earnError("PROVIDER_UNAVAILABLE", /invalid public_key/)
+    );
+  });
+});

--- a/packages/sdp-earn/src/providers/wisdomtree/client.ts
+++ b/packages/sdp-earn/src/providers/wisdomtree/client.ts
@@ -1,20 +1,130 @@
-import type { EarnDeclaredStrategySupport } from "../../types";
+import { wellKnownMint } from "@sdp/types";
+import { wisdomTreeFundsForCluster } from "@sdp/types/wisdomtree-programs";
+import type {
+  EarnDeclaredStrategySupport,
+  EarnDepositEligibility,
+  EarnDepositEligibilityInput,
+  EarnDepositEligibilityProvider,
+  EarnRuntimeContext,
+  ProviderStrategySnapshot,
+} from "../../types";
 import { StubEarnClient } from "../stub";
+import { checkWisdomTreeWalletEligibility, listWisdomTreeProducts } from "./connect";
 
 /**
- * WisdomTree Connect vault-infra client — `StubEarnClient` scaffold; the
- * catalogue read lands in the follow-up change.
+ * WisdomTree Connect vault-infra client — catalogue plus the deposit-eligibility
+ * capability. Instruction building (the on-receipt transfer legs) lives in
+ * `@sdp/wisdomtree`, which extends this class; this package stays chain-SDK-free
+ * for the hourly catalogue cron.
  *
- * WisdomTree fronts tokenized SEC-registered funds (Token-2022 mints with a
- * compliance transfer hook — see `@sdp/types/wisdomtree-programs`), so the
- * envelope is `rwa`, and subscriptions settle in USDC only: the Connect API's
- * non-USD order flow is USDC-denominated, and USD (bank SSI) settlement is not
- * a rail SDP fronts.
+ * ── What a WisdomTree strategy IS ───────────────────────────────────────────
+ * A tokenized SEC-registered fund: a Token-2022 mint with a compliance transfer
+ * hook (see `@sdp/types/wisdomtree-programs`). There is no vault — a deposit is
+ * a USDC transfer into WisdomTree's on-receipt wallet that opens a primary-market
+ * subscription, and fund tokens settle back to the sender after NAV strike. The
+ * snapshot's `providerReference` and `shareMint` are therefore the SAME address:
+ * the fund mint, which is both the instrument's identity and the receipt token.
+ *
+ * ── Two sources, and both must agree ────────────────────────────────────────
+ * The fund registry in `@sdp/types` is measured on-chain and owns identity
+ * (mint, decimals, name — read from the mint's own TokenMetadata, which the
+ * ISSUER controls, unlike Kamino's permissionless vault names). The Connect
+ * products API owns availability: a registry fund the authenticated
+ * organization cannot trade (missing from `/api/orders/products`, or
+ * `can_trade !== true`) is NOT listed, so the sync's delist pass retires it —
+ * fail-closed in the same direction as everything else on the money-in path.
+ *
+ * ── No rate, deliberately ───────────────────────────────────────────────────
+ * WTGXX's 7-day yield lives in WisdomTree's separate Fund Data API (Dataspan),
+ * a second credential SDP does not hold. Until that is provisioned and its
+ * routes measured, snapshots carry no `currentApy` and the dashboard renders
+ * "—" — the Kamino-devnet rule: a missing rate beats a fabricated one.
  */
-export class WisdomTreeEarnClient extends StubEarnClient {
+export class WisdomTreeEarnClient extends StubEarnClient implements EarnDepositEligibilityProvider {
   readonly provider = "wisdomtree" as const;
   readonly declaredSupport: EarnDeclaredStrategySupport = {
     sourceKinds: ["rwa"],
     depositTokens: ["USDC"],
   };
+
+  /**
+   * The shelf. Production only: WisdomTree deploys on Solana mainnet
+   * exclusively (their sandbox is Ethereum Sepolia), so every other
+   * environment honestly answers an empty shelf and its browse rows arrive
+   * via the sync's PRO-1742 production mirror instead.
+   */
+  override async listStrategies(ctx: EarnRuntimeContext): Promise<ProviderStrategySnapshot[]> {
+    if (ctx.environment !== "production") {
+      return [];
+    }
+    const funds = wisdomTreeFundsForCluster("mainnet-beta");
+    if (funds.length === 0) {
+      return [];
+    }
+
+    // One credentialed read for the whole shelf; a malformed response throws
+    // (all-or-nothing) so the sync skips the pass rather than delisting funds
+    // it failed to read.
+    const products = await listWisdomTreeProducts(ctx);
+    const productByExchangeCode = new Map(
+      products.flatMap((product) =>
+        typeof product.exchange_code === "string" ? [[product.exchange_code, product] as const] : []
+      )
+    );
+
+    const usdcMint = wellKnownMint("USDC", "mainnet-beta");
+    if (!usdcMint) {
+      // Unreachable with the pinned token catalogue; stated so a future edit
+      // there fails loudly here instead of listing a fund with no deposit mint.
+      return [];
+    }
+
+    return funds.flatMap((fund): ProviderStrategySnapshot[] => {
+      const product = productByExchangeCode.get(fund.exchangeCode);
+      // `can_trade === true` exactly: a fund the org cannot trade — or whose
+      // tradability the response left unstated — must not be offered as a
+      // deposit target. Skipping (not throwing) lets the delist pass retire it.
+      if (product?.can_trade !== true) {
+        return [];
+      }
+      return [
+        {
+          providerReference: fund.mint,
+          // Issuer-established (the mint's own TokenMetadata, verified when the
+          // registry row was added) — NOT the attacker-controlled free text the
+          // Kamino rule forbids parsing.
+          name: fund.name,
+          sourceKind: "rwa",
+          underlyingSource: fund.exchangeCode.toLowerCase(),
+          depositMints: [usdcMint],
+          shareMint: fund.mint,
+          hostCluster: fund.cluster,
+          // A government MMF's 7-day yield floats with rates; "fixed" would
+          // overstate the promise.
+          apyType: "variable",
+          // Primary-market redemption settles after NAV strike and
+          // transfer-agent processing — T+1 in the ordinary '40 Act cycle.
+          // WisdomTree's 2026 dealer-model instant settlement is a secondary
+          // rail SDP does not front, so the conservative term is the honest one.
+          liquidityTerm: "delayed",
+          redemptionDelayDays: 1,
+          // The issuer curates its own fund; "wisdomtree" is establishable from
+          // the mint's issuer-controlled metadata, unlike a Kamino vault name.
+          riskMetadata: { curator: "wisdomtree" },
+        },
+      ];
+    });
+  }
+
+  /**
+   * WisdomTree's KYC gate, asked API-side before money moves — see
+   * `EarnDepositEligibilityProvider` for why. The `providerReference` is not
+   * consulted: registration is per-wallet, not per-fund, in Connect's model.
+   */
+  async checkDepositEligibility(
+    ctx: EarnRuntimeContext,
+    input: EarnDepositEligibilityInput
+  ): Promise<EarnDepositEligibility> {
+    return checkWisdomTreeWalletEligibility(ctx, input.owner);
+  }
 }

--- a/packages/sdp-earn/src/providers/wisdomtree/connect.ts
+++ b/packages/sdp-earn/src/providers/wisdomtree/connect.ts
@@ -1,0 +1,428 @@
+import type { EarnProviderId } from "@sdp/types/provider-access";
+import { providerNotConfigured, providerUnavailable, SdpEarnError } from "../../errors";
+import { providerFetchJson } from "../../fetch";
+import type { EarnRuntimeContext } from "../../types";
+
+/**
+ * WisdomTree Connect REST client — the HTTP half of the integration, shared by
+ * the catalogue client in this package and the instruction builders in
+ * `@sdp/wisdomtree` (which depends on this package, never the reverse).
+ *
+ * Plain `providerFetchJson` over OAuth2, no chain SDK — this module rides the
+ * hourly catalogue cron, so the @sdp/earn dependency rule (nothing heavier
+ * than @sdp/types) binds it.
+ *
+ * ── Wire shapes are documented, not yet measured ────────────────────────────
+ * Endpoint paths, parameter names and response fields below come from
+ * WisdomTree's published OpenAPI spec and integration guides
+ * (docs.wisdomtreeconnect.com, read 2026-08-28). SDP holds no Connect
+ * credentials yet, so unlike Ground's client none of this is verified against
+ * a live tenant — anything marked UNVERIFIED is the first thing to re-check
+ * when credentials arrive, and each is a constant or a single reader so the
+ * fix is one edit.
+ */
+
+const WISDOMTREE_PROVIDER: EarnProviderId = "wisdomtree";
+
+const WISDOMTREE_PRODUCTION_API_URL = "https://app.wisdomtreeconnect.com";
+const WISDOMTREE_SANDBOX_API_URL = "https://api.sandbox.wisdomtreeconnect.com";
+
+/** Same sizing argument as Kamino's: both callers are deadline-bounded jobs or requests. */
+const WISDOMTREE_REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * The `blockchain` key WisdomTree's order routes take for Solana. UNVERIFIED:
+ * their examples only ever show Ethereum values ("Ethereum", "Ethereum
+ * Testnet Sepolia"); "Solana" matches the docs' chain-selector label. Confirm
+ * against `GET /api/orders/order-mapping` with live credentials.
+ */
+export const WISDOMTREE_SOLANA_BLOCKCHAIN_KEY = "Solana";
+
+/**
+ * Wallet `status` values SDP accepts as deposit-eligible. Fail-closed on
+ * purpose: the docs type the field as an open string and never enumerate it,
+ * so anything not in this set reads as "not approved" until measured.
+ */
+const WISDOMTREE_APPROVED_WALLET_STATUSES: ReadonlySet<string> = new Set(["approved"]);
+
+export interface WisdomTreeCredentials {
+  clientId: string;
+  clientSecret: string;
+  username: string;
+  password: string;
+}
+
+export interface WisdomTreeConfig {
+  baseUrl: string;
+  credentials: WisdomTreeCredentials;
+}
+
+const CREDENTIAL_FIELDS = ["clientId", "clientSecret", "username", "password"] as const;
+
+/**
+ * Parse the packed credential (see `EarnRuntimeEnvironment.WISDOMTREE_API_KEY`).
+ * Missing OR malformed both throw PROVIDER_NOT_CONFIGURED before any network
+ * call — a credential that cannot authenticate is not configured, whatever the
+ * env var contains.
+ */
+export function readWisdomTreeConfig(ctx: EarnRuntimeContext): WisdomTreeConfig {
+  const sandbox = ctx.environment !== "production";
+  const raw = (sandbox ? ctx.env.WISDOMTREE_SANDBOX_API_KEY : ctx.env.WISDOMTREE_API_KEY)?.trim();
+  const keyName = sandbox ? "WISDOMTREE_SANDBOX_API_KEY" : "WISDOMTREE_API_KEY";
+  if (!raw) {
+    throw providerNotConfigured(
+      sandbox
+        ? "WisdomTree sandbox is not configured. Set WISDOMTREE_SANDBOX_API_KEY."
+        : "WisdomTree is not configured. Set WISDOMTREE_API_KEY."
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw providerNotConfigured(
+      `${keyName} is not valid JSON. Expected {"clientId","clientSecret","username","password"}.`
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw providerNotConfigured(
+      `${keyName} must be a JSON object with {"clientId","clientSecret","username","password"}.`
+    );
+  }
+  const record = parsed as Partial<Record<(typeof CREDENTIAL_FIELDS)[number], unknown>>;
+  for (const field of CREDENTIAL_FIELDS) {
+    const value = record[field];
+    if (typeof value !== "string" || value.trim() === "") {
+      throw providerNotConfigured(`${keyName} is missing the "${field}" field.`);
+    }
+  }
+
+  return {
+    baseUrl: sandbox ? WISDOMTREE_SANDBOX_API_URL : WISDOMTREE_PRODUCTION_API_URL,
+    credentials: {
+      clientId: (record.clientId as string).trim(),
+      clientSecret: (record.clientSecret as string).trim(),
+      username: (record.username as string).trim(),
+      password: (record.password as string).trim(),
+    },
+  };
+}
+
+interface CachedToken {
+  token: string;
+  expiresAtMs: number;
+}
+
+/**
+ * Bearer-token cache, keyed by the complete credential tuple so two
+ * environments — or any rotated credential field — can never share a token. Expiry
+ * keeps a safety margin; WisdomTree's `expires_in` is treated as advisory and
+ * an expired-token 401 surfaces as a normal provider error on the next call.
+ */
+const tokenCache = new Map<string, CachedToken>();
+
+/** Test seam: forget cached bearer tokens. */
+export function resetWisdomTreeTokenCache(): void {
+  tokenCache.clear();
+}
+
+const TOKEN_EXPIRY_MARGIN_MS = 60_000;
+const TOKEN_MINIMUM_TTL_MS = 30_000;
+const TOKEN_DEFAULT_TTL_SECONDS = 300;
+
+interface WisdomTreeTokenResponse {
+  access_token?: unknown;
+  expires_in?: unknown;
+}
+
+/** OAuth2 password grant at `POST /o/token/` — the one authentication path Connect documents. */
+async function getWisdomTreeAccessToken(
+  ctx: EarnRuntimeContext
+): Promise<{ token: string; baseUrl: string; cacheKey: string }> {
+  const config = readWisdomTreeConfig(ctx);
+  const cacheKey = JSON.stringify([
+    config.baseUrl,
+    config.credentials.clientId,
+    config.credentials.clientSecret,
+    config.credentials.username,
+    config.credentials.password,
+  ]);
+
+  const cached = tokenCache.get(cacheKey);
+  if (cached && cached.expiresAtMs > Date.now()) {
+    return { token: cached.token, baseUrl: config.baseUrl, cacheKey };
+  }
+
+  const basic = Buffer.from(
+    `${config.credentials.clientId}:${config.credentials.clientSecret}`
+  ).toString("base64");
+  const body = new URLSearchParams({
+    grant_type: "password",
+    username: config.credentials.username,
+    password: config.credentials.password,
+    scope: "read write",
+  });
+  const response = await providerFetchJson<WisdomTreeTokenResponse, URLSearchParams>(
+    WISDOMTREE_PROVIDER,
+    `${config.baseUrl}/o/token/`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${basic}`,
+        // providerFetch defaults to JSON; the token route is the one
+        // form-encoded call Connect takes.
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body,
+      timeoutMs: WISDOMTREE_REQUEST_TIMEOUT_MS,
+    }
+  );
+
+  const token = typeof response.access_token === "string" ? response.access_token.trim() : "";
+  if (!token) {
+    throw providerUnavailable("WisdomTree token endpoint returned no access_token");
+  }
+  const ttlSeconds =
+    typeof response.expires_in === "number" && Number.isFinite(response.expires_in)
+      ? response.expires_in
+      : TOKEN_DEFAULT_TTL_SECONDS;
+  const ttlMs = Math.max(TOKEN_MINIMUM_TTL_MS, ttlSeconds * 1000 - TOKEN_EXPIRY_MARGIN_MS);
+  tokenCache.set(cacheKey, { token, expiresAtMs: Date.now() + ttlMs });
+
+  return { token, baseUrl: config.baseUrl, cacheKey };
+}
+
+async function connectGetJson<TResponse>(
+  ctx: EarnRuntimeContext,
+  path: string,
+  params?: Record<string, string>
+): Promise<TResponse> {
+  let access = await getWisdomTreeAccessToken(ctx);
+  // Connect's docs are emphatic about canonical trailing-slash routes; every
+  // path constant in this module already carries the shape its spec states.
+  const url = new URL(path, access.baseUrl);
+  for (const [key, value] of Object.entries(params ?? {})) {
+    url.searchParams.set(key, value);
+  }
+  const request = (token: string) =>
+    providerFetchJson<TResponse>(WISDOMTREE_PROVIDER, url.toString(), {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}` },
+      timeoutMs: WISDOMTREE_REQUEST_TIMEOUT_MS,
+    });
+  try {
+    return await request(access.token);
+  } catch (error) {
+    if (!(error instanceof SdpEarnError) || error.details?.providerStatus !== 401) {
+      throw error;
+    }
+    // A token may be revoked before its advertised expiry. Forget it, perform
+    // one fresh grant, and retry exactly once; a second 401 is the final error.
+    tokenCache.delete(access.cacheKey);
+    access = await getWisdomTreeAccessToken(ctx);
+    return request(access.token);
+  }
+}
+
+export interface WisdomTreeProduct {
+  id?: number;
+  name?: string;
+  exchange_code?: string;
+  issuer?: string;
+  can_trade?: boolean;
+}
+
+function readWisdomTreeProduct(value: unknown): WisdomTreeProduct {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw providerUnavailable("WisdomTree returned a malformed product entry");
+  }
+  const record = value as Record<string, unknown>;
+  const fields = [
+    ["id", "number"],
+    ["name", "string"],
+    ["exchange_code", "string"],
+    ["issuer", "string"],
+    ["can_trade", "boolean"],
+  ] as const;
+  for (const [field, expectedType] of fields) {
+    if (record[field] !== undefined && typeof record[field] !== expectedType) {
+      throw providerUnavailable(`WisdomTree returned a product with an invalid ${field}`);
+    }
+  }
+  return record as WisdomTreeProduct;
+}
+
+/**
+ * The products available to the authenticated organization. ALL-OR-NOTHING:
+ * a 200 with no `products` array is malformed, not empty — the catalogue sync
+ * deletes rows a provider no longer lists, so a mis-read here would delist the
+ * shelf rather than degrade (same rule as Kamino's metrics pages).
+ */
+export async function listWisdomTreeProducts(
+  ctx: EarnRuntimeContext
+): Promise<WisdomTreeProduct[]> {
+  const response = await connectGetJson<{ products?: unknown }>(ctx, "/api/orders/products");
+  if (!Array.isArray(response.products)) {
+    throw providerUnavailable("WisdomTree returned a products response with no products array");
+  }
+  return response.products.map(readWisdomTreeProduct);
+}
+
+export type WisdomTreeTradeType = "Purchase" | "Sale";
+
+/**
+ * The standing WisdomTree-operated wallet that receives the on-chain leg of a
+ * transfer-triggered order: USDC sent to it opens a Purchase; fund tokens sent
+ * to it open a Sale. Resolved per (trade type, fund, currency) at build time —
+ * never cached across builds, because a stale settlement address is money sent
+ * to the wrong place.
+ */
+export async function getWisdomTreeOnReceiptWallet(
+  ctx: EarnRuntimeContext,
+  input: { tradeType: WisdomTreeTradeType; fund: string; currency: string }
+): Promise<string> {
+  const response = await connectGetJson<{ wallet_address?: unknown }>(
+    ctx,
+    "/api/orders/on-receipt-wallet/",
+    {
+      trade_type: input.tradeType,
+      blockchain: WISDOMTREE_SOLANA_BLOCKCHAIN_KEY,
+      currency: input.currency,
+      fund: input.fund,
+    }
+  );
+  const wallet = typeof response.wallet_address === "string" ? response.wallet_address.trim() : "";
+  if (!wallet) {
+    throw providerUnavailable(
+      `WisdomTree returned no on-receipt ${input.tradeType} wallet for ${input.fund} on Solana`
+    );
+  }
+  return wallet;
+}
+
+interface WisdomTreeOrganizationResponse {
+  guid?: unknown;
+  organisation_guid?: unknown;
+  organization_guid?: unknown;
+}
+
+/**
+ * The authenticated organization's GUID — the path key for wallet reads.
+ * UNVERIFIED field name: the docs show `/api/organizations/me` returning the
+ * organization detail but never print the field; all three spellings Connect
+ * uses elsewhere are accepted.
+ */
+export async function getWisdomTreeOrganizationGuid(ctx: EarnRuntimeContext): Promise<string> {
+  const response = await connectGetJson<WisdomTreeOrganizationResponse>(
+    ctx,
+    "/api/organizations/me"
+  );
+  for (const candidate of [response.guid, response.organisation_guid, response.organization_guid]) {
+    if (typeof candidate === "string" && candidate.trim() !== "") {
+      return candidate.trim();
+    }
+  }
+  throw providerUnavailable("WisdomTree returned an organization response with no guid");
+}
+
+export interface WisdomTreeWalletRecord {
+  wallet_guid?: string;
+  public_key?: string;
+  status?: string;
+}
+
+function readWisdomTreeWalletRecord(value: unknown): WisdomTreeWalletRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw providerUnavailable("WisdomTree returned a malformed wallet entry");
+  }
+  const record = value as Record<string, unknown>;
+  for (const field of ["wallet_guid", "public_key", "status"] as const) {
+    if (record[field] !== undefined && typeof record[field] !== "string") {
+      throw providerUnavailable(`WisdomTree returned a wallet with an invalid ${field}`);
+    }
+  }
+  return record as WisdomTreeWalletRecord;
+}
+
+/**
+ * The organization's registered Solana wallets. The response keys its `data`
+ * map by blockchain name; matched case-insensitively on "solana" so a label
+ * change ("Solana" vs "solana_mainnet") degrades to a re-read, not to every
+ * wallet reading as unregistered... which it would anyway: an ABSENT Solana
+ * lane answers [] here, and eligibility fails closed on it.
+ */
+export async function listWisdomTreeSolanaWallets(
+  ctx: EarnRuntimeContext
+): Promise<WisdomTreeWalletRecord[]> {
+  const guid = await getWisdomTreeOrganizationGuid(ctx);
+  const response = await connectGetJson<{ data?: unknown }>(
+    ctx,
+    `/api/organizations/${guid}/wallets`
+  );
+  const data = response.data;
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    throw providerUnavailable("WisdomTree returned a wallets response with no data map");
+  }
+  const lanes = Object.entries(data as Record<string, unknown>)
+    .filter(([blockchain]) => blockchain.toLowerCase().includes("solana"))
+    .map(([, wallets]) => wallets);
+  return lanes.flatMap((lane) => (Array.isArray(lane) ? lane.map(readWisdomTreeWalletRecord) : []));
+}
+
+export interface WisdomTreeWalletEligibility {
+  eligible: boolean;
+  reason?: string;
+}
+
+/**
+ * Is `address` registered AND approved with WisdomTree Connect?
+ *
+ * This is the API-side half of WisdomTree's KYC model — the on-chain half is
+ * the transfer hook, which would fail the settlement leg anyway. Checking here
+ * turns "your deposit landed at WisdomTree and nothing came back" into a
+ * refusal the caller can act on BEFORE money moves. Fail-closed throughout:
+ * unregistered, unapproved and unknown-status wallets are all ineligible.
+ */
+export async function checkWisdomTreeWalletEligibility(
+  ctx: EarnRuntimeContext,
+  address: string
+): Promise<WisdomTreeWalletEligibility> {
+  const wallets = await listWisdomTreeSolanaWallets(ctx);
+  const match = wallets.find((wallet) => wallet.public_key?.trim() === address);
+  if (!match) {
+    return {
+      eligible: false,
+      reason:
+        "This wallet is not registered with WisdomTree Connect. Fund tokens can only settle " +
+        "to a wallet WisdomTree has verified (KYC) and approved.",
+    };
+  }
+  const status = match.status?.trim().toLowerCase() ?? "";
+  if (!WISDOMTREE_APPROVED_WALLET_STATUSES.has(status)) {
+    return {
+      eligible: false,
+      reason: `This wallet is registered with WisdomTree Connect but its status is "${
+        match.status ?? "unknown"
+      }", not approved.`,
+    };
+  }
+  return { eligible: true };
+}
+
+/**
+ * Raw orders feed — tooling surface (underscore convention, like Ground's
+ * `_iterateYieldSources`): consumed by inventory/settlement tooling and the
+ * future order-settlement reconciler, not part of the provider contract.
+ * Accepts both the bare-array and wrapped shapes because the spec never prints
+ * this route's envelope. UNVERIFIED.
+ */
+export async function _listWisdomTreeOrders(ctx: EarnRuntimeContext): Promise<unknown[]> {
+  const response = await connectGetJson<unknown>(ctx, "/api/orders/all");
+  if (Array.isArray(response)) return response;
+  if (response && typeof response === "object") {
+    const wrapped = (response as { orders?: unknown }).orders;
+    if (Array.isArray(wrapped)) return wrapped;
+  }
+  throw providerUnavailable("WisdomTree returned an orders response in an unrecognized shape");
+}

--- a/packages/sdp-earn/src/types.ts
+++ b/packages/sdp-earn/src/types.ts
@@ -684,6 +684,44 @@ export interface EarnVaultWithdrawProvider extends EarnVaultDirectProvider {
   ): Promise<EarnVaultTransactionPlan>;
 }
 
+export interface EarnDepositEligibilityInput {
+  /** The strategy's `providerReference` (for WisdomTree, the fund's mint). */
+  providerReference: string;
+  /** The wallet whose deposit would settle — the address the provider must have verified. */
+  owner: string;
+}
+
+export interface EarnDepositEligibility {
+  eligible: boolean;
+  /** The provider's stated reason when ineligible — customer-renderable prose. */
+  reason?: string;
+}
+
+/**
+ * Optional capability: a provider-side eligibility check that must pass before
+ * money moves IN.
+ *
+ * Exists for regulated instruments (WisdomTree's tokenized funds): settlement
+ * pays out fund tokens whose Token-2022 transfer hook refuses any wallet the
+ * issuer has not KYC-verified, so a deposit from an unverified wallet is USDC
+ * sent to the issuer with nothing able to come back. The on-chain hook is the
+ * backstop; this check is what turns that failure mode into a refusal BEFORE
+ * the transfer, with the provider's own reason attached.
+ *
+ * MONEY-IN ONLY, by ADR 0002: exits never consult it — a wallet that already
+ * holds the instrument proved its eligibility on-chain, and money out must
+ * never inherit a money-in gate. Discovered via `supportsDepositEligibility`
+ * (capabilities.ts), never provider-id checks. A provider without the
+ * capability is simply not eligibility-gated, which is today's behavior for
+ * every permissionless vault.
+ */
+export interface EarnDepositEligibilityProvider extends EarnVaultProvider {
+  checkDepositEligibility(
+    ctx: EarnRuntimeContext,
+    input: EarnDepositEligibilityInput
+  ): Promise<EarnDepositEligibility>;
+}
+
 /**
  * Optional capability: a live deposit quote (see `EarnVaultDepositQuote`).
  *

--- a/packages/sdp-types/src/earn.ts
+++ b/packages/sdp-types/src/earn.ts
@@ -158,6 +158,10 @@ export const EARN_KNOWN_CURATOR_LABELS: Readonly<Record<string, string>> = {
   superstate: "Superstate",
   maple: "Maple",
   centrifuge: "Centrifuge",
+  // Issuer-curated tokenized funds (WTGXX et al.) — the id the WisdomTree
+  // catalogue client writes, establishable from the mint's issuer-controlled
+  // on-chain metadata.
+  wisdomtree: "WisdomTree",
   // Ids Ground reports when a protocol or fund curates its own vaults;
   // `g<ticker>` is Ground's own wrapper of a Superstate fund. Some stored rows
   // (Aave/Morpho) are hidden by strategy API policy, but inventory tooling still


### PR DESCRIPTION
Implements the SDK-free half of the WisdomTree integration in @sdp/earn:

- providers/wisdomtree/connect.ts — the Connect REST client (OAuth2 password grant with a per-credential token cache, products, on-receipt wallets, organization wallets, an orders tooling read). Wire shapes come from WisdomTree's published OpenAPI spec; SDP holds no credentials yet, so every field the spec leaves unprinted is marked UNVERIFIED and read through one constant or accessor so the live-measurement fix is one edit.
- listStrategies — production only (WisdomTree is Solana-mainnet-only; other environments answer [] and get browse rows via the PRO-1742 mirror). Identity comes from the measured on-chain registry in @sdp/types; availability comes from the products API, fail-closed on can_trade !== true; a malformed response throws so the sync skips the pass rather than delisting the shelf. No currentApy on purpose — the 7-day yield lives in a Fund Data credential SDP does not hold, and a missing rate beats a fabricated one.
- EarnDepositEligibilityProvider — a NEW optional capability: a provider- side eligibility check money-IN paths consult (never exits, per ADR 0002). Exists for regulated instruments whose transfer hook would fail settlement to an unverified wallet: the check turns 'your USDC left and nothing came back' into a refusal with WisdomTree's reason attached, BEFORE money moves. WisdomTree implements it over the Connect wallet registry, fail-closed on unregistered/unapproved/unknown statuses.