### PR TITLE
feat(wisdomtree): execution package — subscription plans and position…

### DIFF
--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -32,6 +32,7 @@ This map is generated from the module-boundary check. It records the permitted w
 | `@sdp/spc-withdraw` | Generated @solana/kit client for the Private Channels withdraw program. | None |
 | `@sdp/types` | Shared runtime types, constants, and product contracts. | None |
 | `@sdp/veda` | Kit-native Veda SVM vault deposit plans and position reads over @vedatech/svm-sdk. | `@sdp/earn`, `@sdp/solana`, `@sdp/types` |
+| `@sdp/wisdomtree` | Kit-native WisdomTree Connect transfer plans (on-receipt subscription/redemption legs) and Token-2022 fund position reads. | `@sdp/earn`, `@sdp/types` |
 | `bigint-buffer` | Private pure-JavaScript compatibility package replacing bigint-buffer's vulnerable native binding. | None |
 | `sdp-docs` | Public documentation site and generated API reference. | `@sdp/env-config`, `@sdp/types` |
 | `sdp-web` | Dashboard application. | `@sdp/issuance`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/solana`, `@sdp/types` |
@@ -56,6 +57,7 @@ This map is generated from the module-boundary check. It records the permitted w
 - `@sdp/spc-withdraw` -> None
 - `@sdp/types` -> None
 - `@sdp/veda` -> `@sdp/earn`, `@sdp/solana`, `@sdp/types`
+- `@sdp/wisdomtree` -> `@sdp/earn`, `@sdp/types`
 - `bigint-buffer` -> None
 - `sdp-docs` -> `@sdp/env-config`, `@sdp/types`
 - `sdp-web` -> `@sdp/issuance`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/solana`, `@sdp/types`

--- a/packages/sdp-earn/package.json
+++ b/packages/sdp-earn/package.json
@@ -68,6 +68,11 @@
       "types": "./src/providers/wisdomtree/client.ts",
       "import": "./src/providers/wisdomtree/client.ts",
       "default": "./src/providers/wisdomtree/client.ts"
+    },
+    "./providers/wisdomtree/connect": {
+      "types": "./src/providers/wisdomtree/connect.ts",
+      "import": "./src/providers/wisdomtree/connect.ts",
+      "default": "./src/providers/wisdomtree/connect.ts"
     }
   },
   "scripts": {

--- a/packages/sdp-wisdomtree/package.json
+++ b/packages/sdp-wisdomtree/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@sdp/wisdomtree",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./types": {
+      "types": "./src/types.ts",
+      "import": "./src/types.ts",
+      "default": "./src/types.ts"
+    },
+    "./errors": {
+      "types": "./src/errors.ts",
+      "import": "./src/errors.ts",
+      "default": "./src/errors.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "biome check src/"
+  },
+  "dependencies": {
+    "@sdp/earn": "workspace:*",
+    "@sdp/types": "workspace:*",
+    "@solana-program/token-2022": "catalog:",
+    "@solana/kit": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "26.1.2",
+    "tsx": "4.23.5",
+    "typescript": "6.0.3",
+    "vitest": "4.1.10"
+  }
+}

--- a/packages/sdp-wisdomtree/src/amounts.test.ts
+++ b/packages/sdp-wisdomtree/src/amounts.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { acceptAtMintScale, formatBaseUnits } from "./amounts";
+import { SdpWisdomTreeError } from "./errors";
+
+describe("acceptAtMintScale", () => {
+  it("returns the canonical form the instruction encodes", () => {
+    expect(acceptAtMintScale("1.500000", 6, "Deposit amount")).toEqual({
+      canonical: "1.5",
+      baseUnits: 1_500_000n,
+    });
+    expect(acceptAtMintScale("25", 6, "Deposit amount")).toEqual({
+      canonical: "25",
+      baseUnits: 25_000_000n,
+    });
+  });
+
+  it("refuses sub-atomic precision rather than flooring silently", () => {
+    expect(() => acceptAtMintScale("1.0000009", 6, "Deposit amount")).toThrowError(
+      SdpWisdomTreeError
+    );
+    // Trailing zeroes past the mint's scale add no precision and are accepted.
+    expect(acceptAtMintScale("1.0000000", 6, "Deposit amount").canonical).toBe("1");
+  });
+
+  it("refuses zero and non-decimal input", () => {
+    for (const bad of ["0", "0.000", "", "1e6", "-1", "1,5", "USDC"]) {
+      expect(() => acceptAtMintScale(bad, 6, "Deposit amount")).toThrowError(SdpWisdomTreeError);
+    }
+  });
+
+  it("rejects adversarially long invalid input in a single pass", () => {
+    const bad = `${"1".repeat(50_000)}.${"1".repeat(50_000)}.`;
+    expect(() => acceptAtMintScale(bad, 6, "Deposit amount")).toThrowError(SdpWisdomTreeError);
+  });
+
+  it("handles quantities beyond 2^53 exactly", () => {
+    const { baseUnits, canonical } = acceptAtMintScale("92233720368.547758079", 9, "Shares");
+    expect(baseUnits).toBe(92_233_720_368_547_758_079n);
+    expect(canonical).toBe("92233720368.547758079");
+  });
+});
+
+describe("formatBaseUnits", () => {
+  it('serializes exactly, zero as "0", no trailing fractional zeroes', () => {
+    expect(formatBaseUnits(0n, 9)).toBe("0");
+    expect(formatBaseUnits(1n, 9)).toBe("0.000000001");
+    expect(formatBaseUnits(37_969_751_026n, 9)).toBe("37.969751026");
+    expect(formatBaseUnits(1_500_000n, 6)).toBe("1.5");
+  });
+});

--- a/packages/sdp-wisdomtree/src/amounts.ts
+++ b/packages/sdp-wisdomtree/src/amounts.ts
@@ -1,0 +1,71 @@
+import { SdpWisdomTreeError } from "./errors";
+
+/**
+ * Amount validation at the MINT's own scale — the `@sdp/kamino amounts.ts`
+ * rule restated for this package: refuse sub-atomic precision rather than
+ * floor it silently, and return the canonical form the instructions actually
+ * encode, because a movement row is a claim about what moved on chain.
+ */
+
+function isPlainPositiveDecimal(value: string): boolean {
+  if (value.length === 0) return false;
+  let decimalPoint = -1;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 48 && code <= 57) continue;
+    if (value[index] !== "." || decimalPoint !== -1 || index === 0 || index === value.length - 1) {
+      return false;
+    }
+    decimalPoint = index;
+  }
+  return true;
+}
+
+export interface AcceptedAmount {
+  /** Canonical decimal string (no trailing fractional zeroes, no leading zeroes). */
+  canonical: string;
+  /** The exact integer the instruction encodes. */
+  baseUnits: bigint;
+}
+
+/**
+ * Parse `amount` against a mint of `decimals`, refusing anything the mint
+ * cannot represent exactly. Zero is refused too: a zero-quantity transfer is
+ * never a subscription or redemption, only a caller bug.
+ */
+export function acceptAtMintScale(amount: string, decimals: number, what: string): AcceptedAmount {
+  const trimmed = amount.trim();
+  if (!isPlainPositiveDecimal(trimmed)) {
+    throw new SdpWisdomTreeError(
+      "INVALID_AMOUNT",
+      `${what} must be a plain positive decimal string; received "${amount}".`
+    );
+  }
+  const [whole = "0", fraction = ""] = trimmed.split(".");
+  const keptFraction = fraction.slice(0, decimals);
+  const discarded = fraction.slice(decimals);
+  if ([...discarded].some((digit) => digit !== "0")) {
+    throw new SdpWisdomTreeError(
+      "INVALID_AMOUNT",
+      `${what} of ${amount} is finer than the mint's ${decimals} decimals; ` +
+        "refusing rather than silently moving a different amount."
+    );
+  }
+
+  const baseUnits =
+    BigInt(whole) * 10n ** BigInt(decimals) + BigInt(keptFraction.padEnd(decimals, "0") || "0");
+  if (baseUnits === 0n) {
+    throw new SdpWisdomTreeError("INVALID_AMOUNT", `${what} must be greater than zero.`);
+  }
+  return { canonical: formatBaseUnits(baseUnits, decimals), baseUnits };
+}
+
+/** Exact base-units → canonical decimal string. Serializes zero as "0". */
+export function formatBaseUnits(baseUnits: bigint, decimals: number): string {
+  const digits = baseUnits.toString().padStart(decimals + 1, "0");
+  const cut = digits.length - decimals;
+  const whole = digits.slice(0, cut);
+  let fraction = digits.slice(cut);
+  while (fraction.endsWith("0")) fraction = fraction.slice(0, -1);
+  return fraction === "" ? whole : `${whole}.${fraction}`;
+}

--- a/packages/sdp-wisdomtree/src/chain.ts
+++ b/packages/sdp-wisdomtree/src/chain.ts
@@ -1,0 +1,90 @@
+import type { Address } from "@solana/kit";
+import {
+  createDefaultRpcTransport,
+  createSolanaRpcFromTransport,
+  type RpcTransport,
+} from "@solana/kit";
+import { SdpWisdomTreeError } from "./errors";
+
+/**
+ * The one chain-read seam the builders consume. An interface rather than a raw
+ * RPC client so unit tests inject a fake and stay offline (the repo rule), and
+ * so every read shares one transport deadline.
+ */
+export interface WisdomTreeChainReader {
+  /** The account's owner program and raw data, or null when it does not exist. */
+  getAccount(accountAddress: Address): Promise<{ owner: string; data: Uint8Array } | null>;
+}
+
+export const WISDOMTREE_RPC_REQUEST_TIMEOUT_MS = 30_000;
+
+/** Same transport-boundary deadline pattern as `@sdp/kamino`'s rpc.ts. */
+function withTimeout(transport: RpcTransport, timeoutMs: number): RpcTransport {
+  return async <TResponse>(config: Parameters<RpcTransport>[0]) => {
+    const controller = new AbortController();
+    const deadlineReason = new Error("WisdomTree RPC deadline elapsed");
+    const timer = setTimeout(() => controller.abort(deadlineReason), timeoutMs);
+    const signal = config.signal
+      ? AbortSignal.any([config.signal, controller.signal])
+      : controller.signal;
+    try {
+      return await transport<TResponse>({ ...config, signal });
+    } catch (cause) {
+      if (signal.aborted && signal.reason === deadlineReason) {
+        throw new Error(`WisdomTree RPC request timed out after ${timeoutMs}ms`, { cause });
+      }
+      throw cause;
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}
+
+export function createWisdomTreeChainReader(
+  rpcUrl: string,
+  timeoutMs = WISDOMTREE_RPC_REQUEST_TIMEOUT_MS
+): WisdomTreeChainReader {
+  const rpc = createSolanaRpcFromTransport(
+    withTimeout(createDefaultRpcTransport({ url: rpcUrl }), timeoutMs)
+  );
+  return {
+    async getAccount(accountAddress) {
+      let value: { owner: unknown; data: unknown } | null;
+      try {
+        const response = await rpc.getAccountInfo(accountAddress, { encoding: "base64" }).send();
+        value = response.value;
+      } catch (cause) {
+        throw new SdpWisdomTreeError(
+          "CHAIN_UNREADABLE",
+          `Failed to read account ${accountAddress}: ${
+            cause instanceof Error ? cause.message : String(cause)
+          }`,
+          { cause }
+        );
+      }
+      if (value === null) {
+        return null;
+      }
+      const encoded = Array.isArray(value.data) ? value.data[0] : undefined;
+      if (typeof encoded !== "string" || typeof value.owner !== "string") {
+        throw new SdpWisdomTreeError(
+          "CHAIN_UNREADABLE",
+          `Account ${accountAddress} came back in an unrecognized RPC shape.`
+        );
+      }
+      return { owner: value.owner, data: Uint8Array.from(Buffer.from(encoded, "base64")) };
+    },
+  };
+}
+
+/** Exact token-account balance in base units, from the raw 165-byte layout (amount is u64 LE at offset 64). */
+export function tokenAccountBaseUnits(data: Uint8Array): bigint {
+  if (data.length < 72) {
+    throw new SdpWisdomTreeError(
+      "CHAIN_UNREADABLE",
+      `Token account data is ${data.length} bytes — shorter than the token-account layout.`
+    );
+  }
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  return view.getBigUint64(64, true);
+}

--- a/packages/sdp-wisdomtree/src/client.test.ts
+++ b/packages/sdp-wisdomtree/src/client.test.ts
@@ -1,0 +1,214 @@
+import {
+  supportsDepositEligibility,
+  supportsVaultDirect,
+  supportsVaultWithdraw,
+} from "@sdp/earn/capabilities";
+import { SdpEarnError } from "@sdp/earn/errors";
+import { resetWisdomTreeTokenCache } from "@sdp/earn/providers/wisdomtree/connect";
+import type { EarnRuntimeContext } from "@sdp/earn/types";
+import { SPL_TOKEN_PROGRAMS, wellKnownMint } from "@sdp/types";
+import { WISDOMTREE_FUNDS } from "@sdp/types/wisdomtree-programs";
+import { address } from "@solana/kit";
+import { findAssociatedTokenPda } from "@solana-program/token-2022";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WisdomTreeChainReader } from "./chain";
+import { assertWisdomTreeNotPortfolioProvider, WisdomTreeVaultDirectClient } from "./client";
+import { fakeReader, tokenAccountData, wtgxxMintAccountData } from "./fixtures.test-helper";
+
+const WTGXX = WISDOMTREE_FUNDS[0];
+const USDC = wellKnownMint("USDC", "mainnet-beta") as string;
+const TOKEN_2022 = SPL_TOKEN_PROGRAMS["token-2022"];
+
+const OWNER = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
+const ON_RECEIPT = "ComputeBudget111111111111111111111111111111";
+
+const credential = JSON.stringify({
+  clientId: "client-id",
+  clientSecret: "client-secret",
+  username: "api-user",
+  password: "api-pass",
+});
+const productionCtx: EarnRuntimeContext = {
+  env: { WISDOMTREE_API_KEY: credential },
+  environment: "production",
+};
+
+/** Offline client: proven-RPC resolver and deadline runner are passthroughs. */
+function offlineClient(reader: WisdomTreeChainReader) {
+  return new WisdomTreeVaultDirectClient(
+    async () => "http://offline.invalid",
+    (_label, operation) => operation(() => {}),
+    () => reader
+  );
+}
+
+/** Stub the Connect API: OAuth token, then the on-receipt Purchase wallet. */
+function stubConnectFetch() {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.endsWith("/o/token/")) {
+      return new Response(JSON.stringify({ access_token: "bearer", expires_in: 600 }), {
+        status: 200,
+      });
+    }
+    if (url.includes("/api/orders/on-receipt-wallet/")) {
+      return new Response(JSON.stringify({ wallet_address: ON_RECEIPT }), { status: 200 });
+    }
+    throw new Error(`Unexpected fetch in offline test: ${url}`);
+  });
+}
+
+beforeEach(() => resetWisdomTreeTokenCache());
+afterEach(() => vi.restoreAllMocks());
+
+describe("capability shape", () => {
+  it("is vault-direct with eligibility, without withdraw, and never custodial", () => {
+    const client = offlineClient(fakeReader({}));
+    expect(supportsVaultDirect(client)).toBe(true);
+    expect(supportsVaultWithdraw(client)).toBe(false);
+    expect(supportsDepositEligibility(client)).toBe(true);
+    expect(() => assertWisdomTreeNotPortfolioProvider(client)).not.toThrow();
+  });
+
+  it("declares the same programs the output guard enforces", () => {
+    const client = offlineClient(fakeReader({}));
+    const mainnet = client.sponsoredPrograms("mainnet-beta");
+    expect(mainnet).toContain("F4wFSShcdmaHWGRRXhCHinNTt8spgdh26Wi8hbN2Rzbh");
+    // Devnet declares no WisdomTree-specific program — nothing is deployed there.
+    expect(client.sponsoredPrograms("devnet")).not.toContain(
+      "F4wFSShcdmaHWGRRXhCHinNTt8spgdh26Wi8hbN2Rzbh"
+    );
+  });
+});
+
+describe("buildVaultDeposit", () => {
+  it("refuses minSharesOut as a caller error, before any network or chain read", async () => {
+    const reader = fakeReader({});
+    const fetchSpy = stubConnectFetch();
+    const client = offlineClient(reader);
+    await expect(
+      client.buildVaultDeposit(productionCtx, {
+        providerReference: WTGXX.mint,
+        owner: OWNER,
+        amount: "10",
+        minSharesOut: "9.9",
+      })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(reader.reads).toEqual([]);
+  });
+
+  it("refuses a reference outside the fund registry", async () => {
+    stubConnectFetch();
+    const client = offlineClient(fakeReader({}));
+    await expect(
+      client.buildVaultDeposit(productionCtx, {
+        providerReference: USDC,
+        owner: OWNER,
+        amount: "10",
+      })
+    ).rejects.toThrowError(SdpEarnError);
+  });
+
+  it("builds the subscription transfer against the API-resolved on-receipt wallet", async () => {
+    stubConnectFetch();
+    const [onReceiptUsdcAta] = await findAssociatedTokenPda({
+      owner: address(ON_RECEIPT),
+      mint: address(USDC),
+      tokenProgram: address(SPL_TOKEN_PROGRAMS["spl-token"]),
+    });
+    const reader = fakeReader({
+      [WTGXX.mint]: { owner: TOKEN_2022, data: wtgxxMintAccountData() },
+      [String(onReceiptUsdcAta)]: { data: tokenAccountData(0n) },
+    });
+    const client = offlineClient(reader);
+
+    const plan = await client.buildVaultDeposit(productionCtx, {
+      providerReference: WTGXX.mint,
+      owner: OWNER,
+      amount: "100.25",
+    });
+
+    expect(plan.cluster).toBe("mainnet-beta");
+    expect(plan.assetIdentity).toEqual({ depositTokenMint: USDC, shareMint: WTGXX.mint });
+    expect(plan.accepted).toEqual({ amount: "100.25" });
+    expect(plan.createsShareAccount).toBe(true);
+    expect(plan.lookupTables).toEqual([]);
+    // Wire shape: plain JSON, base64 data, numeric roles.
+    for (const instruction of plan.instructions) {
+      expect(typeof instruction.data).toBe("string");
+      for (const account of instruction.accounts) {
+        expect(typeof account.role).toBe("number");
+      }
+    }
+  });
+
+  it("maps a sub-atomic amount onto the caller-fault taxonomy", async () => {
+    stubConnectFetch();
+    const reader = fakeReader({
+      [WTGXX.mint]: { owner: TOKEN_2022, data: wtgxxMintAccountData() },
+    });
+    const client = offlineClient(reader);
+    await expect(
+      client.buildVaultDeposit(productionCtx, {
+        providerReference: WTGXX.mint,
+        owner: OWNER,
+        amount: "1.0000001",
+      })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+});
+
+describe("readVaultPositions", () => {
+  it("answers an empty page on devnet, where no instrument exists", async () => {
+    const client = offlineClient(fakeReader({}));
+    const positions = await client.readVaultPositions(
+      { env: {}, environment: "sandbox" },
+      { owner: OWNER, providerReferences: [] }
+    );
+    expect(positions).toEqual([]);
+  });
+
+  it("reports exact balances and drops empty holdings only on discovery", async () => {
+    const [ownerFundAta] = await findAssociatedTokenPda({
+      owner: address(OWNER),
+      mint: address(WTGXX.mint),
+      tokenProgram: address(TOKEN_2022),
+    });
+    const holding = fakeReader({
+      [String(ownerFundAta)]: { owner: TOKEN_2022, data: tokenAccountData(37_969_751_026n) },
+    });
+    const client = offlineClient(holding);
+
+    const discovered = await client.readVaultPositions(productionCtx, {
+      owner: OWNER,
+      providerReferences: [],
+    });
+    expect(discovered).toEqual([
+      {
+        providerReference: WTGXX.mint,
+        owner: OWNER,
+        cluster: "mainnet-beta",
+        shares: "37.969751026",
+        withdrawableShares: "37.969751026",
+        tokenMint: USDC,
+        shareMint: WTGXX.mint,
+      },
+    ]);
+
+    // An explicitly requested fund may truthfully answer zero.
+    const emptyClient = offlineClient(fakeReader({}));
+    const explicit = await emptyClient.readVaultPositions(productionCtx, {
+      owner: OWNER,
+      providerReferences: [WTGXX.mint],
+    });
+    expect(explicit).toHaveLength(1);
+    expect(explicit[0].shares).toBe("0");
+
+    const discoveredEmpty = await emptyClient.readVaultPositions(productionCtx, {
+      owner: OWNER,
+      providerReferences: [],
+    });
+    expect(discoveredEmpty).toEqual([]);
+  });
+});

--- a/packages/sdp-wisdomtree/src/client.ts
+++ b/packages/sdp-wisdomtree/src/client.ts
@@ -1,0 +1,278 @@
+import { supportsPortfolioWallets } from "@sdp/earn/capabilities";
+import { badRequest } from "@sdp/earn/errors";
+import { WisdomTreeEarnClient } from "@sdp/earn/providers/wisdomtree/client";
+import { getWisdomTreeOnReceiptWallet } from "@sdp/earn/providers/wisdomtree/connect";
+import type {
+  EarnRuntimeContext,
+  EarnVaultDepositInput,
+  EarnVaultDirectProvider,
+  EarnVaultInstruction,
+  EarnVaultPositionInput,
+  EarnVaultPositionSnapshot,
+  EarnVaultTransactionPlan,
+} from "@sdp/earn/types";
+import {
+  CLUSTER_BY_SDP_ENVIRONMENT,
+  type SolanaCluster,
+  wellKnownDecimals,
+  wellKnownMint,
+} from "@sdp/types";
+import {
+  type WisdomTreeFund,
+  wisdomTreeFundByMint,
+  wisdomTreeFundsForCluster,
+} from "@sdp/types/wisdomtree-programs";
+import { address, createNoopSigner } from "@solana/kit";
+import { createWisdomTreeChainReader, type WisdomTreeChainReader } from "./chain";
+import { SdpWisdomTreeError } from "./errors";
+import { permittedPlanPrograms } from "./guards";
+import { buildWisdomTreeDepositPlan } from "./plan";
+import { readWisdomTreePosition } from "./positions";
+import type { WisdomTreeInstructionPlan, WisdomTreeRuntime } from "./types";
+
+/** Same API-owned execution guard shape as `KaminoVaultOperationRunner`. */
+export type WisdomTreeVaultOperationRunner = <T>(
+  label: string,
+  operation: (assertActive: () => void) => Promise<T>
+) => Promise<T>;
+
+/** Convert the kit-native plan to the dependency-free Earn wire contract. */
+export function toEarnVaultTransactionPlan(
+  plan: WisdomTreeInstructionPlan
+): EarnVaultTransactionPlan {
+  return {
+    cluster: plan.cluster,
+    instructions: plan.instructions.map(
+      (instruction): EarnVaultInstruction => ({
+        programAddress: String(instruction.programAddress),
+        accounts: (instruction.accounts ?? []).map((account) => ({
+          address: String(account.address),
+          role: Number(account.role),
+        })),
+        data: Buffer.from(instruction.data ?? new Uint8Array()).toString("base64"),
+      })
+    ),
+    lookupTables: plan.lookupTables.map(String),
+    assetIdentity: {
+      depositTokenMint: String(plan.assetIdentity.depositTokenMint),
+      shareMint: String(plan.assetIdentity.shareMint),
+    },
+    accepted: { ...plan.accepted },
+    ...(plan.createsShareAccount === undefined
+      ? {}
+      : { createsShareAccount: plan.createsShareAccount }),
+  };
+}
+
+/**
+ * WisdomTree as an EXECUTING provider: the catalogue + eligibility client plus
+ * the vault-direct capability, money-in and position reads.
+ *
+ * DELIBERATELY NOT `EarnVaultWithdrawProvider` yet — redemptions (the
+ * fund-token transfer through the compliance hook) land as their own change,
+ * per the playbook's money-out-is-separate rule, and `supportsVaultWithdraw`
+ * answering false keeps the exit route honestly 501 until then.
+ *
+ * Lives here rather than in `@sdp/earn` so the hourly catalogue cron never
+ * loads `@solana/kit`. The arrow points inward: this package depends on
+ * `@sdp/earn`, never the reverse.
+ */
+export class WisdomTreeVaultDirectClient
+  extends WisdomTreeEarnClient
+  implements EarnVaultDirectProvider
+{
+  constructor(
+    private readonly resolveProvenRpcUrl: (
+      ctx: EarnRuntimeContext,
+      cluster: SolanaCluster
+    ) => Promise<string>,
+    private readonly runOperation: WisdomTreeVaultOperationRunner,
+    /** Test seam: builders read the chain through this factory. */
+    private readonly createReader: (
+      rpcUrl: string
+    ) => WisdomTreeChainReader = createWisdomTreeChainReader
+  ) {
+    super();
+  }
+
+  private async runtime(ctx: EarnRuntimeContext): Promise<WisdomTreeRuntime> {
+    const cluster = CLUSTER_BY_SDP_ENVIRONMENT[ctx.environment];
+    const rpcUrl = await this.resolveProvenRpcUrl(ctx, cluster);
+    if (!rpcUrl.trim()) {
+      throw new SdpWisdomTreeError(
+        "CHAIN_UNREADABLE",
+        `No Solana RPC endpoint configured for ${cluster}; WisdomTree cannot build a transaction.`
+      );
+    }
+    return { cluster, rpcUrl };
+  }
+
+  private async withRuntime<T>(
+    ctx: EarnRuntimeContext,
+    label: string,
+    operation: (runtime: WisdomTreeRuntime, assertActive: () => void) => Promise<T>
+  ): Promise<T> {
+    return this.runOperation(label, async (assertActive) => {
+      const runtime = await this.runtime(ctx);
+      assertActive();
+      return operation(runtime, assertActive);
+    });
+  }
+
+  /**
+   * Registry resolution for a caller-supplied reference, phrased for the
+   * caller: an unknown or wrong-cluster reference is a request problem, not a
+   * provider outage. Admission gates upstream make the cluster case
+   * unreachable in the API; this is the package's own last line.
+   */
+  private fundFor(reference: string, cluster: SolanaCluster): WisdomTreeFund {
+    const fund = wisdomTreeFundByMint(reference);
+    if (!fund) {
+      throw badRequest(`${reference} names no fund in the WisdomTree registry.`);
+    }
+    if (fund.cluster !== cluster) {
+      throw badRequest(
+        `${fund.exchangeCode} lives on ${fund.cluster}, which is not reachable from a ${cluster} request.`
+      );
+    }
+    return fund;
+  }
+
+  /** See `EarnVaultDirectProvider.sponsoredPrograms` — the enforced set IS the declared set. */
+  sponsoredPrograms(cluster: SolanaCluster): readonly string[] {
+    return [...permittedPlanPrograms(cluster)];
+  }
+
+  async buildVaultDeposit(
+    ctx: EarnRuntimeContext,
+    input: EarnVaultDepositInput
+  ): Promise<EarnVaultTransactionPlan> {
+    if (input.minSharesOut !== undefined) {
+      // A primary-market subscription settles at NAV struck AFTER the transfer
+      // lands; no instruction exists that could encode a share floor, and
+      // accepting the field while enforcing nothing would be the appearance of
+      // slippage protection without the substance (the @sdp/kamino rule).
+      throw badRequest(
+        "WisdomTree subscriptions settle at the fund's struck NAV; minSharesOut cannot be enforced " +
+          "on-chain and is refused rather than silently ignored."
+      );
+    }
+
+    const plan = await this.withRuntime(
+      ctx,
+      "Building the WisdomTree subscription transfer",
+      async (runtime, assertActive) => {
+        const fund = this.fundFor(input.providerReference, runtime.cluster);
+        const depositMint = wellKnownMint("USDC", runtime.cluster);
+        const depositDecimals = wellKnownDecimals("USDC", runtime.cluster);
+        if (!depositMint || depositDecimals === undefined) {
+          throw new SdpWisdomTreeError(
+            "CLUSTER_UNSUPPORTED",
+            `USDC is not catalogued for ${runtime.cluster}.`
+          );
+        }
+
+        // The settlement address comes from WisdomTree's own API at build
+        // time, never from configuration: a stale on-receipt wallet is money
+        // sent to the wrong place.
+        const onReceiptWallet = await getWisdomTreeOnReceiptWallet(ctx, {
+          tradeType: "Purchase",
+          fund: fund.exchangeCode,
+          currency: "USDC",
+        });
+        assertActive();
+
+        try {
+          return await buildWisdomTreeDepositPlan(this.createReader(runtime.rpcUrl), runtime, {
+            fund,
+            owner: this.participant(input.owner),
+            onReceiptWallet: address(onReceiptWallet),
+            depositMint: address(depositMint),
+            depositDecimals,
+            amount: input.amount,
+            ...(input.rentPayer === undefined
+              ? {}
+              : { rentPayer: this.participant(input.rentPayer) }),
+          });
+        } catch (error) {
+          // Amount problems are the caller's to fix; everything else is the
+          // provider integration's.
+          if (error instanceof SdpWisdomTreeError && error.code === "INVALID_AMOUNT") {
+            throw badRequest(error.message);
+          }
+          throw error;
+        }
+      }
+    );
+    return toEarnVaultTransactionPlan(plan);
+  }
+
+  /**
+   * Live positions: the owner's Token-2022 balances in the registry's funds.
+   * The chain is the provider here (ADR 0002) — nothing persisted, exact base
+   * units, and an explicit request may truthfully answer zero while discovery
+   * drops empty holdings.
+   */
+  async readVaultPositions(
+    ctx: EarnRuntimeContext,
+    input: EarnVaultPositionInput
+  ): Promise<EarnVaultPositionSnapshot[]> {
+    return this.withRuntime(ctx, "Reading WisdomTree positions", async (runtime, assertActive) => {
+      const readAllHoldings = input.providerReferences.length === 0;
+      const funds = readAllHoldings
+        ? wisdomTreeFundsForCluster(runtime.cluster)
+        : input.providerReferences.map((reference) => this.fundFor(reference, runtime.cluster));
+      if (funds.length === 0) return [];
+
+      const depositMint = wellKnownMint("USDC", runtime.cluster) ?? "";
+      const reader = this.createReader(runtime.rpcUrl);
+      const owner = address(input.owner);
+
+      // Promise.all, not allSettled: any unreadable fund fails the whole page,
+      // because a partial portfolio is not a truthful portfolio.
+      const positions = await Promise.all(
+        funds.map((fund) => readWisdomTreePosition(reader, { fund, owner }))
+      );
+      assertActive();
+
+      return positions.flatMap((position) => {
+        if (readAllHoldings && position.shares === "0") return [];
+        return [
+          {
+            providerReference: position.fund.mint,
+            owner: String(position.owner),
+            cluster: runtime.cluster,
+            shares: position.shares,
+            // Fund tokens are not staked or locked on-chain; the redeemable
+            // quantity is the balance. (Primary-market settlement timing is a
+            // TERM of the strategy, not a property of the tokens.)
+            withdrawableShares: position.shares,
+            tokenMint: depositMint,
+            shareMint: position.fund.mint,
+          },
+        ];
+      });
+    });
+  }
+
+  /** Addresses stand in as noop signers so kit places the account correctly; no key ever reaches this package. */
+  private participant(value: string) {
+    return createNoopSigner(address(value));
+  }
+}
+
+/**
+ * Same construction-time assertion as `@sdp/kamino`'s: the two capabilities
+ * describe opposite money models, and a client answering yes to both would let
+ * a portfolio route hand out WisdomTree's on-receipt wallet as a fundable
+ * address — which strands money sent from any unregistered wallet.
+ */
+export function assertWisdomTreeNotPortfolioProvider(client: WisdomTreeVaultDirectClient): void {
+  if (supportsPortfolioWallets(client)) {
+    throw new SdpWisdomTreeError(
+      "MINT_MISMATCH",
+      "WisdomTree must never report the portfolio-wallet capability: SDP holds no fundable " +
+        "address for it, and its on-receipt wallet only settles deposits from KYC-registered wallets."
+    );
+  }
+}

--- a/packages/sdp-wisdomtree/src/errors.ts
+++ b/packages/sdp-wisdomtree/src/errors.ts
@@ -1,0 +1,31 @@
+/**
+ * Error taxonomy for `@sdp/wisdomtree` — the package's own class, per the
+ * provider-package convention (`SdpKaminoError` precedent): the API layer maps
+ * codes it recognizes onto HTTP answers and rethrows the rest.
+ */
+export type SdpWisdomTreeErrorCode =
+  /** The providerReference names no fund in the measured registry. */
+  | "FUND_UNKNOWN"
+  /** The fund's instrument does not exist on the requested cluster. */
+  | "CLUSTER_UNSUPPORTED"
+  /** Caller-fault amount problems: unparsable, zero, or sub-atomic precision. */
+  | "INVALID_AMOUNT"
+  /** A chain read failed or returned an account this package refuses to trust. */
+  | "CHAIN_UNREADABLE"
+  /**
+   * The live mint does not match the measured registry (wrong owner program,
+   * decimals, or transfer-hook program). Refusing is the point: building
+   * against a drifted instrument moves money under stale assumptions.
+   */
+  | "MINT_MISMATCH";
+
+export class SdpWisdomTreeError extends Error {
+  constructor(
+    public readonly code: SdpWisdomTreeErrorCode,
+    message: string,
+    options?: { cause?: unknown }
+  ) {
+    super(message, options);
+    this.name = "SdpWisdomTreeError";
+  }
+}

--- a/packages/sdp-wisdomtree/src/fixtures.test-helper.ts
+++ b/packages/sdp-wisdomtree/src/fixtures.test-helper.ts
@@ -1,0 +1,42 @@
+import { SPL_TOKEN_PROGRAMS } from "@sdp/types";
+import type { WisdomTreeChainReader } from "./chain";
+
+/**
+ * The LIVE WTGXX mint account, captured verbatim from mainnet-beta on
+ * 2026-08-28 (`getAccountInfo Em46fxx…`, base64). Real bytes on purpose: the
+ * mint parser and the build-time verification are tested against the exact
+ * account the production path will read, not a hand-built approximation.
+ */
+export const WTGXX_MINT_ACCOUNT_BASE64 =
+  // biome-ignore lint/security/noSecrets: a public on-chain account snapshot, not a credential
+  "AQAAAB2xnEqSO8sZPGeQEhmQ3X+IzhAbQLpJPMnVWbA7sPSP8mss1wgAAAAJAQEAAABzwlqNUhBgDnyX+YoPa5Wi0md+4WM6nid/A/8VcEEz0wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARIAQAAPuJ2FTwKjm2ceUyKz9jasrbpf1dVq06bCcHiC7tAl/cxw/QLM7rMhcoPZgn6ttq9HO8Ub2ACWfUePx93M9ItcGQA4AA+4nYVPAqObZx5TIrP2Nqytul/V1WrTpsJweILu0CX9AAAAAAAA8D8AAAAAAAAAAAAAAAAAAPA/GgAhADPnFWqaIb56oewidAqLHfWwauBugPTClN7oWn2AHJOWAAwAIAAPuJ2FTwKjm2ceUyKz9jasrbpf1dVq06bCcHiC7tAl/Q4AQAAPuJ2FTwKjm2ceUyKz9jasrbpf1dVq06bCcHiC7tAl/dEFsuk4srWpLVcZMSkBnjwGNmWaz3RcDYmrDPu6DxFQEwDhAA+4nYVPAqObZx5TIrP2Nqytul/V1WrTpsJweILu0CX9zHD9AszusyFyg9mCfq22r0c7xRvYAJZ9R4/H3cz0i1wvAAAAV2lzZG9tVHJlZSBHb3Zlcm5tZW50IE1vbmV5IE1hcmtldCBEaWdpdGFsIEZ1bmQFAAAAV1RHWFhdAAAAaHR0cHM6Ly9nYXRld2F5LnBpbmF0YS5jbG91ZC9pcGZzL2JhZmtyZWlobm5oeWx6aGtjaXV3aWs1aG4yNW1nbGFpZ3hsc2plcXZ3NWxtcG1wdTNpb3lvZTMyeTc0AAAAAA==";
+
+export function wtgxxMintAccountData(): Uint8Array {
+  return Uint8Array.from(Buffer.from(WTGXX_MINT_ACCOUNT_BASE64, "base64"));
+}
+
+/** A minimal 165-byte SPL token-account image holding `baseUnits` (u64 LE at offset 64). */
+export function tokenAccountData(baseUnits: bigint): Uint8Array {
+  const data = new Uint8Array(165);
+  new DataView(data.buffer).setBigUint64(64, baseUnits, true);
+  return data;
+}
+
+/**
+ * Fake chain reader keyed by address. Addresses absent from `accounts` read as
+ * nonexistent; `reads` records the order for assertions.
+ */
+export function fakeReader(
+  accounts: Record<string, { owner?: string; data: Uint8Array }>
+): WisdomTreeChainReader & { reads: string[] } {
+  const reads: string[] = [];
+  return {
+    reads,
+    async getAccount(accountAddress) {
+      reads.push(String(accountAddress));
+      const entry = accounts[String(accountAddress)];
+      if (!entry) return null;
+      return { owner: entry.owner ?? SPL_TOKEN_PROGRAMS["spl-token"], data: entry.data };
+    },
+  };
+}

--- a/packages/sdp-wisdomtree/src/guards.ts
+++ b/packages/sdp-wisdomtree/src/guards.ts
@@ -1,0 +1,64 @@
+import type { SolanaCluster } from "@sdp/types";
+import { SPL_TOKEN_PROGRAMS } from "@sdp/types";
+import { WISDOMTREE_TRANSFER_HOOK_PROGRAM_IDS } from "@sdp/types/wisdomtree-programs";
+import type { Address } from "@solana/kit";
+import type { WisdomTreeInstructionPlan } from "./types";
+
+/**
+ * Cluster-invariant programs a plan may name without being cluster-specific —
+ * the same closed set `@sdp/kamino`'s guard carries, for the same reason: an
+ * unexpected program is a finding, not noise.
+ */
+const CLUSTER_INVARIANT_PROGRAMS: readonly string[] = [
+  "11111111111111111111111111111111",
+  SPL_TOKEN_PROGRAMS["spl-token"],
+  SPL_TOKEN_PROGRAMS["token-2022"],
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr",
+  "ComputeBudget111111111111111111111111111111",
+];
+
+export class WisdomTreeProgramMismatchError extends Error {
+  constructor(
+    readonly cluster: SolanaCluster,
+    readonly offendingProgram: Address
+  ) {
+    super(
+      `WisdomTree instruction targets ${offendingProgram}, which is not a permitted ${cluster} ` +
+        "program for this integration."
+    );
+    this.name = "WisdomTreeProgramMismatchError";
+  }
+}
+
+/**
+ * Every program a plan for `cluster` may legitimately contain. Shared with
+ * `sponsoredPrograms` on purpose (the Kamino rule): what this package ENFORCES
+ * on its own output and what it DECLARES to a paymaster must be one object.
+ *
+ * Devnet answers the invariants alone — WisdomTree deploys nothing there, so
+ * no cluster-specific program can legitimately appear, and no plan should ever
+ * be built for it in the first place (the builders refuse earlier).
+ */
+export function permittedPlanPrograms(cluster: SolanaCluster): ReadonlySet<string> {
+  const hookProgram = WISDOMTREE_TRANSFER_HOOK_PROGRAM_IDS[cluster];
+  return new Set<string>([
+    ...CLUSTER_INVARIANT_PROGRAMS,
+    ...(hookProgram === undefined ? [] : [hookProgram]),
+  ]);
+}
+
+/** Output-side allowlist re-check on every emitted plan — belt AND braces, like Kamino's. */
+export function assertPlanTargetsCluster(
+  plan: WisdomTreeInstructionPlan
+): WisdomTreeInstructionPlan {
+  const permitted = permittedPlanPrograms(plan.cluster);
+  for (const instruction of plan.instructions) {
+    if (!permitted.has(String(instruction.programAddress))) {
+      throw new WisdomTreeProgramMismatchError(plan.cluster, instruction.programAddress);
+    }
+  }
+  return plan;
+}

--- a/packages/sdp-wisdomtree/src/index.ts
+++ b/packages/sdp-wisdomtree/src/index.ts
@@ -1,0 +1,26 @@
+export { acceptAtMintScale, formatBaseUnits } from "./amounts";
+export {
+  createWisdomTreeChainReader,
+  tokenAccountBaseUnits,
+  type WisdomTreeChainReader,
+} from "./chain";
+export {
+  assertWisdomTreeNotPortfolioProvider,
+  toEarnVaultTransactionPlan,
+  WisdomTreeVaultDirectClient,
+  type WisdomTreeVaultOperationRunner,
+} from "./client";
+export { SdpWisdomTreeError, type SdpWisdomTreeErrorCode } from "./errors";
+export {
+  assertPlanTargetsCluster,
+  permittedPlanPrograms,
+  WisdomTreeProgramMismatchError,
+} from "./guards";
+export { type ParsedFundMint, parseFundMint } from "./mint";
+export {
+  buildWisdomTreeDepositPlan,
+  verifyFundMint,
+  type WisdomTreeDepositPlanInput,
+} from "./plan";
+export { readWisdomTreePosition, type WisdomTreePositionRead } from "./positions";
+export type { WisdomTreeInstructionPlan, WisdomTreeRuntime } from "./types";

--- a/packages/sdp-wisdomtree/src/mint.ts
+++ b/packages/sdp-wisdomtree/src/mint.ts
@@ -1,0 +1,100 @@
+import { SdpWisdomTreeError } from "./errors";
+
+/**
+ * Minimal Token-2022 mint parser — just the fields this package must verify
+ * before building against a fund: decimals from the base layout, and the
+ * transfer-hook program from the TLV extensions.
+ *
+ * Hand-rolled rather than pulled from `@solana-program/token-2022`'s decoder
+ * because the builders only need two fields and the parse must fail CLOSED on
+ * anything structurally surprising: an account that does not parse is an
+ * account this package refuses to move money against.
+ *
+ * Layout (SPL Token-2022):
+ *   0..82    base mint (decimals at byte 44)
+ *   82..165  padding
+ *   165      account type (1 = mint)
+ *   166..    TLV entries: u16 type, u16 length, body
+ * TransferHook extension (type 14) body: authority (32) ++ hook program (32).
+ */
+
+const MINT_BASE_LENGTH = 82;
+const ACCOUNT_TYPE_OFFSET = 165;
+const ACCOUNT_TYPE_MINT = 1;
+const EXTENSION_TRANSFER_HOOK = 14;
+
+export interface ParsedFundMint {
+  decimals: number;
+  /** Base58 transfer-hook program, absent when the mint carries no hook. */
+  transferHookProgram?: string;
+}
+
+// biome-ignore lint/security/noSecrets: the public base58 alphabet, not a credential
+const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+function encodeBase58(bytes: Uint8Array): string {
+  let value = 0n;
+  for (const byte of bytes) {
+    value = value * 256n + BigInt(byte);
+  }
+  let out = "";
+  while (value > 0n) {
+    out = BASE58_ALPHABET[Number(value % 58n)] + out;
+    value /= 58n;
+  }
+  for (const byte of bytes) {
+    if (byte !== 0) break;
+    out = `1${out}`;
+  }
+  return out === "" ? "1".repeat(bytes.length) : out;
+}
+
+/** All-zero pubkeys mean "none" in several Token-2022 extension slots. */
+function isZeroed(bytes: Uint8Array): boolean {
+  return bytes.every((byte) => byte === 0);
+}
+
+export function parseFundMint(data: Uint8Array): ParsedFundMint {
+  if (data.length < MINT_BASE_LENGTH) {
+    throw new SdpWisdomTreeError(
+      "MINT_MISMATCH",
+      `Mint account data is ${data.length} bytes — shorter than a token mint.`
+    );
+  }
+  const decimals = data[44] as number;
+
+  // A bare 82-byte mint has no extensions and no hook.
+  if (data.length <= ACCOUNT_TYPE_OFFSET) {
+    return { decimals };
+  }
+  if (data[ACCOUNT_TYPE_OFFSET] !== ACCOUNT_TYPE_MINT) {
+    throw new SdpWisdomTreeError(
+      "MINT_MISMATCH",
+      "Token-2022 account type byte does not mark this account as a mint."
+    );
+  }
+
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  let offset = ACCOUNT_TYPE_OFFSET + 1;
+  let transferHookProgram: string | undefined;
+  while (offset + 4 <= data.length) {
+    const extensionType = view.getUint16(offset, true);
+    const length = view.getUint16(offset + 2, true);
+    const bodyStart = offset + 4;
+    if (bodyStart + length > data.length) {
+      throw new SdpWisdomTreeError(
+        "MINT_MISMATCH",
+        "Token-2022 TLV extension overruns the account data; refusing the parse."
+      );
+    }
+    if (extensionType === EXTENSION_TRANSFER_HOOK) {
+      const program = data.subarray(bodyStart + 32, bodyStart + 64);
+      if (program.length === 32 && !isZeroed(program)) {
+        transferHookProgram = encodeBase58(program);
+      }
+    }
+    offset = bodyStart + length;
+  }
+
+  return { decimals, ...(transferHookProgram === undefined ? {} : { transferHookProgram }) };
+}

--- a/packages/sdp-wisdomtree/src/plan.test.ts
+++ b/packages/sdp-wisdomtree/src/plan.test.ts
@@ -1,0 +1,167 @@
+import { SPL_TOKEN_PROGRAMS, wellKnownMint } from "@sdp/types";
+import {
+  WISDOMTREE_FUNDS,
+  WISDOMTREE_TRANSFER_HOOK_PROGRAM_IDS,
+} from "@sdp/types/wisdomtree-programs";
+import { address, createNoopSigner } from "@solana/kit";
+import { findAssociatedTokenPda } from "@solana-program/token-2022";
+import { describe, expect, it } from "vitest";
+import { SdpWisdomTreeError } from "./errors";
+import { fakeReader, tokenAccountData, wtgxxMintAccountData } from "./fixtures.test-helper";
+import { parseFundMint } from "./mint";
+import { buildWisdomTreeDepositPlan, verifyFundMint } from "./plan";
+import type { WisdomTreeRuntime } from "./types";
+
+const WTGXX = WISDOMTREE_FUNDS[0];
+const USDC = wellKnownMint("USDC", "mainnet-beta") as string;
+const TOKEN_2022 = SPL_TOKEN_PROGRAMS["token-2022"];
+const SPL_TOKEN = SPL_TOKEN_PROGRAMS["spl-token"];
+
+// Any valid 32-byte pubkeys serve as wallets in an offline build.
+const OWNER = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
+const ON_RECEIPT = "ComputeBudget111111111111111111111111111111";
+
+const runtime: WisdomTreeRuntime = { cluster: "mainnet-beta", rpcUrl: "http://offline.invalid" };
+
+async function ata(owner: string, mint: string, tokenProgram: string): Promise<string> {
+  const [derived] = await findAssociatedTokenPda({
+    owner: address(owner),
+    mint: address(mint),
+    tokenProgram: address(tokenProgram),
+  });
+  return String(derived);
+}
+
+function depositInput(overrides: Partial<Parameters<typeof buildWisdomTreeDepositPlan>[2]> = {}) {
+  return {
+    fund: WTGXX,
+    owner: createNoopSigner(address(OWNER)),
+    onReceiptWallet: address(ON_RECEIPT),
+    depositMint: address(USDC),
+    depositDecimals: 6,
+    amount: "25.5",
+    ...overrides,
+  };
+}
+
+describe("parseFundMint against the live WTGXX bytes", () => {
+  it("reads the decimals and the transfer-hook program the chain states", () => {
+    const parsed = parseFundMint(wtgxxMintAccountData());
+    expect(parsed.decimals).toBe(9);
+    expect(parsed.transferHookProgram).toBe(WISDOMTREE_TRANSFER_HOOK_PROGRAM_IDS["mainnet-beta"]);
+  });
+});
+
+describe("verifyFundMint", () => {
+  it("accepts the live mainnet mint image", async () => {
+    const reader = fakeReader({
+      [WTGXX.mint]: { owner: TOKEN_2022, data: wtgxxMintAccountData() },
+    });
+    await expect(verifyFundMint(reader, runtime, WTGXX)).resolves.toBeUndefined();
+  });
+
+  it.each([
+    ["a missing mint", {}],
+    [
+      "a mint owned by the classic token program",
+      { [WTGXX.mint]: { owner: SPL_TOKEN, data: wtgxxMintAccountData() } },
+    ],
+  ])("refuses %s", async (_label, accounts) => {
+    const reader = fakeReader(accounts as Parameters<typeof fakeReader>[0]);
+    await expect(verifyFundMint(reader, runtime, WTGXX)).rejects.toThrowError(SdpWisdomTreeError);
+  });
+
+  it("refuses a mint whose hook program drifted from the registry", async () => {
+    const drifted = wtgxxMintAccountData();
+    // Flip one byte inside the TransferHook extension's program field (the
+    // extension body starts at 371: authority 371..403, program 403..435).
+    drifted[403] = drifted[403] === 0 ? 1 : 0;
+    const parsedHook = parseFundMint(drifted).transferHookProgram;
+    // Fixture sanity: the flip landed inside the hook program bytes.
+    expect(parsedHook).not.toBe(WISDOMTREE_TRANSFER_HOOK_PROGRAM_IDS["mainnet-beta"]);
+
+    const reader = fakeReader({ [WTGXX.mint]: { owner: TOKEN_2022, data: drifted } });
+    await expect(verifyFundMint(reader, runtime, WTGXX)).rejects.toThrowError(/transfer hook/);
+  });
+});
+
+describe("buildWisdomTreeDepositPlan", () => {
+  it("builds create-share-ATA + transfer for a first-time owner", async () => {
+    const onReceiptUsdcAta = await ata(ON_RECEIPT, USDC, SPL_TOKEN);
+    const reader = fakeReader({
+      [WTGXX.mint]: { owner: TOKEN_2022, data: wtgxxMintAccountData() },
+      // On-receipt wallet already holds a USDC ATA; the owner holds no fund ATA.
+      [onReceiptUsdcAta]: { data: tokenAccountData(0n) },
+    });
+
+    const plan = await buildWisdomTreeDepositPlan(reader, runtime, depositInput());
+
+    expect(plan.cluster).toBe("mainnet-beta");
+    expect(plan.createsShareAccount).toBe(true);
+    expect(plan.accepted).toEqual({ amount: "25.5" });
+    expect(plan.assetIdentity).toEqual({
+      depositTokenMint: address(USDC),
+      shareMint: address(WTGXX.mint),
+    });
+
+    // ATA program creates the owner's fund-token account, then the classic
+    // token program moves the USDC. No hook program: USDC carries no hook.
+    expect(plan.instructions.map((instruction) => String(instruction.programAddress))).toEqual([
+      "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+      SPL_TOKEN,
+    ]);
+
+    const transfer = plan.instructions.at(-1);
+    const ownerUsdcAta = await ata(OWNER, USDC, SPL_TOKEN);
+    expect(transfer?.accounts?.map((account) => String(account.address))).toEqual([
+      ownerUsdcAta,
+      USDC,
+      onReceiptUsdcAta,
+      OWNER,
+    ]);
+  });
+
+  it("creates the on-receipt USDC ATA only when it is measured absent", async () => {
+    const ownerFundAta = await ata(OWNER, WTGXX.mint, TOKEN_2022);
+    const reader = fakeReader({
+      [WTGXX.mint]: { owner: TOKEN_2022, data: wtgxxMintAccountData() },
+      // Owner already holds the fund ATA; the on-receipt USDC ATA does not exist.
+      [ownerFundAta]: { owner: TOKEN_2022, data: tokenAccountData(1n) },
+    });
+
+    const plan = await buildWisdomTreeDepositPlan(reader, runtime, depositInput());
+    expect(plan.createsShareAccount).toBe(false);
+    expect(plan.instructions).toHaveLength(2);
+    const create = plan.instructions[0];
+    expect(String(create.programAddress)).toBe("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
+    // The created account is WisdomTree's USDC ATA, funded by the rent payer
+    // (defaulting to the owner).
+    const onReceiptUsdcAta = await ata(ON_RECEIPT, USDC, SPL_TOKEN);
+    expect(create.accounts?.some((account) => String(account.address) === onReceiptUsdcAta)).toBe(
+      true
+    );
+  });
+
+  it("routes rent to an explicit rentPayer", async () => {
+    const reader = fakeReader({
+      [WTGXX.mint]: { owner: TOKEN_2022, data: wtgxxMintAccountData() },
+    });
+    const sponsor = "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD";
+    const plan = await buildWisdomTreeDepositPlan(
+      reader,
+      runtime,
+      depositInput({ rentPayer: createNoopSigner(address(sponsor)) })
+    );
+    const create = plan.instructions[0];
+    expect(String(create.accounts?.[0]?.address)).toBe(sponsor);
+  });
+
+  it("refuses a sub-atomic amount before any instruction is built", async () => {
+    const reader = fakeReader({
+      [WTGXX.mint]: { owner: TOKEN_2022, data: wtgxxMintAccountData() },
+    });
+    await expect(
+      buildWisdomTreeDepositPlan(reader, runtime, depositInput({ amount: "1.0000001" }))
+    ).rejects.toThrowError(/finer than the mint's 6 decimals/);
+  });
+});

--- a/packages/sdp-wisdomtree/src/plan.ts
+++ b/packages/sdp-wisdomtree/src/plan.ts
@@ -1,0 +1,174 @@
+import { SPL_TOKEN_PROGRAMS } from "@sdp/types";
+import type { WisdomTreeFund } from "@sdp/types/wisdomtree-programs";
+import { WISDOMTREE_TRANSFER_HOOK_PROGRAM_IDS } from "@sdp/types/wisdomtree-programs";
+import type { Address, Instruction, TransactionSigner } from "@solana/kit";
+import { address } from "@solana/kit";
+import {
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenIdempotentInstruction,
+  getTransferCheckedInstruction,
+} from "@solana-program/token-2022";
+import { acceptAtMintScale } from "./amounts";
+import type { WisdomTreeChainReader } from "./chain";
+import { SdpWisdomTreeError } from "./errors";
+import { assertPlanTargetsCluster } from "./guards";
+import { parseFundMint } from "./mint";
+import type { WisdomTreeInstructionPlan, WisdomTreeRuntime } from "./types";
+
+const SPL_TOKEN_PROGRAM = address(SPL_TOKEN_PROGRAMS["spl-token"]);
+const TOKEN_2022_PROGRAM = address(SPL_TOKEN_PROGRAMS["token-2022"]);
+
+export interface WisdomTreeDepositPlanInput {
+  fund: WisdomTreeFund;
+  /** Wallet whose USDC leaves and whose fund tokens later settle. A signer-shaped address (noop signer). */
+  owner: TransactionSigner;
+  /** WisdomTree's on-receipt Purchase wallet, resolved from the Connect API at build time. */
+  onReceiptWallet: Address;
+  /** The deposit stablecoin's mint and scale on this cluster. */
+  depositMint: Address;
+  depositDecimals: number;
+  /** Deposit amount in the stablecoin's own units, as a decimal string. */
+  amount: string;
+  /** Rent funder for any ATA this plan must create. NOT the fee payer. Defaults to the owner. */
+  rentPayer?: TransactionSigner;
+}
+
+/**
+ * Verify the live fund mint against the measured registry before any plan is
+ * built against it: owner program, decimals, and transfer-hook program must
+ * all match, or the instrument has drifted from what SDP audited and the build
+ * refuses. This is the builder-truth half of `assetIdentity` — for a vaultless
+ * provider the mint account IS the live state a vault read would be.
+ */
+export async function verifyFundMint(
+  reader: WisdomTreeChainReader,
+  runtime: WisdomTreeRuntime,
+  fund: WisdomTreeFund
+): Promise<void> {
+  const account = await reader.getAccount(address(fund.mint));
+  if (account === null) {
+    throw new SdpWisdomTreeError(
+      "MINT_MISMATCH",
+      `Fund mint ${fund.mint} does not exist on ${runtime.cluster}.`
+    );
+  }
+  if (account.owner !== String(TOKEN_2022_PROGRAM)) {
+    throw new SdpWisdomTreeError(
+      "MINT_MISMATCH",
+      `Fund mint ${fund.mint} is owned by ${account.owner}, not the Token-2022 program.`
+    );
+  }
+  const parsed = parseFundMint(account.data);
+  if (parsed.decimals !== fund.decimals) {
+    throw new SdpWisdomTreeError(
+      "MINT_MISMATCH",
+      `Fund mint ${fund.mint} carries ${parsed.decimals} decimals; the registry states ${fund.decimals}.`
+    );
+  }
+  const expectedHook = WISDOMTREE_TRANSFER_HOOK_PROGRAM_IDS[runtime.cluster];
+  if (parsed.transferHookProgram !== expectedHook) {
+    throw new SdpWisdomTreeError(
+      "MINT_MISMATCH",
+      `Fund mint ${fund.mint} names transfer hook ${parsed.transferHookProgram ?? "none"}; ` +
+        `the registry states ${expectedHook ?? "none"} for ${runtime.cluster}.`
+    );
+  }
+}
+
+/**
+ * Build the on-chain leg of a WisdomTree primary-market SUBSCRIPTION: a
+ * TransferChecked of USDC from the owner to WisdomTree's on-receipt Purchase
+ * wallet. There is no vault instruction — receiving the USDC from a
+ * KYC-registered wallet is what opens the order on WisdomTree's side, and the
+ * fund tokens settle back to the owner after NAV strike, OUTSIDE this
+ * transaction.
+ *
+ * The plan also creates (idempotently, and only when measured absent):
+ * - the on-receipt wallet's USDC ATA — so a first-ever transfer to a fresh
+ *   settlement wallet cannot fail on a missing account;
+ * - the owner's fund-token ATA — so WisdomTree's settlement leg has an account
+ *   to land in. This is the `createsShareAccount` the caller records for rent
+ *   attribution, same contract (and same read-then-broadcast residual) as the
+ *   Kamino share ATA.
+ */
+export async function buildWisdomTreeDepositPlan(
+  reader: WisdomTreeChainReader,
+  runtime: WisdomTreeRuntime,
+  input: WisdomTreeDepositPlanInput
+): Promise<WisdomTreeInstructionPlan> {
+  await verifyFundMint(reader, runtime, input.fund);
+
+  const accepted = acceptAtMintScale(input.amount, input.depositDecimals, "Deposit amount");
+  const rentPayer = input.rentPayer ?? input.owner;
+  const fundMint = address(input.fund.mint);
+
+  const [ownerUsdcAta] = await findAssociatedTokenPda({
+    owner: input.owner.address,
+    tokenProgram: SPL_TOKEN_PROGRAM,
+    mint: input.depositMint,
+  });
+  const [onReceiptUsdcAta] = await findAssociatedTokenPda({
+    owner: input.onReceiptWallet,
+    tokenProgram: SPL_TOKEN_PROGRAM,
+    mint: input.depositMint,
+  });
+  const [ownerFundAta] = await findAssociatedTokenPda({
+    owner: input.owner.address,
+    tokenProgram: TOKEN_2022_PROGRAM,
+    mint: fundMint,
+  });
+
+  // Measured, not assumed — the contract's `createsShareAccount` is a claim
+  // about who paid rent, and only a chain read can make it.
+  const [ownerFundAccount, onReceiptUsdcAccount] = await Promise.all([
+    reader.getAccount(ownerFundAta),
+    reader.getAccount(onReceiptUsdcAta),
+  ]);
+  const createsShareAccount = ownerFundAccount === null;
+
+  const instructions: Instruction[] = [];
+  if (createsShareAccount) {
+    instructions.push(
+      getCreateAssociatedTokenIdempotentInstruction({
+        payer: rentPayer,
+        ata: ownerFundAta,
+        owner: input.owner.address,
+        mint: fundMint,
+        tokenProgram: TOKEN_2022_PROGRAM,
+      })
+    );
+  }
+  if (onReceiptUsdcAccount === null) {
+    instructions.push(
+      getCreateAssociatedTokenIdempotentInstruction({
+        payer: rentPayer,
+        ata: onReceiptUsdcAta,
+        owner: input.onReceiptWallet,
+        mint: input.depositMint,
+        tokenProgram: SPL_TOKEN_PROGRAM,
+      })
+    );
+  }
+  instructions.push(
+    getTransferCheckedInstruction(
+      {
+        source: ownerUsdcAta,
+        mint: input.depositMint,
+        destination: onReceiptUsdcAta,
+        authority: input.owner,
+        amount: accepted.baseUnits,
+        decimals: input.depositDecimals,
+      },
+      { programAddress: SPL_TOKEN_PROGRAM }
+    )
+  );
+
+  return assertPlanTargetsCluster({
+    cluster: runtime.cluster,
+    instructions,
+    lookupTables: [],
+    assetIdentity: { depositTokenMint: input.depositMint, shareMint: fundMint },
+    accepted: { amount: accepted.canonical },
+    createsShareAccount,
+  });
+}

--- a/packages/sdp-wisdomtree/src/positions.ts
+++ b/packages/sdp-wisdomtree/src/positions.ts
@@ -1,0 +1,41 @@
+import { SPL_TOKEN_PROGRAMS } from "@sdp/types";
+import type { WisdomTreeFund } from "@sdp/types/wisdomtree-programs";
+import type { Address } from "@solana/kit";
+import { address } from "@solana/kit";
+import { findAssociatedTokenPda } from "@solana-program/token-2022";
+import { formatBaseUnits } from "./amounts";
+import { tokenAccountBaseUnits, type WisdomTreeChainReader } from "./chain";
+
+/**
+ * One owner's live holding in one fund, in base units of truth: the exact
+ * integer amount from the owner's Token-2022 ATA, never `uiAmount` (the same
+ * precision rule `@sdp/kamino`'s share-balance read follows).
+ *
+ * Fund tokens are the position — there is no vault share to convert and no
+ * staking, so `shares` and `withdrawableShares` are the same figure, and a
+ * missing ATA is an exact zero.
+ */
+export interface WisdomTreePositionRead {
+  fund: WisdomTreeFund;
+  owner: Address;
+  /** Fund tokens held, as a decimal string at the mint's own scale. */
+  shares: string;
+}
+
+export async function readWisdomTreePosition(
+  reader: WisdomTreeChainReader,
+  input: { fund: WisdomTreeFund; owner: Address }
+): Promise<WisdomTreePositionRead> {
+  const [ata] = await findAssociatedTokenPda({
+    owner: input.owner,
+    tokenProgram: address(SPL_TOKEN_PROGRAMS["token-2022"]),
+    mint: address(input.fund.mint),
+  });
+  const account = await reader.getAccount(ata);
+  const baseUnits = account === null ? 0n : tokenAccountBaseUnits(account.data);
+  return {
+    fund: input.fund,
+    owner: input.owner,
+    shares: formatBaseUnits(baseUnits, input.fund.decimals),
+  };
+}

--- a/packages/sdp-wisdomtree/src/types.ts
+++ b/packages/sdp-wisdomtree/src/types.ts
@@ -1,0 +1,37 @@
+import type { SolanaCluster } from "@sdp/types";
+import type { Address, Instruction } from "@solana/kit";
+
+/**
+ * Boundary contract for `@sdp/wisdomtree`. Same two rules as `@sdp/kamino`'s
+ * types module: money is a decimal string, and nothing here references any
+ * type outside `@solana/kit` (the repo's pinned version) and `@sdp/types`.
+ */
+
+/** Which cluster a call runs against, and how to reach it. Caller-supplied —
+ * never read from process env — for the same reason as `KaminoRuntime`. */
+export interface WisdomTreeRuntime {
+  cluster: SolanaCluster;
+  rpcUrl: string;
+}
+
+/** A built, unsigned unit of work: one complete transaction's instructions. */
+export interface WisdomTreeInstructionPlan {
+  cluster: SolanaCluster;
+  instructions: readonly Instruction[];
+  /** WisdomTree publishes no lookup tables; always empty, kept for the shared wire shape. */
+  lookupTables: readonly Address[];
+  assetIdentity: {
+    /** The stablecoin leg's mint (USDC). */
+    depositTokenMint: Address;
+    /** The fund's Token-2022 mint — the instrument AND the receipt token. */
+    shareMint: Address;
+  };
+  accepted: {
+    /** Canonical deposit amount the instructions encode (deposits only). */
+    amount?: string;
+    /** Canonical fund-token quantity the instructions encode (redemptions only). */
+    shares?: string;
+  };
+  /** True when this plan creates the owner's fund-token ATA, charging rent to the rent payer. */
+  createsShareAccount?: boolean;
+}

--- a/packages/sdp-wisdomtree/tsconfig.json
+++ b/packages/sdp-wisdomtree/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    // Mirrors packages/sdp-earn: this package typechecks @sdp/earn's sources
+    // through its workspace import, and `fetch.ts` there references the DOM's
+    // `HeadersInit` / `BodyInit`. Without these libs the failure surfaces here
+    // rather than in the package that owns the code.
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -941,6 +941,34 @@ importers:
         specifier: 4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.50.0)(tsx@4.23.5)(yaml@2.9.0))
 
+  packages/sdp-wisdomtree:
+    dependencies:
+      '@sdp/earn':
+        specifier: workspace:*
+        version: link:../sdp-earn
+      '@sdp/types':
+        specifier: workspace:*
+        version: link:../sdp-types
+      '@solana-program/token-2022':
+        specifier: 'catalog:'
+        version: 0.15.0(@solana/kit@7.1.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@7.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/kit':
+        specifier: 'catalog:'
+        version: 7.1.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+    devDependencies:
+      '@types/node':
+        specifier: 26.1.2
+        version: 26.1.2
+      tsx:
+        specifier: 4.23.5
+        version: 4.23.5
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.50.0)(tsx@4.23.5)(yaml@2.9.0))
+
 packages:
 
   '@adraffy/ens-normalize@1.11.0':

--- a/scripts/check-module-boundaries.mjs
+++ b/scripts/check-module-boundaries.mjs
@@ -181,6 +181,18 @@ const MODULE_METADATA = [
     allowedDependencies: [],
   },
   {
+    name: "@sdp/wisdomtree",
+    directory: "packages/sdp-wisdomtree",
+    purpose:
+      "Kit-native WisdomTree Connect transfer plans (on-receipt subscription/redemption legs) and Token-2022 fund position reads.",
+    // Same inward-pointing arrow as @sdp/kamino: this package depends on
+    // @sdp/earn (provider contract + the Connect REST client it extends), and
+    // @sdp/earn must never depend back — the hourly catalogue cron would then
+    // load @solana/kit. The fund registry lives in @sdp/types for the same
+    // no-cycle reason as the Kamino program tables.
+    allowedDependencies: ["@sdp/earn", "@sdp/types"],
+  },
+  {
     name: "@sdp/types",
     directory: "packages/sdp-types",
     purpose: "Shared runtime types, constants, and product contracts.",


### PR DESCRIPTION
… reads

New workspace package @sdp/wisdomtree, mirroring @sdp/kamino's shape: the kit-native half of the integration, consuming @sdp/earn's provider contract and Connect REST client (now a package subpath export) with the arrow pointing strictly inward.

What a deposit IS here: there is no vault instruction. The plan is the on-chain leg of a primary-market subscription — TransferChecked of USDC to WisdomTree's on-receipt Purchase wallet, resolved from their API at build time (never configuration: a stale settlement address is money sent to the wrong place). Fund tokens settle back after NAV strike, outside the transaction, which is why the plan also creates the owner's Token-2022 fund ATA when it is measured absent (the createsShareAccount contract, same read-then-broadcast residual as Kamino's share ATA) — so WisdomTree's settlement leg has an account to land in.

Safety spine, in the package rather than in callers:
- verifyFundMint compares the LIVE mint (owner program, decimals, transfer-hook program) against the measured registry before any build — builder truth for a vaultless provider, refusing drifted instruments. Tested against the verbatim mainnet WTGXX account image.
- acceptAtMintScale refuses sub-atomic precision instead of flooring, and the canonical amount the instructions encode is what gets ledgered.
- assertPlanTargetsCluster re-checks every emitted plan against a closed per-cluster program allowlist, and sponsoredPrograms declares that SAME set to the paymaster harness (the Kamino no-drift rule).
- minSharesOut is refused outright: a NAV-settled subscription has no instruction that could enforce a share floor, and accepting the field while enforcing nothing is slippage protection in appearance only.
- Position reads are exact base units from the owner's ATA (never uiAmount); discovery drops empty holdings, explicit requests may truthfully answer zero, and devnet answers an empty page because no instrument exists there.

supportsVaultWithdraw stays FALSE on purpose — redemptions (the fund-token transfer through the compliance hook) are their own change, per the playbook's money-out-is-separate rule.