### PR TITLE
feat(api): wire wisdomtree execution + the deposit-eligibility gate

### DIFF
--- a/apps/sdp-api/Dockerfile
+++ b/apps/sdp-api/Dockerfile
@@ -32,6 +32,7 @@ COPY packages/sdp-private-channels/package.json ./packages/sdp-private-channels/
 COPY packages/sdp-spc-escrow/package.json ./packages/sdp-spc-escrow/
 COPY packages/sdp-spc-withdraw/package.json ./packages/sdp-spc-withdraw/
 COPY packages/sdp-kamino/package.json ./packages/sdp-kamino/
+COPY packages/sdp-wisdomtree/package.json ./packages/sdp-wisdomtree/
 COPY packages/bigint-buffer/package.json ./packages/bigint-buffer/
 COPY packages/sdp-veda/package.json ./packages/sdp-veda/
 COPY patches ./patches
@@ -59,6 +60,7 @@ COPY packages/sdp-private-channels ./packages/sdp-private-channels
 COPY packages/sdp-spc-escrow ./packages/sdp-spc-escrow
 COPY packages/sdp-spc-withdraw ./packages/sdp-spc-withdraw
 COPY packages/sdp-kamino ./packages/sdp-kamino
+COPY packages/sdp-wisdomtree ./packages/sdp-wisdomtree
 COPY packages/bigint-buffer ./packages/bigint-buffer
 COPY packages/sdp-veda ./packages/sdp-veda
 

--- a/apps/sdp-api/Dockerfile.dockerignore
+++ b/apps/sdp-api/Dockerfile.dockerignore
@@ -31,6 +31,7 @@ packages/*
 !packages/sdp-spc-escrow
 !packages/sdp-spc-withdraw
 !packages/sdp-kamino
+!packages/sdp-wisdomtree
 !packages/bigint-buffer
 !packages/sdp-veda
 docs

--- a/apps/sdp-api/package.json
+++ b/apps/sdp-api/package.json
@@ -65,6 +65,7 @@
     "@sdp/spc-withdraw": "workspace:*",
     "@sdp/types": "workspace:*",
     "@sdp/veda": "workspace:*",
+    "@sdp/wisdomtree": "workspace:*",
     "@sentry/node": "10.70.0",
     "@solana-program/system": "catalog:",
     "@solana-program/token": "catalog:",

--- a/apps/sdp-api/src/services/earn-provider-registry.ts
+++ b/apps/sdp-api/src/services/earn-provider-registry.ts
@@ -10,6 +10,7 @@ import {
   assertNotPortfolioProvider as assertVedaNotPortfolioProvider,
   VedaVaultDirectClient,
 } from "@sdp/veda";
+import { assertWisdomTreeNotPortfolioProvider, WisdomTreeVaultDirectClient } from "@sdp/wisdomtree";
 import type { Env } from "@/types/env";
 import { assertClusterEndpoint, resolveClusterRpcUrl } from "./earn/execution-registry";
 import { createVaultDeadline } from "./earn/vault-deadline";
@@ -45,6 +46,8 @@ assertNotPortfolioProvider(kamino);
 
 const veda = new VedaVaultDirectClient(resolveProvenRpcUrl, runVaultOperation);
 assertVedaNotPortfolioProvider(veda);
+const wisdomtree = new WisdomTreeVaultDirectClient(resolveProvenRpcUrl, runVaultOperation);
+assertWisdomTreeNotPortfolioProvider(wisdomtree);
 
 /**
  * API composition root for Earn providers.
@@ -59,6 +62,7 @@ export const EARN_PROVIDER_CLIENTS = {
   ...CATALOGUE_PROVIDER_CLIENTS,
   kamino,
   veda,
+  wisdomtree,
 } as const satisfies Record<EarnProviderId, EarnVaultProvider>;
 
 export function resolveEarnProviderClient(provider: string): EarnVaultProvider {

--- a/apps/sdp-api/src/services/earn/deposit-eligibility.test.ts
+++ b/apps/sdp-api/src/services/earn/deposit-eligibility.test.ts
@@ -1,0 +1,50 @@
+import type { EarnRuntimeContext, EarnVaultProvider } from "@sdp/earn/types";
+import { describe, expect, it, vi } from "vitest";
+import { AppError } from "@/lib/errors";
+import { assertVaultDepositEligible } from "./deposit-eligibility";
+
+const runtime: EarnRuntimeContext = { env: {}, environment: "production" };
+const input = { providerReference: "FundMint1111", owner: "OwnerWallet1111" };
+
+const baseClient = {
+  provider: "wisdomtree",
+  declaredSupport: { sourceKinds: ["rwa"], depositTokens: ["USDC"] },
+  listStrategies: async () => [],
+} as unknown as EarnVaultProvider;
+
+describe("assertVaultDepositEligible", () => {
+  it("is a no-op for providers without the capability (today's permissionless vaults)", async () => {
+    await expect(assertVaultDepositEligible(baseClient, runtime, input)).resolves.toBeUndefined();
+  });
+
+  it("passes an eligible verdict through silently", async () => {
+    const check = vi.fn().mockResolvedValue({ eligible: true });
+    const client = Object.assign(Object.create(baseClient), { checkDepositEligibility: check });
+    await expect(assertVaultDepositEligible(client, runtime, input)).resolves.toBeUndefined();
+    expect(check).toHaveBeenCalledWith(runtime, input);
+  });
+
+  it("refuses an ineligible wallet with the provider's own reason, as a caller-fault 400", async () => {
+    const client = Object.assign(Object.create(baseClient), {
+      checkDepositEligibility: vi.fn().mockResolvedValue({
+        eligible: false,
+        reason: "This wallet is not registered with WisdomTree Connect.",
+      }),
+    });
+    const refusal = await assertVaultDepositEligible(client, runtime, input).then(
+      () => undefined,
+      (error: unknown) => error
+    );
+    expect(refusal).toBeInstanceOf(AppError);
+    expect((refusal as AppError).message).toMatch(/not registered with WisdomTree Connect/);
+  });
+
+  it("propagates a provider outage rather than failing open", async () => {
+    const client = Object.assign(Object.create(baseClient), {
+      checkDepositEligibility: vi.fn().mockRejectedValue(new Error("connect unreachable")),
+    });
+    await expect(assertVaultDepositEligible(client, runtime, input)).rejects.toThrowError(
+      /connect unreachable/
+    );
+  });
+});

--- a/apps/sdp-api/src/services/earn/deposit-eligibility.ts
+++ b/apps/sdp-api/src/services/earn/deposit-eligibility.ts
@@ -1,0 +1,36 @@
+import { supportsDepositEligibility } from "@sdp/earn/capabilities";
+import type { EarnRuntimeContext, EarnVaultProvider } from "@sdp/earn/types";
+import { badRequest } from "@/lib/errors";
+
+/**
+ * The provider-side eligibility gate for vault MONEY-IN, capability-dispatched
+ * (never a provider-id check) and shared by both deposit paths — custody-signed
+ * and external-wallet — so the rule cannot drift between them.
+ *
+ * Exists for regulated instruments (WisdomTree): settlement pays out fund
+ * tokens whose transfer hook refuses any wallet the issuer has not verified,
+ * so a deposit from an ineligible wallet is USDC that leaves and nothing that
+ * can come back. A provider without the capability is simply not gated —
+ * today's behavior for every permissionless vault.
+ *
+ * MONEY-IN ONLY (ADR 0002): no exit path may ever call this. A wallet holding
+ * the instrument proved its eligibility on-chain, and money out must never
+ * inherit a money-in gate.
+ */
+export async function assertVaultDepositEligible(
+  client: EarnVaultProvider,
+  runtime: EarnRuntimeContext,
+  input: { providerReference: string; owner: string }
+): Promise<void> {
+  if (!supportsDepositEligibility(client)) {
+    return;
+  }
+  const verdict = await client.checkDepositEligibility(runtime, input);
+  if (!verdict.eligible) {
+    throw badRequest(
+      verdict.reason ??
+        `${client.provider} reports this wallet as ineligible to receive the instrument.`,
+      { provider: client.provider, owner: input.owner, reason: verdict.reason }
+    );
+  }
+}

--- a/apps/sdp-api/src/services/earn/execution-registry.test.ts
+++ b/apps/sdp-api/src/services/earn/execution-registry.test.ts
@@ -225,6 +225,23 @@ describe("resolveVaultDirectClient", () => {
     ).rejects.toThrow(/reports genesis/);
   });
 
+  it("resolves WisdomTree as vault-direct with eligibility, without withdraw, I/O-free", async () => {
+    const createRpc = vi.spyOn(solanaRpc, "createRpc");
+    const { supportsDepositEligibility, supportsVaultDirect, supportsVaultWithdraw } = await import(
+      "@sdp/earn/capabilities"
+    );
+
+    const client = resolveVaultDirectClient(executionEnv, "wisdomtree", createVaultDeadline());
+
+    expect(client).not.toBeNull();
+    if (!client) throw new Error("expected WisdomTree vault-direct client");
+    expect(supportsVaultDirect(client)).toBe(true);
+    // Money-out stays honestly 501 until the redemption change lands.
+    expect(supportsVaultWithdraw(client)).toBe(false);
+    expect(supportsDepositEligibility(client)).toBe(true);
+    expect(createRpc).not.toHaveBeenCalled();
+  });
+
   it("does not start provider work after endpoint proof exhausts the shared deadline", async () => {
     vi.useFakeTimers();
     mockGenesisSend().mockReturnValue(new Promise<never>(() => undefined));

--- a/apps/sdp-api/src/services/earn/execution-registry.ts
+++ b/apps/sdp-api/src/services/earn/execution-registry.ts
@@ -19,6 +19,7 @@ import {
   assertNotPortfolioProvider as assertVedaNotPortfolioProvider,
   VedaVaultDirectClient,
 } from "@sdp/veda";
+import { assertWisdomTreeNotPortfolioProvider, WisdomTreeVaultDirectClient } from "@sdp/wisdomtree";
 import { instrumentVendorPort } from "@/runtime/vendor-calls";
 import type { Env } from "@/types/env";
 import type { VaultDeadline } from "./vault-deadline";
@@ -194,6 +195,11 @@ export function resolveEarnExecutionClient(
     const client = new VedaVaultDirectClient(provenRpcUrl, runOperation);
     assertVedaNotPortfolioProvider(client);
     return instrumentVendorPort("veda", client);
+  }
+  if (provider === "wisdomtree") {
+    const client = new WisdomTreeVaultDirectClient(provenRpcUrl, runOperation);
+    assertWisdomTreeNotPortfolioProvider(client);
+    return instrumentVendorPort("wisdomtree", client);
   }
   return null;
 }

--- a/apps/sdp-api/src/services/earn/vault-deposit.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-deposit.service.ts
@@ -15,6 +15,7 @@ import { badRequest, internalError } from "@/lib/errors";
 import { buildEarnVaultDepositFingerprint, resolveIdempotencyReplay } from "@/lib/idempotency";
 import { getLogger } from "@/runtime/logger";
 import type { Env } from "@/types/env";
+import { assertVaultDepositEligible } from "./deposit-eligibility";
 import {
   earnClusterFor,
   resolveClusterRpcUrl,
@@ -208,6 +209,18 @@ export async function depositIntoVault(
   }
   const cluster = earnClusterFor(input.environment);
   const rpcUrl = resolveClusterRpcUrl(env, cluster);
+  const runtime: EarnRuntimeContext = {
+    env,
+    environment: input.environment,
+  };
+
+  // Provider-side KYC/eligibility, before any sponsorship resolution or build:
+  // an ineligible wallet's deposit would settle nowhere (see the helper), so
+  // it must not cost a paymaster reservation or an RPC build either.
+  await assertVaultDepositEligible(client, runtime, {
+    providerReference: input.providerReference,
+    owner: input.wallet.publicKey,
+  });
 
   // Resolved here, AFTER the replay reads above and BEFORE the provider builds.
   // Both halves of that sentence matter: a replay must still answer during a
@@ -233,10 +246,6 @@ export async function depositIntoVault(
   const expectedAssetIdentity = {
     depositTokenMint: input.tokenMint,
     shareMint: input.shareMint,
-  };
-  const runtime: EarnRuntimeContext = {
-    env,
-    environment: input.environment,
   };
 
   /**

--- a/apps/sdp-api/src/services/earn/vault-external-wallet.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-external-wallet.service.ts
@@ -32,6 +32,7 @@ import {
 } from "@/lib/idempotency";
 import { getLogger } from "@/runtime/logger";
 import type { Env } from "@/types/env";
+import { assertVaultDepositEligible } from "./deposit-eligibility";
 import {
   earnClusterFor,
   resolveClusterRpcUrl,
@@ -149,6 +150,16 @@ export async function buildExternalWalletDepositTransaction(
     shareMint: input.shareMint,
   };
   const runtime: EarnRuntimeContext = { env, environment: input.environment };
+
+  // Provider-side KYC/eligibility for the END-USER wallet, before the build.
+  // This is the B2B2C path's whole point of failure for regulated funds: the
+  // partner's user signs, but only an issuer-verified wallet can RECEIVE the
+  // settlement, and the refusal must carry the provider's reason so the
+  // partner UI can send the user to complete verification.
+  await assertVaultDepositEligible(client, runtime, {
+    providerReference: input.providerReference,
+    owner: input.ownerAddress,
+  });
 
   /**
    * One build attempt at a given swap route width. Swap-funded builds may run

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -14,7 +14,7 @@ This map is generated from the module-boundary check. It records the permitted w
 
 | Module | Purpose | Allowed workspace dependencies |
 | --- | --- | --- |
-| `@sdp/api` | Node.js API and application composition root. | `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/helius-rings`, `@sdp/helius-rings-sdk`, `@sdp/issuance`, `@sdp/kamino`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types`, `@sdp/veda` |
+| `@sdp/api` | Node.js API and application composition root. | `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/helius-rings`, `@sdp/helius-rings-sdk`, `@sdp/issuance`, `@sdp/kamino`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types`, `@sdp/veda`, `@sdp/wisdomtree` |
 | `@sdp/api-integration` | Maintainer integration harness for API endpoint and provider coverage. | `@sdp/api`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/spc-escrow`, `@sdp/types` |
 | `@sdp/custody` | Custody provider abstractions and keychain adapters. | `@sdp/types` |
 | `@sdp/earn` | Earn domain services, yield strategies, and vault-infra providers. | `@sdp/payments`, `@sdp/rpc`, `@sdp/solana`, `@sdp/types` |
@@ -39,7 +39,7 @@ This map is generated from the module-boundary check. It records the permitted w
 
 ## Declared Workspace Graph
 
-- `@sdp/api` -> `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/helius-rings`, `@sdp/helius-rings-sdk`, `@sdp/issuance`, `@sdp/kamino`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types`, `@sdp/veda`
+- `@sdp/api` -> `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/helius-rings`, `@sdp/helius-rings-sdk`, `@sdp/issuance`, `@sdp/kamino`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types`, `@sdp/veda`, `@sdp/wisdomtree`
 - `@sdp/api-integration` -> `@sdp/api`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/spc-escrow`, `@sdp/types`
 - `@sdp/custody` -> `@sdp/types`
 - `@sdp/earn` -> `@sdp/types`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       '@sdp/veda':
         specifier: workspace:*
         version: link:../../packages/sdp-veda
+      '@sdp/wisdomtree':
+        specifier: workspace:*
+        version: link:../../packages/sdp-wisdomtree
       '@sentry/node':
         specifier: 10.70.0
         version: 10.70.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))

--- a/scripts/check-kamino-dependency-boundary.mjs
+++ b/scripts/check-kamino-dependency-boundary.mjs
@@ -16,6 +16,10 @@ const SAFE_BIGINT_RESOLUTION = "link:packages/bigint-buffer";
 // tools and tests cannot reach the abandoned package's native binding either.
 assertExactConsumers("@kamino-finance/klend-sdk", [KAMINO_PACKAGE]);
 assertExactConsumers("@sdp/kamino", [API_PACKAGE]);
+// Same rule for the WisdomTree execution package: only the API composes
+// executing providers. (No third-party SDK to pin — the package builds its
+// transfer legs from @solana/kit and @solana-program/token-2022 directly.)
+assertExactConsumers("@sdp/wisdomtree", [API_PACKAGE]);
 
 const safeBigintManifest = JSON.parse(readFileSync(path.join(ROOT, SAFE_BIGINT_PACKAGE), "utf8"));
 if (

--- a/scripts/check-module-boundaries.mjs
+++ b/scripts/check-module-boundaries.mjs
@@ -36,6 +36,7 @@ const MODULE_METADATA = [
       "@sdp/spc-withdraw",
       "@sdp/types",
       "@sdp/veda",
+      "@sdp/wisdomtree",
     ],
   },
   {


### PR DESCRIPTION
Composes the WisdomTree executing client into both provider maps — the execution registry branch (the ONE sanctioned provider-id mapping) and the API's singleton overlay registry — with the same proven-RPC resolver and per-operation deadline Kamino uses, and the portfolio-mutual- exclusion assertion at construction. Adds @sdp/wisdomtree to the API's dependency graph everywhere the graph is enforced: package.json, the Dockerfile's two COPY stages, the Dockerfile.dockerignore re-include allowlist (the build-context trap), module boundaries, and the dependency-boundary script (only the API may ship the package).

Introduces the MONEY-IN eligibility gate: assertVaultDepositEligible, capability-dispatched via supportsDepositEligibility and shared by the custody-signed deposit service and the external-wallet (B2B2C) build so the rule cannot drift between the two paths. It runs after the replay reads (replays stay pure durable reads) and before sponsorship resolution or any provider build — an ineligible wallet's deposit would settle nowhere, so it must not cost a paymaster reservation or an RPC build either. The refusal carries the provider's own reason, which for Embedded Yield is the sentence the partner UI shows a user who still needs to complete issuer verification. No exit path consults it (ADR 0002: money out never inherits a money-in gate) and a provider without the capability is untouched.