### PR TITLE
feat(wisdomtree): redemptions — the money-out half, through the compl…

### DIFF
--- a/apps/sdp-api/src/services/earn/execution-registry.test.ts
+++ b/apps/sdp-api/src/services/earn/execution-registry.test.ts
@@ -225,7 +225,7 @@ describe("resolveVaultDirectClient", () => {
     ).rejects.toThrow(/reports genesis/);
   });
 
-  it("resolves WisdomTree as vault-direct with eligibility, without withdraw, I/O-free", async () => {
+  it("resolves WisdomTree as vault-direct with eligibility and withdraw, I/O-free", async () => {
     const createRpc = vi.spyOn(solanaRpc, "createRpc");
     const { supportsDepositEligibility, supportsVaultDirect, supportsVaultWithdraw } = await import(
       "@sdp/earn/capabilities"
@@ -236,8 +236,7 @@ describe("resolveVaultDirectClient", () => {
     expect(client).not.toBeNull();
     if (!client) throw new Error("expected WisdomTree vault-direct client");
     expect(supportsVaultDirect(client)).toBe(true);
-    // Money-out stays honestly 501 until the redemption change lands.
-    expect(supportsVaultWithdraw(client)).toBe(false);
+    expect(supportsVaultWithdraw(client)).toBe(true);
     expect(supportsDepositEligibility(client)).toBe(true);
     expect(createRpc).not.toHaveBeenCalled();
   });

--- a/packages/sdp-wisdomtree/src/client.test.ts
+++ b/packages/sdp-wisdomtree/src/client.test.ts
@@ -62,10 +62,10 @@ beforeEach(() => resetWisdomTreeTokenCache());
 afterEach(() => vi.restoreAllMocks());
 
 describe("capability shape", () => {
-  it("is vault-direct with eligibility, without withdraw, and never custodial", () => {
+  it("is vault-direct with eligibility AND withdraw, and never custodial", () => {
     const client = offlineClient(fakeReader({}));
     expect(supportsVaultDirect(client)).toBe(true);
-    expect(supportsVaultWithdraw(client)).toBe(false);
+    expect(supportsVaultWithdraw(client)).toBe(true);
     expect(supportsDepositEligibility(client)).toBe(true);
     expect(() => assertWisdomTreeNotPortfolioProvider(client)).not.toThrow();
   });

--- a/packages/sdp-wisdomtree/src/client.ts
+++ b/packages/sdp-wisdomtree/src/client.ts
@@ -5,11 +5,12 @@ import { getWisdomTreeOnReceiptWallet } from "@sdp/earn/providers/wisdomtree/con
 import type {
   EarnRuntimeContext,
   EarnVaultDepositInput,
-  EarnVaultDirectProvider,
   EarnVaultInstruction,
   EarnVaultPositionInput,
   EarnVaultPositionSnapshot,
   EarnVaultTransactionPlan,
+  EarnVaultWithdrawInput,
+  EarnVaultWithdrawProvider,
 } from "@sdp/earn/types";
 import {
   CLUSTER_BY_SDP_ENVIRONMENT,
@@ -26,7 +27,7 @@ import { address, createNoopSigner } from "@solana/kit";
 import { createWisdomTreeChainReader, type WisdomTreeChainReader } from "./chain";
 import { SdpWisdomTreeError } from "./errors";
 import { permittedPlanPrograms } from "./guards";
-import { buildWisdomTreeDepositPlan } from "./plan";
+import { buildWisdomTreeDepositPlan, buildWisdomTreeRedemptionPlan } from "./plan";
 import { readWisdomTreePosition } from "./positions";
 import type { WisdomTreeInstructionPlan, WisdomTreeRuntime } from "./types";
 
@@ -66,12 +67,8 @@ export function toEarnVaultTransactionPlan(
 
 /**
  * WisdomTree as an EXECUTING provider: the catalogue + eligibility client plus
- * the vault-direct capability, money-in and position reads.
- *
- * DELIBERATELY NOT `EarnVaultWithdrawProvider` yet — redemptions (the
- * fund-token transfer through the compliance hook) land as their own change,
- * per the playbook's money-out-is-separate rule, and `supportsVaultWithdraw`
- * answering false keeps the exit route honestly 501 until then.
+ * the vault-direct capability, money in, money OUT (`EarnVaultWithdrawProvider`),
+ * and position reads.
  *
  * Lives here rather than in `@sdp/earn` so the hourly catalogue cron never
  * loads `@solana/kit`. The arrow points inward: this package depends on
@@ -79,7 +76,7 @@ export function toEarnVaultTransactionPlan(
  */
 export class WisdomTreeVaultDirectClient
   extends WisdomTreeEarnClient
-  implements EarnVaultDirectProvider
+  implements EarnVaultWithdrawProvider
 {
   constructor(
     private readonly resolveProvenRpcUrl: (
@@ -197,6 +194,63 @@ export class WisdomTreeVaultDirectClient
         } catch (error) {
           // Amount problems are the caller's to fix; everything else is the
           // provider integration's.
+          if (error instanceof SdpWisdomTreeError && error.code === "INVALID_AMOUNT") {
+            throw badRequest(error.message);
+          }
+          throw error;
+        }
+      }
+    );
+    return toEarnVaultTransactionPlan(plan);
+  }
+
+  /**
+   * The money-OUT half: the on-chain leg of a primary-market redemption —
+   * a Token-2022 TransferChecked of fund tokens to WisdomTree's on-receipt
+   * Sale wallet, hook accounts resolved live. Implementing this is what flips
+   * `supportsVaultWithdraw` to true (the same PRO-1702 mechanism Kamino used).
+   *
+   * Per ADR 0002 this path takes NO surfacing/entitlement/eligibility gate —
+   * a wallet holding the tokens proved its standing on-chain, and the hook
+   * re-proves it at execution. `rentRefundTo` is accepted and unused: no
+   * account is closed by a redemption (see the builder).
+   */
+  async buildVaultWithdrawal(
+    ctx: EarnRuntimeContext,
+    input: EarnVaultWithdrawInput
+  ): Promise<EarnVaultTransactionPlan> {
+    const plan = await this.withRuntime(
+      ctx,
+      "Building the WisdomTree redemption transfer",
+      async (runtime, assertActive) => {
+        const fund = this.fundFor(input.providerReference, runtime.cluster);
+        const depositMint = wellKnownMint("USDC", runtime.cluster);
+        if (!depositMint) {
+          throw new SdpWisdomTreeError(
+            "CLUSTER_UNSUPPORTED",
+            `USDC is not catalogued for ${runtime.cluster}.`
+          );
+        }
+
+        const onReceiptWallet = await getWisdomTreeOnReceiptWallet(ctx, {
+          tradeType: "Sale",
+          fund: fund.exchangeCode,
+          currency: "USDC",
+        });
+        assertActive();
+
+        try {
+          return await buildWisdomTreeRedemptionPlan(this.createReader(runtime.rpcUrl), runtime, {
+            fund,
+            owner: this.participant(input.owner),
+            onReceiptWallet: address(onReceiptWallet),
+            depositMint: address(depositMint),
+            shares: input.shares,
+            ...(input.rentPayer === undefined
+              ? {}
+              : { rentPayer: this.participant(input.rentPayer) }),
+          });
+        } catch (error) {
           if (error instanceof SdpWisdomTreeError && error.code === "INVALID_AMOUNT") {
             throw badRequest(error.message);
           }

--- a/packages/sdp-wisdomtree/src/errors.ts
+++ b/packages/sdp-wisdomtree/src/errors.ts
@@ -13,6 +13,12 @@ export type SdpWisdomTreeErrorCode =
   /** A chain read failed or returned an account this package refuses to trust. */
   | "CHAIN_UNREADABLE"
   /**
+   * The transfer hook's required accounts could not be resolved. For
+   * WisdomTree's compliance hook, the usual cause is a wallet the issuer has
+   * not verified — resolution failing IS the KYC gate answering no.
+   */
+  | "HOOK_UNRESOLVED"
+  /**
    * The live mint does not match the measured registry (wrong owner program,
    * decimals, or transfer-hook program). Refusing is the point: building
    * against a drifted instrument moves money under stale assumptions.

--- a/packages/sdp-wisdomtree/src/index.ts
+++ b/packages/sdp-wisdomtree/src/index.ts
@@ -19,8 +19,18 @@ export {
 export { type ParsedFundMint, parseFundMint } from "./mint";
 export {
   buildWisdomTreeDepositPlan,
+  buildWisdomTreeRedemptionPlan,
   verifyFundMint,
   type WisdomTreeDepositPlanInput,
+  type WisdomTreeRedemptionPlanInput,
 } from "./plan";
 export { readWisdomTreePosition, type WisdomTreePositionRead } from "./positions";
+export {
+  deriveExtraAccountMetasAddress,
+  parseExtraAccountMetaList,
+  type ResolvedHookAccount,
+  resolveTransferHookAccounts,
+  TRANSFER_HOOK_EXECUTE_DISCRIMINATOR,
+  type TransferHookResolutionInput,
+} from "./transfer-hook";
 export type { WisdomTreeInstructionPlan, WisdomTreeRuntime } from "./types";

--- a/packages/sdp-wisdomtree/src/plan.ts
+++ b/packages/sdp-wisdomtree/src/plan.ts
@@ -2,7 +2,7 @@ import { SPL_TOKEN_PROGRAMS } from "@sdp/types";
 import type { WisdomTreeFund } from "@sdp/types/wisdomtree-programs";
 import { WISDOMTREE_TRANSFER_HOOK_PROGRAM_IDS } from "@sdp/types/wisdomtree-programs";
 import type { Address, Instruction, TransactionSigner } from "@solana/kit";
-import { address } from "@solana/kit";
+import { AccountRole, address } from "@solana/kit";
 import {
   findAssociatedTokenPda,
   getCreateAssociatedTokenIdempotentInstruction,
@@ -13,6 +13,8 @@ import type { WisdomTreeChainReader } from "./chain";
 import { SdpWisdomTreeError } from "./errors";
 import { assertPlanTargetsCluster } from "./guards";
 import { parseFundMint } from "./mint";
+import { encodeWisdomTreeFundTokenAccount } from "./token-account";
+import { type ResolvedHookAccount, resolveTransferHookAccounts } from "./transfer-hook";
 import type { WisdomTreeInstructionPlan, WisdomTreeRuntime } from "./types";
 
 const SPL_TOKEN_PROGRAM = address(SPL_TOKEN_PROGRAMS["spl-token"]);
@@ -171,4 +173,149 @@ export async function buildWisdomTreeDepositPlan(
     accepted: { amount: accepted.canonical },
     createsShareAccount,
   });
+}
+
+export interface WisdomTreeRedemptionPlanInput {
+  fund: WisdomTreeFund;
+  /** Wallet whose fund tokens leave and whose USDC later settles back. */
+  owner: TransactionSigner;
+  /** WisdomTree's on-receipt Sale wallet, resolved from the Connect API at build time. */
+  onReceiptWallet: Address;
+  /** The stablecoin the redemption settles in, for the plan's asset identity. */
+  depositMint: Address;
+  /** Fund tokens to redeem, in the fund's own units, as a decimal string. */
+  shares: string;
+  /** Rent funder for any ATA this plan must create. NOT the fee payer. Defaults to the owner. */
+  rentPayer?: TransactionSigner;
+}
+
+/**
+ * Build the on-chain leg of a WisdomTree primary-market REDEMPTION: a
+ * Token-2022 TransferChecked of fund tokens from the owner to WisdomTree's
+ * on-receipt Sale wallet, with the compliance hook's account set resolved live
+ * and appended (extras, hook program, validation account — the interface
+ * order). USDC settles back to the owner's registered wallet after NAV
+ * strike, outside this transaction.
+ *
+ * The hook resolution is where an unverified wallet fails: a missing
+ * compliance account surfaces as HOOK_UNRESOLVED at build, and anything the
+ * resolver cannot see fails at simulation when the hook's execute refuses.
+ * Both refusals happen BEFORE money moves, which is the point.
+ *
+ * No account is ever closed here — the owner's fund ATA survives a full
+ * redemption (a later subscription settles into it), so `rentRefundTo` has no
+ * meaning for this provider and the caller's recorded funder is untouched.
+ */
+export async function buildWisdomTreeRedemptionPlan(
+  reader: WisdomTreeChainReader,
+  runtime: WisdomTreeRuntime,
+  input: WisdomTreeRedemptionPlanInput
+): Promise<WisdomTreeInstructionPlan> {
+  await verifyFundMint(reader, runtime, input.fund);
+  const hookProgram = WISDOMTREE_TRANSFER_HOOK_PROGRAM_IDS[runtime.cluster];
+  if (hookProgram === undefined) {
+    throw new SdpWisdomTreeError(
+      "CLUSTER_UNSUPPORTED",
+      `WisdomTree deploys no compliance hook on ${runtime.cluster}; nothing can be redeemed there.`
+    );
+  }
+
+  const accepted = acceptAtMintScale(input.shares, input.fund.decimals, "Redemption quantity");
+  const rentPayer = input.rentPayer ?? input.owner;
+  const fundMint = address(input.fund.mint);
+
+  const [ownerFundAta] = await findAssociatedTokenPda({
+    owner: input.owner.address,
+    tokenProgram: TOKEN_2022_PROGRAM,
+    mint: fundMint,
+  });
+  const [onReceiptFundAta] = await findAssociatedTokenPda({
+    owner: input.onReceiptWallet,
+    tokenProgram: TOKEN_2022_PROGRAM,
+    mint: fundMint,
+  });
+
+  const instructions: Instruction[] = [];
+  const onReceiptFundAccount = await reader.getAccount(onReceiptFundAta);
+  if (onReceiptFundAccount === null) {
+    instructions.push(
+      getCreateAssociatedTokenIdempotentInstruction({
+        payer: rentPayer,
+        ata: onReceiptFundAta,
+        owner: input.onReceiptWallet,
+        mint: fundMint,
+        tokenProgram: TOKEN_2022_PROGRAM,
+      })
+    );
+  }
+
+  const transfer = getTransferCheckedInstruction(
+    {
+      source: ownerFundAta,
+      mint: fundMint,
+      destination: onReceiptFundAta,
+      authority: input.owner,
+      amount: accepted.baseUnits,
+      decimals: input.fund.decimals,
+    },
+    { programAddress: TOKEN_2022_PROGRAM }
+  );
+  // A transfer-hook recipe may read the destination token account's data. If
+  // this plan creates that ATA first, resolution still happens before the
+  // transaction is submitted, so project the exact initialized Token-2022
+  // account bytes the preceding idempotent create will produce.
+  const hookReader: WisdomTreeChainReader =
+    onReceiptFundAccount === null
+      ? {
+          getAccount: async (accountAddress) =>
+            String(accountAddress) === String(onReceiptFundAta)
+              ? {
+                  owner: String(TOKEN_2022_PROGRAM),
+                  data: encodeWisdomTreeFundTokenAccount(fundMint, input.onReceiptWallet),
+                }
+              : reader.getAccount(accountAddress),
+        }
+      : reader;
+  const hookAccounts = await resolveTransferHookAccounts(hookReader, {
+    hookProgram: address(hookProgram),
+    mint: fundMint,
+    source: ownerFundAta,
+    destination: onReceiptFundAta,
+    owner: input.owner.address,
+    amount: accepted.baseUnits,
+  });
+  instructions.push({
+    ...transfer,
+    accounts: [
+      ...(transfer.accounts ?? []),
+      ...hookAccounts.map((account) => ({
+        address: account.address,
+        role: hookAccountRole(account),
+      })),
+    ],
+  } as Instruction);
+
+  return assertPlanTargetsCluster({
+    cluster: runtime.cluster,
+    instructions,
+    lookupTables: [],
+    assetIdentity: { depositTokenMint: input.depositMint, shareMint: fundMint },
+    accepted: { shares: accepted.canonical },
+  });
+}
+
+/**
+ * Appended hook accounts never escalate: the resolver's signer/writable flags
+ * map onto kit's numeric AccountRole, and a signer flag on a resolved extra is
+ * refused outright — the only signer this transfer carries is the owner, and a
+ * hook demanding another signature cannot be satisfied by SDP's signing model.
+ */
+function hookAccountRole(account: ResolvedHookAccount): AccountRole {
+  if (account.isSigner) {
+    throw new SdpWisdomTreeError(
+      "HOOK_UNRESOLVED",
+      `The transfer hook demands a signature from ${account.address}, which SDP cannot provide.`
+    );
+  }
+  return account.isWritable ? AccountRole.WRITABLE : AccountRole.READONLY;
 }

--- a/packages/sdp-wisdomtree/src/token-account.ts
+++ b/packages/sdp-wisdomtree/src/token-account.ts
@@ -1,0 +1,31 @@
+import type { Address } from "@solana/kit";
+import { AccountState, extension, getTokenEncoder } from "@solana-program/token-2022";
+
+/**
+ * Encode the initialized Token-2022 account shape inherited from WisdomTree's
+ * live fund mints. The ATA program installs ImmutableOwner, while the mint's
+ * TransferHook and Pausable extensions require their account-side companions.
+ */
+export function encodeWisdomTreeFundTokenAccount(
+  mint: Address,
+  owner: Address,
+  amount = 0n
+): Uint8Array {
+  return Uint8Array.from(
+    getTokenEncoder().encode({
+      mint,
+      owner,
+      amount,
+      delegate: null,
+      state: AccountState.Initialized,
+      isNative: null,
+      delegatedAmount: 0n,
+      closeAuthority: null,
+      extensions: [
+        extension("ImmutableOwner", {}),
+        extension("TransferHookAccount", { transferring: false }),
+        extension("PausableAccount", {}),
+      ],
+    })
+  );
+}

--- a/packages/sdp-wisdomtree/src/transfer-hook.test.ts
+++ b/packages/sdp-wisdomtree/src/transfer-hook.test.ts
@@ -1,0 +1,275 @@
+import { createHash } from "node:crypto";
+import { SPL_TOKEN_PROGRAMS, wellKnownMint } from "@sdp/types";
+import {
+  WISDOMTREE_FUNDS,
+  WISDOMTREE_TRANSFER_HOOK_PROGRAM_IDS,
+} from "@sdp/types/wisdomtree-programs";
+import {
+  address,
+  createNoopSigner,
+  getAddressEncoder,
+  getProgramDerivedAddress,
+} from "@solana/kit";
+import { findAssociatedTokenPda } from "@solana-program/token-2022";
+import { describe, expect, it } from "vitest";
+import { SdpWisdomTreeError } from "./errors";
+import { fakeReader, tokenAccountData, wtgxxMintAccountData } from "./fixtures.test-helper";
+import { buildWisdomTreeRedemptionPlan } from "./plan";
+import {
+  deriveExtraAccountMetasAddress,
+  resolveTransferHookAccounts,
+  TRANSFER_HOOK_EXECUTE_DISCRIMINATOR,
+} from "./transfer-hook";
+import type { WisdomTreeRuntime } from "./types";
+
+const WTGXX = WISDOMTREE_FUNDS[0];
+const HOOK = WISDOMTREE_TRANSFER_HOOK_PROGRAM_IDS["mainnet-beta"] as string;
+const USDC = wellKnownMint("USDC", "mainnet-beta") as string;
+const TOKEN_2022 = SPL_TOKEN_PROGRAMS["token-2022"];
+
+const OWNER = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
+const ON_RECEIPT = "ComputeBudget111111111111111111111111111111";
+
+const runtime: WisdomTreeRuntime = { cluster: "mainnet-beta", rpcUrl: "http://offline.invalid" };
+const encoder = getAddressEncoder();
+
+/** Serialize an ExtraAccountMetaList account image: TLV header + count + entries. */
+function metaListAccount(entries: Uint8Array[]): Uint8Array {
+  const body = new Uint8Array(4 + entries.length * 35);
+  new DataView(body.buffer).setUint32(0, entries.length, true);
+  entries.forEach((entry, index) => {
+    body.set(entry, 4 + index * 35);
+  });
+  const data = new Uint8Array(12 + body.length);
+  data.set(TRANSFER_HOOK_EXECUTE_DISCRIMINATOR, 0);
+  new DataView(data.buffer).setUint32(8, body.length, true);
+  data.set(body, 12);
+  return data;
+}
+
+function literalEntry(pubkey: string, flags: { isSigner?: boolean; isWritable?: boolean } = {}) {
+  const entry = new Uint8Array(35);
+  entry[0] = 0;
+  entry.set(encoder.encode(address(pubkey)), 1);
+  entry[33] = flags.isSigner ? 1 : 0;
+  entry[34] = flags.isWritable ? 1 : 0;
+  return entry;
+}
+
+/** PDA on the hook program from a literal seed plus the mint's account key (execute index 1). */
+function pdaEntry(literalSeed: string) {
+  const entry = new Uint8Array(35);
+  entry[0] = 1;
+  const seedBytes = new TextEncoder().encode(literalSeed);
+  let offset = 1;
+  entry[offset] = 1; // literal seed tag
+  entry[offset + 1] = seedBytes.length;
+  entry.set(seedBytes, offset + 2);
+  offset += 2 + seedBytes.length;
+  entry[offset] = 3; // account-key seed tag
+  entry[offset + 1] = 1; // execute index 1 = the mint
+  entry[34] = 0;
+  return entry;
+}
+
+/** PDA on the hook program seeded from the destination token account's owner field. */
+function destinationOwnerPdaEntry() {
+  const entry = new Uint8Array(35);
+  entry[0] = 1;
+  entry[1] = 4; // account-data seed tag
+  entry[2] = 2; // execute index 2 = destination token account
+  entry[3] = 32; // token-account owner field offset
+  entry[4] = 32;
+  return entry;
+}
+
+describe("discriminator derivation", () => {
+  it("pins the execute discriminator to its sha256 derivation", () => {
+    const derived = createHash("sha256")
+      .update("spl-transfer-hook-interface:execute")
+      .digest()
+      .subarray(0, 8);
+    expect([...TRANSFER_HOOK_EXECUTE_DISCRIMINATOR]).toEqual([...derived]);
+  });
+});
+
+describe("resolveTransferHookAccounts", () => {
+  async function fixtures(entries: Uint8Array[]) {
+    const validation = await deriveExtraAccountMetasAddress(address(HOOK), address(WTGXX.mint));
+    const [source] = await findAssociatedTokenPda({
+      owner: address(OWNER),
+      mint: address(WTGXX.mint),
+      tokenProgram: address(TOKEN_2022),
+    });
+    const [destination] = await findAssociatedTokenPda({
+      owner: address(ON_RECEIPT),
+      mint: address(WTGXX.mint),
+      tokenProgram: address(TOKEN_2022),
+    });
+    const reader = fakeReader({
+      [String(validation)]: { owner: HOOK, data: metaListAccount(entries) },
+    });
+    return { validation, source, destination, reader };
+  }
+
+  it("resolves literal and PDA-recipe entries and appends program + validation last", async () => {
+    const { validation, source, destination, reader } = await fixtures([
+      literalEntry(USDC),
+      pdaEntry("wt-compliance"),
+    ]);
+
+    const accounts = await resolveTransferHookAccounts(reader, {
+      hookProgram: address(HOOK),
+      mint: address(WTGXX.mint),
+      source,
+      destination,
+      owner: address(OWNER),
+      amount: 1_000_000_000n,
+    });
+
+    const [expectedPda] = await getProgramDerivedAddress({
+      programAddress: address(HOOK),
+      seeds: ["wt-compliance", encoder.encode(address(WTGXX.mint))],
+    });
+    expect(accounts.map((account) => String(account.address))).toEqual([
+      USDC,
+      String(expectedPda),
+      HOOK,
+      String(validation),
+    ]);
+  });
+
+  it("fails closed when the validation account does not exist", async () => {
+    const reader = fakeReader({});
+    const [source] = await findAssociatedTokenPda({
+      owner: address(OWNER),
+      mint: address(WTGXX.mint),
+      tokenProgram: address(TOKEN_2022),
+    });
+    await expect(
+      resolveTransferHookAccounts(reader, {
+        hookProgram: address(HOOK),
+        mint: address(WTGXX.mint),
+        source,
+        destination: source,
+        owner: address(OWNER),
+        amount: 1n,
+      })
+    ).rejects.toThrowError(SdpWisdomTreeError);
+  });
+
+  it("surfaces a missing compliance account (account-data seed) as HOOK_UNRESOLVED", async () => {
+    // An entry whose PDA seed slices data out of execute account 3 (the owner):
+    // the owner's account does not exist in the fake chain, which is exactly
+    // what an unverified wallet looks like to a compliance hook.
+    const entry = new Uint8Array(35);
+    entry[0] = 1;
+    entry[1] = 4; // account-data seed tag
+    entry[2] = 3; // execute account index 3 = owner
+    entry[3] = 0; // data offset
+    entry[4] = 8; // length
+    const { source, destination, reader } = await fixtures([entry]);
+
+    const refusal = await resolveTransferHookAccounts(reader, {
+      hookProgram: address(HOOK),
+      mint: address(WTGXX.mint),
+      source,
+      destination,
+      owner: address(OWNER),
+      amount: 1n,
+    }).then(
+      () => undefined,
+      (error: unknown) => error
+    );
+    expect(refusal).toBeInstanceOf(SdpWisdomTreeError);
+    expect((refusal as SdpWisdomTreeError).code).toBe("HOOK_UNRESOLVED");
+    expect((refusal as SdpWisdomTreeError).message).toMatch(/not been verified/);
+  });
+});
+
+describe("buildWisdomTreeRedemptionPlan", () => {
+  it("appends the resolved hook accounts to the Token-2022 transfer", async () => {
+    const validation = await deriveExtraAccountMetasAddress(address(HOOK), address(WTGXX.mint));
+    const [onReceiptFundAta] = await findAssociatedTokenPda({
+      owner: address(ON_RECEIPT),
+      mint: address(WTGXX.mint),
+      tokenProgram: address(TOKEN_2022),
+    });
+    const reader = fakeReader({
+      [WTGXX.mint]: { owner: TOKEN_2022, data: wtgxxMintAccountData() },
+      [String(onReceiptFundAta)]: { owner: TOKEN_2022, data: tokenAccountData(0n) },
+      [String(validation)]: { owner: HOOK, data: metaListAccount([literalEntry(USDC)]) },
+    });
+
+    const plan = await buildWisdomTreeRedemptionPlan(reader, runtime, {
+      fund: WTGXX,
+      owner: createNoopSigner(address(OWNER)),
+      onReceiptWallet: address(ON_RECEIPT),
+      depositMint: address(USDC),
+      shares: "12.5",
+    });
+
+    expect(plan.accepted).toEqual({ shares: "12.5" });
+    expect(plan.assetIdentity).toEqual({
+      depositTokenMint: address(USDC),
+      shareMint: address(WTGXX.mint),
+    });
+    const transfer = plan.instructions.at(-1);
+    expect(String(transfer?.programAddress)).toBe(TOKEN_2022);
+    const tail = (transfer?.accounts ?? []).slice(-3).map((account) => String(account.address));
+    expect(tail).toEqual([USDC, HOOK, String(validation)]);
+  });
+
+  it("resolves account-data seeds against an ATA created earlier in the plan", async () => {
+    const validation = await deriveExtraAccountMetasAddress(address(HOOK), address(WTGXX.mint));
+    const [expectedCompliancePda] = await getProgramDerivedAddress({
+      programAddress: address(HOOK),
+      seeds: [encoder.encode(address(ON_RECEIPT))],
+    });
+    const reader = fakeReader({
+      [WTGXX.mint]: { owner: TOKEN_2022, data: wtgxxMintAccountData() },
+      [String(validation)]: {
+        owner: HOOK,
+        data: metaListAccount([destinationOwnerPdaEntry()]),
+      },
+      // The destination ATA is deliberately absent: the plan creates it.
+    });
+
+    const plan = await buildWisdomTreeRedemptionPlan(reader, runtime, {
+      fund: WTGXX,
+      owner: createNoopSigner(address(OWNER)),
+      onReceiptWallet: address(ON_RECEIPT),
+      depositMint: address(USDC),
+      shares: "1",
+    });
+
+    expect(plan.instructions).toHaveLength(2);
+    const transfer = plan.instructions[1];
+    expect((transfer.accounts ?? []).slice(-3).map((account) => String(account.address))).toEqual([
+      String(expectedCompliancePda),
+      HOOK,
+      String(validation),
+    ]);
+  });
+
+  it("refuses a hook entry that demands an extra signer", async () => {
+    const validation = await deriveExtraAccountMetasAddress(address(HOOK), address(WTGXX.mint));
+    const reader = fakeReader({
+      [WTGXX.mint]: { owner: TOKEN_2022, data: wtgxxMintAccountData() },
+      [String(validation)]: {
+        owner: HOOK,
+        data: metaListAccount([literalEntry(USDC, { isSigner: true })]),
+      },
+    });
+
+    await expect(
+      buildWisdomTreeRedemptionPlan(reader, runtime, {
+        fund: WTGXX,
+        owner: createNoopSigner(address(OWNER)),
+        onReceiptWallet: address(ON_RECEIPT),
+        depositMint: address(USDC),
+        shares: "1",
+      })
+    ).rejects.toThrowError(/demands a signature/);
+  });
+});

--- a/packages/sdp-wisdomtree/src/transfer-hook.ts
+++ b/packages/sdp-wisdomtree/src/transfer-hook.ts
@@ -1,0 +1,279 @@
+import type { Address } from "@solana/kit";
+import { getAddressDecoder, getAddressEncoder, getProgramDerivedAddress } from "@solana/kit";
+import type { WisdomTreeChainReader } from "./chain";
+import { SdpWisdomTreeError } from "./errors";
+
+/**
+ * SPL transfer-hook account resolution — the standard
+ * `spl-tlv-account-resolution` algorithm reimplemented over `@solana/kit`,
+ * because a fund-token transfer is INVALID without it: Token-2022 CPIs the
+ * hook's `execute` on every transfer of a hooked mint, and the accounts that
+ * call needs must already ride the outer TransferChecked instruction.
+ *
+ * The account list is data, not code: the hook program publishes an
+ * `ExtraAccountMetaList` account (PDA `["extra-account-metas", mint]`) whose
+ * entries are either literal pubkeys or PDA RECIPES — seed programs referencing
+ * the execute instruction's own accounts and data. This module fetches that
+ * account and evaluates the recipes exactly the way SPL's own
+ * `addExtraAccountMetasForExecute` does, so what SDP appends is what the
+ * runtime will demand.
+ *
+ * For WisdomTree specifically this is the KYC surface: the resolved accounts
+ * include the compliance state the hook checks (the registrar-issued SBT
+ * credential among them), and a transfer from or to an unverified wallet fails
+ * HERE — at resolution when a required account cannot be derived, or on-chain
+ * when the hook's execute refuses. Both are the compliance model working.
+ */
+
+/** First 8 bytes of sha256("spl-transfer-hook-interface:execute") — pinned by test. */
+export const TRANSFER_HOOK_EXECUTE_DISCRIMINATOR = Uint8Array.from([
+  105, 37, 101, 197, 75, 251, 102, 26,
+]);
+
+const EXTRA_ACCOUNT_META_SIZE = 35;
+/** Seed-config tags, per spl-tlv-account-resolution. */
+const SEED_LITERAL = 1;
+const SEED_INSTRUCTION_DATA = 2;
+const SEED_ACCOUNT_KEY = 3;
+const SEED_ACCOUNT_DATA = 4;
+
+const addressEncoder = getAddressEncoder();
+
+export interface ResolvedHookAccount {
+  address: Address;
+  isSigner: boolean;
+  isWritable: boolean;
+}
+
+/** The hook's validation account: PDA `["extra-account-metas", mint]` on the hook program. */
+export async function deriveExtraAccountMetasAddress(
+  hookProgram: Address,
+  mint: Address
+): Promise<Address> {
+  const [pda] = await getProgramDerivedAddress({
+    programAddress: hookProgram,
+    seeds: ["extra-account-metas", addressEncoder.encode(mint)],
+  });
+  return pda;
+}
+
+interface ExtraAccountMetaEntry {
+  discriminator: number;
+  addressConfig: Uint8Array;
+  isSigner: boolean;
+  isWritable: boolean;
+}
+
+/** Parse the ExtraAccountMetaList TLV out of the validation account's data. */
+export function parseExtraAccountMetaList(data: Uint8Array): ExtraAccountMetaEntry[] {
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  let offset = 0;
+  while (offset + 12 <= data.length) {
+    const discriminator = data.subarray(offset, offset + 8);
+    const length = view.getUint32(offset + 8, true);
+    const valueStart = offset + 12;
+    if (valueStart + length > data.length) {
+      throw new SdpWisdomTreeError(
+        "HOOK_UNRESOLVED",
+        "ExtraAccountMetaList TLV overruns the validation account data."
+      );
+    }
+    if (TRANSFER_HOOK_EXECUTE_DISCRIMINATOR.every((byte, index) => discriminator[index] === byte)) {
+      const count = view.getUint32(valueStart, true);
+      const entries: ExtraAccountMetaEntry[] = [];
+      let entryOffset = valueStart + 4;
+      for (let index = 0; index < count; index += 1) {
+        if (entryOffset + EXTRA_ACCOUNT_META_SIZE > valueStart + length) {
+          throw new SdpWisdomTreeError(
+            "HOOK_UNRESOLVED",
+            "ExtraAccountMetaList declares more entries than its TLV holds."
+          );
+        }
+        entries.push({
+          discriminator: data[entryOffset] as number,
+          addressConfig: data.subarray(entryOffset + 1, entryOffset + 33),
+          isSigner: data[entryOffset + 33] === 1,
+          isWritable: data[entryOffset + 34] === 1,
+        });
+        entryOffset += EXTRA_ACCOUNT_META_SIZE;
+      }
+      return entries;
+    }
+    offset = valueStart + length;
+  }
+  throw new SdpWisdomTreeError(
+    "HOOK_UNRESOLVED",
+    "The validation account carries no execute-instruction ExtraAccountMetaList."
+  );
+}
+
+function decodeBase58Address(value: Address): Uint8Array {
+  return Uint8Array.from(addressEncoder.encode(value));
+}
+
+/** Evaluate one entry's seed program against the execute instruction being assembled. */
+async function unpackSeeds(
+  reader: WisdomTreeChainReader,
+  addressConfig: Uint8Array,
+  executeKeys: readonly ResolvedHookAccount[],
+  instructionData: Uint8Array
+): Promise<Uint8Array[]> {
+  const seeds: Uint8Array[] = [];
+  let offset = 0;
+  while (offset < addressConfig.length) {
+    const tag = addressConfig[offset] as number;
+    if (tag === 0) break; // zero padding = end of seed list
+    if (tag === SEED_LITERAL) {
+      const length = addressConfig[offset + 1] as number;
+      seeds.push(addressConfig.subarray(offset + 2, offset + 2 + length));
+      offset += 2 + length;
+      continue;
+    }
+    if (tag === SEED_INSTRUCTION_DATA) {
+      const index = addressConfig[offset + 1] as number;
+      const length = addressConfig[offset + 2] as number;
+      if (index + length > instructionData.length) {
+        throw new SdpWisdomTreeError(
+          "HOOK_UNRESOLVED",
+          "A hook seed references execute-instruction data beyond its length."
+        );
+      }
+      seeds.push(instructionData.subarray(index, index + length));
+      offset += 3;
+      continue;
+    }
+    if (tag === SEED_ACCOUNT_KEY) {
+      const index = addressConfig[offset + 1] as number;
+      const key = executeKeys[index];
+      if (!key) {
+        throw new SdpWisdomTreeError(
+          "HOOK_UNRESOLVED",
+          `A hook seed references execute account index ${index}, which is not present yet.`
+        );
+      }
+      seeds.push(decodeBase58Address(key.address));
+      offset += 2;
+      continue;
+    }
+    if (tag === SEED_ACCOUNT_DATA) {
+      const accountIndex = addressConfig[offset + 1] as number;
+      const dataIndex = addressConfig[offset + 2] as number;
+      const length = addressConfig[offset + 3] as number;
+      const key = executeKeys[accountIndex];
+      if (!key) {
+        throw new SdpWisdomTreeError(
+          "HOOK_UNRESOLVED",
+          `A hook seed references execute account index ${accountIndex}, which is not present yet.`
+        );
+      }
+      const account = await reader.getAccount(key.address);
+      if (!account || dataIndex + length > account.data.length) {
+        throw new SdpWisdomTreeError(
+          "HOOK_UNRESOLVED",
+          `A hook seed needs ${length} bytes of ${key.address}'s data, which is missing or short. ` +
+            "For WisdomTree this usually means a compliance account for one of the wallets does " +
+            "not exist — the wallet has not been verified by the issuer."
+        );
+      }
+      seeds.push(account.data.subarray(dataIndex, dataIndex + length));
+      offset += 4;
+      continue;
+    }
+    throw new SdpWisdomTreeError("HOOK_UNRESOLVED", `Unknown hook seed tag ${tag}.`);
+  }
+  return seeds;
+}
+
+export interface TransferHookResolutionInput {
+  hookProgram: Address;
+  mint: Address;
+  /** The transfer's token accounts and authority, in TransferChecked order. */
+  source: Address;
+  destination: Address;
+  owner: Address;
+  /** Base units the transfer encodes — part of the execute data seeds may reference. */
+  amount: bigint;
+}
+
+/**
+ * The accounts to APPEND to a TransferChecked of a hooked mint: the resolved
+ * extra metas, then the hook program, then the validation account — the exact
+ * order and privilege de-escalation of SPL's `addExtraAccountMetasForExecute`.
+ */
+export async function resolveTransferHookAccounts(
+  reader: WisdomTreeChainReader,
+  input: TransferHookResolutionInput
+): Promise<ResolvedHookAccount[]> {
+  const validationAddress = await deriveExtraAccountMetasAddress(input.hookProgram, input.mint);
+  const validationAccount = await reader.getAccount(validationAddress);
+  if (validationAccount === null) {
+    throw new SdpWisdomTreeError(
+      "HOOK_UNRESOLVED",
+      `The hook program publishes no ExtraAccountMetaList for mint ${input.mint} at ${validationAddress}.`
+    );
+  }
+  if (validationAccount.owner !== String(input.hookProgram)) {
+    throw new SdpWisdomTreeError(
+      "HOOK_UNRESOLVED",
+      `Validation account ${validationAddress} is owned by ${validationAccount.owner}, not the hook program.`
+    );
+  }
+  const entries = parseExtraAccountMetaList(validationAccount.data);
+
+  // The execute instruction's data: discriminator ++ amount, which
+  // instruction-data seeds may slice.
+  const executeData = new Uint8Array(16);
+  executeData.set(TRANSFER_HOOK_EXECUTE_DISCRIMINATOR, 0);
+  new DataView(executeData.buffer).setBigUint64(8, input.amount, true);
+
+  // Execute's base accounts, in interface order; seed account-key indexes
+  // reference this list AS IT GROWS.
+  const executeKeys: ResolvedHookAccount[] = [
+    { address: input.source, isSigner: false, isWritable: true },
+    { address: input.mint, isSigner: false, isWritable: false },
+    { address: input.destination, isSigner: false, isWritable: true },
+    { address: input.owner, isSigner: true, isWritable: false },
+    { address: validationAddress, isSigner: false, isWritable: false },
+  ];
+
+  for (const entry of entries) {
+    let resolvedAddress: Address;
+    if (entry.discriminator === 0) {
+      resolvedAddress = getAddressDecoder().decode(entry.addressConfig);
+    } else {
+      const seeds = await unpackSeeds(reader, entry.addressConfig, executeKeys, executeData);
+      let programAddress: Address;
+      if (entry.discriminator === 1) {
+        programAddress = input.hookProgram;
+      } else {
+        const programIndex = entry.discriminator - (1 << 7);
+        const programKey = executeKeys[programIndex];
+        if (!programKey) {
+          throw new SdpWisdomTreeError(
+            "HOOK_UNRESOLVED",
+            `A hook meta derives from execute account index ${programIndex}, which is not present.`
+          );
+        }
+        programAddress = programKey.address;
+      }
+      const [pda] = await getProgramDerivedAddress({ programAddress, seeds });
+      resolvedAddress = pda;
+    }
+    executeKeys.push({
+      address: resolvedAddress,
+      isSigner: entry.isSigner,
+      isWritable: entry.isWritable,
+    });
+  }
+
+  // The accounts the OUTER transfer carries: extras (execute keys past the five
+  // base ones), then the hook program, then the validation account. The
+  // runtime demands signer/writable privileges never ESCALATE past what the
+  // outer instruction grants, so extras are appended read-only-signerless
+  // unless the entry itself asked for more.
+  return [
+    ...executeKeys.slice(5),
+    { address: input.hookProgram, isSigner: false, isWritable: false },
+    { address: validationAddress, isSigner: false, isWritable: false },
+  ];
+}


### PR DESCRIPTION
…iance hook

Implements buildVaultWithdrawal, flipping supportsVaultWithdraw to true (the PRO-1702 mechanism: implementing the capability is what opens the exit route). A redemption's on-chain leg is a Token-2022 TransferChecked of fund tokens to WisdomTree's on-receipt Sale wallet; USDC settles back to the owner's registered wallet after NAV strike, outside the transaction. Per ADR 0002 the path takes no surfacing, entitlement, or eligibility gate — a wallet holding the tokens proved its standing on-chain, and the hook re-proves it at execution.

The load-bearing piece is transfer-hook.ts: the standard SPL tlv-account-resolution algorithm over @solana/kit, because a transfer of a hooked mint is invalid without the hook's account set appended. The ExtraAccountMetaList is fetched live from the hook program's validation PDA and its entries — literal pubkeys and PDA recipes over literal / instruction-data / account-key / account-data seeds — are evaluated exactly as SPL's addExtraAccountMetasForExecute does, appended in interface order (extras, hook program, validation account). The execute discriminator is pinned to its sha256 derivation by test.

This resolver is also where WisdomTree's KYC model surfaces on the exit: a compliance account that does not exist for one of the wallets fails resolution as HOOK_UNRESOLVED with prose naming the cause, and anything the resolver cannot see fails at simulation when the hook refuses — both BEFORE money moves. A hook entry demanding an extra SIGNER is refused outright: the only signer this transfer carries is the owner.

No account is ever closed by a redemption (the fund ATA survives a full exit), so rentRefundTo is accepted and deliberately unused.