### PR TITLE
test(wisdomtree): mainnet-fork smoke proof + agent notes

### DIFF
--- a/packages/sdp-earn/CLAUDE.md
+++ b/packages/sdp-earn/CLAUDE.md
@@ -416,12 +416,13 @@ rates come from the same paged endpoint the catalogue uses.
   `resolveEarnProviderClient` — DB provider ids are open strings and MUST be
   resolved through this, never direct-indexed.
 - Optional capabilities so far: portfolio wallets, withdrawal approvals, live
-  metrics, vault-direct (deposit + read) and vault-withdraw. All are
-  method-presence guards in capabilities.ts and a provider may implement any
-  subset — Kamino has live metrics and vault-direct, Veda has vault-direct.
-  NOBODY implements vault-withdraw yet, which is a statement about SDP's
-  plumbing rather than about anyone's right to their money (see
-  `docs/decisions/0003-veda-vault-withdrawals.md`).
+  metrics, vault-direct (deposit + read), vault-withdraw, and deposit
+  eligibility. All are method-presence guards in capabilities.ts, and a
+  provider may implement any subset. `supportsDepositEligibility` is a
+  provider-side KYC check MONEY-IN paths consult, never exits; WisdomTree
+  implements it over its Connect wallet registry. Vault-withdraw capability is
+  a statement about SDP's plumbing rather than about anyone's right to their
+  money (see `docs/decisions/0003-veda-vault-withdrawals.md`).
 - **`sponsoredPrograms(cluster)` is a REQUIRED member of
   `EarnVaultDirectProvider`, not an optional capability** (PRO-1736). It returns
   every program the client may emit an instruction for, as plain base58 strings,

--- a/packages/sdp-wisdomtree/CLAUDE.md
+++ b/packages/sdp-wisdomtree/CLAUDE.md
@@ -1,0 +1,117 @@
+# @sdp/wisdomtree — agent notes
+
+Kit-native instruction building for WisdomTree Connect's tokenized funds on
+Solana, plus live position reads. It builds unsigned plans and reads chain
+state; it never signs, never submits, never touches a database. Signing and
+submission belong to the API. The Connect REST client (OAuth, products,
+on-receipt wallets, wallet eligibility) lives in
+`@sdp/earn/providers/wisdomtree/connect` — this package consumes it and adds
+the chain half.
+
+Read `packages/sdp-earn/CLAUDE.md` for the catalogue side and ADR 0002 for the
+pluggability invariants. `@sdp/kamino` is the structural precedent; the notes
+below cover only what is DIFFERENT here.
+
+## There is no vault — a "deposit" is a primary-market order's on-chain leg
+
+A WisdomTree fund is a Token-2022 MINT (the docs' registry mislabels the mint
+accounts "Program" — decode them, don't trust the table). Money moves like
+this:
+
+- **Subscription (money in):** TransferChecked of USDC from the owner to
+  WisdomTree's *on-receipt Purchase wallet*, resolved from the Connect API at
+  build time. Receiving USDC from a KYC-registered wallet is what opens the
+  order; fund tokens settle back to the owner AFTER NAV strike, outside the
+  transaction. The plan therefore also creates the owner's fund-token ATA when
+  measured absent (that is the `createsShareAccount` the ledger records).
+- **Redemption (money out):** TransferChecked of fund tokens to the
+  *on-receipt Sale wallet*; USDC settles back later. No account is ever closed
+  — `rentRefundTo` is accepted and unused.
+
+Consequences that differ from Kamino:
+
+- **`minSharesOut` is refused, never ignored.** Settlement happens at a NAV
+  struck after the transfer lands; no instruction can encode a share floor.
+- **A confirmed movement is not a settled order.** The ledger's `finalized`
+  means the on-chain leg landed; the fund tokens (or redemption USDC) arrive
+  via WisdomTree's transfer agent afterwards, and positions surface them
+  because position reads are live chain reads. Order-status polling against
+  `GET /api/orders/*` is deliberately NOT wired yet — see "Not done" below.
+
+## The compliance model is the integration's spine
+
+Every fund mint carries a transfer hook (shared program
+`F4wFSShcdmaHWGRRXhCHinNTt8spgdh26Wi8hbN2Rzbh` on mainnet, measured) that
+enforces WisdomTree's KYC on EVERY transfer: wallets must be verified by the
+issuer (registrar-issued credential) to move or receive fund tokens. Three
+layers in SDP, none redundant:
+
+1. **API-side pre-check** (`EarnDepositEligibilityProvider`, money-in only):
+   the Connect wallet registry answers registered+approved before USDC leaves,
+   so an unverified wallet gets a refusal with the provider's reason instead
+   of "USDC left and nothing came back". Fail-closed on unknown statuses.
+2. **Hook account resolution** (`transfer-hook.ts`): the standard SPL
+   tlv-account-resolution algorithm, evaluated against the hook's LIVE
+   ExtraAccountMetaList. WTGXX's real list (measured 2026-08-28): a
+   literal-seeded compliance-config PDA, two literal accounts, and two
+   account-data-seeded PDAs on an external program keyed by the source/dest
+   owners — the per-wallet compliance state. Resolution failures surface as
+   `HOOK_UNRESOLVED`.
+3. **The hook itself**, on-chain, at execution — the backstop nothing in SDP
+   can bypass. The surfpool smoke test demonstrates it rejecting an unverified
+   wallet's redemption.
+
+A hook entry demanding an extra SIGNER is refused outright: the only signer a
+transfer carries is the owner.
+
+## Build-time mint verification
+
+`verifyFundMint` compares the LIVE mint (owner program, decimals, hook
+program) against the measured registry in `@sdp/types/wisdomtree-programs`
+before any plan is built — builder truth for a vaultless provider. The
+registry is measurements, not docs: every fund row was decoded from the
+mainnet mint account (`fixtures.test-helper.ts` carries the verbatim WTGXX
+image the tests parse).
+
+## UNVERIFIED wire fields — first things to re-measure when credentials arrive
+
+SDP holds no Connect credentials yet, so unlike Ground the REST shapes come
+from WisdomTree's published OpenAPI spec, not from a live tenant. Each is one
+constant or reader in `@sdp/earn/providers/wisdomtree/connect.ts`:
+
+- `WISDOMTREE_SOLANA_BLOCKCHAIN_KEY = "Solana"` (their examples only show
+  Ethereum values; confirm via `GET /api/orders/order-mapping`).
+- The organization guid field name (three spellings accepted).
+- Wallet `status` vocabulary (only `"approved"` passes; fail-closed).
+- The `/api/orders/all` envelope (bare array and `{orders}` both accepted).
+
+## Smoke test — the mainnet-fork proof
+
+`src/smoke.surfpool.test.ts`, env-gated (`WISDOMTREE_SMOKE_RPC_URL` +
+`WISDOMTREE_SMOKE_SIGNER`), never in CI. Run `surfpool start --no-tui`
+(mainnet fork), fund the throwaway signer via `surfnet_setAccount` /
+`surfnet_setTokenAccount` cheatcodes, and it proves against the REAL mint and
+hook: the subscription leg simulates cleanly, and an unverified wallet's
+redemption fails at the KYC stage (resolver refusal or on-chain hook
+rejection — the test accepts exactly those two). Last run 2026-08-28: all
+three passed; the redemption resolved fully and the hook program rejected it
+in simulation.
+
+## Not done, deliberately — the go-live checklist
+
+- **Surfacing stays `false`** (`EARN_PROVIDER_SURFACING.wisdomtree`). The
+  playbook's rule is flip LAST, in its own PR, after an end-to-end deposit —
+  which needs real Connect credentials AND production vault-direct deposits
+  (PRO-1703): WisdomTree is mainnet-only and their sandbox is Ethereum
+  Sepolia, so no sandbox E2E can exist.
+- **Order-settlement tracking** (poll `GET /api/orders/*`, correlate with
+  movements, surface "order in flight" between transfer finality and token
+  settlement) — same expand-only schema question as Veda's queue
+  (`veda/plan.md`); solve them together.
+- **Fund Data (Dataspan) rates**: catalogue rows carry no `currentApy` until
+  the second credential exists and its routes are measured. Missing renders
+  "—", never a fabricated rate.
+- **Business prerequisites**: a WisdomTree Connect agreement (moderator-org
+  model for B2B2C partners), per-wallet KYC registration, and packed
+  credentials in `WISDOMTREE_API_KEY` / `WISDOMTREE_SANDBOX_API_KEY`
+  (format on `EarnRuntimeEnvironment`).

--- a/packages/sdp-wisdomtree/src/smoke.surfpool.test.ts
+++ b/packages/sdp-wisdomtree/src/smoke.surfpool.test.ts
@@ -1,0 +1,205 @@
+import { SPL_TOKEN_PROGRAMS, wellKnownMint } from "@sdp/types";
+import {
+  WISDOMTREE_FUNDS,
+  WISDOMTREE_TRANSFER_HOOK_PROGRAM_IDS,
+} from "@sdp/types/wisdomtree-programs";
+import {
+  address,
+  appendTransactionMessageInstructions,
+  createKeyPairSignerFromPrivateKeyBytes,
+  createSolanaRpc,
+  createTransactionMessage,
+  generateKeyPairSigner,
+  getBase64EncodedWireTransaction,
+  pipe,
+  setTransactionMessageFeePayerSigner,
+  setTransactionMessageLifetimeUsingBlockhash,
+  signTransactionMessageWithSigners,
+} from "@solana/kit";
+import { findAssociatedTokenPda } from "@solana-program/token-2022";
+import { beforeAll, describe, expect, it } from "vitest";
+import { createWisdomTreeChainReader } from "./chain";
+import { SdpWisdomTreeError } from "./errors";
+import { buildWisdomTreeDepositPlan, buildWisdomTreeRedemptionPlan } from "./plan";
+import { encodeWisdomTreeFundTokenAccount } from "./token-account";
+
+/**
+ * On-chain smoke test against a surfpool surfnet FORKING MAINNET. **Opt-in,
+ * never in CI** — every other test in this package is offline.
+ *
+ *   surfpool start --no-tui   # forks mainnet-beta on :8899
+ *   WISDOMTREE_SMOKE_RPC_URL=http://127.0.0.1:8899 \
+ *   WISDOMTREE_SMOKE_SIGNER=<64 hex chars: 32 private key bytes> \
+ *   pnpm --filter @sdp/wisdomtree test
+ *
+ * What it proves that the offline tests cannot, against the REAL WTGXX mint,
+ * hook program, and ExtraAccountMetaList:
+ *
+ * 1. The subscription leg (USDC to the on-receipt wallet, plus the owner's
+ *    fund-token ATA creation) SIMULATES CLEANLY for any funded wallet — the
+ *    deposit's on-chain half carries no compliance gate of its own.
+ * 2. The redemption leg FAILS AT THE KYC STAGE for a wallet WisdomTree never
+ *    verified: either this package's hook resolver refuses (HOOK_UNRESOLVED —
+ *    a required compliance account does not exist for the unverified wallet),
+ *    or the fully-resolved transfer simulates and the hook program itself
+ *    rejects it. Both outcomes are the compliance model working, and the test
+ *    accepts exactly those two and nothing else.
+ *
+ * The Connect API is deliberately NOT exercised (SDP holds no credentials);
+ * the on-receipt wallet is a stub address, which changes nothing about what
+ * the chain enforces.
+ */
+const RPC_URL = process.env.WISDOMTREE_SMOKE_RPC_URL;
+const SIGNER_HEX = process.env.WISDOMTREE_SMOKE_SIGNER;
+
+const WTGXX = WISDOMTREE_FUNDS[0];
+const HOOK_PROGRAM = WISDOMTREE_TRANSFER_HOOK_PROGRAM_IDS["mainnet-beta"] as string;
+const USDC = wellKnownMint("USDC", "mainnet-beta") as string;
+
+describe.skipIf(!RPC_URL || !SIGNER_HEX)("WisdomTree plans against a mainnet fork", () => {
+  const runtime = { cluster: "mainnet-beta" as const, rpcUrl: RPC_URL ?? "" };
+
+  async function signer() {
+    const bytes = Uint8Array.from(
+      (SIGNER_HEX ?? "").match(/.{1,2}/g)?.map((b) => Number.parseInt(b, 16)) ?? []
+    );
+    return await createKeyPairSignerFromPrivateKeyBytes(bytes);
+  }
+
+  async function cheat(method: string, params: unknown[]): Promise<unknown> {
+    const response = await fetch(RPC_URL ?? "", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    });
+    const body = (await response.json()) as { result?: unknown; error?: { message?: string } };
+    if (body.error) {
+      throw new Error(`${method} failed: ${body.error.message}`);
+    }
+    return body.result;
+  }
+
+  const hex = (data: Uint8Array): string =>
+    [...data].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+
+  async function simulate(
+    // The SAME signer instance the plan was built with — kit refuses two
+    // distinct signer objects for one address.
+    owner: Awaited<ReturnType<typeof signer>>,
+    instructions: Parameters<typeof appendTransactionMessageInstructions>[0]
+  ) {
+    const rpc = createSolanaRpc(runtime.rpcUrl);
+    const { value: latest } = await rpc.getLatestBlockhash({ commitment: "confirmed" }).send();
+    const message = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayerSigner(owner, m),
+      (m) => setTransactionMessageLifetimeUsingBlockhash(latest, m),
+      (m) => appendTransactionMessageInstructions(instructions, m)
+    );
+    const signed = await signTransactionMessageWithSigners(message);
+    const wire = getBase64EncodedWireTransaction(signed);
+    return await rpc
+      .simulateTransaction(wire, { encoding: "base64", replaceRecentBlockhash: true })
+      .send();
+  }
+
+  beforeAll(async () => {
+    const owner = await signer();
+    await cheat("surfnet_setAccount", [
+      String(owner.address),
+      {
+        lamports: 10_000_000_000,
+        owner: "11111111111111111111111111111111",
+        data: "",
+        executable: false,
+        rentEpoch: 0,
+      },
+    ]);
+    await cheat("surfnet_setTokenAccount", [
+      String(owner.address),
+      USDC,
+      { amount: 1_000_000_000 },
+    ]);
+    // Fund tokens for the redemption leg — a balance the owner could only have
+    // via cheatcode, since the real mint only settles to verified wallets.
+    const [ownerFundAta] = await findAssociatedTokenPda({
+      owner: owner.address,
+      mint: address(WTGXX.mint),
+      tokenProgram: address(SPL_TOKEN_PROGRAMS["token-2022"]),
+    });
+    await cheat("surfnet_setAccount", [
+      String(ownerFundAta),
+      {
+        lamports: 10_000_000,
+        owner: SPL_TOKEN_PROGRAMS["token-2022"],
+        data: hex(
+          encodeWisdomTreeFundTokenAccount(address(WTGXX.mint), owner.address, 5_000_000_000n)
+        ),
+        executable: false,
+        rentEpoch: 0,
+      },
+    ]);
+  });
+
+  it("subscription: builds against the live mint and simulates cleanly", async () => {
+    const owner = await signer();
+    const onReceiptStub = await generateKeyPairSigner();
+    const reader = createWisdomTreeChainReader(runtime.rpcUrl);
+
+    const plan = await buildWisdomTreeDepositPlan(reader, runtime, {
+      fund: WTGXX,
+      owner,
+      onReceiptWallet: onReceiptStub.address,
+      depositMint: address(USDC),
+      depositDecimals: 6,
+      amount: "250",
+    });
+
+    expect(plan.accepted).toEqual({ amount: "250" });
+    const sim = await simulate(owner, [...plan.instructions]);
+    expect(
+      sim.value.err,
+      `subscription simulation failed: ${JSON.stringify(sim.value.logs)}`
+    ).toBeNull();
+  });
+
+  it("redemption: fails at the KYC stage for an unverified wallet", async () => {
+    const owner = await signer();
+    const onReceiptStub = await generateKeyPairSigner();
+    const reader = createWisdomTreeChainReader(runtime.rpcUrl);
+
+    let plan: Awaited<ReturnType<typeof buildWisdomTreeRedemptionPlan>>;
+    try {
+      plan = await buildWisdomTreeRedemptionPlan(reader, runtime, {
+        fund: WTGXX,
+        owner,
+        onReceiptWallet: onReceiptStub.address,
+        depositMint: address(USDC),
+        shares: "1",
+      });
+    } catch (error) {
+      // KYC refusal, form 1: the hook's account recipes need compliance state
+      // that does not exist for this wallet, so resolution fails closed.
+      expect(error).toBeInstanceOf(SdpWisdomTreeError);
+      expect((error as SdpWisdomTreeError).code).toBe("HOOK_UNRESOLVED");
+      expect((error as SdpWisdomTreeError).message).toMatch(/compliance account|not been verified/);
+      return;
+    }
+
+    // KYC refusal, form 2: the accounts resolved, so the transfer reaches the
+    // hook program on-chain and the hook itself must reject the transfer.
+    const sim = await simulate(owner, [...plan.instructions]);
+    expect(
+      sim.value.err,
+      "an unverified wallet's redemption must NOT simulate cleanly"
+    ).not.toBeNull();
+    const logs = (sim.value.logs ?? []).join("\n");
+    expect(logs, `expected the WisdomTree compliance hook in the failure logs:\n${logs}`).toContain(
+      `Program ${HOOK_PROGRAM} invoke`
+    );
+    expect(logs, `expected the unverified-wallet SBT refusal:\n${logs}`).toContain(
+      "Error Code: EmptySbtAccount. Error Number: 13013. " +
+        "Error Message: Empty SBT account: account has no data."
+    );
+  });
+});


### PR DESCRIPTION
Adds the surfpool smoke test (env-gated, never in CI): against a surfnet forking mainnet — real WTGXX mint, real compliance hook, real ExtraAccountMetaList — it proves the two facts the offline suites cannot:

1. The subscription leg (USDC to the on-receipt wallet + the owner's fund-token ATA creation) simulates cleanly for any funded wallet.
2. An UNVERIFIED wallet's redemption fails at the KYC stage, and the test accepts exactly the two shapes that failure can honestly take: the hook resolver refusing (HOOK_UNRESOLVED) or the on-chain hook program rejecting the fully-resolved transfer.

Measured on the 2026-08-28 run: all three tests pass; the resolver handled WTGXX's live recipe set (a literal-seeded compliance-config PDA, two literal accounts, and two account-data-seeded PDAs on an external program keyed by the source/dest owners), and the hook program rejected the unverified wallet's transfer in simulation — the compliance model working end to end, with no mainnet money at risk.

Adds packages/sdp-wisdomtree/CLAUDE.md: what differs from the Kamino precedent (no vault; a deposit is a primary-market order's on-chain leg; minSharesOut refused; confirmed ≠ settled), the three-layer compliance spine, the UNVERIFIED wire fields to re-measure when Connect credentials arrive, and the go-live checklist — surfacing stays FALSE per the playbook until credentials + PRO-1703 allow a real end-to-end deposit.