### PR TITLE
fix(cron): emit sdp_cron_run proof-of-life for feature-gated ticks

### DIFF
--- a/apps/sdp-api/src/cron/runner.node.test.ts
+++ b/apps/sdp-api/src/cron/runner.node.test.ts
@@ -7,13 +7,22 @@ import {
   APPROVED_WALLET_OPERATIONS_CRON,
   runApprovedWalletOperationRecovery,
 } from "./approved-wallet-operations";
+import { EARN_CATALOGUE_SYNC_CRON } from "./earn-catalogue-sync";
+import { EARN_METRICS_REFRESH_CRON, EARN_METRICS_REFRESH_MONITOR } from "./earn-metrics-refresh";
 import {
   EARN_VAULT_MOVEMENTS_CRON,
   runEarnVaultMovementsReconciliation,
 } from "./earn-vault-movements";
-import { runPendingDepositsReconciliation } from "./pending-deposits";
+import {
+  PENDING_DEPOSITS_CRON,
+  PENDING_DEPOSITS_MONITOR,
+  runPendingDepositsReconciliation,
+} from "./pending-deposits";
 import { PENDING_TRANSFERS_CRON, runPendingTransfersReconciliation } from "./pending-transfers";
-import { runPendingWithdrawalsReconciliation } from "./pending-withdrawals";
+import {
+  PENDING_WITHDRAWALS_CRON,
+  runPendingWithdrawalsReconciliation,
+} from "./pending-withdrawals";
 import {
   RECURRING_PAYMENTS_COLLECTION_CRON,
   runRecurringPaymentsCollection,
@@ -81,17 +90,20 @@ vi.mock("./recurring-payments", () => {
 // rejects), which also poisons the module graph for any test file sharing the pool.
 vi.mock("./pending-deposits", () => ({
   PENDING_DEPOSITS_CRON: "* * * * *",
+  PENDING_DEPOSITS_MONITOR: "sdp-api-track-pending-deposits",
   runPendingDepositsReconciliation: vi.fn(),
 }));
 
 vi.mock("./pending-withdrawals", () => ({
   PENDING_WITHDRAWALS_CRON: "* * * * *",
+  PENDING_WITHDRAWALS_MONITOR: "sdp-api-track-pending-withdrawals",
   runPendingWithdrawalsReconciliation: vi.fn(),
 }));
 
 // The workflow engine reaches the same heavy Solana modules as the reconcilers above.
 vi.mock("./workflow-executions", () => ({
   WORKFLOW_EXECUTIONS_CRON: "* * * * *",
+  WORKFLOW_EXECUTIONS_MONITOR: "sdp-api-run-workflow-executions",
   runWorkflowExecutions: vi.fn(),
 }));
 
@@ -130,7 +142,9 @@ describe("startCron", () => {
     scheduleMock.mockReturnValue(fakeTask);
     vi.mocked(runApprovedWalletOperationRecovery).mockReset();
     vi.mocked(runEarnVaultMovementsReconciliation).mockReset();
+    vi.mocked(runPendingDepositsReconciliation).mockReset();
     vi.mocked(runPendingTransfersReconciliation).mockReset();
+    vi.mocked(runPendingWithdrawalsReconciliation).mockReset();
     vi.mocked(runRecurringPaymentsCollection).mockReset();
     vi.mocked(runRingsIndexingPoll).mockReset();
     vi.mocked(runWorkflowExecutions).mockReset();
@@ -145,7 +159,12 @@ describe("startCron", () => {
   //
   // The secret-retirement sweep is registered last and behind no flag at all, so it is
   // in every count below too — including the ones where asset profiles is off.
+  //
+  // Feature-gated ticks whose flag is off are still scheduled as sdp_cron_run
+  // proof-of-life no-ops, so every configuration schedules all 11 tasks. What a
+  // flag changes is whether the tick does real work, asserted by firing it.
   const SELF_HOSTED_NO_PROFILES = { SDP_DEPLOYMENT_MODE: "self_hosted" } as Env;
+  const ALL_TASKS = 11;
 
   it("returns null and does not schedule when DISABLE_CRON=true", () => {
     const result = startCron({ env: { DISABLE_CRON: "true" } as Env, bg: makeBg() });
@@ -161,14 +180,18 @@ describe("startCron", () => {
 
   it("schedules a task with PENDING_TRANSFERS_CRON when DISABLE_CRON is unset", () => {
     startCron({ env: {} as Env, bg: makeBg() });
-    expect(scheduleMock).toHaveBeenCalledTimes(7);
+    expect(scheduleMock).toHaveBeenCalledTimes(ALL_TASKS);
     expect(scheduleMock.mock.calls[0][0]).toBe(APPROVED_WALLET_OPERATIONS_CRON);
     expect(scheduleMock.mock.calls[1][0]).toBe(PENDING_TRANSFERS_CRON);
     expect(scheduleMock.mock.calls[2][0]).toBe(RECURRING_PAYMENTS_COLLECTION_CRON);
     expect(scheduleMock.mock.calls[3][0]).toBe(WORKFLOW_EXECUTIONS_CRON);
-    expect(scheduleMock.mock.calls[4][0]).toBe(RINGS_INDEXING_CRON);
-    expect(scheduleMock.mock.calls[5][0]).toBe(WORKFLOW_SECRET_RETIREMENTS_CRON);
-    expect(scheduleMock.mock.calls[6][0]).toBe(EARN_VAULT_MOVEMENTS_CRON);
+    expect(scheduleMock.mock.calls[4][0]).toBe(PENDING_DEPOSITS_CRON);
+    expect(scheduleMock.mock.calls[5][0]).toBe(PENDING_WITHDRAWALS_CRON);
+    expect(scheduleMock.mock.calls[6][0]).toBe(RINGS_INDEXING_CRON);
+    expect(scheduleMock.mock.calls[7][0]).toBe(EARN_CATALOGUE_SYNC_CRON);
+    expect(scheduleMock.mock.calls[8][0]).toBe(EARN_METRICS_REFRESH_CRON);
+    expect(scheduleMock.mock.calls[9][0]).toBe(WORKFLOW_SECRET_RETIREMENTS_CRON);
+    expect(scheduleMock.mock.calls[10][0]).toBe(EARN_VAULT_MOVEMENTS_CRON);
   });
 
   it("schedules workflow executions by default, and its tick runs the engine", () => {
@@ -238,7 +261,7 @@ describe("startCron", () => {
   it("omits workflow executions when asset profiles is off", () => {
     startCron({ env: SELF_HOSTED_NO_PROFILES, bg: makeBg() });
 
-    expect(scheduleMock).toHaveBeenCalledTimes(6);
+    expect(scheduleMock).toHaveBeenCalledTimes(ALL_TASKS);
     for (const call of scheduleMock.mock.calls) {
       (call[1] as () => void)();
     }
@@ -278,7 +301,7 @@ describe("startCron", () => {
       env: { K_SERVICE: "sdp-api", DISABLE_CRON: "false" } as Env,
       bg: makeBg(),
     });
-    expect(scheduleMock).toHaveBeenCalledTimes(7);
+    expect(scheduleMock).toHaveBeenCalledTimes(ALL_TASKS);
     expect(scheduleMock.mock.calls[0][0]).toBe(APPROVED_WALLET_OPERATIONS_CRON);
     expect(scheduleMock.mock.calls[1][0]).toBe(PENDING_TRANSFERS_CRON);
   });
@@ -288,7 +311,7 @@ describe("startCron", () => {
   it("schedules recurring collection unconditionally", () => {
     startCron({ env: {} as Env, bg: makeBg() });
 
-    expect(scheduleMock).toHaveBeenCalledTimes(7);
+    expect(scheduleMock).toHaveBeenCalledTimes(ALL_TASKS);
     expect(scheduleMock.mock.calls[2][0]).toBe(RECURRING_PAYMENTS_COLLECTION_CRON);
   });
 
@@ -297,9 +320,7 @@ describe("startCron", () => {
     const env = { PRIVATE_CHANNELS_ENABLED: "true" } as Env;
     startCron({ env, bg });
 
-    // approved-operation recovery + transfers + recurring + workflow executions +
-    // deposits + withdrawals + rings poll + retirements + vault movements.
-    expect(scheduleMock).toHaveBeenCalledTimes(9);
+    expect(scheduleMock).toHaveBeenCalledTimes(ALL_TASKS);
 
     // Fire every scheduled tick; the two private-channels reconcilers must run.
     for (const call of scheduleMock.mock.calls) {
@@ -317,10 +338,50 @@ describe("startCron", () => {
     });
   });
 
+  // The proof-of-life staleness alert counts distinct sdp_cron_run monitors per
+  // window, so a tick whose feature flag is off must still emit its event (as
+  // the managed job does) — silence is reserved for a dead scheduler.
+  it("emits proof-of-life without running the reconciler when private channels is off", async () => {
+    const bg = makeBg();
+    startCron({ env: {} as Env, bg });
+
+    (scheduleMock.mock.calls[4][1] as () => void)();
+    expect(runPendingDepositsReconciliation).not.toHaveBeenCalled();
+    expect(bg.run).toHaveBeenCalledTimes(1);
+    await vi.mocked(bg.run).mock.calls[0][0];
+
+    expect(logEvent).toHaveBeenCalledWith(
+      "info",
+      expect.objectContaining({
+        event: "sdp_cron_run",
+        monitor: PENDING_DEPOSITS_MONITOR,
+        status: "ok",
+      })
+    );
+  });
+
+  it("emits proof-of-life without refreshing metrics when earn is off", async () => {
+    const bg = makeBg();
+    startCron({ env: {} as Env, bg });
+
+    (scheduleMock.mock.calls[8][1] as () => void)();
+    expect(bg.run).toHaveBeenCalledTimes(1);
+    await vi.mocked(bg.run).mock.calls[0][0];
+
+    expect(logEvent).toHaveBeenCalledWith(
+      "info",
+      expect.objectContaining({
+        event: "sdp_cron_run",
+        monitor: EARN_METRICS_REFRESH_MONITOR,
+        status: "ok",
+      })
+    );
+  });
+
   it("schedules when DISABLE_CRON is set to a recognised falsy value ('false' / '0')", () => {
     startCron({ env: { DISABLE_CRON: "false" } as Env, bg: makeBg() });
     startCron({ env: { DISABLE_CRON: "0" } as Env, bg: makeBg() });
-    expect(scheduleMock).toHaveBeenCalledTimes(14);
+    expect(scheduleMock).toHaveBeenCalledTimes(2 * ALL_TASKS);
   });
 
   it("throws on an unrecognised DISABLE_CRON value to surface env typos", () => {
@@ -428,7 +489,7 @@ describe("startCron", () => {
     const handle = startCron({ env: {} as Env, bg: makeBg() });
     expect(handle).not.toBeNull();
     await handle?.stop();
-    expect(stopMock).toHaveBeenCalledTimes(7);
+    expect(stopMock).toHaveBeenCalledTimes(ALL_TASKS);
   });
 
   it("returned handle.stop() stops every scheduled task", async () => {
@@ -438,7 +499,7 @@ describe("startCron", () => {
     });
     expect(handle).not.toBeNull();
     await handle?.stop();
-    expect(stopMock).toHaveBeenCalledTimes(9);
+    expect(stopMock).toHaveBeenCalledTimes(ALL_TASKS);
   });
 
   it("tick invokes the rings indexing poll with the supplied deps", () => {
@@ -446,7 +507,7 @@ describe("startCron", () => {
     const env = {} as Env;
     const observability = makeObservability();
     startCron({ env, bg, observability });
-    const tick = scheduleMock.mock.calls[4][1] as () => void;
+    const tick = scheduleMock.mock.calls[6][1] as () => void;
     tick();
     expect(runRingsIndexingPoll).toHaveBeenCalledWith({
       env,

--- a/apps/sdp-api/src/cron/runner.ts
+++ b/apps/sdp-api/src/cron/runner.ts
@@ -22,16 +22,29 @@ import {
   APPROVED_WALLET_OPERATIONS_CRON,
   runApprovedWalletOperationRecovery,
 } from "./approved-wallet-operations";
-import { EARN_CATALOGUE_SYNC_CRON, runEarnCatalogueSync } from "./earn-catalogue-sync";
-import { EARN_METRICS_REFRESH_CRON, runEarnMetricsRefresh } from "./earn-metrics-refresh";
+import {
+  EARN_CATALOGUE_SYNC_CRON,
+  EARN_CATALOGUE_SYNC_MONITOR,
+  runEarnCatalogueSync,
+} from "./earn-catalogue-sync";
+import {
+  EARN_METRICS_REFRESH_CRON,
+  EARN_METRICS_REFRESH_MONITOR,
+  runEarnMetricsRefresh,
+} from "./earn-metrics-refresh";
 import {
   EARN_VAULT_MOVEMENTS_CRON,
   runEarnVaultMovementsReconciliation,
 } from "./earn-vault-movements";
-import { PENDING_DEPOSITS_CRON, runPendingDepositsReconciliation } from "./pending-deposits";
+import {
+  PENDING_DEPOSITS_CRON,
+  PENDING_DEPOSITS_MONITOR,
+  runPendingDepositsReconciliation,
+} from "./pending-deposits";
 import { PENDING_TRANSFERS_CRON, runPendingTransfersReconciliation } from "./pending-transfers";
 import {
   PENDING_WITHDRAWALS_CRON,
+  PENDING_WITHDRAWALS_MONITOR,
   runPendingWithdrawalsReconciliation,
 } from "./pending-withdrawals";
 import {
@@ -40,7 +53,11 @@ import {
 } from "./recurring-payments";
 import { RINGS_INDEXING_CRON, runRingsIndexingPoll } from "./rings-indexing";
 import { runWithCronRunEvent } from "./run-event";
-import { runWorkflowExecutions, WORKFLOW_EXECUTIONS_CRON } from "./workflow-executions";
+import {
+  runWorkflowExecutions,
+  WORKFLOW_EXECUTIONS_CRON,
+  WORKFLOW_EXECUTIONS_MONITOR,
+} from "./workflow-executions";
 import {
   runWorkflowSecretRetirements,
   WORKFLOW_SECRET_RETIREMENTS_CRON,
@@ -109,6 +126,21 @@ export function startCron(deps: CronDeps): CronHandle | null {
 
   const tasks: ScheduledTask[] = [];
 
+  // Feature-gated ticks keep emitting their sdp_cron_run proof-of-life while
+  // the flag is off, mirroring the managed job (job.ts): the staleness alert
+  // counts distinct monitors per window, so a disabled feature must read as a
+  // healthy no-op, not as the silence that means the scheduler died.
+  const scheduleDisabledTickProofOfLife = (cron: string, monitor: string) => {
+    tasks.push(
+      schedule(cron, () => {
+        if (stopping) {
+          return;
+        }
+        deps.bg.run(runWithCronRunEvent(monitor, async () => undefined));
+      })
+    );
+  };
+
   tasks.push(
     schedule(APPROVED_WALLET_OPERATIONS_CRON, () => {
       if (stopping) {
@@ -161,6 +193,8 @@ export function startCron(deps: CronDeps): CronHandle | null {
         });
       })
     );
+  } else {
+    scheduleDisabledTickProofOfLife(WORKFLOW_EXECUTIONS_CRON, WORKFLOW_EXECUTIONS_MONITOR);
   }
 
   if (isPrivateChannelsEnabled(deps.env)) {
@@ -188,6 +222,9 @@ export function startCron(deps: CronDeps): CronHandle | null {
         });
       })
     );
+  } else {
+    scheduleDisabledTickProofOfLife(PENDING_DEPOSITS_CRON, PENDING_DEPOSITS_MONITOR);
+    scheduleDisabledTickProofOfLife(PENDING_WITHDRAWALS_CRON, PENDING_WITHDRAWALS_MONITOR);
   }
 
   // Cheap to schedule unconditionally: the job early-returns unless the rings
@@ -234,6 +271,9 @@ export function startCron(deps: CronDeps): CronHandle | null {
         });
       })
     );
+  } else {
+    scheduleDisabledTickProofOfLife(EARN_CATALOGUE_SYNC_CRON, EARN_CATALOGUE_SYNC_MONITOR);
+    scheduleDisabledTickProofOfLife(EARN_METRICS_REFRESH_CRON, EARN_METRICS_REFRESH_MONITOR);
   }
 
   // Deliberately outside every feature gate, and in particular outside the asset-profiles


### PR DESCRIPTION
The always-on worker runs the in-process runner, which skipped gated-off ticks entirely. The staleness alert counts distinct monitors (>=9), so prod sat at 7 and fired constantly. Mirror the managed job: a disabled tick still emits a no-op ok event at its cadence.