### PR TITLE
fix: make the i18n audit and ramp-support tooling usable on Windows

### DIFF
--- a/apps/sdp-api/scripts/ramp-support.ts
+++ b/apps/sdp-api/scripts/ramp-support.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import path from "node:path";
 import {
   type ProviderRailSupportSnapshot,
@@ -239,8 +240,11 @@ async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
  * what the pre-commit hook enforces; without this, committed snapshots and the
  * generated file drift purely on formatting.
  */
+// Run through node: `pnpm` is a .cmd shim on Windows, which execFileSync cannot spawn.
+const biomeCli = createRequire(import.meta.url).resolve("@biomejs/biome/bin/biome");
+
 function biomeFormat(filePaths: readonly string[]): void {
-  execFileSync("pnpm", ["exec", "biome", "format", "--write", ...filePaths], {
+  execFileSync(process.execPath, [biomeCli, "format", "--write", ...filePaths], {
     stdio: "ignore",
   });
 }
@@ -250,7 +254,7 @@ function biomeFormat(filePaths: readonly string[]): void {
  * given path. Used by the drift check so no scratch file is ever written.
  */
 function biomeFormatText(virtualPath: string, text: string): string {
-  return execFileSync("pnpm", ["exec", "biome", "format", `--stdin-file-path=${virtualPath}`], {
+  return execFileSync(process.execPath, [biomeCli, "format", `--stdin-file-path=${virtualPath}`], {
     input: text,
     encoding: "utf8",
   });

--- a/apps/sdp-web/scripts/audit-ui-copy.mjs
+++ b/apps/sdp-web/scripts/audit-ui-copy.mjs
@@ -124,7 +124,8 @@ async function collectSourceFiles(directory) {
 
 function candidateId(filePath, sourceFile, node, value) {
   const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
-  return `${path.relative(webDirectory, filePath)}:${line + 1}:${character + 1}:${value}`;
+  const relativePath = path.relative(webDirectory, filePath).split(path.sep).join(path.posix.sep);
+  return `${relativePath}:${line + 1}:${character + 1}:${value}`;
 }
 
 function stableCandidateId(candidate) {


### PR DESCRIPTION
Two independent Windows-only breakages in the repo's own tooling. Both are the same root cause class — spawning or comparing paths the way the host OS does, where the committed data and the shims assume POSIX. Neither affects Linux or CI; both make the tooling unusable for a contributor on Windows.

---

## 1. `check:i18n` — every baselined string reports as new copy

`candidateId()` built its id from a raw `path.relative()`, which returns OS-native separators:

```js
return `${path.relative(webDirectory, filePath)}:${line + 1}:${character + 1}:${value}`;
```

`ui-copy-baseline.json` and `ui-copy-exemptions.json` are both committed with POSIX separators. On Windows every generated id reads `src\lib\ramps.ts:41:17:BVNK` and matches neither file, so **all 157 baselined strings and every brand-name exemption report as new, unapproved copy**.

| on a clean Windows checkout | findings |
| --- | --- |
| before | 163 |
| after | 31 |

The remaining 31 are genuinely un-baselined strings (`flags/index.ts`, `helius-rings/activity-card.tsx`, `ramp-status-panel.tsx` — in neither the baseline nor the exemptions), unrelated to this change and reporting on any platform. This fixes the path mismatch; it does not claim to make the check green.

**Why it matters beyond one platform:** the obvious workaround is the damaging one. `check:i18n:baseline --write` makes the check pass locally by rewriting the baseline with backslash ids, which then matches nothing on Linux or in CI. A Windows contributor either abandons the check or silently poisons it for everyone — and the resulting ~160-entry diff is easy to wave through in review.

```js
const relativePath = path.relative(webDirectory, filePath).split(path.sep).join(path.posix.sep);
```

`candidateId()` is the only place ids are constructed. Every other `path.relative()` in the repo's scripts feeds a `console.log`, where the native separator is correct.

Not a new convention — `apps/sdp-docs/scripts/check-links.ts` already normalises the same way for the same reason:

```ts
const relativePath = path.relative(docsContentDir, filePath).replace(/\\/g, "/");
```

## 2. `ramp-support:generate` / `:drift` — cannot run at all

`biomeFormat()` and `biomeFormatText()` spawned `pnpm exec biome` via `execFileSync`. `pnpm` on Windows is a `.cmd` shim, which `execFileSync` cannot spawn without a shell, so both died:

```
Error: spawnSync pnpm ENOENT
    at biomeFormat (apps/sdp-api/scripts/ramp-support.ts:243:3)
    at runGenerate (apps/sdp-api/scripts/ramp-support.ts:1015:3)
```

This is worse than a hard failure. `runGenerate` writes the generated file *before* formatting it, so the crash leaves a correctly-generated but unformatted `ramp.generated.ts` on disk — which then reads as drift, and invites someone to "fix" the formatting by hand.

The fix resolves biome's own JS launcher and runs it through `process.execPath`, sidestepping the shim:

```ts
const biomeCli = createRequire(import.meta.url).resolve("@biomejs/biome/bin/biome");
execFileSync(process.execPath, [biomeCli, "format", "--write", ...filePaths], { stdio: "ignore" });
```

This mirrors how `dev-local.mjs` already resolves `tsx` after #1525, so it follows an established pattern in the repo rather than introducing `shell: true` (which would also reintroduce quoting risk on paths with spaces).

---

## Testing

Windows 11 / Node 26:

- `pnpm --filter sdp-web check:i18n` — 163 findings to 31, every path-mismatch finding gone.
- `pnpm --filter @sdp/api ramp-support:generate` — previously `ENOENT`, now exits 0 and writes a formatted `ramp.generated.ts`. Re-running against the committed snapshots is a no-op, confirming the output matches what the formatted pipeline produces.

No behaviour change on POSIX: `path.sep` is already `/` there, so the `split`/`join` is an identity transform, and `process.execPath` + the resolved launcher runs the same biome binary `pnpm exec` would have.