### PR TITLE
ci: authenticate CI and deploy workflows to Doppler via OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,8 +174,11 @@ jobs:
   test:
     name: Unit Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     env:
-      CI_HAS_DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI != '' }}
+      CI_HAS_DOPPLER_TOKEN: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       TEST_DATABASE_URL: postgresql://sdp:sdp@127.0.0.1:5432/sdp_test
       REDIS_URL: redis://127.0.0.1:6379
       TEST_CHANGED_SINCE: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || '' }}
@@ -223,13 +226,11 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      - name: Validate Doppler bootstrap secret
+      - name: Validate Doppler OIDC configuration
         if: env.CI_IS_FORK_PULL_REQUEST != 'true'
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
         run: |
-          if [ -z "${DOPPLER_TOKEN}" ]; then
-            echo "DOPPLER_TOKEN_CI must be configured for secret-aware CI jobs." >&2
+          if [ -z "${{ vars.DOPPLER_CI_IDENTITY_ID }}" ]; then
+            echo "DOPPLER_CI_IDENTITY_ID must be configured as a repository variable for secret-aware CI jobs." >&2
             exit 1
           fi
 
@@ -237,17 +238,23 @@ jobs:
         if: env.CI_HAS_DOPPLER_TOKEN == 'true'
         uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4.0.1
 
+      - name: Doppler OIDC login
+        if: env.CI_HAS_DOPPLER_TOKEN == 'true'
+        run: |
+          oidc_jwt=$(curl -sf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/solana-foundation" | jq -r '.value')
+          doppler oidc login --scope=. --identity="${{ vars.DOPPLER_CI_IDENTITY_ID }}" --token="${oidc_jwt}"
+
       - name: Unit tests (Doppler)
         if: env.CI_HAS_DOPPLER_TOKEN == 'true'
         env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
           DOPPLER_CONFIG: dev_ci
         run: pnpm test
 
       - name: Unit tests (fork-safe)
         if: env.CI_IS_FORK_PULL_REQUEST == 'true' && env.CI_HAS_DOPPLER_TOKEN != 'true'
         run: |
-          echo "::notice title=Fork-safe unit tests::DOPPLER_TOKEN_CI is unavailable to forked pull requests, so unit tests are running with local defaults instead of Doppler dev_ci secrets."
+          echo "::notice title=Fork-safe unit tests::Doppler OIDC authentication is unavailable to forked pull requests, so unit tests are running with local defaults instead of Doppler dev_ci secrets."
           node scripts/run-workspace-tests.mjs unit
 
       - name: Scripts tests
@@ -467,6 +474,9 @@ jobs:
   integration_tests_shard:
     name: Integration Tests (${{ matrix.name }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -514,7 +524,7 @@ jobs:
             rpc_provider: alchemy
             custody_provider: local
     env:
-      CI_HAS_DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI != '' }}
+      CI_HAS_DOPPLER_TOKEN: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       TEST_DATABASE_URL: postgresql://sdp:sdp@127.0.0.1:5432/sdp_test
       REDIS_URL: redis://127.0.0.1:6379
       DOPPLER_PRESERVE_ENV: TEST_DATABASE_URL,REDIS_URL,SOLANA_NETWORK,KORA_SURFPOOL_MODE
@@ -567,13 +577,11 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      - name: Validate Doppler bootstrap secret
+      - name: Validate Doppler OIDC configuration
         if: matrix.provider == 'kora' && env.CI_IS_FORK_PULL_REQUEST != 'true'
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
         run: |
-          if [ -z "${DOPPLER_TOKEN}" ]; then
-            echo "DOPPLER_TOKEN_CI must be configured for secret-aware CI jobs." >&2
+          if [ -z "${{ vars.DOPPLER_CI_IDENTITY_ID }}" ]; then
+            echo "DOPPLER_CI_IDENTITY_ID must be configured as a repository variable for secret-aware CI jobs." >&2
             exit 1
           fi
 
@@ -581,10 +589,15 @@ jobs:
         if: env.CI_HAS_DOPPLER_TOKEN == 'true'
         uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4.0.1
 
+      - name: Doppler OIDC login
+        if: env.CI_HAS_DOPPLER_TOKEN == 'true'
+        run: |
+          oidc_jwt=$(curl -sf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/solana-foundation" | jq -r '.value')
+          doppler oidc login --scope=. --identity="${{ vars.DOPPLER_CI_IDENTITY_ID }}" --token="${oidc_jwt}"
+
       - name: Validate integration runtime secrets
         if: matrix.provider == 'kora' && env.CI_HAS_DOPPLER_TOKEN == 'true'
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
         run: |
           doppler run --config dev_ci -- bash <<'EOF'
           set -euo pipefail
@@ -601,7 +614,6 @@ jobs:
       - name: Surfpool integration tests
         if: matrix.provider == 'surfpool'
         env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
           DOPPLER_CONFIG: dev_ci
           DOPPLER_PRESERVE_ENV: TEST_DATABASE_URL,REDIS_URL,SOLANA_NETWORK,KORA_SURFPOOL_MODE
           SDP_INTEGRATION_CUSTODY_PROVIDER: ${{ matrix.custody_provider }}
@@ -615,14 +627,13 @@ jobs:
           elif [ "${CI_IS_FORK_PULL_REQUEST}" = "true" ]; then
             echo "::notice title=Fork-safe Surfpool integration skip::Forked pull requests cannot access managed Solana RPC secrets, so this Surfpool shard is skipped."
           else
-            echo "DOPPLER_TOKEN_CI must be configured for Surfpool integration shards." >&2
+            echo "Doppler OIDC authentication is required for Surfpool integration shards." >&2
             exit 1
           fi
 
       - name: Live Kora integration tests
         if: matrix.provider == 'kora' && env.CI_HAS_DOPPLER_TOKEN == 'true'
         env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
           DOPPLER_CONFIG: dev_ci
         run: |
           read -r -a test_files <<< "${INTEGRATION_TEST_FILES}"
@@ -631,7 +642,7 @@ jobs:
       - name: Skip secret-backed integration tests for fork
         if: matrix.provider == 'kora' && env.CI_IS_FORK_PULL_REQUEST == 'true' && env.CI_HAS_DOPPLER_TOKEN != 'true'
         run: |
-          echo "::notice title=Fork-safe integration skip::Forked pull requests cannot access DOPPLER_TOKEN_CI, so Kora/Privy-backed integration tests are skipped. Run this PR from an upstream branch before merge if secret-backed coverage is required."
+          echo "::notice title=Fork-safe integration skip::Forked pull requests cannot authenticate to Doppler via OIDC, so Kora/Privy-backed integration tests are skipped. Run this PR from an upstream branch before merge if secret-backed coverage is required."
 
   integration_tests:
     name: Integration Tests (Surfpool/Kora)
@@ -641,14 +652,14 @@ jobs:
     if: always()
     timeout-minutes: 5
     env:
-      CI_HAS_DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI != '' }}
+      CI_HAS_DOPPLER_TOKEN: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Check integration test results
         env:
           INTEGRATION_SHARD_RESULT: ${{ needs.integration_tests_shard.result }}
         run: |
           if [ "${CI_IS_FORK_PULL_REQUEST}" = "true" ] && [ "${CI_HAS_DOPPLER_TOKEN}" != "true" ] && [ "${INTEGRATION_SHARD_RESULT}" = "success" ]; then
-            echo "::notice title=Fork-safe integration skip::Forked pull requests cannot access DOPPLER_TOKEN_CI, so the secret-backed integration matrix was intentionally skipped."
+            echo "::notice title=Fork-safe integration skip::Forked pull requests cannot authenticate to Doppler via OIDC, so the secret-backed integration matrix was intentionally skipped."
             exit 0
           fi
           if [ "${CI_HAS_DOPPLER_TOKEN}" != "true" ]; then
@@ -664,6 +675,9 @@ jobs:
   browser_e2e:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -679,7 +693,7 @@ jobs:
             test_script: kora:surfpool:e2e:issuance
             artifact_suffix: issuance
     env:
-      CI_HAS_DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI != '' }}
+      CI_HAS_DOPPLER_TOKEN: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       DATABASE_URL: postgresql://sdp:sdp@127.0.0.1:5432/sdp
       REDIS_URL: redis://127.0.0.1:6379
       DOPPLER_PRESERVE_ENV: DATABASE_URL,REDIS_URL,SOLANA_NETWORK,NEXT_PUBLIC_SENTRY_DSN,SDP_API_BASE_URL,NEXT_PUBLIC_SDP_API_BASE_URL,PLAYWRIGHT_API_URL,PLAYWRIGHT_API_PORT,PLAYWRIGHT_BASE_URL,PLAYWRIGHT_NEXT_DIST_DIR,PLAYWRIGHT_USE_NEXT_START
@@ -734,13 +748,11 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      - name: Validate Doppler bootstrap secret
+      - name: Validate Doppler OIDC configuration
         if: env.CI_IS_FORK_PULL_REQUEST != 'true'
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
         run: |
-          if [ -z "${DOPPLER_TOKEN}" ]; then
-            echo "DOPPLER_TOKEN_CI must be configured for secret-aware CI jobs." >&2
+          if [ -z "${{ vars.DOPPLER_CI_IDENTITY_ID }}" ]; then
+            echo "DOPPLER_CI_IDENTITY_ID must be configured as a repository variable for secret-aware CI jobs." >&2
             exit 1
           fi
 
@@ -748,10 +760,15 @@ jobs:
         if: env.CI_HAS_DOPPLER_TOKEN == 'true'
         uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4.0.1
 
+      - name: Doppler OIDC login
+        if: env.CI_HAS_DOPPLER_TOKEN == 'true'
+        run: |
+          oidc_jwt=$(curl -sf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/solana-foundation" | jq -r '.value')
+          doppler oidc login --scope=. --identity="${{ vars.DOPPLER_CI_IDENTITY_ID }}" --token="${oidc_jwt}"
+
       - name: Validate browser e2e runtime secrets
         if: env.CI_HAS_DOPPLER_TOKEN == 'true'
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
         run: |
           doppler run --config dev_ci -- bash <<'EOF'
           set -euo pipefail
@@ -767,8 +784,6 @@ jobs:
 
       - name: Derive Clerk issuer for local API
         if: env.CI_HAS_DOPPLER_TOKEN == 'true'
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
         run: |
           CLERK_HOST=$(doppler run --config dev_ci -- node - <<'NODE'
           const key = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || "";
@@ -795,7 +810,6 @@ jobs:
       - name: Build web app for Playwright
         if: env.CI_HAS_DOPPLER_TOKEN == 'true'
         env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
           DOPPLER_CONFIG: dev_ci
           SDP_API_BASE_URL: ${{ env.PLAYWRIGHT_API_URL }}
           NEXT_PUBLIC_SDP_API_BASE_URL: ${{ env.PLAYWRIGHT_API_URL }}
@@ -805,7 +819,6 @@ jobs:
       - name: Run browser e2e suite
         if: env.CI_HAS_DOPPLER_TOKEN == 'true'
         env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
           DOPPLER_CONFIG: dev_ci
           SOLANA_RPC_CI_PREFERRED_PROVIDER: quicknode
         run: |
@@ -818,7 +831,7 @@ jobs:
       - name: Skip secret-backed browser e2e for fork
         if: env.CI_IS_FORK_PULL_REQUEST == 'true' && env.CI_HAS_DOPPLER_TOKEN != 'true'
         run: |
-          echo "::notice title=Fork-safe browser e2e skip::Forked pull requests cannot access DOPPLER_TOKEN_CI, so Clerk/Privy-backed browser e2e is skipped. Run this PR from an upstream branch before merge if browser e2e coverage is required."
+          echo "::notice title=Fork-safe browser e2e skip::Forked pull requests cannot authenticate to Doppler via OIDC, so Clerk/Privy-backed browser e2e is skipped. Run this PR from an upstream branch before merge if browser e2e coverage is required."
 
       - name: Upload Playwright artifacts
         if: always() && env.CI_HAS_DOPPLER_TOKEN == 'true'

--- a/.github/workflows/deploy-sdp-api-gcp-prod.yml
+++ b/.github/workflows/deploy-sdp-api-gcp-prod.yml
@@ -18,9 +18,6 @@ on:
         type: string
         required: false
         default: ""
-    secrets:
-      DOPPLER_TOKEN_CI:
-        required: true
   workflow_dispatch:
     inputs:
       image_sha:
@@ -53,10 +50,15 @@ jobs:
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4.0.1
 
+      - name: Doppler OIDC login
+        run: |
+          oidc_jwt=$(curl -sf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/solana-foundation" | jq -r '.value')
+          doppler oidc login --scope=. --identity="${{ vars.DOPPLER_CI_IDENTITY_ID }}" --token="${oidc_jwt}"
+
       - name: Notify Slack — deploy started
         env:
           GH_TOKEN: ${{ github.token }}
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
           DOPPLER_PROJECT: solana-developer-platform
           DOPPLER_CONFIG: dev_ci
           SERVICE: sdp-api
@@ -80,10 +82,9 @@ jobs:
       github.event_name != 'workflow_dispatch' &&
       inputs.image_sha == ''
     uses: ./.github/workflows/sdp-dev-smoke.yml
-    secrets:
-      DOPPLER_TOKEN_CI: ${{ secrets.DOPPLER_TOKEN_CI }}
     permissions:
       contents: read
+      id-token: write
 
   deploy:
     name: Deploy production image
@@ -533,10 +534,15 @@ jobs:
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4.0.1
 
+      - name: Doppler OIDC login
+        run: |
+          oidc_jwt=$(curl -sf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/solana-foundation" | jq -r '.value')
+          doppler oidc login --scope=. --identity="${{ vars.DOPPLER_CI_IDENTITY_ID }}" --token="${oidc_jwt}"
+
       - name: Notify Slack — deploy result
         env:
           GH_TOKEN: ${{ github.token }}
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
           DOPPLER_PROJECT: solana-developer-platform
           DOPPLER_CONFIG: dev_ci
           SERVICE: sdp-api

--- a/.github/workflows/deploy-sdp-api-gcp.yml
+++ b/.github/workflows/deploy-sdp-api-gcp.yml
@@ -3,9 +3,6 @@ name: Deploy sdp-api to Cloud Run (dev)
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      DOPPLER_TOKEN_CI:
-        required: true
 
 permissions:
   contents: read
@@ -93,7 +90,6 @@ jobs:
     needs: deploy
     permissions:
       contents: read
+      id-token: write
     uses: ./.github/workflows/sdp-dev-smoke.yml
-    secrets:
-      DOPPLER_TOKEN_CI: ${{ secrets.DOPPLER_TOKEN_CI }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,16 +73,21 @@ jobs:
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4.0.1
 
+      - name: Doppler OIDC login
+        run: |
+          oidc_jwt=$(curl -sf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/solana-foundation" | jq -r '.value')
+          doppler oidc login --scope=. --identity="${{ vars.DOPPLER_CI_IDENTITY_ID }}" --token="${oidc_jwt}"
+
       - name: Notify Slack — deploy started
         env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
           SERVICES: api
           ACTOR: ${{ github.actor }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
-          SLACK=$(doppler secrets get SLACK_DEPLOY_WEBHOOK_URL --plain --project solana-developer-platform --config dev_ci 2>/dev/null || true)
+          SLACK=$(doppler secrets get SLACK_DEPLOY_WEBHOOK_URL --plain --scope=. --project solana-developer-platform --config dev_ci 2>/dev/null || true)
           [ -z "$SLACK" ] && exit 0
           echo "::add-mask::$SLACK"
           SHA=$(git rev-parse HEAD)
@@ -122,9 +127,14 @@ jobs:
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4.0.1
 
+      - name: Doppler OIDC login
+        run: |
+          oidc_jwt=$(curl -sf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/solana-foundation" | jq -r '.value')
+          doppler oidc login --scope=. --identity="${{ vars.DOPPLER_CI_IDENTITY_ID }}" --token="${oidc_jwt}"
+
       - name: Notify Slack — deploy result
         env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
           SERVICES: api
           OUTCOME: >-
             ${{ (needs.deploy-api-dev.result == 'failure' || needs.deploy-api-prod.result == 'failure') && 'FAILED' ||
@@ -135,7 +145,7 @@ jobs:
           RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
-          SLACK=$(doppler secrets get SLACK_DEPLOY_WEBHOOK_URL --plain --project solana-developer-platform --config dev_ci 2>/dev/null || true)
+          SLACK=$(doppler secrets get SLACK_DEPLOY_WEBHOOK_URL --plain --scope=. --project solana-developer-platform --config dev_ci 2>/dev/null || true)
           [ -z "$SLACK" ] && exit 0
           echo "::add-mask::$SLACK"
           MARKER="[${OUTCOME}] SDP Deploy"
@@ -172,8 +182,6 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/deploy-sdp-api-gcp.yml
-    secrets:
-      DOPPLER_TOKEN_CI: ${{ secrets.DOPPLER_TOKEN_CI }}
 
   deploy-api-prod:
     name: sdp-api + worker + cron — prod
@@ -187,7 +195,5 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/deploy-sdp-api-gcp-prod.yml
-    secrets:
-      DOPPLER_TOKEN_CI: ${{ secrets.DOPPLER_TOKEN_CI }}
     with:
       image_sha: ${{ github.sha }}

--- a/.github/workflows/ramp-rails-refresh.yml
+++ b/.github/workflows/ramp-rails-refresh.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 concurrency:
   group: ramp-rails-refresh
@@ -41,21 +42,23 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      - name: Validate Doppler token
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
+      - name: Validate Doppler OIDC configuration
         run: |
-          if [ -z "${DOPPLER_TOKEN}" ]; then
-            echo "DOPPLER_TOKEN_CI must be configured for live ramp rail discovery." >&2
+          if [ -z "${{ vars.DOPPLER_CI_IDENTITY_ID }}" ]; then
+            echo "DOPPLER_CI_IDENTITY_ID must be configured as a repository variable for live ramp rail discovery." >&2
             exit 1
           fi
 
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4.0.1
 
+      - name: Doppler OIDC login
+        run: |
+          oidc_jwt=$(curl -sf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/solana-foundation" | jq -r '.value')
+          doppler oidc login --scope=. --identity="${{ vars.DOPPLER_CI_IDENTITY_ID }}" --token="${oidc_jwt}"
+
       - name: Discover rails live
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
         run: pnpm --filter @sdp/api currencies:discover
 
       - name: Regenerate matrix from snapshots

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -183,8 +183,6 @@ jobs:
       id-token: write
       packages: read
     uses: ./.github/workflows/deploy-sdp-api-gcp-prod.yml
-    secrets:
-      DOPPLER_TOKEN_CI: ${{ secrets.DOPPLER_TOKEN_CI }}
     with:
       release_sha: ${{ needs.publish-release.outputs.release_sha }}
       release_tag: ${{ needs.publish-release.outputs.release_tag }}

--- a/.github/workflows/sdp-dev-smoke.yml
+++ b/.github/workflows/sdp-dev-smoke.yml
@@ -3,12 +3,10 @@ name: SDP smoke canary
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      DOPPLER_TOKEN_CI:
-        required: true
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: sdp-smoke-${{ github.event_name }}-${{ github.ref }}
@@ -54,12 +52,17 @@ jobs:
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4.0.1
 
+      - name: Doppler OIDC login
+        run: |
+          oidc_jwt=$(curl -sf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/solana-foundation" | jq -r '.value')
+          doppler oidc login --scope=. --identity="${{ vars.DOPPLER_CI_IDENTITY_ID }}" --token="${oidc_jwt}"
+
       - name: Install Playwright browser
         run: pnpm --filter sdp-web exec playwright install --with-deps chromium
 
       - name: Build web app against the dev API
         env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
           DOPPLER_CONFIG: dev_ci
           SDP_API_BASE_URL: ${{ env.PLAYWRIGHT_API_URL }}
           NEXT_PUBLIC_SDP_API_BASE_URL: ${{ env.PLAYWRIGHT_API_URL }}
@@ -69,7 +72,6 @@ jobs:
       - name: Run GCP read-only smoke
         id: smoke
         env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
           DOPPLER_CONFIG: dev_ci
           NODE_ENV: production
           VERCEL_ENV: production
@@ -82,14 +84,13 @@ jobs:
         if: always()
         continue-on-error: true
         env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
           DOPPLER_PROJECT: solana-developer-platform
           DOPPLER_CONFIG: dev_ci
           SMOKE_OUTCOME: ${{ steps.smoke.outcome }}
           SMOKE_TARGET: dev
           RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: doppler run --project "$DOPPLER_PROJECT" --config "$DOPPLER_CONFIG" --preserve-env=SMOKE_OUTCOME,SMOKE_TARGET,RUN_ID,RUN_URL -- ./scripts/report-smoke-to-loki.sh
+        run: doppler run --scope=. --project "$DOPPLER_PROJECT" --config "$DOPPLER_CONFIG" --preserve-env=SMOKE_OUTCOME,SMOKE_TARGET,RUN_ID,RUN_URL -- ./scripts/report-smoke-to-loki.sh
 
       - name: Upload Playwright artifacts
         if: always()

--- a/.github/workflows/vendor-asset-drift.yml
+++ b/.github/workflows/vendor-asset-drift.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: vendor-asset-drift
@@ -54,16 +55,22 @@ jobs:
         if: failure()
         uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4.0.1
 
+      - name: Doppler OIDC login
+        if: failure()
+        run: |
+          oidc_jwt=$(curl -sf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/solana-foundation" | jq -r '.value')
+          doppler oidc login --scope=. --identity="${{ vars.DOPPLER_CI_IDENTITY_ID }}" --token="${oidc_jwt}"
+
       - name: Notify Slack on drift
         if: failure()
         continue-on-error: true
         env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
           DRIFTED: ${{ steps.check.outputs.drifted }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          SLACK=$(doppler secrets get SLACK_ALERT_WEBHOOK_URL --plain --project solana-developer-platform --config dev_ci 2>/dev/null || true)
+          SLACK=$(doppler secrets get SLACK_ALERT_WEBHOOK_URL --plain --scope=. --project solana-developer-platform --config dev_ci 2>/dev/null || true)
           if [ -z "$SLACK" ]; then echo "::warning::SLACK_ALERT_WEBHOOK_URL missing — skipping notification"; exit 0; fi
           echo "::add-mask::$SLACK"
           PAYLOAD=$(jq -n --arg drifted "$DRIFTED" --arg run "$RUN_URL" \

--- a/docs/ops/MAINTAINERS.md
+++ b/docs/ops/MAINTAINERS.md
@@ -72,7 +72,7 @@ Cloud Run image deployment does not fetch Doppler. The API service and jobs rece
 | --- | --- | --- |
 | `DEPLOY_WIF_PROVIDER` | Variable | Google Workload Identity provider used by Cloud Run deploy workflows |
 | `DEPLOY_SA` | Variable | Google service account used by Cloud Run deploy workflows |
-| `DOPPLER_TOKEN_CI` | Repository secret | Read access to `dev_ci` for secret-aware CI |
+| `DOPPLER_CI_IDENTITY_ID` | Variable | Doppler service-account identity for OIDC access to `dev_ci` in secret-aware CI |
 | `RELEASE_APP_ID` | Repository secret | GitHub App used by release automation |
 | `RELEASE_APP_PRIVATE_KEY` | Repository secret | GitHub App private key used by release automation |
 

--- a/docs/ops/doppler-secrets.md
+++ b/docs/ops/doppler-secrets.md
@@ -77,12 +77,12 @@ doppler run --config "${DOPPLER_CONFIG}" -- <command>
 
 ## CI Behavior
 
-- Secret-aware CI jobs use the repository secret `DOPPLER_TOKEN_CI` to read `dev_ci`.
-- Fork pull requests cannot access that secret and use the workflow's documented fork-safe paths or skip live provider coverage.
+- Secret-aware CI jobs authenticate to Doppler via OIDC: each job exchanges its GitHub Actions identity token for a short-lived Doppler session using the service-account identity in the `DOPPLER_CI_IDENTITY_ID` repository variable, then reads `dev_ci`.
+- Fork pull requests cannot mint the GitHub OIDC token and use the workflow's documented fork-safe paths or skip live provider coverage.
 - Vercel receives web/docs configuration through the configured Doppler integration.
 - Release automation does not need a Doppler token.
 
-Keep `DOPPLER_TOKEN_CI` narrowly scoped, rotate it through Doppler and GitHub together, and verify a secret-aware CI run after rotation.
+Keep the CI service account scoped to read-only `dev_ci` access. There is no long-lived token to rotate; changing the identity means updating `DOPPLER_CI_IDENTITY_ID` and verifying a secret-aware CI run.
 
 ## Cloud Run Boundary
 

--- a/docs/ops/release-operations.md
+++ b/docs/ops/release-operations.md
@@ -42,7 +42,7 @@ Release automation also reads these repository variables:
 
 ### Repository secrets
 
-- `DOPPLER_TOKEN_CI` — Doppler token for secret-aware CI
+- `DOPPLER_CI_IDENTITY_ID` (repository variable) — Doppler service-account identity for OIDC-based secret-aware CI
 - `RELEASE_APP_ID` — GitHub App ID used by release automation
 - `RELEASE_APP_PRIVATE_KEY` — corresponding GitHub App private key
 - `TRANSLATION_AGENT_USERNAME` and `TRANSLATION_AGENT_PASSWORD` — HTTP Basic credentials required when a release has missing UI translations
@@ -207,7 +207,7 @@ After this change is merged, a maintainer with access to every historical Cloudf
 4. Observe the legacy Worker routes and direct `workers.dev` endpoints for the agreed rollback window. That window must cover the longest relevant DNS/client cache TTL plus the team's monitoring period. Confirm that no application traffic reaches the Workers; do not delete them before this observation completes.
 5. Remove only the SDP API Worker triggers, custom-domain routes, and `workers.dev` exposure, then delete the inventoried API Workers. Preserve the shared DNS zone, nameservers, API DNS records, and unrelated Cloudflare resources.
 6. After a fresh dependency and retention check, delete only the dedicated Hyperdrive configurations and API-key, rate-limit, cache, and session KV namespaces. Those namespaces held transient state; Postgres remains authoritative, so no normal data migration is required.
-7. Remove the retired `CLOUDFLARE_*` resource IDs and credentials from Doppler and GitHub. Revoke a token only if the inventory proves it was dedicated to the API Workers; otherwise remove its API Worker access or rotate it with the owners of its remaining consumers. If no external consumer remains, also remove the obsolete production `DOPPLER_TOKEN` secret, `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`, and `CLOUD_SQL_INSTANCE_CONNECTION_NAME` variables, and unused `dev` or `release-production` GitHub environments. Preserve the `production` environment, `DEPLOY_WIF_PROVIDER`, `DEPLOY_SA`, and `DOPPLER_TOKEN_CI`.
+7. Remove the retired `CLOUDFLARE_*` resource IDs and credentials from Doppler and GitHub. Revoke a token only if the inventory proves it was dedicated to the API Workers; otherwise remove its API Worker access or rotate it with the owners of its remaining consumers. If no external consumer remains, also remove the obsolete production `DOPPLER_TOKEN` secret, `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`, and `CLOUD_SQL_INSTANCE_CONNECTION_NAME` variables, and unused `dev` or `release-production` GitHub environments. Preserve the `production` environment, `DEPLOY_WIF_PROVIDER`, `DEPLOY_SA`, and `DOPPLER_CI_IDENTITY_ID`.
 8. Re-run the GCP and application checks, confirm no retired Worker route or runtime remains and no traffic reaches it, and verify that the service and cron job still reference the intended production digest. Record every resource identifier, action, timestamp, operator, and verification artifact in the access-controlled change record.
 
 Do not copy old resource IDs into this repository. Resolve deletion targets from the secret manager and provider dashboards immediately before each action, and store credentials and other sensitive evidence in the approved secret-bearing system.

--- a/packages/sdp-api-integration/README.md
+++ b/packages/sdp-api-integration/README.md
@@ -74,7 +74,7 @@ Use Doppler (team members) or export manually:
 **Required for Surfpool/local lanes:**
 
 - `DATABASE_URL` — Defaults to `postgresql://sdp:sdp@127.0.0.1:5432/sdp` in local scripts.
-- `DOPPLER_TOKEN_CI` — Required in upstream CI for managed RPC/browser secrets; fork-safe local shards can run without it where CI says so.
+- Doppler OIDC (`DOPPLER_CI_IDENTITY_ID` repository variable) — required in upstream CI for managed RPC/browser secrets; fork-safe local shards can run without it where CI says so.
 
 **Optional:**
 
@@ -223,7 +223,7 @@ under Doppler, the harness ignores Doppler's hosted `KORA_RPC_URL` and uses
 
 ### Secret-backed browser or custody smoke failed
 
-- Forked pull requests do not receive `DOPPLER_TOKEN_CI`, so secret-backed browser and live-provider smoke jobs intentionally skip there.
+- Forked pull requests cannot authenticate to Doppler via OIDC, so secret-backed browser and live-provider smoke jobs intentionally skip there.
 - For upstream branches, verify Doppler `dev_ci` has `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`, `PRIVY_APP_ID`, and `PRIVY_APP_SECRET`.
 - If Clerk auth fails before any Solana transaction runs, debug the browser E2E secret setup rather than the Surfpool harness.
 

--- a/scripts/deploy-sdp-api-gcp-prod-workflow.test.mjs
+++ b/scripts/deploy-sdp-api-gcp-prod-workflow.test.mjs
@@ -197,3 +197,8 @@ test("rollback verification accepts release-tag and merge-to-main identities", (
   );
   assert.match(workflow, /refs\/tags\/v\.\+\|refs\/heads\/main/);
 });
+
+test("no static Doppler token remains in the deploy pipeline", () => {
+  assert.doesNotMatch(workflow, /DOPPLER_TOKEN_CI/);
+  assert.match(workflow, /- name: Doppler OIDC login/);
+});


### PR DESCRIPTION
Converts every workflow off the static `DOPPLER_TOKEN_CI` secret to Doppler OIDC (HOO-442), following the pattern already running in sdp-infra's grafana-push and the private repo's CI.

## What changed
- Every Doppler-using job gains `id-token: write` and a `Doppler OIDC login` step after the CLI install; all `DOPPLER_TOKEN` env plumbing is removed.
- `CI_HAS_DOPPLER_TOKEN` is now derived from the event (`pull_request` from a fork = false) instead of secret presence — same fork-safe behavior, no secret probe.
- `DOPPLER_TOKEN_CI` is removed from `workflow_call` contracts and every call site (deploy.yml → dev deploy → smoke; release flow → prod deploy).
- vendor-asset-drift logs in only `if: failure()` — the login exists solely for the Slack alert.
- Inline `doppler secrets get`/`doppler run` calls get explicit `--scope=.`.
- Contract test added: no `DOPPLER_TOKEN_CI` remains in the prod deploy workflow and the OIDC login step is present. `pnpm test:scripts` 119/119.

## Required setup before merge
- Doppler service-account identity with OIDC rule: issuer `https://token.actions.githubusercontent.com`, audience `https://github.com/solana-foundation`, repository claim `solana-foundation/solana-developer-platform`; read access to project `solana-developer-platform`, config `dev_ci`.
- Repository variable `DOPPLER_CI_IDENTITY_ID` set to that identity's UUID.

After a clean run on main, the `DOPPLER_TOKEN_CI` repository secret can be revoked.