### PR TITLE
feat(payments): collect Lightspark purpose-of-payment in counterparty requirements

### DIFF
--- a/apps/sdp-api/src/lib/ramps/providers/lightspark/client.test.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark/client.test.ts
@@ -211,6 +211,7 @@ describe("LightsparkRampClient", () => {
       cryptoToken: "USDC",
       fiatCurrency: "USD",
       fiatAmount: "25",
+      purposeOfPayment: "GOODS_OR_SERVICES",
     });
 
     expect(quote.provider).toBe("lightspark");
@@ -276,6 +277,7 @@ describe("LightsparkRampClient", () => {
       cryptoToken: "USDC",
       fiatCurrency: "USD",
       cryptoAmount: "25",
+      purposeOfPayment: "GOODS_OR_SERVICES",
     });
 
     expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(`${LIGHTSPARK_GRID_API_BASE_URL}/quotes`);
@@ -295,6 +297,8 @@ describe("LightsparkRampClient", () => {
       lockedCurrencySide: "SENDING",
       lockedCurrencyAmount: 25000000,
       description: "SDP offramp",
+      purposeOfPayment: "GOODS_OR_SERVICES",
+      senderCustomerInfo: { PURPOSE_OF_PAYMENT: "GOODS_OR_SERVICES" },
     });
 
     expect(quote.provider).toBe("lightspark");
@@ -474,6 +478,7 @@ describe("LightsparkRampClient", () => {
         cryptoToken: "USDC",
         fiatCurrency: "USD",
         fiatAmount: "25",
+        purposeOfPayment: "GOODS_OR_SERVICES",
       })
     ).rejects.toThrow(/does not match the requested/);
   });
@@ -505,6 +510,7 @@ describe("LightsparkRampClient", () => {
         cryptoToken: "USDC",
         fiatCurrency: "USD",
         cryptoAmount: "25",
+        purposeOfPayment: "GOODS_OR_SERVICES",
       })
     ).rejects.toThrow(/does not match the requested/);
   });

--- a/apps/sdp-api/src/lib/ramps/providers/lightspark/counterparty.test.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark/counterparty.test.ts
@@ -66,6 +66,7 @@ describe("lightsparkCounterpartyRequirements", () => {
       "customer.nationality",
       "customer.region",
       "customer.email",
+      "purposeOfPayment",
       "customer.address",
     ]);
     const addressField = requirements.fields.at(-1);
@@ -95,17 +96,35 @@ describe("lightsparkCounterpartyRequirements", () => {
     expect(
       lightsparkCounterpartyRequirements(counterparty(), {
         direction: "onramp",
-        providerData: {},
+        providerData: { lightspark: { purposeOfPayment: "GOODS_OR_SERVICES" } },
         providerCustomerReference: "Customer:cus_123",
       })
     ).toEqual({ provider: "lightspark", direction: "onramp", status: "ready" });
+  });
+
+  it("collects only the purpose-of-payment for linked customers missing it", () => {
+    const requirements = lightsparkCounterpartyRequirements(counterparty(), {
+      direction: "onramp",
+      providerData: {},
+      providerCustomerReference: "Customer:cus_123",
+    });
+
+    if (requirements.status !== "collect_counterparty") {
+      throw new Error("Expected collect_counterparty requirements");
+    }
+    expect(requirements.fields.map((field) => field.key)).toEqual(["purposeOfPayment"]);
+    const purposeField = requirements.fields[0];
+    if (purposeField?.kind !== "select") {
+      throw new Error("Expected purposeOfPayment select field");
+    }
+    expect(purposeField.options.map((option) => option.value)).toContain("GOODS_OR_SERVICES");
   });
 
   it("requires fiatCurrency for offramp", () => {
     expect(() =>
       lightsparkCounterpartyRequirements(counterparty(), {
         direction: "offramp",
-        providerData: {},
+        providerData: { lightspark: { purposeOfPayment: "GOODS_OR_SERVICES" } },
         providerCustomerReference: "Customer:cus_123",
       })
     ).toThrowError(SdpPaymentsError);
@@ -114,7 +133,7 @@ describe("lightsparkCounterpartyRequirements", () => {
   it("collects USD payout bank fields including the rail select", () => {
     const requirements = lightsparkCounterpartyRequirements(counterparty(), {
       direction: "offramp",
-      providerData: {},
+      providerData: { lightspark: { purposeOfPayment: "GOODS_OR_SERVICES" } },
       fiatCurrency: "USD",
       providerCustomerReference: "Customer:cus_123",
     });
@@ -152,7 +171,7 @@ describe("lightsparkCounterpartyRequirements", () => {
   it("offers SWIFT alongside the local rails for every currency", () => {
     const requirements = lightsparkCounterpartyRequirements(counterparty(), {
       direction: "offramp",
-      providerData: {},
+      providerData: { lightspark: { purposeOfPayment: "GOODS_OR_SERVICES" } },
       fiatCurrency: "GBP",
       providerCustomerReference: "Customer:cus_123",
     });
@@ -182,6 +201,7 @@ describe("lightsparkCounterpartyRequirements", () => {
       providerData: {
         lightspark: {
           customerId: "Customer:cus_123",
+          purposeOfPayment: "GOODS_OR_SERVICES",
           payoutAccounts: {
             "USD:ab12cd34ef56ab12": {
               accountId: "ExternalAccount:acc_payout_123",
@@ -201,7 +221,7 @@ describe("lightsparkCounterpartyRequirements", () => {
   it("returns unsupported for currencies without a Grid payout account type", () => {
     const requirements = lightsparkCounterpartyRequirements(counterparty(), {
       direction: "offramp",
-      providerData: {},
+      providerData: { lightspark: { purposeOfPayment: "GOODS_OR_SERVICES" } },
       fiatCurrency: "TRY",
       providerCustomerReference: "Customer:cus_123",
     });
@@ -222,13 +242,14 @@ describe("lightsparkCounterpartyRequirements", () => {
       "businessLegalName",
       "businessTaxId",
       "businessIncorporatedOn",
+      "purposeOfPayment",
     ]);
   });
 
   it("returns ready for a business on-ramp once the provider customer is linked", () => {
     const requirements = lightsparkCounterpartyRequirements(businessCounterparty(), {
       direction: "onramp",
-      providerData: {},
+      providerData: { lightspark: { purposeOfPayment: "GOODS_OR_SERVICES" } },
       providerCustomerReference: "Customer:cus_123",
     });
 
@@ -238,7 +259,7 @@ describe("lightsparkCounterpartyRequirements", () => {
   it("collects only payout fields once the business has a provider customer", () => {
     const requirements = lightsparkCounterpartyRequirements(businessCounterparty(), {
       direction: "offramp",
-      providerData: {},
+      providerData: { lightspark: { purposeOfPayment: "GOODS_OR_SERVICES" } },
       fiatCurrency: "USD",
       providerCustomerReference: "Customer:cus_123",
     });
@@ -269,6 +290,7 @@ describe("buildLightsparkBusinessInfo", () => {
         businessLegalName: "Acme Corporation, Inc.",
         businessTaxId: "47-1234567",
         businessIncorporatedOn: "2018-03-14",
+        purposeOfPayment: "GOODS_OR_SERVICES",
       })
     ).toEqual({
       legalName: "Acme Corporation, Inc.",
@@ -287,6 +309,7 @@ describe("buildLightsparkBusinessInfo", () => {
         businessLegalName: "Acme Corporation, Inc.",
         businessTaxId: "47-1234567",
         businessIncorporatedOn: "March 14, 2018",
+        purposeOfPayment: "GOODS_OR_SERVICES",
       })
     ).toThrowError(SdpPaymentsError);
   });
@@ -299,6 +322,7 @@ describe("lightsparkPayoutCollectedData", () => {
         businessLegalName: "Acme Corporation, Inc.",
         businessTaxId: "47-1234567",
         businessIncorporatedOn: "2018-03-14",
+        purposeOfPayment: "GOODS_OR_SERVICES",
         paymentRails: "ACH",
         routingNumber: "021000021",
         accountNumber: "12345678901",

--- a/apps/sdp-api/src/lib/ramps/providers/lightspark/counterparty.test.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark/counterparty.test.ts
@@ -5,6 +5,7 @@ import {
   lightsparkCounterpartyRequirements,
   lightsparkPayoutCollectedData,
 } from "@sdp/payments/ramps/providers/lightspark/counterparty";
+import { isLightsparkPurposeOfPayment } from "@sdp/payments/ramps/providers/lightspark/provider-data";
 import type { Counterparty } from "@sdp/types";
 import { describe, expect, it } from "vitest";
 import type { CounterpartyRow } from "@/db/repositories/counterparty.repository";
@@ -118,6 +119,12 @@ describe("lightsparkCounterpartyRequirements", () => {
       throw new Error("Expected purposeOfPayment select field");
     }
     expect(purposeField.options.map((option) => option.value)).toContain("GOODS_OR_SERVICES");
+  });
+
+  it("rejects prototype property names as purpose-of-payment codes", () => {
+    expect(isLightsparkPurposeOfPayment("GOODS_OR_SERVICES")).toBe(true);
+    expect(isLightsparkPurposeOfPayment("toString")).toBe(false);
+    expect(isLightsparkPurposeOfPayment("constructor")).toBe(false);
   });
 
   it("requires fiatCurrency for offramp", () => {

--- a/apps/sdp-api/src/routes/counterparties.test.ts
+++ b/apps/sdp-api/src/routes/counterparties.test.ts
@@ -363,6 +363,7 @@ describe("Counterparties Routes", () => {
         "customer.nationality",
         "customer.region",
         "customer.email",
+        "purposeOfPayment",
         "customer.address.line1",
         "customer.address.city",
         "customer.address.postalCode",
@@ -395,6 +396,7 @@ describe("Counterparties Routes", () => {
             "customer.address.city": "San Francisco",
             "customer.address.postalCode": "94105",
             "customer.address.countryCode": "US",
+            purposeOfPayment: "GOODS_OR_SERVICES",
           },
         };
         const res = await app.request(

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -14,10 +14,12 @@ import {
 import {
   lightsparkPayoutCollectedData,
   lightsparkPayoutFields,
+  lightsparkPurposeOfPaymentRequirement,
 } from "@sdp/payments/ramps/providers/lightspark/counterparty";
 import {
   isLightsparkExternalAccountActive,
   latestLightsparkPayoutAccount,
+  readLightsparkPurposeOfPayment,
 } from "@sdp/payments/ramps/providers/lightspark/provider-data";
 import { readMuralOrganization } from "@sdp/payments/ramps/providers/mural/provider-data";
 import { readyCounterparty } from "@sdp/payments/ramps/requirements";
@@ -108,6 +110,7 @@ import {
 import {
   ensureLightsparkCustomer,
   ensureLightsparkPayoutAccount,
+  ensureLightsparkPurposeOfPayment,
   lightsparkProviderCustomerId,
 } from "./ramps/lightspark";
 import {
@@ -522,11 +525,21 @@ export async function advanceCounterpartyRequirements(
     case "moneygram":
       return readyCounterparty("moneygram", input.direction);
     case "lightspark": {
-      const customer = await ensureLightsparkCustomer(c, {
-        counterparty: input.counterparty,
-        projectId: input.projectId,
-        collectedData: input.collectedData,
-      });
+      const [customer, purposeOfPayment] = await Promise.all([
+        ensureLightsparkCustomer(c, {
+          counterparty: input.counterparty,
+          projectId: input.projectId,
+          collectedData: input.collectedData,
+        }),
+        ensureLightsparkPurposeOfPayment(c, {
+          counterparty: input.counterparty,
+          projectId: input.projectId,
+          collectedData: input.collectedData,
+        }),
+      ]);
+      if (purposeOfPayment === null) {
+        return lightsparkPurposeOfPaymentRequirement(input.direction);
+      }
       if (input.direction === "offramp") {
         const payoutData =
           input.collectedData === undefined
@@ -797,7 +810,8 @@ export async function createOnrampQuote(c: AppContext): Promise<Response> {
     }
     case "lightspark": {
       const customerId = await lightsparkProviderCustomerId(c, counterparty, projectId);
-      if (customerId === null) {
+      const purposeOfPayment = readLightsparkPurposeOfPayment(counterparty.provider_data);
+      if (customerId === null || purposeOfPayment === null) {
         throw counterpartyNotProvisioned("lightspark", "onramp");
       }
       quote = await RAMP_PROVIDER_CLIENTS.lightspark.createOnrampQuote(rampRuntime(c), {
@@ -807,6 +821,7 @@ export async function createOnrampQuote(c: AppContext): Promise<Response> {
         destinationWalletAddress,
         externalCustomerId: counterparty.id,
         customerId,
+        purposeOfPayment,
       });
       break;
     }
@@ -993,12 +1008,14 @@ export async function createOfframpQuote(c: AppContext): Promise<Response> {
         throw badRequest("fiatCurrency is required for Lightspark off-ramp.");
       }
       const customerId = await lightsparkProviderCustomerId(c, counterparty, projectId);
+      const purposeOfPayment = readLightsparkPurposeOfPayment(counterparty.provider_data);
       const payoutAccount = latestLightsparkPayoutAccount(
         counterparty.provider_data,
         input.fiatCurrency
       );
       if (
         customerId === null ||
+        purposeOfPayment === null ||
         !payoutAccount ||
         !isLightsparkExternalAccountActive(payoutAccount.status)
       ) {
@@ -1011,6 +1028,7 @@ export async function createOfframpQuote(c: AppContext): Promise<Response> {
         sourceWalletAddress,
         externalCustomerId: counterparty.id,
         customerId,
+        purposeOfPayment,
         payoutAccountId: payoutAccount.accountId,
       });
       break;

--- a/apps/sdp-api/src/routes/payments/handlers/ramps/lightspark.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps/lightspark.ts
@@ -7,13 +7,17 @@ import {
 } from "@sdp/payments/ramps/providers/lightspark/counterparty";
 import {
   isLightsparkExternalAccountActive,
+  isLightsparkPurposeOfPayment,
+  LIGHTSPARK_PURPOSE_OF_PAYMENT_LABELS,
   type LightsparkPayoutAccount,
   type LightsparkPayoutAccountEntry,
+  type LightsparkPurposeOfPayment,
   latestLightsparkPayoutAccount,
   lightsparkPayoutAccountKey,
   readLightsparkData,
   readLightsparkPayoutAccountByKey,
   readLightsparkPayoutAccounts,
+  readLightsparkPurposeOfPayment,
 } from "@sdp/payments/ramps/providers/lightspark/provider-data";
 import type { LightsparkCustomerResolution } from "@sdp/payments/ramps/types";
 import type { RampFiatCurrency } from "@sdp/types/generated/ramp";
@@ -145,6 +149,34 @@ export async function ensureLightsparkCustomer(
     provider_customer_reference: customer.id,
   });
   return { customerId: customer.id };
+}
+
+/**
+ * Returns the counterparty's purpose-of-payment, persisting a newly collected
+ * value into provider_data first. The stored code is required on every Grid
+ * quote because some payout corridors mandate it.
+ *
+ * @param c - Request context for database access.
+ * @param input - Parent counterparty, project scope, and transient collected fields.
+ * @returns The stored purpose-of-payment, or null when none has been collected.
+ */
+export async function ensureLightsparkPurposeOfPayment(
+  c: AppContext,
+  input: { counterparty: CounterpartyRow; projectId: string; collectedData?: CollectedFieldData }
+): Promise<LightsparkPurposeOfPayment | null> {
+  const supplied = input.collectedData?.purposeOfPayment;
+  if (supplied === undefined) {
+    return readLightsparkPurposeOfPayment(input.counterparty.provider_data);
+  }
+  if (!isLightsparkPurposeOfPayment(supplied)) {
+    throw badRequest(
+      `purposeOfPayment must be one of: ${Object.keys(LIGHTSPARK_PURPOSE_OF_PAYMENT_LABELS).join(", ")}`
+    );
+  }
+  await persistLightsparkData(c, input.counterparty, input.projectId, {
+    purposeOfPayment: supplied,
+  });
+  return supplied;
 }
 
 async function persistLightsparkPayoutAccount(

--- a/packages/sdp-payments/src/ramps/providers/lightspark/client.ts
+++ b/packages/sdp-payments/src/ramps/providers/lightspark/client.ts
@@ -41,6 +41,7 @@ import {
   lightsparkCounterpartyRequirements,
 } from "./counterparty";
 import { discoverLightsparkCurrencyAndRails } from "./currencies";
+import type { LightsparkPurposeOfPayment } from "./provider-data";
 
 export const LIGHTSPARK_DEFAULT_GRID_API_URL = "https://api.lightspark.com/grid/2025-10-13";
 
@@ -275,6 +276,14 @@ interface GridCreateQuoteBody {
   lockedCurrencySide: "SENDING" | "RECEIVING";
   lockedCurrencyAmount: number;
   description: string;
+  /** Some payout corridors mandate a purpose-of-payment code on the quote. */
+  purposeOfPayment: LightsparkPurposeOfPayment;
+  /**
+   * Mirror of `purposeOfPayment`: receiver-mandated sender fields are
+   * checked against this key-value map, and a receiver that requires
+   * PURPOSE_OF_PAYMENT rejects the quote when it is absent here.
+   */
+  senderCustomerInfo: { PURPOSE_OF_PAYMENT: LightsparkPurposeOfPayment };
 }
 
 interface GridPaymentInstruction {
@@ -446,6 +455,8 @@ export interface CreateLightsparkOnrampQuoteInput {
   cryptoCurrency: string;
   /** Locked sending amount in the fiat currency's smallest unit (cents). */
   fiatAmountMinorUnits: number;
+  /** Purpose-of-payment code collected during counterparty onboarding. */
+  purposeOfPayment: LightsparkPurposeOfPayment;
   description?: string;
 }
 
@@ -621,6 +632,8 @@ export class LightsparkRampClient implements RampProvider {
         lockedCurrencySide: "SENDING",
         lockedCurrencyAmount: input.fiatAmountMinorUnits,
         description: input.description ?? "SDP onramp",
+        purposeOfPayment: input.purposeOfPayment,
+        senderCustomerInfo: { PURPOSE_OF_PAYMENT: input.purposeOfPayment },
       },
     });
 
@@ -832,6 +845,9 @@ export class LightsparkRampClient implements RampProvider {
     if (!input.customerId) {
       throw badRequest("Lightspark on-ramp requires a resolved customerId");
     }
+    if (!input.purposeOfPayment) {
+      throw badRequest("Lightspark on-ramp requires a resolved purposeOfPayment");
+    }
     const config = readLightsparkConfig(env, mode);
     const cryptoCurrency = normalizeLightsparkCurrencyCode(input.cryptoToken);
     const fiatCurrency = input.fiatCurrency ?? "USD";
@@ -852,6 +868,7 @@ export class LightsparkRampClient implements RampProvider {
       fiatCurrency,
       cryptoCurrency,
       fiatAmountMinorUnits,
+      purposeOfPayment: input.purposeOfPayment,
     });
     assertLightsparkQuoteMatchesRequest(quote, {
       sendingCurrencyCode: fiatCurrency,
@@ -969,6 +986,9 @@ export class LightsparkRampClient implements RampProvider {
     if (!input.payoutAccountId) {
       throw badRequest("Lightspark off-ramp requires a resolved payoutAccountId");
     }
+    if (!input.purposeOfPayment) {
+      throw badRequest("Lightspark off-ramp requires a resolved purposeOfPayment");
+    }
     if (!input.fiatCurrency) {
       throw badRequest("fiatCurrency is required for Lightspark off-ramp.");
     }
@@ -1001,6 +1021,8 @@ export class LightsparkRampClient implements RampProvider {
         lockedCurrencySide: "SENDING",
         lockedCurrencyAmount: cryptoAmountMinorUnits,
         description: "SDP offramp",
+        purposeOfPayment: input.purposeOfPayment,
+        senderCustomerInfo: { PURPOSE_OF_PAYMENT: input.purposeOfPayment },
       },
     });
 

--- a/packages/sdp-payments/src/ramps/providers/lightspark/counterparty.ts
+++ b/packages/sdp-payments/src/ramps/providers/lightspark/counterparty.ts
@@ -17,7 +17,11 @@ import {
   textField,
 } from "../../requirements";
 import type { ValidateCounterpartyOptions } from "../../types";
-import { latestLightsparkPayoutAccount } from "./provider-data";
+import {
+  LIGHTSPARK_PURPOSE_OF_PAYMENT_LABELS,
+  latestLightsparkPayoutAccount,
+  readLightsparkPurposeOfPayment,
+} from "./provider-data";
 
 const LIGHTSPARK_RAIL_LABELS = {
   ACH: "ACH",
@@ -204,8 +208,46 @@ function lightsparkRailLabel(rail: string): string {
 }
 
 /**
+ * Purpose-of-payment selector. Grid mandates the code on quotes for some
+ * payout corridors, so it is collected once during counterparty onboarding
+ * and stored in provider_data.
+ *
+ * @returns Requirement field for the purpose-of-payment code.
+ */
+export function lightsparkPurposeOfPaymentField(): RequirementField {
+  return selectField({
+    key: "purposeOfPayment",
+    label: "Purpose of payment",
+    required: true,
+    options: Object.entries(LIGHTSPARK_PURPOSE_OF_PAYMENT_LABELS).map(([value, label]) => ({
+      value,
+      label,
+    })),
+  });
+}
+
+/**
+ * Requirements asking for just the purpose-of-payment code: the follow-up
+ * collection state for customers linked before the field existed.
+ *
+ * @param direction - Ramp direction the requirements were requested for.
+ * @returns collect_counterparty requirements with only the purpose field.
+ */
+export function lightsparkPurposeOfPaymentRequirement(
+  direction: "onramp" | "offramp"
+): CounterpartyRequirements {
+  return {
+    provider: "lightspark",
+    direction,
+    status: "collect_counterparty",
+    fields: [lightsparkPurposeOfPaymentField()],
+  };
+}
+
+/**
  * Business details collected to create the Grid BUSINESS customer. Values pass
- * through to Grid just-in-time and are never persisted.
+ * through to Grid just-in-time and are never persisted, except the
+ * purpose-of-payment code, which is stored for quote requests.
  *
  * @returns Business requirement fields for a business counterparty.
  */
@@ -231,6 +273,7 @@ export function lightsparkBusinessInfoFields(): RequirementField[] {
       required: true,
       before: new Date().toISOString().slice(0, 10),
     }),
+    lightsparkPurposeOfPaymentField(),
   ];
 }
 
@@ -347,7 +390,8 @@ function lightsparkCountrySelect(key: string, label: string): RequirementField {
 
 /**
  * PII collected to create the Grid INDIVIDUAL customer. Values pass through
- * to Grid just-in-time and are never persisted.
+ * to Grid just-in-time and are never persisted, except the purpose-of-payment
+ * code, which is stored for quote requests.
  *
  * @returns Identity requirement fields for an individual counterparty.
  */
@@ -370,6 +414,7 @@ export function lightsparkIndividualInfoFields(): RequirementField[] {
       pattern: "^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$",
       placeholder: "name@example.com",
     }),
+    lightsparkPurposeOfPaymentField(),
     {
       kind: "address",
       key: "customer.address",
@@ -472,8 +517,10 @@ export function buildLightsparkIndividualInfo(
 /**
  * Requirement state machine keyed on the handler-resolved
  * `counterparty_provider_accounts` link: no link → collect_counterparty (PII
- * to create the Grid customer); linked onramp → ready; linked offramp →
- * collect_account until a payout account exists for the currency.
+ * to create the Grid customer); linked but no stored purpose-of-payment →
+ * collect_counterparty for just that field (customers linked before the field
+ * existed); linked onramp → ready; linked offramp → collect_account until a
+ * payout account exists for the currency.
  */
 export function lightsparkCounterpartyRequirements(
   counterparty: Counterparty,
@@ -489,6 +536,9 @@ export function lightsparkCounterpartyRequirements(
           ? lightsparkIndividualInfoFields()
           : lightsparkBusinessInfoFields(),
     };
+  }
+  if (readLightsparkPurposeOfPayment(options.providerData) === null) {
+    return lightsparkPurposeOfPaymentRequirement(options.direction);
   }
   if (options.direction === "onramp") {
     return readyCounterparty("lightspark", "onramp");

--- a/packages/sdp-payments/src/ramps/providers/lightspark/provider-data.ts
+++ b/packages/sdp-payments/src/ramps/providers/lightspark/provider-data.ts
@@ -39,7 +39,7 @@ export const LIGHTSPARK_PURPOSE_OF_PAYMENT_LABELS = {
 export type LightsparkPurposeOfPayment = keyof typeof LIGHTSPARK_PURPOSE_OF_PAYMENT_LABELS;
 
 export function isLightsparkPurposeOfPayment(value: string): value is LightsparkPurposeOfPayment {
-  return value in LIGHTSPARK_PURPOSE_OF_PAYMENT_LABELS;
+  return Object.hasOwn(LIGHTSPARK_PURPOSE_OF_PAYMENT_LABELS, value);
 }
 
 /**

--- a/packages/sdp-payments/src/ramps/providers/lightspark/provider-data.ts
+++ b/packages/sdp-payments/src/ramps/providers/lightspark/provider-data.ts
@@ -18,6 +18,43 @@ export function isLightsparkExternalAccountActive(status: string): boolean {
   return status.trim().toUpperCase() === "ACTIVE";
 }
 
+/** Grid purpose-of-payment codes with display labels; some payout corridors mandate one on every quote. */
+export const LIGHTSPARK_PURPOSE_OF_PAYMENT_LABELS = {
+  GIFT: "Personal gift",
+  SELF: "Transfer to yourself",
+  GOODS_OR_SERVICES: "Goods or services",
+  EDUCATION: "Education",
+  HEALTH_OR_MEDICAL: "Health or medical",
+  REAL_ESTATE_PURCHASE: "Real estate purchase",
+  TAX_PAYMENT: "Tax payment",
+  LOAN_PAYMENT: "Loan payment",
+  UTILITY_BILL: "Utility bill",
+  DONATION: "Donation",
+  TRAVEL: "Travel",
+  FAMILY_SUPPORT: "Family support",
+  SALARY_PAYMENT: "Salary or wages",
+  OTHER: "Other",
+} as const satisfies Record<string, string>;
+
+export type LightsparkPurposeOfPayment = keyof typeof LIGHTSPARK_PURPOSE_OF_PAYMENT_LABELS;
+
+export function isLightsparkPurposeOfPayment(value: string): value is LightsparkPurposeOfPayment {
+  return value in LIGHTSPARK_PURPOSE_OF_PAYMENT_LABELS;
+}
+
+/**
+ * Reads the purpose-of-payment stored during counterparty onboarding.
+ *
+ * @param providerData - Counterparty provider_data blob.
+ * @returns The stored code, or null when none has been collected.
+ */
+export function readLightsparkPurposeOfPayment(
+  providerData: CounterpartyProviderData
+): LightsparkPurposeOfPayment | null {
+  const value = readLightsparkData(providerData).purposeOfPayment;
+  return typeof value === "string" && isLightsparkPurposeOfPayment(value) ? value : null;
+}
+
 /** Cache key for a payout account: same collected details always map to the same key, distinct details never collide. */
 export async function lightsparkPayoutAccountKey(
   fiatCurrency: string,

--- a/packages/sdp-payments/src/ramps/types.ts
+++ b/packages/sdp-payments/src/ramps/types.ts
@@ -22,6 +22,7 @@ import type { RampProviderId } from "@sdp/types/provider-access";
 import type { CounterpartyRequirements } from "@sdp/types/ramp-requirements";
 import { z } from "zod";
 import type { BvnkComplianceInput } from "./providers/bvnk/provider-data";
+import type { LightsparkPurposeOfPayment } from "./providers/lightspark/provider-data";
 import type { StripeCustomerInfo } from "./providers/stripe/client";
 
 export type {
@@ -232,6 +233,8 @@ export interface RampOnrampQuoteInput {
   paymentTransferId?: string;
   /** Handler-resolved Grid customer id (Lightspark); resolved via DB + getOrCreateCustomer. */
   customerId?: string;
+  /** Handler-resolved purpose-of-payment code stored during counterparty onboarding (Lightspark). */
+  purposeOfPayment?: LightsparkPurposeOfPayment;
   bvnkCompliance?: BvnkComplianceInput;
   /** Buyer contact required by Coinbase headless create-order; sourced from the counterparty. */
   email?: string;
@@ -253,6 +256,8 @@ export interface RampOfframpQuoteInput {
   paymentTransferId?: string;
   externalCustomerId: string;
   customerId?: string;
+  /** Handler-resolved purpose-of-payment code stored during counterparty onboarding (Lightspark). */
+  purposeOfPayment?: LightsparkPurposeOfPayment;
   /** Handler-resolved Grid external payout account id (Lightspark). */
   payoutAccountId?: string;
   /** Handler-provisioned merchant-owned BVNK off-ramp fiat wallet id. */


### PR DESCRIPTION
Grid rejected quotes for receivers that mandate `PURPOSE_OF_PAYMENT` ("Missing mandatory customer info field"). This collects the code once at the Lightspark counterparty requirement stage and sends it on every Grid quote.

**Requirement stage**

- `purposeOfPayment` select (14 Grid enum codes, e.g. `GOODS_OR_SERVICES`, `FAMILY_SUPPORT`) added to both individual and business `collect_counterparty` field sets; placed before the address block for individuals.
- Linked customers created before this field existed get a follow-up `collect_counterparty` state containing only the `purposeOfPayment` field — the dashboard re-prompts for the one missing value.
- The advance handler validates the code against the enum and persists it to `provider_data.lightspark.purposeOfPayment` (tenant-scoped `mutateProviderData`), running concurrently with Grid customer creation.

**Quote path**

- Both quote handlers read the stored code and throw `counterpartyNotProvisioned` when it is absent, matching the existing `customerId`/payout-account gating.
- The Grid quote body carries it twice on purpose: the typed `purposeOfPayment` field (documented corridor requirement) and `senderCustomerInfo.PURPOSE_OF_PAYMENT` (the key the live error names for receiver-mandated sender fields).
- Verified against the Grid sandbox that customers cannot store the field (`POST`/`PATCH /customers` silently drop it), so SDP persistence + quote-time pass-through is the only reliable shape. The code is a fixed enum, not PII — identity and bank details remain JIT pass-through only.

**before** — quote to a receiver requiring purpose of payment:

1. Counterparty onboarding collects identity/payout fields only.
2. Quote request reaches Grid without `PURPOSE_OF_PAYMENT`.
3. Grid rejects: "Missing mandatory customer info field: PURPOSE_OF_PAYMENT".

**after**:

1. `collect_counterparty` includes the `purposeOfPayment` select; advance validates and stores it in `provider_data.lightspark` (existing linked customers are re-prompted for just this field).
2. Quote handlers gate on the stored code (`counterpartyNotProvisioned` when missing) and pass it as `purposeOfPayment` + `senderCustomerInfo.PURPOSE_OF_PAYMENT`.
3. Receiver-mandated corridors accept the quote; corridors that don't need it ignore the extra fields.

**Verification**

- `npx vitest run src/lib/ramps/providers/lightspark/ src/routes/counterparties.test.ts src/routes/payments.ramps.test.ts` (sdp-api) — 88 passed.
- `npm test` (sdp-payments) — 44 passed.
- `tsc --noEmit` + `biome check` on both packages — clean.
