### PR TITLE
ci: unit tests on the self-hosted dev-VM runner, packages split out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,8 +175,11 @@ jobs:
     name: Unit Tests
     runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJson('["self-hosted", "sdp-dev-vm"]') }}
     timeout-minutes: 40
+    permissions:
+      contents: read
+      id-token: write
     env:
-      CI_HAS_DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI != '' }}
+      CI_HAS_DOPPLER_TOKEN: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       TEST_WORKSPACE_SPLIT: api
       TEST_DATABASE_URL: postgresql://sdp:sdp@127.0.0.1:5432/sdp_test
       REDIS_URL: redis://127.0.0.1:6379
@@ -225,13 +228,11 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      - name: Validate Doppler bootstrap secret
+      - name: Validate Doppler OIDC configuration
         if: env.CI_IS_FORK_PULL_REQUEST != 'true'
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
         run: |
-          if [ -z "${DOPPLER_TOKEN}" ]; then
-            echo "DOPPLER_TOKEN_CI must be configured for secret-aware CI jobs." >&2
+          if [ -z "${{ vars.DOPPLER_CI_IDENTITY_ID }}" ]; then
+            echo "DOPPLER_CI_IDENTITY_ID must be configured as a repository variable for secret-aware CI jobs." >&2
             exit 1
           fi
 
@@ -239,25 +240,34 @@ jobs:
         if: env.CI_HAS_DOPPLER_TOKEN == 'true'
         uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4.0.1
 
+      - name: Doppler OIDC login
+        if: env.CI_HAS_DOPPLER_TOKEN == 'true'
+        run: |
+          oidc_jwt=$(curl -sf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/solana-foundation" | jq -r '.value')
+          doppler oidc login --scope=. --identity="${{ vars.DOPPLER_CI_IDENTITY_ID }}" --token="${oidc_jwt}"
+
       - name: Unit tests (Doppler)
         if: env.CI_HAS_DOPPLER_TOKEN == 'true'
         env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
           DOPPLER_CONFIG: dev_ci
         run: pnpm test
 
       - name: Unit tests (fork-safe)
         if: env.CI_IS_FORK_PULL_REQUEST == 'true' && env.CI_HAS_DOPPLER_TOKEN != 'true'
         run: |
-          echo "::notice title=Fork-safe unit tests::DOPPLER_TOKEN_CI is unavailable to forked pull requests, so unit tests are running with local defaults instead of Doppler dev_ci secrets."
+          echo "::notice title=Fork-safe unit tests::Doppler OIDC authentication is unavailable to forked pull requests, so unit tests are running with local defaults instead of Doppler dev_ci secrets."
           node scripts/run-workspace-tests.mjs unit
 
   test_packages:
     name: Unit Tests (packages)
     runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJson('["self-hosted", "sdp-dev-vm"]') }}
     timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
     env:
-      CI_HAS_DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI != '' }}
+      CI_HAS_DOPPLER_TOKEN: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       TEST_WORKSPACE_SPLIT: rest
       TEST_DATABASE_URL: postgresql://sdp:sdp@127.0.0.1:5432/sdp_test
       REDIS_URL: redis://127.0.0.1:6379

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,16 +173,95 @@ jobs:
 
   test:
     name: Unit Tests
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJson('["self-hosted", "sdp-dev-vm"]') }}
+    timeout-minutes: 40
     env:
-      CI_HAS_DOPPLER_TOKEN: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      CI_HAS_DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI != '' }}
+      TEST_WORKSPACE_SPLIT: api
       TEST_DATABASE_URL: postgresql://sdp:sdp@127.0.0.1:5432/sdp_test
       REDIS_URL: redis://127.0.0.1:6379
       TEST_CHANGED_SINCE: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || '' }}
-      DOPPLER_PRESERVE_ENV: TEST_DATABASE_URL,REDIS_URL,TEST_CHANGED_SINCE
+      DOPPLER_PRESERVE_ENV: TEST_DATABASE_URL,REDIS_URL,TEST_CHANGED_SINCE,TEST_WORKSPACE_SPLIT
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: sdp
+          POSTGRES_USER: sdp
+          POSTGRES_PASSWORD: sdp
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U sdp -d sdp"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
+        with:
+          version: 10.16.0
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate Doppler bootstrap secret
+        if: env.CI_IS_FORK_PULL_REQUEST != 'true'
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
+        run: |
+          if [ -z "${DOPPLER_TOKEN}" ]; then
+            echo "DOPPLER_TOKEN_CI must be configured for secret-aware CI jobs." >&2
+            exit 1
+          fi
+
+      - name: Install Doppler CLI
+        if: env.CI_HAS_DOPPLER_TOKEN == 'true'
+        uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4.0.1
+
+      - name: Unit tests (Doppler)
+        if: env.CI_HAS_DOPPLER_TOKEN == 'true'
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
+          DOPPLER_CONFIG: dev_ci
+        run: pnpm test
+
+      - name: Unit tests (fork-safe)
+        if: env.CI_IS_FORK_PULL_REQUEST == 'true' && env.CI_HAS_DOPPLER_TOKEN != 'true'
+        run: |
+          echo "::notice title=Fork-safe unit tests::DOPPLER_TOKEN_CI is unavailable to forked pull requests, so unit tests are running with local defaults instead of Doppler dev_ci secrets."
+          node scripts/run-workspace-tests.mjs unit
+
+  test_packages:
+    name: Unit Tests (packages)
+    runs-on: ubuntu-latest
+    env:
+      CI_HAS_DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI != '' }}
+      TEST_WORKSPACE_SPLIT: rest
+      TEST_DATABASE_URL: postgresql://sdp:sdp@127.0.0.1:5432/sdp_test
+      REDIS_URL: redis://127.0.0.1:6379
+      TEST_CHANGED_SINCE: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || '' }}
+      DOPPLER_PRESERVE_ENV: TEST_DATABASE_URL,REDIS_URL,TEST_CHANGED_SINCE,TEST_WORKSPACE_SPLIT
     services:
       postgres:
         image: postgres:16-alpine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,8 @@ jobs:
 
   test_packages:
     name: Unit Tests (packages)
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJson('["self-hosted", "sdp-dev-vm"]') }}
+    timeout-minutes: 30
     env:
       CI_HAS_DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI != '' }}
       TEST_WORKSPACE_SPLIT: rest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
 
   test:
     name: Unit Tests
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJson('["self-hosted", "sdp-dev-vm"]') }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJson('["self-hosted", "sdp-ci"]') }}
     timeout-minutes: 40
     permissions:
       contents: read
@@ -261,7 +261,7 @@ jobs:
 
   test_packages:
     name: Unit Tests (packages)
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJson('["self-hosted", "sdp-dev-vm"]') }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJson('["self-hosted", "sdp-ci"]') }}
     timeout-minutes: 30
     permissions:
       contents: read

--- a/scripts/run-workspace-tests.mjs
+++ b/scripts/run-workspace-tests.mjs
@@ -103,12 +103,19 @@ try {
     ]);
   } else {
     const changedSince = mode === "unit" ? process.env.TEST_CHANGED_SINCE?.trim() : undefined;
+    const split = mode === "unit" ? process.env.TEST_WORKSPACE_SPLIT?.trim() : undefined;
     const filters =
       mode === "integration"
         ? ["--filter=@sdp/api-integration"]
-        : changedSince
-          ? [`--filter=...[${changedSince}]`, "--filter=!@sdp/api-integration"]
-          : ["--filter=!@sdp/api-integration"];
+        : split === "api"
+          ? ["--filter=@sdp/api"]
+          : split === "rest"
+            ? changedSince
+              ? [`--filter=...[${changedSince}]`, "--filter=!@sdp/api", "--filter=!@sdp/api-integration"]
+              : ["--filter=!@sdp/api", "--filter=!@sdp/api-integration"]
+            : changedSince
+              ? [`--filter=...[${changedSince}]`, "--filter=!@sdp/api-integration"]
+              : ["--filter=!@sdp/api-integration"];
     await run("pnpm", [
       "exec",
       "turbo",

--- a/scripts/run-workspace-tests.mjs
+++ b/scripts/run-workspace-tests.mjs
@@ -111,7 +111,11 @@ try {
           ? ["--filter=@sdp/api"]
           : split === "rest"
             ? changedSince
-              ? [`--filter=...[${changedSince}]`, "--filter=!@sdp/api", "--filter=!@sdp/api-integration"]
+              ? [
+                  `--filter=...[${changedSince}]`,
+                  "--filter=!@sdp/api",
+                  "--filter=!@sdp/api-integration",
+                ]
               : ["--filter=!@sdp/api", "--filter=!@sdp/api-integration"]
             : changedSince
               ? [`--filter=...[${changedSince}]`, "--filter=!@sdp/api-integration"]


### PR DESCRIPTION
## What

Splits the monolithic Unit Tests job and routes both legs to the self-hosted runner in the dev GCP project:

- **`test` ("Unit Tests")** — runs only `@sdp/api` (`TEST_WORKSPACE_SPLIT=api`).
- **`test_packages` ("Unit Tests (packages)")** — everything except `@sdp/api`/`@sdp/api-integration` (`TEST_WORKSPACE_SPLIT=rest`, still changed-scoped on PRs), keeping the scripts tests, SecretRef serialization, and UI flow matrix checks.
- Both legs: `runs-on` routes pushes and same-repo PRs to `[self-hosted, sdp-ci]` — the JIT ephemeral runner pool from sdp-infra#136 (label standardized per review there). **Fork PRs never reach self-hosted** — they route to `ubuntu-latest`, keeping the public-repo safety line and the existing fork-safe steps.

`run-workspace-tests.mjs` gains the `TEST_WORKSPACE_SPLIT` env (`api` | `rest`); unset preserves today's behavior exactly. Contract tests: 119 pass.

## Merge order

1. sdp-infra#136 merges and applies, its GitHub App gets installed, and the `sdp-ci` pool comes online (repo-level JIT runners — no org runner-group toggle involved).
2. Then this merges. Until the pool is live, these jobs would queue forever — do not merge first.
3. At merge: add "Unit Tests (packages)" to the required-check list alongside "Unit Tests".
4. After cutover: retire the interim dev-project VM `gha-runner-sdp-dev-1` (it never served a job — the org runner-group toggle was never enabled, which the repo-level JIT pool makes moot).

## Note

An earlier revision of this PR targeted a dedicated 2× n2d-standard-16 spot pool in `solana-developer-platform-ci` (label `sdp-ci`). That was superseded by the dev-project VM; the two spot VMs never registered (their registration secret has no versions) and are now stopped. The `terraform/envs/ci` stack in sdp-infra can be destroyed or revived later if the 8-core VM proves too small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
