### PR TITLE
fix(ci): grant packages read to the prod deploy lane so the orchestrator can start

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -194,6 +194,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: read
     uses: ./.github/workflows/deploy-sdp-api-gcp-prod.yml
     with:
       image_sha: ${{ github.sha }}

--- a/scripts/deploy-sdp-api-gcp-prod-workflow.test.mjs
+++ b/scripts/deploy-sdp-api-gcp-prod-workflow.test.mjs
@@ -208,11 +208,14 @@ test("the orchestrator grants every permission the prod workflow requests", () =
     path.resolve(here, "../.github/workflows/deploy.yml"),
     "utf8"
   );
-  const requested = workflow
-    .match(/^permissions:\n((?:  [a-z-]+: [a-z-]+\n)+)/m)[1]
+  const permissionsBlock = workflow.match(/^permissions:\n((?:  [a-z-]+: [a-z-]+\n)+)/m);
+  assert.ok(permissionsBlock, "prod workflow must declare a top-level permissions block");
+  const requested = permissionsBlock[1]
     .trim()
     .split("\n")
-    .map((line) => line.trim());
+    .map((line) => line.trim())
+    .filter(Boolean);
+  assert.ok(requested.length >= 3, "expected at least contents, id-token, and packages grants");
   const callerJob = orchestrator.match(
     /deploy-api-prod:[\s\S]*?permissions:\n((?:      [a-z-]+: [a-z-]+\n)+)/
   )[1];

--- a/scripts/deploy-sdp-api-gcp-prod-workflow.test.mjs
+++ b/scripts/deploy-sdp-api-gcp-prod-workflow.test.mjs
@@ -202,3 +202,24 @@ test("no static Doppler token remains in the deploy pipeline", () => {
   assert.doesNotMatch(workflow, /DOPPLER_TOKEN_CI/);
   assert.match(workflow, /- name: Doppler OIDC login/);
 });
+
+test("the orchestrator grants every permission the prod workflow requests", () => {
+  const orchestrator = fs.readFileSync(
+    path.resolve(here, "../.github/workflows/deploy.yml"),
+    "utf8"
+  );
+  const requested = workflow
+    .match(/^permissions:\n((?:  [a-z-]+: [a-z-]+\n)+)/m)[1]
+    .trim()
+    .split("\n")
+    .map((line) => line.trim());
+  const callerJob = orchestrator.match(
+    /deploy-api-prod:[\s\S]*?permissions:\n((?:      [a-z-]+: [a-z-]+\n)+)/
+  )[1];
+  for (const grant of requested) {
+    assert.ok(
+      callerJob.includes(grant),
+      `deploy.yml's deploy-api-prod must grant "${grant}" or the run fails at startup`
+    );
+  }
+});


### PR DESCRIPTION
Every `SDP Deploy` run since #1544 merged (13/13, including plain pushes to main) dies at startup:

> Error calling workflow 'deploy-sdp-api-gcp-prod.yml'. The workflow is requesting 'packages: read', but is only allowed 'packages: none'.

The prod deploy workflow declares `packages: read` at the top level (it pulls the signed image from GHCR), and a reusable workflow cannot request more than its caller grants — `deploy-api-prod` granted only `contents` + `id-token`. This never surfaced in review because the failure only exists at run time on main: actionlint and the workflow contract tests both pass on the broken file.

One line adds the grant. A new contract test parses the prod workflow's top-level permissions and asserts the orchestrator's `deploy-api-prod` job grants each of them, so the next permission added to the called workflow fails `pnpm test:scripts` instead of every deploy run.

Note: today this startup failure is cosmetic-but-loud — `CONTINUOUS_PROD_DEPLOY` is unset, so the prod lane would have skipped anyway, but the dev deploy lane also never ran, meaning merges since #1544 have not auto-deployed to dev. After this merges, the next push to main resumes dev deploys.