### PR TITLE
test(earn): stop pinning surfaced-shelf size in workspace tests

### DIFF
--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-program-workspace.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-program-workspace.unit.test.tsx
@@ -194,13 +194,14 @@ describe("EarnProgramWorkspace", () => {
       />
     );
 
-    expect(screen.getAllByText("Sandbox only")).toHaveLength(2);
+    // The shelf size is a BD decision (EARN_PROVIDER_SURFACING), so assert the
+    // invariant per rendered instance — every strategy (desktop row + mobile
+    // card) is production-closed — rather than pinning a count.
+    const selectButtons = screen.getAllByRole("button", { name: "Select" });
+    expect(screen.getAllByText("Sandbox only")).toHaveLength(selectButtons.length);
+    expect(screen.queryByText("Sandbox ready")).toBeNull();
     expect(screen.queryByLabelText("Strategy network")).toBeNull();
-    expect(
-      screen
-        .getAllByRole("button", { name: "Select" })
-        .every((button) => (button as HTMLButtonElement).disabled)
-    ).toBe(true);
+    expect(selectButtons.every((button) => (button as HTMLButtonElement).disabled)).toBe(true);
     expect(document.body.textContent).toContain("intentionally closed in production");
   });
 
@@ -214,11 +215,11 @@ describe("EarnProgramWorkspace", () => {
       />
     );
 
-    expect(screen.getAllByText("Setup required")).toHaveLength(2);
-    expect(
-      screen
-        .getAllByRole("button", { name: "Select" })
-        .every((button) => (button as HTMLButtonElement).disabled)
-    ).toBe(true);
+    // Same rule as the production test above: no access entry means every
+    // surfaced provider fails closed, however many are surfaced today.
+    const selectButtons = screen.getAllByRole("button", { name: "Select" });
+    expect(screen.getAllByText("Setup required")).toHaveLength(selectButtons.length);
+    expect(screen.queryByText("Sandbox ready")).toBeNull();
+    expect(selectButtons.every((button) => (button as HTMLButtonElement).disabled)).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes the two `EarnProgramWorkspace` unit tests that turned main CI red on #1564.

They asserted `toHaveLength(2)` on the "Sandbox only" / "Setup required" chips, which silently encoded "only Kamino is surfaced". Surfacing Veda made its (already-mocked) row render the same chips (2 strategies x desktop table + mobile cards = 4). The behavior is correct; the assertions pinned a BD decision, exactly the trap `curation.ts` warns about ("tests must not depend on today's picks").

**Reviewer notes**

- The tests now assert the invariant per rendered instance: chip count equals Select-button count, and no row shows "Sandbox ready". The next surfacing change won't touch them.
- This does not unblock the dev deploy: `SDP Deploy` fails separately in the `sdp-dev-api-public-migrate` job (needs someone with dev-project log access).

**Verification**: file 5/5, earn dir 138/138, full sdp-web unit suite 1542/1543. The one red is a pre-existing timezone-sensitive asset-profile date test, unrelated, passes under `TZ=UTC` (as CI runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)