### PR TITLE
feat(custody): expose connection inventory runtime state

### DIFF
--- a/apps/sdp-api/src/routes/internal-custody/connections.test.ts
+++ b/apps/sdp-api/src/routes/internal-custody/connections.test.ts
@@ -22,6 +22,7 @@ const USER = {
   clerkId: "clerk_connections_read",
 };
 const SECRET_PAYLOAD = "encrypted-connections-read-secret";
+const ORIGINAL_PRIVY_BYOK_ENABLED = env.PRIVY_BYOK_ENABLED;
 
 function encodeJwtPart(value: Record<string, unknown>): string {
   return Buffer.from(JSON.stringify(value)).toString("base64url");
@@ -104,6 +105,7 @@ async function seedScope(): Promise<void> {
 async function seedCredentialAndConnection(input: {
   credentialId: string;
   connectionId: string;
+  label?: string;
   status: string;
   createdAt: string;
   failureCode?: string;
@@ -117,7 +119,13 @@ async function seedCredentialAndConnection(input: {
           encrypted_secret_payload, status)
        VALUES (?, ?, ?, 'privy', ?, 'project', 'stored', 'encrypted_db', ?, 'active')`
     )
-    .bind(input.credentialId, ORG.id, PROJECT.id, `Label ${input.credentialId}`, SECRET_PAYLOAD)
+    .bind(
+      input.credentialId,
+      ORG.id,
+      PROJECT.id,
+      input.label ?? `Label ${input.credentialId}`,
+      SECRET_PAYLOAD
+    )
     .run();
   await db
     .prepare(
@@ -146,6 +154,47 @@ async function seedCredentialAndConnection(input: {
     .run();
 }
 
+async function makeConnectionRuntimeReady(
+  connectionId: string,
+  custodyWalletId: string
+): Promise<void> {
+  const db = getDb(env);
+  await db.batch([
+    db
+      .prepare(
+        `INSERT INTO custody_wallets
+           (id, custody_connection_id, wallet_id, public_key, status)
+         VALUES (?, ?, ?, ?, 'active')`
+      )
+      .bind(
+        custodyWalletId,
+        connectionId,
+        `provider-${custodyWalletId}`,
+        `address-${custodyWalletId}`
+      ),
+    db
+      .prepare(
+        `UPDATE custody_connections
+         SET status = 'active', last_check_status = 'success',
+             last_check_at = sdp_iso_now(), provider_account_fingerprint = ?,
+             default_custody_wallet_id = ?, activated_at = sdp_iso_now()
+         WHERE id = ?`
+      )
+      .bind(`fingerprint-${connectionId}`, custodyWalletId, connectionId),
+  ]);
+}
+
+async function selectConnection(connectionId: string): Promise<void> {
+  await getDb(env)
+    .prepare(
+      `INSERT INTO custody_scope_defaults
+         (id, organization_id, project_id, default_custody_connection_id)
+       VALUES ('csd_connections_read', ?, ?, ?)`
+    )
+    .bind(ORG.id, PROJECT.id, connectionId)
+    .run();
+}
+
 async function listConnections(query = ""): Promise<{
   connections: Array<Record<string, unknown>>;
   pagination: { limit: number; offset: number; total: number };
@@ -168,6 +217,7 @@ describe("internal custody connections", () => {
   });
 
   afterEach(async () => {
+    env.PRIVY_BYOK_ENABLED = ORIGINAL_PRIVY_BYOK_ENABLED;
     await clearKVStores(env);
   });
 
@@ -181,10 +231,11 @@ describe("internal custody connections", () => {
     expect(response.status).toBeGreaterThanOrEqual(401);
   });
 
-  it("lists the scope's connections newest first with lifecycle and safe credential fields", async () => {
+  it("lists the scope's connections newest first through the safe Connection contract", async () => {
     await seedCredentialAndConnection({
       credentialId: "pcred_read_a",
       connectionId: "ccon_read_a",
+      label: "Failed treasury",
       status: "failed",
       createdAt: "2026-08-01T00:00:00.000Z",
       failureCode: "invalid_credentials",
@@ -192,6 +243,7 @@ describe("internal custody connections", () => {
     await seedCredentialAndConnection({
       credentialId: "pcred_read_b",
       connectionId: "ccon_read_b",
+      label: "Pending treasury",
       status: "pending",
       createdAt: "2026-08-02T00:00:00.000Z",
       pendingWalletLabel: "Treasury wallet",
@@ -199,31 +251,139 @@ describe("internal custody connections", () => {
 
     const data = await listConnections();
 
-    expect(data.pagination.total).toBe(2);
-    expect(data.connections.map((c) => c.id)).toEqual(["ccon_read_b", "ccon_read_a"]);
-
-    const pending = data.connections[0] as Record<string, unknown>;
-    expect(pending.status).toBe("pending");
-    expect(pending.pendingWalletLabel).toBe("Treasury wallet");
-    expect((pending.providerCredential as Record<string, unknown>).label).toBe(
-      "Label pcred_read_b"
-    );
-
-    const failed = data.connections[1] as Record<string, unknown>;
-    expect((failed.lastCheck as Record<string, unknown>).failureCode).toBe("invalid_credentials");
+    expect(data).toEqual({
+      connections: [
+        {
+          id: "ccon_read_b",
+          provider: "privy",
+          label: "Pending treasury",
+          status: "pending",
+          isDefault: false,
+          isRuntimeExecutionAllowed: false,
+          defaultCustodyWalletId: null,
+          createdAt: "2026-08-02T00:00:00.000Z",
+          activatedAt: null,
+          lastCheck: null,
+          pendingWalletLabel: "Treasury wallet",
+        },
+        {
+          id: "ccon_read_a",
+          provider: "privy",
+          label: "Failed treasury",
+          status: "failed",
+          isDefault: false,
+          isRuntimeExecutionAllowed: false,
+          defaultCustodyWalletId: null,
+          createdAt: "2026-08-01T00:00:00.000Z",
+          activatedAt: null,
+          lastCheck: {
+            status: "failed",
+            at: "2026-08-01T00:00:00.000Z",
+            failureCode: "invalid_credentials",
+          },
+          pendingWalletLabel: null,
+        },
+      ],
+      pagination: { limit: 20, offset: 0, total: 2 },
+    });
+    expect(JSON.stringify(data)).not.toContain("pcred_read_");
+    expect(JSON.stringify(data)).not.toContain("providerCredential");
   });
 
-  it("never returns secret material in any field", async () => {
+  it("never returns secret material or unknown failure codes", async () => {
     await seedCredentialAndConnection({
       credentialId: "pcred_read_secret",
       connectionId: "ccon_read_secret",
-      status: "pending",
+      status: "failed",
       createdAt: "2026-08-01T00:00:00.000Z",
+      failureCode: "raw_provider_stack",
     });
 
     const data = await listConnections();
     expect(JSON.stringify(data)).not.toContain(SECRET_PAYLOAD);
     expect(JSON.stringify(data)).not.toContain("encrypted_secret_payload");
+    expect(JSON.stringify(data)).not.toContain("raw_provider_stack");
+    expect(data.connections[0]?.lastCheck).toMatchObject({ failureCode: null });
+  });
+
+  it("separates effective default selection from runtime eligibility", async () => {
+    env.PRIVY_BYOK_ENABLED = "true";
+    await seedCredentialAndConnection({
+      credentialId: "pcred_read_selected",
+      connectionId: "ccon_read_selected",
+      label: "Shared label",
+      status: "pending",
+      createdAt: "2026-08-01T00:00:00.000Z",
+    });
+    await makeConnectionRuntimeReady("ccon_read_selected", "cwlt_read_selected");
+    await seedCredentialAndConnection({
+      credentialId: "pcred_read_unselected",
+      connectionId: "ccon_read_unselected",
+      label: "Shared label",
+      status: "pending",
+      createdAt: "2026-08-02T00:00:00.000Z",
+    });
+    await makeConnectionRuntimeReady("ccon_read_unselected", "cwlt_read_unselected");
+    await selectConnection("ccon_read_selected");
+
+    const data = await listConnections();
+    const selected = data.connections.find((connection) => connection.id === "ccon_read_selected");
+    const unselected = data.connections.find(
+      (connection) => connection.id === "ccon_read_unselected"
+    );
+
+    expect(selected).toMatchObject({
+      label: "Shared label",
+      status: "active",
+      isDefault: true,
+      isRuntimeExecutionAllowed: true,
+      defaultCustodyWalletId: "cwlt_read_selected",
+    });
+    expect(unselected).toMatchObject({
+      label: "Shared label",
+      status: "active",
+      isDefault: false,
+      isRuntimeExecutionAllowed: true,
+      defaultCustodyWalletId: "cwlt_read_unselected",
+    });
+
+    await getDb(env)
+      .prepare(
+        `UPDATE custody_wallets SET status = 'inactive'
+         WHERE id = 'cwlt_read_selected'`
+      )
+      .run();
+    const unavailableDefault = (await listConnections()).connections.find(
+      (connection) => connection.id === "ccon_read_selected"
+    );
+    expect(unavailableDefault).toMatchObject({
+      isDefault: true,
+      isRuntimeExecutionAllowed: false,
+    });
+  });
+
+  it("keeps Connections visible but runtime-disabled while BYOK is off", async () => {
+    env.PRIVY_BYOK_ENABLED = "false";
+    await seedCredentialAndConnection({
+      credentialId: "pcred_read_flag_off",
+      connectionId: "ccon_read_flag_off",
+      label: "Dormant treasury",
+      status: "pending",
+      createdAt: "2026-08-01T00:00:00.000Z",
+    });
+    await makeConnectionRuntimeReady("ccon_read_flag_off", "cwlt_read_flag_off");
+    await selectConnection("ccon_read_flag_off");
+
+    expect((await listConnections()).connections).toEqual([
+      expect.objectContaining({
+        id: "ccon_read_flag_off",
+        label: "Dormant treasury",
+        status: "active",
+        isDefault: false,
+        isRuntimeExecutionAllowed: false,
+        defaultCustodyWalletId: "cwlt_read_flag_off",
+      }),
+    ]);
   });
 
   it("bounds the page size and honors offsets", async () => {

--- a/apps/sdp-api/src/routes/internal-custody/index.ts
+++ b/apps/sdp-api/src/routes/internal-custody/index.ts
@@ -1,13 +1,16 @@
+import { CUSTODY_CONNECTION_FAILURE_CODES } from "@sdp/types";
 import { Hono } from "hono";
 import { z } from "zod";
 import { getDb } from "@/db";
 import { getAuth, requireProjectId } from "@/lib/auth";
 import { badRequest, badRequestParams } from "@/lib/errors";
+import { isCustodyConnectionRuntimeEnabled } from "@/lib/feature-flags";
 import { created, success } from "@/lib/response";
 import { credentialAdminAuthMiddleware } from "@/middleware/credential-admin-auth";
 import { idempotencyKeyMiddleware } from "@/middleware/idempotency-key";
 import { projectContextMiddleware } from "@/middleware/project-context";
 import { getCustodySetupStatus } from "@/services/custody-setup-status.service";
+import { isCustodyConnectionRuntimeAvailable } from "@/services/domain/signing/custody-runtime-target";
 import { getProviderCredentialInstallation } from "@/services/provider-credential-installation.service";
 import { getProviderSetupDefinition } from "@/services/provider-setup-registry";
 import {
@@ -52,22 +55,24 @@ internalCustody.get("/connections", async (c) => {
     connections: connections.map((row) => ({
       id: row.id,
       provider: row.provider,
-      status: row.status,
+      label: row.credential_label,
+      status: row.connection_status,
+      isDefault: isCustodyConnectionRuntimeEnabled(c.env, row.provider) && row.is_selected,
+      isRuntimeExecutionAllowed: isCustodyConnectionRuntimeAvailable(c.env, row.provider, row),
+      defaultCustodyWalletId: row.default_custody_wallet_id,
       createdAt: row.created_at,
       activatedAt: row.activated_at,
       lastCheck: row.last_check_status
         ? {
             status: row.last_check_status,
             at: row.last_check_at,
-            failureCode: row.last_check_failure_code,
+            failureCode:
+              CUSTODY_CONNECTION_FAILURE_CODES.find(
+                (code) => code === row.last_check_failure_code
+              ) ?? null,
           }
         : null,
       pendingWalletLabel: getPendingWalletLabel(row.setup_metadata) ?? null,
-      providerCredential: {
-        id: row.credential_id,
-        label: row.credential_label,
-        status: row.credential_status,
-      },
     })),
     pagination: { limit, offset, total },
   });

--- a/apps/sdp-api/src/services/domain/signing/custody-runtime-target.ts
+++ b/apps/sdp-api/src/services/domain/signing/custody-runtime-target.ts
@@ -1,6 +1,12 @@
 import { CUSTODY_PROVIDERS, type CustodyProvider, normalizePrivyWalletId } from "@sdp/custody";
 import { isFullSigningPort, SigningError, type SigningPort } from "@sdp/custody/signing";
-import type { CustodyWalletPurpose } from "@sdp/types";
+import type {
+  CustodyConnectionCheckStatus,
+  CustodyConnectionLifecycle,
+  CustodyWalletPurpose,
+  CustodyWalletStatus,
+  ProviderCredentialStatus,
+} from "@sdp/types";
 import type { Address, TransactionSigner } from "@solana/kit";
 import type { DatabaseClient, DatabaseExecutor } from "@/db";
 import {
@@ -147,19 +153,22 @@ interface ConfigWalletRow extends ConfigRow {
   wallet_status: string;
 }
 
-interface ConnectionTargetRow {
-  connection_id: string;
-  organization_id: string;
-  project_id: string;
-  provider: string;
-  connection_status: string;
-  last_check_status: string | null;
-  credential_status: string;
+export interface CustodyConnectionRuntimeAvailabilityFacts {
+  connection_status: CustodyConnectionLifecycle;
+  last_check_status: CustodyConnectionCheckStatus | null;
+  credential_status: ProviderCredentialStatus;
   provider_account_fingerprint: string | null;
   default_custody_wallet_id: string | null;
   default_wallet_id: string | null;
   default_wallet_public_key: string | null;
-  default_wallet_status: string | null;
+  default_wallet_status: CustodyWalletStatus | null;
+}
+
+interface ConnectionTargetRow extends CustodyConnectionRuntimeAvailabilityFacts {
+  connection_id: string;
+  organization_id: string;
+  project_id: string;
+  provider: string;
   wallet_id: string | null;
   wallet_public_key: string | null;
   wallet_status: string | null;
@@ -248,6 +257,34 @@ export interface CustodyConnectionSelectionResult {
   provider: CustodyProvider;
   walletId: string;
   publicKey: string;
+}
+
+export function isCustodyConnectionRuntimeAvailable(
+  env: Pick<Env, "PRIVY_BYOK_ENABLED">,
+  provider: CustodyProvider,
+  row: CustodyConnectionRuntimeAvailabilityFacts
+): boolean {
+  return (
+    isCustodyConnectionOwnerRuntimeAvailable(env, provider, row) &&
+    row.default_custody_wallet_id !== null &&
+    row.default_wallet_id !== null &&
+    row.default_wallet_public_key !== null &&
+    row.default_wallet_status === "active"
+  );
+}
+
+function isCustodyConnectionOwnerRuntimeAvailable(
+  env: Pick<Env, "PRIVY_BYOK_ENABLED">,
+  provider: CustodyProvider,
+  row: CustodyConnectionRuntimeAvailabilityFacts
+): boolean {
+  return (
+    isCustodyConnectionRuntimeEnabled(env, provider) &&
+    row.connection_status === "active" &&
+    row.last_check_status === "success" &&
+    row.credential_status === "active" &&
+    row.provider_account_fingerprint !== null
+  );
 }
 
 const RUNTIME_EXECUTION_PAUSED_REASON = "runtime_execution_paused";
@@ -1271,22 +1308,16 @@ export class CustodyRuntimeTargets {
 
   private isConnectionRuntimeAvailable(row: ConnectionTargetRow): boolean {
     return (
-      this.isConnectionOwnerRuntimeAvailable(row) &&
-      row.wallet_status === "active" &&
-      row.default_custody_wallet_id !== null &&
-      row.default_wallet_id !== null &&
-      row.default_wallet_public_key !== null &&
-      row.default_wallet_status === "active"
+      isCustodyConnectionRuntimeAvailable(this.env, this.parseProvider(row.provider), row) &&
+      row.wallet_status === "active"
     );
   }
 
   private isConnectionOwnerRuntimeAvailable(row: ConnectionTargetRow): boolean {
-    return (
-      isCustodyConnectionRuntimeEnabled(this.env, this.parseProvider(row.provider)) &&
-      row.connection_status === "active" &&
-      row.last_check_status === "success" &&
-      row.credential_status === "active" &&
-      row.provider_account_fingerprint !== null
+    return isCustodyConnectionOwnerRuntimeAvailable(
+      this.env,
+      this.parseProvider(row.provider),
+      row
     );
   }
 

--- a/apps/sdp-api/src/services/stores/provider-credential.store.ts
+++ b/apps/sdp-api/src/services/stores/provider-credential.store.ts
@@ -1,3 +1,4 @@
+import type { CustodyConnectionCheckStatus, CustodyWalletStatus } from "@sdp/types";
 import type { DatabaseExecutor } from "@/db";
 import { parsePostgresJsonOr } from "@/db/postgres-utils";
 import type { StoredCredentialSecret } from "@/services/credential-secret-store";
@@ -42,7 +43,7 @@ export interface CustodyConnectionRow {
   request_delay_ms: number | null;
   status: CustodyConnectionStatus;
   setup_metadata: unknown;
-  last_check_status: string | null;
+  last_check_status: CustodyConnectionCheckStatus | null;
   last_check_at: string | null;
   last_check_failure_code: string | null;
   activated_at: string | null;
@@ -53,17 +54,21 @@ export interface CustodyConnectionRow {
 export interface ProjectConnectionListRow {
   id: string;
   provider: "privy";
-  status: CustodyConnectionStatus;
+  connection_status: CustodyConnectionStatus;
   setup_metadata: unknown;
-  last_check_status: string | null;
+  last_check_status: CustodyConnectionCheckStatus | null;
   last_check_at: string | null;
   last_check_failure_code: string | null;
   activated_at: string | null;
   created_at: string;
-  credential_id: string;
   credential_label: string;
   credential_status: ProviderCredentialStatus;
-  credential_display_metadata: unknown;
+  provider_account_fingerprint: string | null;
+  default_custody_wallet_id: string | null;
+  default_wallet_id: string | null;
+  default_wallet_public_key: string | null;
+  default_wallet_status: CustodyWalletStatus | null;
+  is_selected: boolean;
 }
 
 export interface ProjectConnectionState extends CustodyConnectionRow {
@@ -192,19 +197,32 @@ export class ProviderCredentialStore {
     const connections = await this.db.queryMany<ProjectConnectionListRow>(
       `SELECT c.id,
               c.provider,
-              c.status,
+              c.status AS connection_status,
               c.setup_metadata,
               c.last_check_status,
               c.last_check_at,
               c.last_check_failure_code,
               c.activated_at,
               c.created_at,
-              pc.id AS credential_id,
               pc.label AS credential_label,
               pc.status AS credential_status,
-              pc.display_metadata AS credential_display_metadata
+              c.provider_account_fingerprint,
+              c.default_custody_wallet_id,
+              default_wallet.wallet_id AS default_wallet_id,
+              default_wallet.public_key AS default_wallet_public_key,
+              default_wallet.status AS default_wallet_status,
+              EXISTS (
+                SELECT 1
+                FROM custody_scope_defaults selected
+                WHERE selected.organization_id = c.organization_id
+                  AND selected.project_id = c.project_id
+                  AND selected.default_custody_connection_id = c.id
+              ) AS is_selected
          FROM custody_connections c
          JOIN provider_credentials pc ON pc.id = c.provider_credential_id
+         LEFT JOIN custody_wallets default_wallet
+           ON default_wallet.id = c.default_custody_wallet_id
+          AND default_wallet.custody_connection_id = c.id
         WHERE c.organization_id = ? AND c.project_id = ?
         ORDER BY c.created_at DESC, c.id DESC
         LIMIT ? OFFSET ?`,

--- a/apps/sdp-api/src/services/stores/provider-credential.store.ts
+++ b/apps/sdp-api/src/services/stores/provider-credential.store.ts
@@ -188,15 +188,14 @@ export class ProviderCredentialStore {
     projectId: string,
     options: { limit: number; offset: number }
   ): Promise<{ connections: ProjectConnectionListRow[]; total: number }> {
-    const [totalRow, connections] = await Promise.all([
-      this.db.queryOne<{ total: number | string }>(
-        `SELECT COUNT(*) AS total
-           FROM custody_connections
-          WHERE organization_id = ? AND project_id = ?`,
-        [organizationId, projectId]
-      ),
-      this.db.queryMany<ProjectConnectionListRow>(
-        `SELECT c.id,
+    const totalRow = await this.db.queryOne<{ total: number | string }>(
+      `SELECT COUNT(*) AS total
+         FROM custody_connections
+        WHERE organization_id = ? AND project_id = ?`,
+      [organizationId, projectId]
+    );
+    const connections = await this.db.queryMany<ProjectConnectionListRow>(
+      `SELECT c.id,
               c.provider,
               c.status AS connection_status,
               c.setup_metadata,
@@ -227,9 +226,8 @@ export class ProviderCredentialStore {
         WHERE c.organization_id = ? AND c.project_id = ?
         ORDER BY c.created_at DESC, c.id DESC
         LIMIT ? OFFSET ?`,
-        [organizationId, projectId, options.limit, options.offset]
-      ),
-    ]);
+      [organizationId, projectId, options.limit, options.offset]
+    );
     return { connections, total: Number(totalRow?.total ?? 0) };
   }
 

--- a/apps/sdp-api/src/services/stores/provider-credential.store.ts
+++ b/apps/sdp-api/src/services/stores/provider-credential.store.ts
@@ -188,14 +188,15 @@ export class ProviderCredentialStore {
     projectId: string,
     options: { limit: number; offset: number }
   ): Promise<{ connections: ProjectConnectionListRow[]; total: number }> {
-    const totalRow = await this.db.queryOne<{ total: number | string }>(
-      `SELECT COUNT(*) AS total
-         FROM custody_connections
-        WHERE organization_id = ? AND project_id = ?`,
-      [organizationId, projectId]
-    );
-    const connections = await this.db.queryMany<ProjectConnectionListRow>(
-      `SELECT c.id,
+    const [totalRow, connections] = await Promise.all([
+      this.db.queryOne<{ total: number | string }>(
+        `SELECT COUNT(*) AS total
+           FROM custody_connections
+          WHERE organization_id = ? AND project_id = ?`,
+        [organizationId, projectId]
+      ),
+      this.db.queryMany<ProjectConnectionListRow>(
+        `SELECT c.id,
               c.provider,
               c.status AS connection_status,
               c.setup_metadata,
@@ -226,8 +227,9 @@ export class ProviderCredentialStore {
         WHERE c.organization_id = ? AND c.project_id = ?
         ORDER BY c.created_at DESC, c.id DESC
         LIMIT ? OFFSET ?`,
-      [organizationId, projectId, options.limit, options.offset]
-    );
+        [organizationId, projectId, options.limit, options.offset]
+      ),
+    ]);
     return { connections, total: Number(totalRow?.total ?? 0) };
   }
 

--- a/apps/sdp-web/src/app/dashboard/custody/connections/connections-list.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/connections/connections-list.tsx
@@ -230,7 +230,7 @@ export function ConnectionsList({
           {connections.map((connection) => (
             <TableRow key={connection.id} data-connection-id={connection.id}>
               <TableCell className="font-medium">
-                <span className="block truncate">{connection.providerCredential.label}</span>
+                <span className="block truncate">{connection.label}</span>
                 <span className="mt-1 block truncate font-mono text-[11px] font-normal text-tertiary">
                   {formatWalletMeta(connection.id, 10, 6)}
                 </span>

--- a/apps/sdp-web/src/app/dashboard/custody/connections/connections-list.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/connections/connections-list.unit.test.tsx
@@ -37,7 +37,10 @@ function makeConnection(
     activatedAt: "2026-08-10T09:05:00.000Z",
     lastCheck: { status: "success", at: "2026-08-10T09:05:00.000Z", failureCode: null },
     pendingWalletLabel: null,
-    providerCredential: { id: `cred-${overrides.id}`, label: "Ops Privy app", status: "active" },
+    label: "Ops Privy app",
+    isDefault: false,
+    isRuntimeExecutionAllowed: true,
+    defaultCustodyWalletId: `wallet-${overrides.id}`,
     ...overrides,
   };
 }
@@ -90,17 +93,23 @@ const connectionWallet: CustodyWalletSummary = {
 };
 
 describe("connections list", () => {
-  it("renders one row per connection without collapsing same-provider connections", () => {
+  it("renders one row per exact connection without collapsing duplicate labels", () => {
     const html = renderList({
       result: makeResult([
-        makeConnection({ id: "conn-active" }),
-        makeConnection({ id: "conn-second", status: "pending", activatedAt: null }),
+        makeConnection({ id: "conn-active", label: "Shared Privy app" }),
+        makeConnection({
+          id: "conn-second",
+          label: "Shared Privy app",
+          status: "pending",
+          activatedAt: null,
+        }),
       ]),
     });
 
     expect(html.match(/data-connection-id=/g)).toHaveLength(2);
     expect(html).toContain('data-connection-id="conn-active"');
     expect(html).toContain('data-connection-id="conn-second"');
+    expect(html.match(/Shared Privy app/g)).toHaveLength(2);
     expect(html).toContain("Active");
     expect(html).toContain("Pending");
   });

--- a/apps/sdp-web/src/app/dashboard/custody/connections/connections.data.ts
+++ b/apps/sdp-web/src/app/dashboard/custody/connections/connections.data.ts
@@ -4,7 +4,6 @@ import type {
   CustodyConnectionLifecycle,
   CustodyProvider,
   CustodyWalletSummary,
-  ProviderCredentialStatus,
 } from "@sdp/types";
 import type { SdpApiClient } from "@/lib/sdp-api";
 
@@ -19,16 +18,15 @@ export interface ConnectionLastCheck {
 export interface CustodyConnectionListItem {
   id: string;
   provider: CustodyProvider;
+  label: string;
   status: CustodyConnectionLifecycle;
+  isDefault: boolean;
+  isRuntimeExecutionAllowed: boolean;
+  defaultCustodyWalletId: string | null;
   createdAt: string;
   activatedAt: string | null;
   lastCheck: ConnectionLastCheck | null;
   pendingWalletLabel: string | null;
-  providerCredential: {
-    id: string;
-    label: string;
-    status: ProviderCredentialStatus;
-  };
 }
 
 export interface ConnectionsPageResult {

--- a/apps/sdp-web/src/app/dashboard/custody/connections/connections.data.ts
+++ b/apps/sdp-web/src/app/dashboard/custody/connections/connections.data.ts
@@ -10,52 +10,38 @@ import type { SdpApiClient } from "@/lib/sdp-api";
 
 export const CONNECTIONS_PAGE_SIZE = 20;
 
-const connectionLastCheckSchema = z
-  .object({
-    status: z.enum(CUSTODY_CONNECTION_CHECK_STATUSES),
-    at: z.string().nullable(),
-    failureCode: z.enum(CUSTODY_CONNECTION_FAILURE_CODES).nullable(),
-  })
-  .strict();
+const connectionLastCheckSchema = z.object({
+  status: z.enum(CUSTODY_CONNECTION_CHECK_STATUSES),
+  at: z.string().nullable(),
+  failureCode: z.enum(CUSTODY_CONNECTION_FAILURE_CODES).nullable(),
+});
 
-const custodyConnectionListItemSchema = z
-  .object({
-    id: z.string(),
-    provider: z.enum(CUSTODY_PROVIDERS),
-    label: z.string(),
-    status: z.enum(CUSTODY_CONNECTION_LIFECYCLES),
-    isDefault: z.boolean(),
-    isRuntimeExecutionAllowed: z.boolean(),
-    defaultCustodyWalletId: z.string().nullable(),
-    createdAt: z.string(),
-    activatedAt: z.string().nullable(),
-    lastCheck: connectionLastCheckSchema.nullable(),
-    pendingWalletLabel: z.string().nullable(),
-  })
-  .strict();
+const custodyConnectionListItemSchema = z.object({
+  id: z.string(),
+  provider: z.enum(CUSTODY_PROVIDERS),
+  label: z.string(),
+  status: z.enum(CUSTODY_CONNECTION_LIFECYCLES),
+  isDefault: z.boolean(),
+  isRuntimeExecutionAllowed: z.boolean(),
+  defaultCustodyWalletId: z.string().nullable(),
+  createdAt: z.string(),
+  activatedAt: z.string().nullable(),
+  lastCheck: connectionLastCheckSchema.nullable(),
+  pendingWalletLabel: z.string().nullable(),
+});
 
-const connectionsPageResultSchema = z
-  .object({
-    connections: z.array(custodyConnectionListItemSchema),
-    pagination: z
-      .object({
-        limit: z.number().int().nonnegative(),
-        offset: z.number().int().nonnegative(),
-        total: z.number().int().nonnegative(),
-      })
-      .strict(),
-  })
-  .strict();
+const connectionsPageResultSchema = z.object({
+  connections: z.array(custodyConnectionListItemSchema),
+  pagination: z.object({
+    limit: z.number().int().nonnegative(),
+    offset: z.number().int().nonnegative(),
+    total: z.number().int().nonnegative(),
+  }),
+});
 
-const connectionsPageEnvelopeSchema = z
-  .object({
-    data: connectionsPageResultSchema,
-    meta: z
-      .object({ requestId: z.string().optional(), timestamp: z.string().optional() })
-      .strict()
-      .optional(),
-  })
-  .strict();
+const connectionsPageEnvelopeSchema = z.object({
+  data: connectionsPageResultSchema,
+});
 
 export type ConnectionLastCheck = z.infer<typeof connectionLastCheckSchema>;
 export type CustodyConnectionListItem = z.infer<typeof custodyConnectionListItemSchema>;

--- a/apps/sdp-web/src/app/dashboard/custody/connections/connections.data.ts
+++ b/apps/sdp-web/src/app/dashboard/custody/connections/connections.data.ts
@@ -1,38 +1,65 @@
-import type {
-  CustodyConnectionCheckStatus,
-  CustodyConnectionFailureCode,
-  CustodyConnectionLifecycle,
-  CustodyProvider,
-  CustodyWalletSummary,
+import {
+  CUSTODY_CONNECTION_CHECK_STATUSES,
+  CUSTODY_CONNECTION_FAILURE_CODES,
+  CUSTODY_CONNECTION_LIFECYCLES,
+  CUSTODY_PROVIDERS,
+  type CustodyWalletSummary,
 } from "@sdp/types";
+import { z } from "zod";
 import type { SdpApiClient } from "@/lib/sdp-api";
 
 export const CONNECTIONS_PAGE_SIZE = 20;
 
-export interface ConnectionLastCheck {
-  status: CustodyConnectionCheckStatus;
-  at: string | null;
-  failureCode: CustodyConnectionFailureCode | null;
-}
+const connectionLastCheckSchema = z
+  .object({
+    status: z.enum(CUSTODY_CONNECTION_CHECK_STATUSES),
+    at: z.string().nullable(),
+    failureCode: z.enum(CUSTODY_CONNECTION_FAILURE_CODES).nullable(),
+  })
+  .strict();
 
-export interface CustodyConnectionListItem {
-  id: string;
-  provider: CustodyProvider;
-  label: string;
-  status: CustodyConnectionLifecycle;
-  isDefault: boolean;
-  isRuntimeExecutionAllowed: boolean;
-  defaultCustodyWalletId: string | null;
-  createdAt: string;
-  activatedAt: string | null;
-  lastCheck: ConnectionLastCheck | null;
-  pendingWalletLabel: string | null;
-}
+const custodyConnectionListItemSchema = z
+  .object({
+    id: z.string(),
+    provider: z.enum(CUSTODY_PROVIDERS),
+    label: z.string(),
+    status: z.enum(CUSTODY_CONNECTION_LIFECYCLES),
+    isDefault: z.boolean(),
+    isRuntimeExecutionAllowed: z.boolean(),
+    defaultCustodyWalletId: z.string().nullable(),
+    createdAt: z.string(),
+    activatedAt: z.string().nullable(),
+    lastCheck: connectionLastCheckSchema.nullable(),
+    pendingWalletLabel: z.string().nullable(),
+  })
+  .strict();
 
-export interface ConnectionsPageResult {
-  connections: CustodyConnectionListItem[];
-  pagination: { limit: number; offset: number; total: number };
-}
+const connectionsPageResultSchema = z
+  .object({
+    connections: z.array(custodyConnectionListItemSchema),
+    pagination: z
+      .object({
+        limit: z.number().int().nonnegative(),
+        offset: z.number().int().nonnegative(),
+        total: z.number().int().nonnegative(),
+      })
+      .strict(),
+  })
+  .strict();
+
+const connectionsPageEnvelopeSchema = z
+  .object({
+    data: connectionsPageResultSchema,
+    meta: z
+      .object({ requestId: z.string().optional(), timestamp: z.string().optional() })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+export type ConnectionLastCheck = z.infer<typeof connectionLastCheckSchema>;
+export type CustodyConnectionListItem = z.infer<typeof custodyConnectionListItemSchema>;
+export type ConnectionsPageResult = z.infer<typeof connectionsPageResultSchema>;
 
 export interface ConnectionsFilters {
   page: number;
@@ -82,8 +109,7 @@ export async function fetchConnectionsPage(
   if (!res.ok) {
     throw new ConnectionsRequestError(res.status);
   }
-  const json = (await res.json()) as { data: ConnectionsPageResult };
-  return json.data;
+  return connectionsPageEnvelopeSchema.parse(await res.json()).data;
 }
 
 /**

--- a/apps/sdp-web/src/app/dashboard/custody/connections/connections.data.unit.test.ts
+++ b/apps/sdp-web/src/app/dashboard/custody/connections/connections.data.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildConnectionsSearchParams,
   ConnectionsRequestError,
+  type CustodyConnectionListItem,
   fetchConnectionsPage,
   fetchWalletsByConnection,
   parseConnectionsFilters,
@@ -13,6 +14,26 @@ function jsonResponse(body: unknown): Response {
     status: 200,
     headers: { "Content-Type": "application/json" },
   });
+}
+
+function connection(id: string): CustodyConnectionListItem {
+  return {
+    id,
+    provider: "privy",
+    label: "Treasury",
+    status: "active",
+    isDefault: true,
+    isRuntimeExecutionAllowed: true,
+    defaultCustodyWalletId: "cwlt_treasury",
+    createdAt: "2026-08-10T09:00:00.000Z",
+    activatedAt: "2026-08-10T09:05:00.000Z",
+    lastCheck: {
+      status: "success",
+      at: "2026-08-10T09:05:00.000Z",
+      failureCode: null,
+    },
+    pendingWalletLabel: null,
+  };
 }
 
 describe("parseConnectionsFilters", () => {
@@ -34,7 +55,10 @@ describe("buildConnectionsSearchParams", () => {
 describe("fetchConnectionsPage", () => {
   it("converts the page to a limit/offset query", async () => {
     const request = vi.fn(async () =>
-      jsonResponse({ data: { connections: [], pagination: { limit: 20, offset: 40, total: 0 } } })
+      jsonResponse({
+        data: { connections: [], pagination: { limit: 20, offset: 40, total: 0 } },
+        meta: { requestId: "req-connections", timestamp: "2026-09-01T12:00:00.000Z" },
+      })
     );
 
     await fetchConnectionsPage(request, { page: 3 });
@@ -55,6 +79,14 @@ describe("fetchConnectionsPage", () => {
       ConnectionsRequestError
     );
   });
+
+  it("rejects a malformed successful response", async () => {
+    const request = vi.fn(async () =>
+      jsonResponse({ data: { connections: [{ id: "conn-1" }], pagination: {} } })
+    );
+
+    await expect(fetchConnectionsPage(request, { page: 1 })).rejects.toThrow();
+  });
 });
 
 describe("resolveConnectionsPage", () => {
@@ -66,7 +98,7 @@ describe("resolveConnectionsPage", () => {
           })
         : jsonResponse({
             data: {
-              connections: [{ id: "conn-1" }],
+              connections: [connection("conn-1")],
               pagination: { limit: 20, offset: 0, total: 4 },
             },
           })
@@ -91,7 +123,7 @@ describe("resolveConnectionsPage", () => {
       .mockResolvedValueOnce(
         jsonResponse({
           data: {
-            connections: [{ id: "conn-1" }],
+            connections: [connection("conn-1")],
             pagination: { limit: 20, offset: 0, total: 20 },
           },
         })
@@ -119,7 +151,7 @@ describe("resolveConnectionsPage", () => {
       .mockResolvedValueOnce(
         jsonResponse({
           data: {
-            connections: [{ id: "conn-1" }],
+            connections: [connection("conn-1")],
             pagination: { limit: 20, offset: 0, total: 5 },
           },
         })

--- a/apps/sdp-web/src/app/dashboard/custody/connections/connections.data.unit.test.ts
+++ b/apps/sdp-web/src/app/dashboard/custody/connections/connections.data.unit.test.ts
@@ -68,6 +68,32 @@ describe("fetchConnectionsPage", () => {
     );
   });
 
+  it("accepts additive fields from a newer API response", async () => {
+    const expectedConnection = connection("conn-1");
+    const request = vi.fn(async () =>
+      jsonResponse({
+        data: {
+          connections: [
+            {
+              ...expectedConnection,
+              lastCheck: { ...expectedConnection.lastCheck, futureField: true },
+              futureField: true,
+            },
+          ],
+          pagination: { limit: 20, offset: 0, total: 1, futureField: true },
+          futureField: true,
+        },
+        meta: { requestId: "req-connections", futureField: true },
+        futureField: true,
+      })
+    );
+
+    await expect(fetchConnectionsPage(request, { page: 1 })).resolves.toEqual({
+      connections: [expectedConnection],
+      pagination: { limit: 20, offset: 0, total: 1 },
+    });
+  });
+
   it("throws a typed error carrying the response status", async () => {
     const request = vi.fn(async () => new Response(null, { status: 403 }));
 


### PR DESCRIPTION
## What changed

- Replaced the internal Connections response field `providerCredential: { id, label, status }` with a connection-level contract containing `label`, `isDefault`, `isRuntimeExecutionAllowed`, and `defaultCustodyWalletId`.
- Kept the existing Connection lifecycle status unchanged.
- Extracted and reused the existing connection runtime-availability predicate without changing signing semantics.
- Normalized unknown stored failure codes to `null`.
- Added Zod validation in Web while accepting additive response fields.
- Updated the Connections page to consume the new label field and started the independent count and page queries concurrently.

## Why

HOO-1024 needs Connection selection and runtime state for the Dashboard without exposing provider credential internals.

Sharing the existing runtime-availability rules keeps the inventory consistent with runtime target resolution.

## Impact

- This is a breaking internal contract change between `sdp-api` and `sdp-web`; mixed old/new versions can break the Connections page.
- The current table continues to display the same label and lifecycle status.
- No default/runtime UI or management actions are added yet.
- No public API, OpenAPI, database, persistence, or dependency changes.
- No intended signing or value-moving behavior change.
- This PR does not enable the API or Web BYOK feature flags.

## Pre/post release actions

### Pre-release

- Deploy API and Web together, or keep the Web BYOK flag disabled until both revisions are live.

### Post-release

- Smoke-test the Connections page with selected, unselected, available, and unavailable Connections.
- If rollback is required, roll back API and Web together.
- No database rollback, migration, backfill, dependency installation, or configuration migration is required.

## Result Validation

- `pnpm typecheck` — passed.
- `pnpm check:module-boundaries` — passed.
- Focused API route tests — 7/7 passed.
- Full Web test suite — 185 files / 1,533 tests passed.
- Focused changed Web tests — 17/17 passed.

## Does it affect current flows & behavior and how

### Before

1. The internal API returned Connection lifecycle data with nested provider credential ID, label, and status.
2. Web rendered the nested credential label.
3. Selection and runtime availability were not exposed.

### After

1. The API returns the credential-derived label without exposing credential ID or status.
2. `isDefault` is `true` when BYOK runtime is enabled and the Connection is selected for the organization/project.
3. `isRuntimeExecutionAllowed` is calculated independently from local Connection, Credential, fingerprint, health-check, and default-wallet state.
4. Web validates required response fields and ignores additive fields.
5. Malformed required data produces the existing Connections load-error state.

When the API BYOK flag is disabled, rows still return with `isDefault: false` and `isRuntimeExecutionAllowed: false`. When the Web BYOK flag is disabled, the Connections page continues to redirect to Wallets.

## Known gaps

- The Dashboard does not yet display the new default/runtime fields or provide create, switch, or deactivate actions.
- There is no compatibility bridge between the old and new internal response formats.
- This remains an internal admin-only API; no public Connections API or non-admin restricted-state UX is added.

## Notes

- The endpoint remains dashboard-session-only with `custody:admin`; API keys are rejected.
- Both inventory queries remain scoped to the authenticated organization and project.
- `isDefault` and `isRuntimeExecutionAllowed` are independent: a selected Connection can be unavailable.
- Runtime availability represents local admission state, not live provider health or a guarantee that signing will succeed.
- Concurrent count and page queries preserve the existing non-atomic pagination model.