### PR TITLE
feat(api): list counterparty provider accounts with JIT Grid enrichment

### DIFF
--- a/apps/sdp-api/src/db/repositories/counterparty-provider-account.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty-provider-account.repository.postgres.ts
@@ -9,6 +9,7 @@ import type {
   InsertPendingExternalAccountInput,
   ListActiveExternalAccountsInput,
   ListExternalAccountsInput,
+  ListProviderAccountsInput,
   UpdateExternalAccountStatusInput,
   UpsertCounterpartyProviderAccountInput,
 } from "./counterparty-provider-account.repository";
@@ -147,6 +148,41 @@ export function createPostgresCounterpartyProviderAccountsRepository(
           input.provider,
           input.fiatCurrency
         )
+        .all<Record<string, unknown>>();
+
+      return result.results.map((row) => counterpartyProviderAccountRowSchema.parse(row));
+    },
+
+    async listProviderAccounts(input: ListProviderAccountsInput) {
+      const conditions = [
+        "organization_id = ?",
+        "project_id = ?",
+        "counterparty_id = ?",
+        "fiat_currency IS NOT NULL",
+      ];
+      const bindings: string[] = [input.organizationId, input.projectId, input.counterpartyId];
+
+      if (input.provider !== undefined) {
+        conditions.push("provider = ?");
+        bindings.push(input.provider);
+      }
+      if (input.fiatCurrency !== undefined) {
+        conditions.push("fiat_currency = ?");
+        bindings.push(input.fiatCurrency);
+      }
+      if (input.destinationCountry !== undefined) {
+        conditions.push("destination_country = ?");
+        bindings.push(input.destinationCountry);
+      }
+
+      const result = await db
+        .prepare(
+          `SELECT *
+           FROM counterparty_provider_accounts
+           WHERE ${conditions.join(" AND ")}
+           ORDER BY created_at ASC`
+        )
+        .bind(...bindings)
         .all<Record<string, unknown>>();
 
       return result.results.map((row) => counterpartyProviderAccountRowSchema.parse(row));

--- a/apps/sdp-api/src/db/repositories/counterparty-provider-account.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty-provider-account.repository.test.ts
@@ -312,4 +312,74 @@ describe("CounterpartyProviderAccountsRepository (postgres)", () => {
 
     expect(replacement.id).not.toBe(first.id);
   });
+
+  it("lists active and archived external rows with parent and tenant filters", async () => {
+    const counterparty = await seedCounterparty("cpacc_list_provider_accounts");
+    const otherCounterparty = await seedCounterparty("cpacc_list_provider_accounts_other");
+    const customer = await repository.upsertProviderAccount({
+      organizationId: TEST_ORG.id,
+      projectId: TEST_PROJECT_ID,
+      counterpartyId: counterparty.id,
+      provider: "lightspark",
+      providerCustomerReference: "Customer:list_provider_accounts",
+    });
+    const usd = await repository.insertPendingExternalAccount({
+      organizationId: TEST_ORG.id,
+      projectId: TEST_PROJECT_ID,
+      counterpartyId: counterparty.id,
+      provider: "lightspark",
+      providerCustomerReference: customer.provider_customer_reference,
+      fiatCurrency: "USD",
+      destinationCountry: "US",
+      paymentRail: "ACH",
+    });
+    const gbp = await repository.insertPendingExternalAccount({
+      organizationId: TEST_ORG.id,
+      projectId: TEST_PROJECT_ID,
+      counterpartyId: counterparty.id,
+      provider: "lightspark",
+      providerCustomerReference: customer.provider_customer_reference,
+      fiatCurrency: "GBP",
+      destinationCountry: "GB",
+      paymentRail: "FPS",
+    });
+    await repository.archiveExternalAccount({
+      organizationId: TEST_ORG.id,
+      projectId: TEST_PROJECT_ID,
+      counterpartyId: counterparty.id,
+      provider: "lightspark",
+      id: gbp.id,
+    });
+
+    expect(
+      await repository.listProviderAccounts({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: counterparty.id,
+      })
+    ).toEqual([usd, expect.objectContaining({ id: gbp.id, status: "archived" })]);
+    expect(
+      await repository.listProviderAccounts({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: counterparty.id,
+        fiatCurrency: "USD",
+        destinationCountry: "US",
+      })
+    ).toEqual([usd]);
+    expect(
+      await repository.listProviderAccounts({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: otherCounterparty.id,
+      })
+    ).toEqual([]);
+    expect(
+      await repository.listProviderAccounts({
+        organizationId: "org_not_owned",
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: counterparty.id,
+      })
+    ).toEqual([]);
+  });
 });

--- a/apps/sdp-api/src/db/repositories/counterparty-provider-account.repository.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty-provider-account.repository.ts
@@ -49,6 +49,15 @@ export interface ListExternalAccountsInput extends GetCounterpartyProviderAccoun
   fiatCurrency: string;
 }
 
+export interface ListProviderAccountsInput {
+  organizationId: string;
+  projectId: string;
+  counterpartyId: string;
+  provider?: RampProviderId;
+  fiatCurrency?: string;
+  destinationCountry?: CountryCode;
+}
+
 export interface GetExternalAccountByIdInput extends GetCounterpartyProviderAccountInput {
   id: string;
 }
@@ -125,6 +134,14 @@ export interface CounterpartyProviderAccountsRepository {
    * @returns Active corridor rows with provider statuses.
    */
   listExternalAccounts(input: ListExternalAccountsInput): Promise<CounterpartyProviderAccountRow[]>;
+
+  /**
+   * Lists all external provider-account rows for one counterparty.
+   *
+   * @param input - Tenant, project, counterparty, and optional corridor filters.
+   * @returns Active and archived external-account rows in creation order.
+   */
+  listProviderAccounts(input: ListProviderAccountsInput): Promise<CounterpartyProviderAccountRow[]>;
 
   /**
    * Inserts an active corridor row before provider account creation.

--- a/apps/sdp-api/src/db/repositories/index.ts
+++ b/apps/sdp-api/src/db/repositories/index.ts
@@ -51,6 +51,7 @@ export type {
   InsertPendingExternalAccountInput,
   ListActiveExternalAccountsInput,
   ListExternalAccountsInput,
+  ListProviderAccountsInput,
   UpdateExternalAccountStatusInput,
   UpsertCounterpartyProviderAccountInput,
 } from "./counterparty-provider-account.repository";

--- a/apps/sdp-api/src/openapi/paths/counterparties.ts
+++ b/apps/sdp-api/src/openapi/paths/counterparties.ts
@@ -10,6 +10,7 @@ import {
   errorResponseSchema,
   listCounterpartiesQuerySchema,
   listCounterpartyAccountsQuerySchema,
+  listCounterpartyProviderAccountsQuerySchema,
   updateCounterpartyAccountRequestSchema,
   updateCounterpartyRequestSchema,
 } from "../schemas";
@@ -21,6 +22,7 @@ import {
   counterpartyResponse,
   listCounterpartiesResponse,
   listCounterpartyAccountsResponse,
+  listCounterpartyProviderAccountsResponse,
 } from "./responses";
 
 export function registerCounterpartyPaths(registry: OpenAPIRegistry) {
@@ -211,6 +213,31 @@ export function registerCounterpartyPaths(registry: OpenAPIRegistry) {
         content: jsonContent(listCounterpartyAccountsResponse),
       },
       ...errorResponses(errorResponseSchema, [400, 401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/counterparties/{counterpartyId}/provider-accounts",
+    tags: ["Counterparties"],
+    summary: "List counterparty provider accounts",
+    operationId: "listCounterpartyProviderAccounts",
+    description:
+      "Lists provider-owned fiat payout accounts for a counterparty. Provider details are fetched just in time and account numbers are returned only as last-four digits.",
+    security: [{ apiKeyAuth: [] }],
+    request: {
+      headers: projectScopeHeaders,
+      params: z.object({
+        counterpartyId: counterpartyIdParamSchema,
+      }),
+      query: listCounterpartyProviderAccountsQuerySchema,
+    },
+    responses: {
+      200: {
+        description: "Counterparty provider-account list",
+        content: jsonContent(listCounterpartyProviderAccountsResponse),
+      },
+      ...errorResponses(errorResponseSchema, [400, 401, 403, 404, 500, 503]),
     },
   });
 

--- a/apps/sdp-api/src/openapi/paths/responses.ts
+++ b/apps/sdp-api/src/openapi/paths/responses.ts
@@ -39,6 +39,7 @@ import {
   listAssetProfilesResponseSchema,
   listCounterpartiesResponseSchema,
   listCounterpartyAccountsResponseSchema,
+  listCounterpartyProviderAccountsResponseSchema,
   listMembersResponseSchema,
   listProjectApiKeysResponseSchema,
   listProjectMembersResponseSchema,
@@ -146,6 +147,9 @@ export const listCounterpartiesResponse = successResponseSchema(listCounterparti
 export const counterpartyAccountResponse = successResponseSchema(counterpartyAccountResponseSchema);
 export const listCounterpartyAccountsResponse = successResponseSchema(
   listCounterpartyAccountsResponseSchema
+);
+export const listCounterpartyProviderAccountsResponse = successResponseSchema(
+  listCounterpartyProviderAccountsResponseSchema
 );
 
 export const projectResponse = successResponseSchema(projectResponseSchema);

--- a/apps/sdp-api/src/openapi/schemas/counterparties.ts
+++ b/apps/sdp-api/src/openapi/schemas/counterparties.ts
@@ -15,6 +15,7 @@ import {
   listCounterpartyAccountsQuerySchema as listCounterpartyAccountsQuerySchemaBase,
   updateCounterpartyAccountObjectSchema as updateCounterpartyAccountSchemaBase,
 } from "../../routes/counterparty-accounts/schemas";
+import { listCounterpartyProviderAccountsQuerySchema as listCounterpartyProviderAccountsQuerySchemaBase } from "../../routes/counterparty-provider-accounts/schemas";
 import { rampDirectionSchema as rampDirectionSchemaBase } from "../../routes/payments/schemas";
 import {
   isoDateTimeSchema,
@@ -448,6 +449,86 @@ export const listCounterpartyAccountsQuerySchema = listCounterpartyAccountsQuery
     }),
   })
   .openapi({ description: "Counterparty account list filters." });
+
+export const counterpartyProviderAccountSchema = withOpenApi(
+  z.object({
+    id: withOpenApi(z.string(), {
+      description: "Counterparty provider-account row identifier.",
+      example: "counterparty_provider_account_example",
+    }),
+    provider: withOpenApi(z.enum(RAMP_PROVIDERS), {
+      description: "Ramp provider owning the account.",
+      example: "lightspark",
+    }),
+    fiatCurrency: withOpenApi(z.string(), {
+      description: "Fiat currency for the provider account corridor.",
+      example: "USD",
+    }),
+    destinationCountry: withOpenApi(z.enum(COUNTRY_CODES), {
+      description: "Destination country for the provider account corridor.",
+      example: "US",
+    }),
+    paymentRail: withOpenApi(z.string().nullable(), {
+      description: "Payment rail selected for the corridor row.",
+      example: "ACH",
+    }),
+    status: counterpartyAccountStatusSchema,
+    providerStatus: withOpenApi(z.string().nullable(), {
+      description: "Current provider-side account status when known.",
+      example: "ACTIVE",
+    }),
+    createdAt: withOpenApi(isoDateTimeSchema, {
+      description: "SDP row creation timestamp.",
+      example: "2025-01-01T00:00:00.000Z",
+    }),
+    bankName: withOpenApi(z.string().optional(), {
+      description: "Bank name returned by the provider when available.",
+      example: "Example Bank",
+    }),
+    accountNumberLast4: withOpenApi(z.string().optional(), {
+      description: "Last four digits of the provider account number.",
+      example: "6789",
+    }),
+    paymentRails: withOpenApi(z.array(z.string()).optional(), {
+      description: "Payment rails returned by the provider when available.",
+      example: ["ACH", "WIRE"],
+    }),
+  }),
+  { description: "Counterparty provider-account row with optional JIT provider details." }
+);
+
+export const listCounterpartyProviderAccountsResponseSchema = withOpenApi(
+  z.object({
+    accounts: withOpenApi(z.array(counterpartyProviderAccountSchema), {
+      description: "External provider accounts for the counterparty.",
+    }),
+  }),
+  { description: "Counterparty provider-account list." }
+);
+
+export const listCounterpartyProviderAccountsQuerySchema =
+  listCounterpartyProviderAccountsQuerySchemaBase
+    .extend({
+      provider: withOpenApi(listCounterpartyProviderAccountsQuerySchemaBase.shape.provider, {
+        description: "Filter by ramp provider.",
+        example: "lightspark",
+      }),
+      fiatCurrency: withOpenApi(
+        listCounterpartyProviderAccountsQuerySchemaBase.shape.fiatCurrency,
+        {
+          description: "Filter by fiat currency.",
+          example: "USD",
+        }
+      ),
+      destinationCountry: withOpenApi(
+        listCounterpartyProviderAccountsQuerySchemaBase.shape.destinationCountry,
+        {
+          description: "Filter by ISO 3166-1 alpha-2 destination country.",
+          example: "US",
+        }
+      ),
+    })
+    .openapi({ description: "Counterparty provider-account list filters." });
 
 const createCounterpartyDocFields = {
   externalId: withOpenApi(createCounterpartySchemaBase.shape.externalId, {

--- a/apps/sdp-api/src/routes/counterparties.test.ts
+++ b/apps/sdp-api/src/routes/counterparties.test.ts
@@ -1,6 +1,7 @@
 import { hashString } from "@sdp/payments/hash";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
+import { createPostgresCounterpartyProviderAccountsRepository } from "@/db/repositories";
 import app from "@/index";
 import { createKVStoreSet } from "@/runtime/kv-redis";
 import { TEST_API_KEY, TEST_CACHED_API_KEY } from "@/test/fixtures/api-keys";
@@ -122,6 +123,68 @@ describe("Counterparties Routes", () => {
       },
       env
     );
+
+  /**
+   * Inserts one provider-account fixture with explicit timestamps.
+   *
+   * @param input - Provider-account fixture values.
+   * @returns The inserted provider-account row.
+   */
+  async function seedProviderAccount(input: {
+    id: string;
+    counterpartyId: string;
+    provider: "lightspark" | "mural";
+    providerCustomerReference: string;
+    externalAccountReference: string | null;
+    fiatCurrency: string;
+    destinationCountry: "US" | "GB";
+    paymentRail: string;
+    providerStatus: string | null;
+    status: "active" | "archived";
+    createdAt: string;
+  }) {
+    const row = await getDb(env)
+      .prepare(
+        `INSERT INTO counterparty_provider_accounts (
+           id, organization_id, project_id, counterparty_id, provider,
+           provider_customer_reference, external_account_reference, fiat_currency,
+           destination_country, payment_rail, provider_status, status, metadata,
+           created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         RETURNING *`
+      )
+      .bind(
+        input.id,
+        TEST_ORG.id,
+        TEST_PROJECT_ID,
+        input.counterpartyId,
+        input.provider,
+        input.providerCustomerReference,
+        input.externalAccountReference,
+        input.fiatCurrency,
+        input.destinationCountry,
+        input.paymentRail,
+        input.providerStatus,
+        input.status,
+        JSON.stringify({}),
+        input.createdAt,
+        input.createdAt
+      )
+      .first<Record<string, unknown>>();
+    expect(row).not.toBeNull();
+    const repository = createPostgresCounterpartyProviderAccountsRepository(getDb(env));
+    const inserted = await repository.listProviderAccounts({
+      organizationId: TEST_ORG.id,
+      projectId: TEST_PROJECT_ID,
+      counterpartyId: input.counterpartyId,
+    });
+    const result = inserted.find((candidate) => candidate.id === input.id);
+    expect(result).toBeDefined();
+    if (result === undefined) {
+      throw new Error("Provider-account fixture was not inserted");
+    }
+    return result;
+  }
 
   describe("GET /v1/counterparties/metadata", () => {
     it("returns field options (enums + countries)", async () => {
@@ -596,6 +659,203 @@ describe("Counterparties Routes", () => {
       expect(res.status).toBe(400);
       const body = await res.json();
       expect(body.error.code).toBe("BAD_REQUEST");
+    });
+  });
+
+  describe("GET /v1/counterparties/:counterpartyId/provider-accounts", () => {
+    beforeEach(() => {
+      env.LIGHTSPARK_GRID_SANDBOX_CLIENT_ID = "lightspark_client_id";
+      env.LIGHTSPARK_GRID_SANDBOX_CLIENT_SECRET = "lightspark_client_secret";
+    });
+
+    afterEach(() => {
+      env.LIGHTSPARK_GRID_SANDBOX_CLIENT_ID = undefined;
+      env.LIGHTSPARK_GRID_SANDBOX_CLIENT_SECRET = undefined;
+      vi.restoreAllMocks();
+    });
+
+    it("lists scoped rows with grouped JIT enrichment, filters, and pending rows", async () => {
+      const created = await createCounterparty({ externalId: "provider_accounts_owner" });
+      const owner = (await created.json()).data.counterparty;
+      const otherCreated = await createCounterparty({ externalId: "provider_accounts_other" });
+      const other = (await otherCreated.json()).data.counterparty;
+
+      await seedProviderAccount({
+        id: "provider_account_usd_completed",
+        counterpartyId: owner.id,
+        provider: "lightspark",
+        providerCustomerReference: "Customer:owner",
+        externalAccountReference: "ExternalAccount:usd_completed",
+        fiatCurrency: "USD",
+        destinationCountry: "US",
+        paymentRail: "ACH",
+        providerStatus: "PENDING",
+        status: "active",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      });
+      await seedProviderAccount({
+        id: "provider_account_usd_pending",
+        counterpartyId: owner.id,
+        provider: "lightspark",
+        providerCustomerReference: "Customer:owner",
+        externalAccountReference: null,
+        fiatCurrency: "USD",
+        destinationCountry: "US",
+        paymentRail: "WIRE",
+        providerStatus: null,
+        status: "active",
+        createdAt: "2026-01-02T00:00:00.000Z",
+      });
+      await seedProviderAccount({
+        id: "provider_account_gbp_archived",
+        counterpartyId: owner.id,
+        provider: "mural",
+        providerCustomerReference: "mural_customer",
+        externalAccountReference: "mural_external",
+        fiatCurrency: "GBP",
+        destinationCountry: "GB",
+        paymentRail: "FPS",
+        providerStatus: "ACTIVE",
+        status: "archived",
+        createdAt: "2026-01-03T00:00:00.000Z",
+      });
+      await seedProviderAccount({
+        id: "provider_account_other_counterparty",
+        counterpartyId: other.id,
+        provider: "lightspark",
+        providerCustomerReference: "Customer:owner",
+        externalAccountReference: "ExternalAccount:other",
+        fiatCurrency: "USD",
+        destinationCountry: "US",
+        paymentRail: "ACH",
+        providerStatus: "ACTIVE",
+        status: "active",
+        createdAt: "2026-01-04T00:00:00.000Z",
+      });
+
+      const enrichmentPage = JSON.stringify({
+        data: [
+          {
+            platformAccountId: "provider_account_usd_completed",
+            status: "ACTIVE",
+            accountInfo: {
+              accountType: "USD_ACCOUNT",
+              paymentRails: ["ACH", "WIRE"],
+              bankName: "Example Bank",
+              accountNumber: "123456789",
+            },
+          },
+          {
+            platformAccountId: "provider_account_usd_pending",
+            status: "ACTIVE",
+            accountInfo: {
+              accountType: "USD_ACCOUNT",
+              paymentRails: ["ACH"],
+              bankName: "Should Stay Absent",
+              accountNumber: "999999999",
+            },
+          },
+        ],
+        hasMore: false,
+      });
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(() =>
+        Promise.resolve(
+          new Response(enrichmentPage, {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const response = await app.request(
+        `/v1/counterparties/${owner.id}/provider-accounts`,
+        { headers: { Authorization: authHeader } },
+        env
+      );
+
+      expect(response.status).toBe(200);
+      expect((await response.json()).data).toEqual({
+        accounts: [
+          {
+            id: "provider_account_usd_completed",
+            provider: "lightspark",
+            fiatCurrency: "USD",
+            destinationCountry: "US",
+            paymentRail: "ACH",
+            status: "active",
+            providerStatus: "ACTIVE",
+            createdAt: "2026-01-01T00:00:00.000Z",
+            bankName: "Example Bank",
+            accountNumberLast4: "6789",
+            paymentRails: ["ACH", "WIRE"],
+          },
+          {
+            id: "provider_account_usd_pending",
+            provider: "lightspark",
+            fiatCurrency: "USD",
+            destinationCountry: "US",
+            paymentRail: "WIRE",
+            status: "active",
+            providerStatus: null,
+            createdAt: "2026-01-02T00:00:00.000Z",
+          },
+          {
+            id: "provider_account_gbp_archived",
+            provider: "mural",
+            fiatCurrency: "GBP",
+            destinationCountry: "GB",
+            paymentRail: "FPS",
+            status: "archived",
+            providerStatus: "ACTIVE",
+            createdAt: "2026-01-03T00:00:00.000Z",
+          },
+        ],
+      });
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const requestUrl = new URL(String(fetchSpy.mock.calls[0][0]));
+      expect(requestUrl.searchParams.get("customerId")).toBe("Customer:owner");
+      expect(requestUrl.searchParams.get("currency")).toBe("USD");
+
+      const filtered = await app.request(
+        `/v1/counterparties/${owner.id}/provider-accounts?provider=lightspark&fiatCurrency=USD&destinationCountry=US`,
+        { headers: { Authorization: authHeader } },
+        env
+      );
+      expect(filtered.status).toBe(200);
+      const filteredBody = await filtered.json();
+      expect(filteredBody.data.accounts.map((account: { id: string }) => account.id)).toEqual([
+        "provider_account_usd_completed",
+        "provider_account_usd_pending",
+      ]);
+    });
+
+    it("returns 503 when Grid enrichment fails", async () => {
+      const created = await createCounterparty({ externalId: "provider_accounts_failure" });
+      const owner = (await created.json()).data.counterparty;
+      await seedProviderAccount({
+        id: "provider_account_failure",
+        counterpartyId: owner.id,
+        provider: "lightspark",
+        providerCustomerReference: "Customer:failure",
+        externalAccountReference: "ExternalAccount:failure",
+        fiatCurrency: "USD",
+        destinationCountry: "US",
+        paymentRail: "ACH",
+        providerStatus: "PENDING",
+        status: "active",
+        createdAt: "2026-02-01T00:00:00.000Z",
+      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ message: "Grid unavailable" }), { status: 503 })
+      );
+
+      const response = await app.request(
+        `/v1/counterparties/${owner.id}/provider-accounts`,
+        { headers: { Authorization: authHeader } },
+        env
+      );
+
+      expect(response.status).toBe(503);
     });
   });
 

--- a/apps/sdp-api/src/routes/counterparties/index.ts
+++ b/apps/sdp-api/src/routes/counterparties/index.ts
@@ -5,6 +5,7 @@ import { validateBody } from "@/middleware/validate";
 import { submitCounterpartyRequirementsSchema } from "@/routes/payments/schemas";
 import type { Env } from "@/types/env";
 import counterpartyAccounts from "../counterparty-accounts";
+import counterpartyProviderAccounts from "../counterparty-provider-accounts";
 import {
   archiveCounterparty,
   createCounterparty,
@@ -65,5 +66,6 @@ counterparties.delete(
 );
 
 counterparties.route("/:counterpartyId/accounts", counterpartyAccounts);
+counterparties.route("/:counterpartyId/provider-accounts", counterpartyProviderAccounts);
 
 export default counterparties;

--- a/apps/sdp-api/src/routes/counterparty-provider-accounts/context.ts
+++ b/apps/sdp-api/src/routes/counterparty-provider-accounts/context.ts
@@ -1,0 +1,13 @@
+import { getDb } from "@/db";
+import { createPostgresCounterpartyProviderAccountsRepository } from "@/db/repositories";
+import type { AppContext } from "../counterparties/context";
+
+/**
+ * Creates the provider-account repository scoped to the current request tenant.
+ *
+ * @param c - Authenticated request context.
+ * @returns Tenant-scoped provider-account repository.
+ */
+export function getCounterpartyProviderAccountsRepository(c: AppContext) {
+  return createPostgresCounterpartyProviderAccountsRepository(getDb(c.env));
+}

--- a/apps/sdp-api/src/routes/counterparty-provider-accounts/handlers.ts
+++ b/apps/sdp-api/src/routes/counterparty-provider-accounts/handlers.ts
@@ -1,0 +1,102 @@
+import type { RampExternalAccountDetails } from "@sdp/payments/ramps/types";
+import type {
+  CounterpartyProviderAccount,
+  ListCounterpartyProviderAccountsResponse,
+} from "@sdp/types";
+import { z } from "zod";
+import type { CounterpartyProviderAccountRow } from "@/db/repositories/counterparty-provider-account.repository";
+import { getAuth, requireProjectId } from "@/lib/auth";
+import { badRequestParams, badRequestQuery, internalError, notFound } from "@/lib/errors";
+import { success } from "@/lib/response";
+import { rampRuntime } from "@/routes/payments/context";
+import { enrichCounterpartyProviderAccounts } from "@/services/payments/provider-account-enrichment";
+import type { AppContext } from "../counterparties/context";
+import { getCounterpartiesRepository } from "../counterparties/context";
+import { getCounterpartyProviderAccountsRepository } from "./context";
+import {
+  counterpartyProviderAccountParamsSchema,
+  listCounterpartyProviderAccountsQuerySchema,
+} from "./schemas";
+
+/**
+ * Lists parent-scoped provider accounts with just-in-time provider enrichment.
+ *
+ * @param c - Authenticated request context.
+ * @returns Provider-account rows in the standard success envelope.
+ */
+export const listCounterpartyProviderAccounts = async (c: AppContext) => {
+  const auth = getAuth(c);
+  const projectId = requireProjectId(c);
+  const params = counterpartyProviderAccountParamsSchema.safeParse(c.req.param());
+  if (!params.success) {
+    throw badRequestParams();
+  }
+
+  const query = listCounterpartyProviderAccountsQuerySchema.safeParse(c.req.query());
+  if (!query.success) {
+    throw badRequestQuery({ errors: z.treeifyError(query.error) });
+  }
+
+  const counterparty = await getCounterpartiesRepository(c).getCounterpartyById({
+    counterpartyId: params.data.counterpartyId,
+    organizationId: auth.organizationId,
+    projectId,
+  });
+  if (!counterparty) {
+    throw notFound("Counterparty");
+  }
+
+  const rows = await getCounterpartyProviderAccountsRepository(c).listProviderAccounts({
+    organizationId: auth.organizationId,
+    projectId,
+    counterpartyId: counterparty.id,
+    ...query.data,
+  });
+  const enriched = await enrichCounterpartyProviderAccounts(rampRuntime(c), rows);
+
+  const response: ListCounterpartyProviderAccountsResponse = {
+    accounts: rows.map((row) => mapProviderAccount(row, enriched)),
+  };
+  return success(c, response);
+};
+
+/**
+ * Maps a database row and optional JIT details into the public provider-account shape.
+ *
+ * @param row - Parent-scoped provider-account row.
+ * @param enriched - Sanitized provider details indexed by row id.
+ * @returns Public provider-account response row.
+ */
+function mapProviderAccount(
+  row: CounterpartyProviderAccountRow,
+  enriched: ReadonlyMap<string, RampExternalAccountDetails>
+): CounterpartyProviderAccount {
+  if (row.fiat_currency === null || row.destination_country === null) {
+    throw internalError("External provider-account row is missing corridor data.");
+  }
+
+  const detail = enriched.get(row.id);
+  const result: CounterpartyProviderAccount = {
+    id: row.id,
+    provider: row.provider,
+    fiatCurrency: row.fiat_currency,
+    destinationCountry: row.destination_country,
+    paymentRail: row.payment_rail,
+    status: row.status,
+    providerStatus: row.provider_status,
+    createdAt: row.created_at,
+  };
+
+  if (detail !== undefined) {
+    result.providerStatus = detail.providerStatus;
+    if (detail.bankName !== undefined) {
+      result.bankName = detail.bankName;
+    }
+    if (detail.accountNumberLast4 !== undefined) {
+      result.accountNumberLast4 = detail.accountNumberLast4;
+    }
+    result.paymentRails = detail.paymentRails;
+  }
+
+  return result;
+}

--- a/apps/sdp-api/src/routes/counterparty-provider-accounts/index.ts
+++ b/apps/sdp-api/src/routes/counterparty-provider-accounts/index.ts
@@ -1,0 +1,14 @@
+import { Hono } from "hono";
+import { requirePermissions } from "@/middleware/auth";
+import type { Env } from "@/types/env";
+import { listCounterpartyProviderAccounts } from "./handlers";
+
+const counterpartyProviderAccounts = new Hono<{ Bindings: Env }>();
+
+counterpartyProviderAccounts.get(
+  "/",
+  requirePermissions("counterparties:read"),
+  listCounterpartyProviderAccounts
+);
+
+export default counterpartyProviderAccounts;

--- a/apps/sdp-api/src/routes/counterparty-provider-accounts/schemas.ts
+++ b/apps/sdp-api/src/routes/counterparty-provider-accounts/schemas.ts
@@ -1,0 +1,13 @@
+import { COUNTRY_CODES } from "@sdp/types";
+import { RAMP_PROVIDERS } from "@sdp/types/provider-access";
+import { z } from "zod";
+
+export const counterpartyProviderAccountParamsSchema = z.object({
+  counterpartyId: z.string().min(1),
+});
+
+export const listCounterpartyProviderAccountsQuerySchema = z.object({
+  provider: z.enum(RAMP_PROVIDERS).optional(),
+  fiatCurrency: z.string().min(1).optional(),
+  destinationCountry: z.enum(COUNTRY_CODES).optional(),
+});

--- a/apps/sdp-api/src/services/payments/provider-account-enrichment.ts
+++ b/apps/sdp-api/src/services/payments/provider-account-enrichment.ts
@@ -1,0 +1,129 @@
+import { RAMP_PROVIDER_CLIENTS } from "@sdp/payments/ramps";
+import type {
+  RampExternalAccountDetails,
+  RampProvider,
+  RampRuntimeContext,
+} from "@sdp/payments/ramps/types";
+import type { RampProviderId } from "@sdp/types/provider-access";
+import type { CounterpartyProviderAccountRow } from "@/db/repositories/counterparty-provider-account.repository";
+import { mapSettledWithConcurrency } from "@/lib/concurrency";
+import { internalError, serviceUnavailable } from "@/lib/errors";
+import { describeError, logEvent } from "@/runtime/money-path-events";
+
+const ENRICHMENT_GROUP_CONCURRENCY = 4;
+
+interface ProviderAccountGroup {
+  counterpartyId: string;
+  provider: RampProviderId;
+  fiatCurrency: string;
+  providerCustomerReference: string;
+  rowIds: Set<string>;
+}
+
+/**
+ * Fetches just-in-time external account details once per provider, currency,
+ * and provider customer reference group.
+ *
+ * @param runtime - Provider runtime context (env and environment mode).
+ * @param rows - Parent-scoped external provider-account rows.
+ * @returns Sanitized provider details indexed by SDP row id.
+ */
+export async function enrichCounterpartyProviderAccounts(
+  runtime: RampRuntimeContext,
+  rows: readonly CounterpartyProviderAccountRow[]
+): Promise<Map<string, RampExternalAccountDetails>> {
+  const groups = [...groupProviderAccounts(rows).values()];
+  const enriched = new Map<string, RampExternalAccountDetails>();
+
+  const settled = await mapSettledWithConcurrency(
+    groups,
+    ENRICHMENT_GROUP_CONCURRENCY,
+    async (group) => ({ group, details: await fetchGroupDetails(runtime, group) })
+  );
+
+  for (const [index, result] of settled.entries()) {
+    if (result.status === "rejected") {
+      const group = groups[index];
+      logEvent("error", {
+        event: "sdp_api_counterparty_provider_account_enrichment_failed",
+        provider: group.provider,
+        counterparty_id: group.counterpartyId,
+        row_ids: [...group.rowIds],
+        ...describeError(result.reason),
+      });
+      throw serviceUnavailable("Counterparty provider-account enrichment failed.");
+    }
+    for (const detail of result.value.details) {
+      if (!result.value.group.rowIds.has(detail.platformAccountId)) {
+        continue;
+      }
+      if (enriched.has(detail.platformAccountId)) {
+        throw internalError("Provider returned duplicate external-account platform ids.");
+      }
+      enriched.set(detail.platformAccountId, detail);
+    }
+  }
+
+  return enriched;
+}
+
+/**
+ * Fetches sanitized details for one enrichment group when the provider
+ * supports the capability.
+ *
+ * @param runtime - Provider runtime context.
+ * @param group - Rows sharing one provider, currency, and customer reference.
+ * @returns Provider details, or none when the provider lacks the capability.
+ */
+async function fetchGroupDetails(
+  runtime: RampRuntimeContext,
+  group: ProviderAccountGroup
+): Promise<RampExternalAccountDetails[]> {
+  const provider: RampProvider = RAMP_PROVIDER_CLIENTS[group.provider];
+  if (provider.listExternalAccountDetails === undefined) {
+    return [];
+  }
+  return provider.listExternalAccountDetails(runtime, {
+    providerCustomerReference: group.providerCustomerReference,
+    fiatCurrency: group.fiatCurrency,
+  });
+}
+
+/**
+ * Groups completed rows by provider, fiat currency, and customer reference so
+ * rows that drifted to a new provider customer are enriched against their own
+ * reference instead of failing the read.
+ *
+ * @param rows - External provider-account rows to group.
+ * @returns Groups keyed by provider, fiat currency, and customer reference.
+ */
+function groupProviderAccounts(
+  rows: readonly CounterpartyProviderAccountRow[]
+): Map<string, ProviderAccountGroup> {
+  const groups = new Map<string, ProviderAccountGroup>();
+
+  for (const row of rows) {
+    if (row.fiat_currency === null) {
+      throw internalError("External provider-account row is missing fiat currency.");
+    }
+    if (row.external_account_reference === null) {
+      continue;
+    }
+
+    const key = `${row.provider}:${row.fiat_currency}:${row.provider_customer_reference}`;
+    const group = groups.get(key);
+    if (group === undefined) {
+      groups.set(key, {
+        counterpartyId: row.counterparty_id,
+        provider: row.provider,
+        fiatCurrency: row.fiat_currency,
+        providerCustomerReference: row.provider_customer_reference,
+        rowIds: new Set([row.id]),
+      });
+      continue;
+    }
+    group.rowIds.add(row.id);
+  }
+
+  return groups;
+}

--- a/apps/sdp-web/src/lib/api-playground-catalog.generated.json
+++ b/apps/sdp-web/src/lib/api-playground-catalog.generated.json
@@ -5,7 +5,7 @@
     "modules": {
       "wallets": 19,
       "payments": 38,
-      "counterparties": 12,
+      "counterparties": 13,
       "issuance": 46
     }
   },
@@ -6425,6 +6425,1097 @@
               "createdAt": "2025-01-01T00:00:00.000Z",
               "updatedAt": "2025-01-02T00:00:00.000Z"
             }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "list-counterparty-provider-accounts",
+        "operationId": "listCounterpartyProviderAccounts",
+        "title": "List counterparty provider accounts",
+        "method": "GET",
+        "path": "/v1/counterparties/{counterpartyId}/provider-accounts?provider={provider}&fiatCurrency={fiatCurrency}&destinationCountry={destinationCountry}",
+        "pathFields": [
+          {
+            "key": "counterpartyId",
+            "label": "{counterpartyId}",
+            "description": "Counterparty identifier.",
+            "defaultValue": "cpty_example",
+            "required": true
+          },
+          {
+            "key": "provider",
+            "label": "provider",
+            "description": "Filter by ramp provider.",
+            "defaultValue": "lightspark",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "moonpay",
+                "value": "moonpay"
+              },
+              {
+                "label": "lightspark",
+                "value": "lightspark"
+              },
+              {
+                "label": "bvnk",
+                "value": "bvnk"
+              },
+              {
+                "label": "moneygram",
+                "value": "moneygram"
+              },
+              {
+                "label": "coinbase",
+                "value": "coinbase"
+              },
+              {
+                "label": "mural",
+                "value": "mural"
+              },
+              {
+                "label": "stripe",
+                "value": "stripe"
+              }
+            ]
+          },
+          {
+            "key": "fiatCurrency",
+            "label": "fiatCurrency",
+            "description": "Filter by fiat currency.",
+            "defaultValue": "USD",
+            "required": false
+          },
+          {
+            "key": "destinationCountry",
+            "label": "destinationCountry",
+            "description": "Filter by ISO 3166-1 alpha-2 destination country.",
+            "defaultValue": "US",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "AF",
+                "value": "AF"
+              },
+              {
+                "label": "AX",
+                "value": "AX"
+              },
+              {
+                "label": "AL",
+                "value": "AL"
+              },
+              {
+                "label": "DZ",
+                "value": "DZ"
+              },
+              {
+                "label": "AS",
+                "value": "AS"
+              },
+              {
+                "label": "AD",
+                "value": "AD"
+              },
+              {
+                "label": "AO",
+                "value": "AO"
+              },
+              {
+                "label": "AI",
+                "value": "AI"
+              },
+              {
+                "label": "AQ",
+                "value": "AQ"
+              },
+              {
+                "label": "AG",
+                "value": "AG"
+              },
+              {
+                "label": "AR",
+                "value": "AR"
+              },
+              {
+                "label": "AM",
+                "value": "AM"
+              },
+              {
+                "label": "AW",
+                "value": "AW"
+              },
+              {
+                "label": "AU",
+                "value": "AU"
+              },
+              {
+                "label": "AT",
+                "value": "AT"
+              },
+              {
+                "label": "AZ",
+                "value": "AZ"
+              },
+              {
+                "label": "BS",
+                "value": "BS"
+              },
+              {
+                "label": "BH",
+                "value": "BH"
+              },
+              {
+                "label": "BD",
+                "value": "BD"
+              },
+              {
+                "label": "BB",
+                "value": "BB"
+              },
+              {
+                "label": "BY",
+                "value": "BY"
+              },
+              {
+                "label": "BE",
+                "value": "BE"
+              },
+              {
+                "label": "BZ",
+                "value": "BZ"
+              },
+              {
+                "label": "BJ",
+                "value": "BJ"
+              },
+              {
+                "label": "BM",
+                "value": "BM"
+              },
+              {
+                "label": "BT",
+                "value": "BT"
+              },
+              {
+                "label": "BO",
+                "value": "BO"
+              },
+              {
+                "label": "BA",
+                "value": "BA"
+              },
+              {
+                "label": "BW",
+                "value": "BW"
+              },
+              {
+                "label": "BV",
+                "value": "BV"
+              },
+              {
+                "label": "BR",
+                "value": "BR"
+              },
+              {
+                "label": "IO",
+                "value": "IO"
+              },
+              {
+                "label": "VG",
+                "value": "VG"
+              },
+              {
+                "label": "BN",
+                "value": "BN"
+              },
+              {
+                "label": "BG",
+                "value": "BG"
+              },
+              {
+                "label": "BF",
+                "value": "BF"
+              },
+              {
+                "label": "BI",
+                "value": "BI"
+              },
+              {
+                "label": "KH",
+                "value": "KH"
+              },
+              {
+                "label": "CM",
+                "value": "CM"
+              },
+              {
+                "label": "CA",
+                "value": "CA"
+              },
+              {
+                "label": "CV",
+                "value": "CV"
+              },
+              {
+                "label": "BQ",
+                "value": "BQ"
+              },
+              {
+                "label": "KY",
+                "value": "KY"
+              },
+              {
+                "label": "CF",
+                "value": "CF"
+              },
+              {
+                "label": "TD",
+                "value": "TD"
+              },
+              {
+                "label": "CL",
+                "value": "CL"
+              },
+              {
+                "label": "CN",
+                "value": "CN"
+              },
+              {
+                "label": "CX",
+                "value": "CX"
+              },
+              {
+                "label": "CC",
+                "value": "CC"
+              },
+              {
+                "label": "CO",
+                "value": "CO"
+              },
+              {
+                "label": "KM",
+                "value": "KM"
+              },
+              {
+                "label": "CG",
+                "value": "CG"
+              },
+              {
+                "label": "CD",
+                "value": "CD"
+              },
+              {
+                "label": "CK",
+                "value": "CK"
+              },
+              {
+                "label": "CR",
+                "value": "CR"
+              },
+              {
+                "label": "CI",
+                "value": "CI"
+              },
+              {
+                "label": "HR",
+                "value": "HR"
+              },
+              {
+                "label": "CU",
+                "value": "CU"
+              },
+              {
+                "label": "CW",
+                "value": "CW"
+              },
+              {
+                "label": "CY",
+                "value": "CY"
+              },
+              {
+                "label": "CZ",
+                "value": "CZ"
+              },
+              {
+                "label": "DK",
+                "value": "DK"
+              },
+              {
+                "label": "DJ",
+                "value": "DJ"
+              },
+              {
+                "label": "DM",
+                "value": "DM"
+              },
+              {
+                "label": "DO",
+                "value": "DO"
+              },
+              {
+                "label": "EC",
+                "value": "EC"
+              },
+              {
+                "label": "EG",
+                "value": "EG"
+              },
+              {
+                "label": "SV",
+                "value": "SV"
+              },
+              {
+                "label": "GQ",
+                "value": "GQ"
+              },
+              {
+                "label": "ER",
+                "value": "ER"
+              },
+              {
+                "label": "EE",
+                "value": "EE"
+              },
+              {
+                "label": "SZ",
+                "value": "SZ"
+              },
+              {
+                "label": "ET",
+                "value": "ET"
+              },
+              {
+                "label": "FK",
+                "value": "FK"
+              },
+              {
+                "label": "FO",
+                "value": "FO"
+              },
+              {
+                "label": "FJ",
+                "value": "FJ"
+              },
+              {
+                "label": "FI",
+                "value": "FI"
+              },
+              {
+                "label": "FR",
+                "value": "FR"
+              },
+              {
+                "label": "GF",
+                "value": "GF"
+              },
+              {
+                "label": "PF",
+                "value": "PF"
+              },
+              {
+                "label": "TF",
+                "value": "TF"
+              },
+              {
+                "label": "GA",
+                "value": "GA"
+              },
+              {
+                "label": "GM",
+                "value": "GM"
+              },
+              {
+                "label": "GE",
+                "value": "GE"
+              },
+              {
+                "label": "DE",
+                "value": "DE"
+              },
+              {
+                "label": "GH",
+                "value": "GH"
+              },
+              {
+                "label": "GI",
+                "value": "GI"
+              },
+              {
+                "label": "GR",
+                "value": "GR"
+              },
+              {
+                "label": "GL",
+                "value": "GL"
+              },
+              {
+                "label": "GD",
+                "value": "GD"
+              },
+              {
+                "label": "GP",
+                "value": "GP"
+              },
+              {
+                "label": "GU",
+                "value": "GU"
+              },
+              {
+                "label": "GT",
+                "value": "GT"
+              },
+              {
+                "label": "GG",
+                "value": "GG"
+              },
+              {
+                "label": "GN",
+                "value": "GN"
+              },
+              {
+                "label": "GW",
+                "value": "GW"
+              },
+              {
+                "label": "GY",
+                "value": "GY"
+              },
+              {
+                "label": "HT",
+                "value": "HT"
+              },
+              {
+                "label": "HM",
+                "value": "HM"
+              },
+              {
+                "label": "HN",
+                "value": "HN"
+              },
+              {
+                "label": "HK",
+                "value": "HK"
+              },
+              {
+                "label": "HU",
+                "value": "HU"
+              },
+              {
+                "label": "IS",
+                "value": "IS"
+              },
+              {
+                "label": "IN",
+                "value": "IN"
+              },
+              {
+                "label": "ID",
+                "value": "ID"
+              },
+              {
+                "label": "IR",
+                "value": "IR"
+              },
+              {
+                "label": "IQ",
+                "value": "IQ"
+              },
+              {
+                "label": "IE",
+                "value": "IE"
+              },
+              {
+                "label": "IM",
+                "value": "IM"
+              },
+              {
+                "label": "IL",
+                "value": "IL"
+              },
+              {
+                "label": "IT",
+                "value": "IT"
+              },
+              {
+                "label": "JM",
+                "value": "JM"
+              },
+              {
+                "label": "JP",
+                "value": "JP"
+              },
+              {
+                "label": "JE",
+                "value": "JE"
+              },
+              {
+                "label": "JO",
+                "value": "JO"
+              },
+              {
+                "label": "KZ",
+                "value": "KZ"
+              },
+              {
+                "label": "KE",
+                "value": "KE"
+              },
+              {
+                "label": "KI",
+                "value": "KI"
+              },
+              {
+                "label": "KW",
+                "value": "KW"
+              },
+              {
+                "label": "KG",
+                "value": "KG"
+              },
+              {
+                "label": "LA",
+                "value": "LA"
+              },
+              {
+                "label": "LV",
+                "value": "LV"
+              },
+              {
+                "label": "LB",
+                "value": "LB"
+              },
+              {
+                "label": "LS",
+                "value": "LS"
+              },
+              {
+                "label": "LR",
+                "value": "LR"
+              },
+              {
+                "label": "LY",
+                "value": "LY"
+              },
+              {
+                "label": "LI",
+                "value": "LI"
+              },
+              {
+                "label": "LT",
+                "value": "LT"
+              },
+              {
+                "label": "LU",
+                "value": "LU"
+              },
+              {
+                "label": "MO",
+                "value": "MO"
+              },
+              {
+                "label": "MG",
+                "value": "MG"
+              },
+              {
+                "label": "MW",
+                "value": "MW"
+              },
+              {
+                "label": "MY",
+                "value": "MY"
+              },
+              {
+                "label": "MV",
+                "value": "MV"
+              },
+              {
+                "label": "ML",
+                "value": "ML"
+              },
+              {
+                "label": "MT",
+                "value": "MT"
+              },
+              {
+                "label": "MH",
+                "value": "MH"
+              },
+              {
+                "label": "MQ",
+                "value": "MQ"
+              },
+              {
+                "label": "MR",
+                "value": "MR"
+              },
+              {
+                "label": "MU",
+                "value": "MU"
+              },
+              {
+                "label": "YT",
+                "value": "YT"
+              },
+              {
+                "label": "MX",
+                "value": "MX"
+              },
+              {
+                "label": "FM",
+                "value": "FM"
+              },
+              {
+                "label": "MD",
+                "value": "MD"
+              },
+              {
+                "label": "MC",
+                "value": "MC"
+              },
+              {
+                "label": "MN",
+                "value": "MN"
+              },
+              {
+                "label": "ME",
+                "value": "ME"
+              },
+              {
+                "label": "MS",
+                "value": "MS"
+              },
+              {
+                "label": "MA",
+                "value": "MA"
+              },
+              {
+                "label": "MZ",
+                "value": "MZ"
+              },
+              {
+                "label": "MM",
+                "value": "MM"
+              },
+              {
+                "label": "NA",
+                "value": "NA"
+              },
+              {
+                "label": "NR",
+                "value": "NR"
+              },
+              {
+                "label": "NP",
+                "value": "NP"
+              },
+              {
+                "label": "NL",
+                "value": "NL"
+              },
+              {
+                "label": "NC",
+                "value": "NC"
+              },
+              {
+                "label": "NZ",
+                "value": "NZ"
+              },
+              {
+                "label": "NI",
+                "value": "NI"
+              },
+              {
+                "label": "NE",
+                "value": "NE"
+              },
+              {
+                "label": "NG",
+                "value": "NG"
+              },
+              {
+                "label": "NU",
+                "value": "NU"
+              },
+              {
+                "label": "NF",
+                "value": "NF"
+              },
+              {
+                "label": "KP",
+                "value": "KP"
+              },
+              {
+                "label": "MK",
+                "value": "MK"
+              },
+              {
+                "label": "MP",
+                "value": "MP"
+              },
+              {
+                "label": "NO",
+                "value": "NO"
+              },
+              {
+                "label": "OM",
+                "value": "OM"
+              },
+              {
+                "label": "PK",
+                "value": "PK"
+              },
+              {
+                "label": "PW",
+                "value": "PW"
+              },
+              {
+                "label": "PS",
+                "value": "PS"
+              },
+              {
+                "label": "PA",
+                "value": "PA"
+              },
+              {
+                "label": "PG",
+                "value": "PG"
+              },
+              {
+                "label": "PY",
+                "value": "PY"
+              },
+              {
+                "label": "PE",
+                "value": "PE"
+              },
+              {
+                "label": "PH",
+                "value": "PH"
+              },
+              {
+                "label": "PN",
+                "value": "PN"
+              },
+              {
+                "label": "PL",
+                "value": "PL"
+              },
+              {
+                "label": "PT",
+                "value": "PT"
+              },
+              {
+                "label": "PR",
+                "value": "PR"
+              },
+              {
+                "label": "QA",
+                "value": "QA"
+              },
+              {
+                "label": "RE",
+                "value": "RE"
+              },
+              {
+                "label": "RO",
+                "value": "RO"
+              },
+              {
+                "label": "RU",
+                "value": "RU"
+              },
+              {
+                "label": "RW",
+                "value": "RW"
+              },
+              {
+                "label": "WS",
+                "value": "WS"
+              },
+              {
+                "label": "SM",
+                "value": "SM"
+              },
+              {
+                "label": "ST",
+                "value": "ST"
+              },
+              {
+                "label": "SA",
+                "value": "SA"
+              },
+              {
+                "label": "SN",
+                "value": "SN"
+              },
+              {
+                "label": "RS",
+                "value": "RS"
+              },
+              {
+                "label": "SC",
+                "value": "SC"
+              },
+              {
+                "label": "SL",
+                "value": "SL"
+              },
+              {
+                "label": "SG",
+                "value": "SG"
+              },
+              {
+                "label": "SX",
+                "value": "SX"
+              },
+              {
+                "label": "SK",
+                "value": "SK"
+              },
+              {
+                "label": "SI",
+                "value": "SI"
+              },
+              {
+                "label": "SB",
+                "value": "SB"
+              },
+              {
+                "label": "SO",
+                "value": "SO"
+              },
+              {
+                "label": "ZA",
+                "value": "ZA"
+              },
+              {
+                "label": "GS",
+                "value": "GS"
+              },
+              {
+                "label": "KR",
+                "value": "KR"
+              },
+              {
+                "label": "SS",
+                "value": "SS"
+              },
+              {
+                "label": "ES",
+                "value": "ES"
+              },
+              {
+                "label": "LK",
+                "value": "LK"
+              },
+              {
+                "label": "BL",
+                "value": "BL"
+              },
+              {
+                "label": "SH",
+                "value": "SH"
+              },
+              {
+                "label": "KN",
+                "value": "KN"
+              },
+              {
+                "label": "LC",
+                "value": "LC"
+              },
+              {
+                "label": "MF",
+                "value": "MF"
+              },
+              {
+                "label": "PM",
+                "value": "PM"
+              },
+              {
+                "label": "VC",
+                "value": "VC"
+              },
+              {
+                "label": "SD",
+                "value": "SD"
+              },
+              {
+                "label": "SR",
+                "value": "SR"
+              },
+              {
+                "label": "SJ",
+                "value": "SJ"
+              },
+              {
+                "label": "SE",
+                "value": "SE"
+              },
+              {
+                "label": "CH",
+                "value": "CH"
+              },
+              {
+                "label": "SY",
+                "value": "SY"
+              },
+              {
+                "label": "TW",
+                "value": "TW"
+              },
+              {
+                "label": "TJ",
+                "value": "TJ"
+              },
+              {
+                "label": "TZ",
+                "value": "TZ"
+              },
+              {
+                "label": "TH",
+                "value": "TH"
+              },
+              {
+                "label": "TL",
+                "value": "TL"
+              },
+              {
+                "label": "TG",
+                "value": "TG"
+              },
+              {
+                "label": "TK",
+                "value": "TK"
+              },
+              {
+                "label": "TO",
+                "value": "TO"
+              },
+              {
+                "label": "TT",
+                "value": "TT"
+              },
+              {
+                "label": "TN",
+                "value": "TN"
+              },
+              {
+                "label": "TR",
+                "value": "TR"
+              },
+              {
+                "label": "TM",
+                "value": "TM"
+              },
+              {
+                "label": "TC",
+                "value": "TC"
+              },
+              {
+                "label": "TV",
+                "value": "TV"
+              },
+              {
+                "label": "UM",
+                "value": "UM"
+              },
+              {
+                "label": "VI",
+                "value": "VI"
+              },
+              {
+                "label": "UG",
+                "value": "UG"
+              },
+              {
+                "label": "UA",
+                "value": "UA"
+              },
+              {
+                "label": "AE",
+                "value": "AE"
+              },
+              {
+                "label": "GB",
+                "value": "GB"
+              },
+              {
+                "label": "US",
+                "value": "US"
+              },
+              {
+                "label": "UY",
+                "value": "UY"
+              },
+              {
+                "label": "UZ",
+                "value": "UZ"
+              },
+              {
+                "label": "VU",
+                "value": "VU"
+              },
+              {
+                "label": "VA",
+                "value": "VA"
+              },
+              {
+                "label": "VE",
+                "value": "VE"
+              },
+              {
+                "label": "VN",
+                "value": "VN"
+              },
+              {
+                "label": "WF",
+                "value": "WF"
+              },
+              {
+                "label": "EH",
+                "value": "EH"
+              },
+              {
+                "label": "YE",
+                "value": "YE"
+              },
+              {
+                "label": "ZM",
+                "value": "ZM"
+              },
+              {
+                "label": "ZW",
+                "value": "ZW"
+              }
+            ]
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "accounts": [
+              {
+                "id": "counterparty_provider_account_example",
+                "provider": "lightspark",
+                "fiatCurrency": "USD",
+                "destinationCountry": "US",
+                "paymentRail": "ACH",
+                "status": "active",
+                "providerStatus": "ACTIVE",
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "bankName": "Example Bank",
+                "accountNumberLast4": "6789",
+                "paymentRails": ["ACH", "WIRE"]
+              }
+            ]
           },
           "meta": {
             "requestId": "req_example",

--- a/packages/sdp-payments/src/ramps/index.ts
+++ b/packages/sdp-payments/src/ramps/index.ts
@@ -22,6 +22,7 @@ export type {
   RampDiscoveryContext,
   RampDiscoveryResponseDump,
   RampDumpWriter,
+  RampExternalAccountDetails,
   RampFetchJson,
   RampProvider,
   RampRawDumpReader,

--- a/packages/sdp-payments/src/ramps/providers/lightspark/client.test.ts
+++ b/packages/sdp-payments/src/ramps/providers/lightspark/client.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { LightsparkRampClient } from "./client";
+
+const runtimeContext = {
+  env: {
+    LIGHTSPARK_GRID_SANDBOX_CLIENT_ID: "client_id",
+    LIGHTSPARK_GRID_SANDBOX_CLIENT_SECRET: "client_secret",
+  },
+  mode: "sandbox",
+} as const;
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("LightsparkRampClient.listExternalAccountDetails", () => {
+  it("maps Grid accounts and exposes only the account-number last four digits", async () => {
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              id: "ExternalAccount:grid_123",
+              customerId: "Customer:customer_123",
+              platformAccountId: "counterparty_provider_account_123",
+              currency: "USD",
+              status: "ACTIVE",
+              accountInfo: {
+                accountType: "USD_ACCOUNT",
+                paymentRails: ["ACH", "SWIFT"],
+                bankName: "Example Bank",
+                accountNumber: "123456789",
+                swiftCode: "EXAMPLEUS",
+                country: "US",
+                beneficiary: { name: "Example" },
+              },
+            },
+          ],
+          hasMore: false,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+
+    const details = await new LightsparkRampClient().listExternalAccountDetails(runtimeContext, {
+      providerCustomerReference: "Customer:customer_123",
+      fiatCurrency: "USD",
+    });
+
+    assert.deepEqual(details, [
+      {
+        platformAccountId: "counterparty_provider_account_123",
+        providerStatus: "ACTIVE",
+        bankName: "Example Bank",
+        accountNumberLast4: "6789",
+        paymentRails: ["ACH", "SWIFT"],
+      },
+    ]);
+  });
+});

--- a/packages/sdp-payments/src/ramps/providers/lightspark/client.ts
+++ b/packages/sdp-payments/src/ramps/providers/lightspark/client.ts
@@ -14,6 +14,7 @@ import {
 import { type CryptoAssetSymbol, getCryptoRailAssetLabel } from "@sdp/types/payment-rails";
 import type { CounterpartyRequirements } from "@sdp/types/ramp-requirements";
 import { isAddress } from "@solana/addresses";
+import { z } from "zod";
 import { divideDecimalAmounts } from "../../../decimal";
 import {
   badRequest,
@@ -29,6 +30,7 @@ import type {
   RampDiscoveryContext,
   RampEstimateOfframpInput,
   RampEstimateOnrampInput,
+  RampExternalAccountDetails,
   RampOfframpQuoteInput,
   RampOnrampQuoteInput,
   RampProvider,
@@ -158,41 +160,67 @@ function readRequiredGridString(
   return value.trim();
 }
 
-/**
- * Reads payment rails from a provider account payload.
- *
- * @param value - Untrusted payment-rails payload value.
- * @returns The provider payment rails, or undefined when the field is absent.
- */
-function readOptionalGridPaymentRails(value: unknown): string[] | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (!Array.isArray(value)) {
-    throw badRequest("Lightspark external account paymentRails must be an array");
-  }
-  const paymentRails: string[] = [];
-  for (const paymentRail of value) {
-    if (typeof paymentRail !== "string" || paymentRail.trim().length === 0) {
-      throw badRequest("Lightspark external account paymentRails must contain strings");
+const lightsparkExternalAccountInfoSchema = z.object({
+  accountType: z.string().min(1).optional(),
+  address: z.string().optional(),
+  paymentRails: z.array(z.string().min(1)).optional(),
+});
+
+const lightsparkExternalAccountSchema = z.object({
+  id: z.string().min(1).optional(),
+  status: z.string().min(1).optional(),
+  platformAccountId: z.string().min(1).optional(),
+  accountInfo: lightsparkExternalAccountInfoSchema.optional(),
+});
+
+export type LightsparkExternalAccountInfo = z.infer<typeof lightsparkExternalAccountInfoSchema>;
+type LightsparkExternalAccount = z.infer<typeof lightsparkExternalAccountSchema>;
+
+const lightsparkExternalAccountInfoDetailsSchema = z.preprocess(
+  (value) => {
+    if (!isGridRecord(value) || typeof value.accountType !== "string") {
+      return value;
     }
-    paymentRails.push(paymentRail);
-  }
-  return paymentRails;
-}
+    return {
+      ...value,
+      variant: value.accountType.toUpperCase() === "SOLANA_WALLET" ? "solana" : "bank",
+    };
+  },
+  z.discriminatedUnion("variant", [
+    z.object({
+      variant: z.literal("solana"),
+      accountType: z.string().min(1),
+      paymentRails: z.array(z.string().min(1)),
+      address: z.string().optional(),
+    }),
+    z.object({
+      variant: z.literal("bank"),
+      accountType: z.string().min(1),
+      paymentRails: z.array(z.string().min(1)),
+      bankName: z.string().min(1).optional(),
+      accountNumber: z.string().min(1).optional(),
+    }),
+  ])
+);
 
-interface LightsparkExternalAccount {
-  id?: string;
-  status?: string;
-  platformAccountId?: string;
-  accountInfo?: LightsparkExternalAccountInfo;
-}
+const lightsparkExternalAccountDetailsPageSchema = z.object({
+  data: z.array(
+    z.object({
+      platformAccountId: z.string().min(1),
+      status: z.string().min(1),
+      accountInfo: lightsparkExternalAccountInfoDetailsSchema,
+    })
+  ),
+  hasMore: z.boolean(),
+  nextCursor: z.string().min(1).optional(),
+});
 
-export interface LightsparkExternalAccountInfo {
-  accountType?: string;
-  address?: string;
-  paymentRails?: string[];
-}
+type LightsparkExternalAccountInfoDetails = z.infer<
+  typeof lightsparkExternalAccountInfoDetailsSchema
+>;
+type LightsparkExternalAccountDetailsPage = z.infer<
+  typeof lightsparkExternalAccountDetailsPageSchema
+>;
 
 export interface LightsparkExternalAccountResolution {
   id: string;
@@ -218,37 +246,7 @@ function parseLightsparkExternalAccountResolution(
 }
 
 function parseLightsparkExternalAccount(payload: unknown): LightsparkExternalAccount {
-  if (typeof payload !== "object" || payload === null) {
-    return {};
-  }
-  const raw = payload as {
-    id?: unknown;
-    status?: unknown;
-    platformAccountId?: unknown;
-    accountInfo?: {
-      accountType?: unknown;
-      address?: unknown;
-      paymentRails?: unknown;
-    };
-  };
-  return {
-    id: typeof raw.id === "string" ? raw.id : undefined,
-    status: typeof raw.status === "string" ? raw.status : undefined,
-    platformAccountId:
-      typeof raw.platformAccountId === "string" ? raw.platformAccountId : undefined,
-    accountInfo:
-      raw.accountInfo && typeof raw.accountInfo === "object"
-        ? {
-            accountType:
-              typeof raw.accountInfo.accountType === "string"
-                ? raw.accountInfo.accountType
-                : undefined,
-            address:
-              typeof raw.accountInfo.address === "string" ? raw.accountInfo.address : undefined,
-            paymentRails: readOptionalGridPaymentRails(raw.accountInfo.paymentRails),
-          }
-        : undefined,
-  };
+  return lightsparkExternalAccountSchema.parse(payload);
 }
 
 /** Connection details for live Grid API calls. */
@@ -529,6 +527,51 @@ export class LightsparkRampClient implements RampProvider {
     context: RampDiscoveryContext
   ): Promise<ProviderRailSupportDistillation> {
     return discoverLightsparkCurrencyAndRails(context);
+  }
+
+  /**
+   * Lists and sanitizes all Grid external accounts for one customer and fiat currency.
+   *
+   * @param ctx - Runtime provider credentials and environment.
+   * @param input - Grid customer reference and fiat currency.
+   * @returns Sanitized external account details keyed by SDP platform account id.
+   */
+  async listExternalAccountDetails(
+    { env, mode }: RampRuntimeContext,
+    input: { providerCustomerReference: string; fiatCurrency: string }
+  ): Promise<RampExternalAccountDetails[]> {
+    const config = readLightsparkConfig(env, mode);
+    let cursor: string | undefined;
+    const details: RampExternalAccountDetails[] = [];
+
+    for (let page = 0; page < 10; page += 1) {
+      const query = new URLSearchParams();
+      query.set("customerId", input.providerCustomerReference);
+      query.set("currency", input.fiatCurrency);
+      query.set("limit", "100");
+      if (cursor !== undefined) {
+        query.set("cursor", cursor);
+      }
+
+      const response = await this.request<unknown>(
+        config,
+        `customers/external-accounts?${query.toString()}`,
+        { method: "GET" }
+      );
+      const pageResponse: LightsparkExternalAccountDetailsPage =
+        lightsparkExternalAccountDetailsPageSchema.parse(response);
+      details.push(...pageResponse.data.map(mapLightsparkExternalAccountDetails));
+
+      if (!pageResponse.hasMore) {
+        return details;
+      }
+      if (pageResponse.nextCursor === undefined) {
+        throw providerUnavailable("Lightspark external-account pagination is missing nextCursor.");
+      }
+      cursor = pageResponse.nextCursor;
+    }
+
+    throw providerUnavailable("Lightspark external-account pagination exceeded the page limit.");
   }
 
   private async request<TResponse, TBody = never>(
@@ -1082,6 +1125,37 @@ export class LightsparkRampClient implements RampProvider {
       body: payload,
     });
   }
+}
+
+/**
+ * Converts one validated Grid account into the sanitized provider contract.
+ *
+ * @param account - Validated Grid external account payload.
+ * @returns Provider account details with only the account-number last four digits.
+ */
+function mapLightsparkExternalAccountDetails(
+  account: LightsparkExternalAccountDetailsPage["data"][number]
+): RampExternalAccountDetails {
+  const result: RampExternalAccountDetails = {
+    platformAccountId: account.platformAccountId,
+    providerStatus: account.status,
+    paymentRails: account.accountInfo.paymentRails,
+  };
+  const accountInfo: LightsparkExternalAccountInfoDetails = account.accountInfo;
+  if (accountInfo.variant === "solana") {
+    return result;
+  }
+
+  if (accountInfo.bankName !== undefined) {
+    result.bankName = accountInfo.bankName;
+  }
+  if (accountInfo.accountNumber !== undefined) {
+    if (accountInfo.accountNumber.length < 4) {
+      throw providerUnavailable("Lightspark external account number is too short.");
+    }
+    result.accountNumberLast4 = accountInfo.accountNumber.slice(-4);
+  }
+  return result;
 }
 
 function parseLightsparkQuote(raw: GridQuoteResponse): LightsparkQuote {

--- a/packages/sdp-payments/src/ramps/types.ts
+++ b/packages/sdp-payments/src/ramps/types.ts
@@ -212,6 +212,14 @@ export interface RampRuntimeContext {
   mode: SdpEnvironment;
 }
 
+export interface RampExternalAccountDetails {
+  platformAccountId: string;
+  providerStatus: string;
+  bankName?: string;
+  accountNumberLast4?: string;
+  paymentRails: string[];
+}
+
 export interface RampEstimateOnrampInput {
   assetRail: CryptoRailId;
   fiatCurrency: RampFiatCurrency;
@@ -317,6 +325,10 @@ export interface RampProvider {
     ctx: RampRuntimeContext,
     input: RampOfframpQuoteInput
   ): Promise<PaymentRampQuote>;
+  listExternalAccountDetails?(
+    ctx: RampRuntimeContext,
+    input: { providerCustomerReference: string; fiatCurrency: string }
+  ): Promise<RampExternalAccountDetails[]>;
   validateCounterparty(
     counterparty: Counterparty,
     options: ValidateCounterpartyOptions

--- a/packages/sdp-types/src/counterparties.ts
+++ b/packages/sdp-types/src/counterparties.ts
@@ -1,4 +1,5 @@
-import type { Country } from "./countries";
+import type { Country, CountryCode } from "./countries";
+import type { RampProviderId } from "./provider-access";
 
 export const COUNTERPARTY_ENTITY_TYPES = ["individual", "business"] as const;
 export type CounterpartyEntityType = (typeof COUNTERPARTY_ENTITY_TYPES)[number];
@@ -189,4 +190,22 @@ export interface ListCounterpartyAccountsResponse {
   total: number;
   page: number;
   pageSize: number;
+}
+
+export interface CounterpartyProviderAccount {
+  id: string;
+  provider: RampProviderId;
+  fiatCurrency: string;
+  destinationCountry: CountryCode;
+  paymentRail: string | null;
+  status: CounterpartyAccountStatus;
+  providerStatus: string | null;
+  createdAt: string;
+  bankName?: string;
+  accountNumberLast4?: string;
+  paymentRails?: string[];
+}
+
+export interface ListCounterpartyProviderAccountsResponse {
+  accounts: CounterpartyProviderAccount[];
 }


### PR DESCRIPTION
Implements PRO-1807 (PRO-1804 epic). Stacked on #1586.

**Endpoint**

- `GET /v1/counterparties/:counterpartyId/provider-accounts` (filters: `provider`, `fiatCurrency`, `destinationCountry`) — first public surface for `counterparty_provider_accounts`; the existing `/accounts` route stays crypto-wallet-only.
- Dedicated route module mirroring `counterparty-accounts` (inherits counterparties auth + project middleware; `counterparties:read`).
- Rows include archived (soft-delete history) and pending (reserved, never completed) accounts; pending rows surface without enrichment.

**Provider-generic enrichment**

- New optional `listExternalAccountDetails` capability on `RampProvider`; handler dispatches through `RAMP_PROVIDER_CLIENTS` with a capability check — no provider conditionals. Providers without it return bare rows with enriched fields absent (typed optional, never defaulted).
- Lightspark implementation walks Grid's `customers/external-accounts` pages (bounded, loud on missing cursor) and **masks account numbers to last-4 inside the provider module** — an unmasked number never leaves it; nothing enriched is ever persisted.
- Shared helper `services/payments/provider-account-enrichment.ts` (Hono-free, `ramp-settlements` pattern): one Grid call per (provider, currency, customer-reference) group with bounded concurrency; grouping by reference means tolerated customer-reference drift (`metadata.mismatchedReferences`) enriches per-reference instead of failing the read. Provider outage → 503 with row-id-only logging, no partial-silent success. Reused by the payout-tree ticket next in the stack.

## API before/after (live against local API + real Grid sandbox)

New endpoint — single **after** example (counterparty with one USD→MY account):

```jsonc
// GET /v1/counterparties/cpty_…/provider-accounts → 200
{ "data": { "accounts": [ {
  "id": "counterparty_provider_account_5e5b…",
  "provider": "lightspark", "fiatCurrency": "USD", "destinationCountry": "MY",
  "paymentRail": "SWIFT", "status": "active", "providerStatus": "ACTIVE",
  "createdAt": "2026-09-01T15:30:40.550Z",              // ours — Grid accounts carry no timestamps
  "bankName": "Maybank", "accountNumberLast4": "5678",  // JIT from Grid, masked in the provider module
  "paymentRails": ["SWIFT"]
} ] } }
```

**Tenant isolation (live probes)**

- another org's counterparty id with our key → `404`
- no Authorization header → `401`

**Verification**

- typecheck + biome clean; counterparties contract suite 24/24 (incl. grouped enrichment, filters, pending rows, cross-counterparty isolation, Grid-failure 503); sdp-payments 45/45; CI gates the full suites
- live: response above is a real Grid sandbox read; DB holds no bank fields (store-nothing)

**Known follow-up**

- `listExternalAccountDetails` and the pre-existing `findCustomerExternalAccount` each walk the same Grid pagination; left un-unified deliberately — the 409-recovery path is forgiving where the public read fails loudly, and merging failure semantics belongs in its own change.
