### PR TITLE
feat(ramps): payout tree surfaces account id, rail, and display info

### DIFF
--- a/apps/sdp-api/src/lib/ramps/providers/lightspark/counterparty.test.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark/counterparty.test.ts
@@ -191,7 +191,14 @@ describe("lightsparkCounterpartyRequirements", () => {
       },
       fiatCurrency: "USD",
       cryptoRail: "usdc.solana",
-      payoutAccounts: [{ destinationCountry: "US", status: "ACTIVE" }],
+      payoutAccounts: [
+        {
+          id: "account_us",
+          destinationCountry: "US",
+          paymentRail: null,
+          status: "ACTIVE",
+        },
+      ],
       providerCustomerReference: "Customer:cus_123",
     });
 
@@ -199,7 +206,14 @@ describe("lightsparkCounterpartyRequirements", () => {
     if (requirements.status !== "collect_account") {
       throw new Error("Expected collect_account requirements");
     }
-    expect(requirements.payout.accounts).toEqual([{ destinationCountry: "US", status: "ACTIVE" }]);
+    expect(requirements.payout.accounts).toEqual([
+      {
+        id: "account_us",
+        destinationCountry: "US",
+        paymentRail: null,
+        status: "ACTIVE",
+      },
+    ]);
   });
 
   it("returns unsupported for currencies without a Grid payout account type", () => {

--- a/apps/sdp-api/src/openapi/__snapshots__/spec.test.ts.snap
+++ b/apps/sdp-api/src/openapi/__snapshots__/spec.test.ts.snap
@@ -786,6 +786,12 @@ exports[`OpenAPI spec > documents counterparty ramp requirements 1`] = `
                       "accounts": {
                         "items": {
                           "properties": {
+                            "accountNumberLast4": {
+                              "type": "string",
+                            },
+                            "bankName": {
+                              "type": "string",
+                            },
                             "destinationCountry": {
                               "enum": [
                                 "AF",
@@ -1040,12 +1046,21 @@ exports[`OpenAPI spec > documents counterparty ramp requirements 1`] = `
                               ],
                               "type": "string",
                             },
+                            "id": {
+                              "type": "string",
+                            },
+                            "paymentRail": {
+                              "nullable": true,
+                              "type": "string",
+                            },
                             "status": {
                               "type": "string",
                             },
                           },
                           "required": [
+                            "id",
                             "destinationCountry",
+                            "paymentRail",
                             "status",
                           ],
                           "type": "object",

--- a/apps/sdp-api/src/openapi/schemas/counterparties.ts
+++ b/apps/sdp-api/src/openapi/schemas/counterparties.ts
@@ -145,8 +145,12 @@ const payoutRequirementTreeSchema = z.object({
   railFields: z.record(z.string(), z.array(requirementFieldSchema)),
   accounts: z.array(
     z.object({
+      id: z.string(),
       destinationCountry: z.enum(COUNTRY_CODES),
+      paymentRail: z.string().nullable(),
       status: z.string(),
+      bankName: z.string().optional(),
+      accountNumberLast4: z.string().optional(),
     })
   ),
 });

--- a/apps/sdp-api/src/routes/counterparties.test.ts
+++ b/apps/sdp-api/src/routes/counterparties.test.ts
@@ -358,6 +358,17 @@ describe("Counterparties Routes", () => {
   });
 
   describe("GET /v1/counterparties/:counterpartyId/requirements", () => {
+    beforeEach(() => {
+      env.LIGHTSPARK_GRID_SANDBOX_CLIENT_ID = "lightspark_client_id";
+      env.LIGHTSPARK_GRID_SANDBOX_CLIENT_SECRET = "lightspark_client_secret";
+    });
+
+    afterEach(() => {
+      env.LIGHTSPARK_GRID_SANDBOX_CLIENT_ID = undefined;
+      env.LIGHTSPARK_GRID_SANDBOX_CLIENT_SECRET = undefined;
+      vi.restoreAllMocks();
+    });
+
     it("surfaces the missing destination wallet for onramp requirements", async () => {
       const created = await createCounterparty();
       const cp = (await created.json()).data.counterparty;
@@ -380,6 +391,114 @@ describe("Counterparties Routes", () => {
           }),
         ])
       );
+    });
+
+    it("returns enriched Lightspark payout accounts in the payout tree", async () => {
+      const created = await createCounterparty({ externalId: "requirements_lightspark_accounts" });
+      const counterparty = (await created.json()).data.counterparty;
+      const providerAccounts = createPostgresCounterpartyProviderAccountsRepository(getDb(env));
+
+      await providerAccounts.upsertProviderAccount({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: counterparty.id,
+        provider: "lightspark",
+        providerCustomerReference: "Customer:requirements_accounts",
+      });
+      await getDb(env)
+        .prepare("UPDATE counterparties SET provider_data = ? WHERE id = ?")
+        .bind(
+          JSON.stringify({ lightspark: { purposeOfPayment: "GOODS_OR_SERVICES" } }),
+          counterparty.id
+        )
+        .run();
+      await seedProviderAccount({
+        id: "provider_account_requirements_ach",
+        counterpartyId: counterparty.id,
+        provider: "lightspark",
+        providerCustomerReference: "Customer:requirements_accounts",
+        externalAccountReference: "ExternalAccount:requirements_ach",
+        fiatCurrency: "USD",
+        destinationCountry: "US",
+        paymentRail: "ACH",
+        providerStatus: "ACTIVE",
+        status: "active",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      });
+      await seedProviderAccount({
+        id: "provider_account_requirements_wire",
+        counterpartyId: counterparty.id,
+        provider: "lightspark",
+        providerCustomerReference: "Customer:requirements_accounts",
+        externalAccountReference: "ExternalAccount:requirements_wire",
+        fiatCurrency: "USD",
+        destinationCountry: "US",
+        paymentRail: "WIRE",
+        providerStatus: "ACTIVE",
+        status: "active",
+        createdAt: "2026-01-02T00:00:00.000Z",
+      });
+
+      const enrichmentPage = {
+        data: [
+          {
+            platformAccountId: "provider_account_requirements_ach",
+            status: "ACTIVE",
+            accountInfo: {
+              accountType: "USD_ACCOUNT",
+              paymentRails: ["ACH"],
+              bankName: "ACH Bank",
+              accountNumber: "123456789",
+            },
+          },
+          {
+            platformAccountId: "provider_account_requirements_wire",
+            status: "ACTIVE",
+            accountInfo: {
+              accountType: "USD_ACCOUNT",
+              paymentRails: ["WIRE"],
+              bankName: "Wire Bank",
+              accountNumber: "987654321",
+            },
+          },
+        ],
+        hasMore: false,
+      };
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify(enrichmentPage), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+
+      const response = await app.request(
+        `/v1/counterparties/${counterparty.id}/requirements?provider=lightspark&direction=offramp&cryptoToken=USDC&fiatCurrency=USD`,
+        { headers: { Authorization: authHeader } },
+        env
+      );
+
+      expect(response.status).toBe(200);
+      expect((await response.json()).data.payout.accounts).toEqual([
+        {
+          id: "provider_account_requirements_ach",
+          destinationCountry: "US",
+          paymentRail: "ACH",
+          status: "ACTIVE",
+          bankName: "ACH Bank",
+          accountNumberLast4: "6789",
+        },
+        {
+          id: "provider_account_requirements_wire",
+          destinationCountry: "US",
+          paymentRail: "WIRE",
+          status: "ACTIVE",
+          bankName: "Wire Bank",
+          accountNumberLast4: "4321",
+        },
+      ]);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/sdp-api/src/routes/counterparties/handlers.ts
+++ b/apps/sdp-api/src/routes/counterparties/handlers.ts
@@ -28,6 +28,7 @@ import {
 import { created, noContent, success } from "@/lib/response";
 import { resolveSdpEnvironment } from "@/lib/sdp-environment";
 import type { ValidatedBodyContext } from "@/middleware/validate";
+import { rampRuntime } from "@/routes/payments/context";
 import {
   advanceCounterpartyRequirements,
   assertRampProviderAvailable,
@@ -37,6 +38,8 @@ import { resolveMuralRequirements } from "@/routes/payments/handlers/ramps/mural
 import type { submitCounterpartyRequirementsSchema } from "@/routes/payments/schemas";
 import { resolveScope, resolveWalletAddress } from "@/routes/payments/wallets";
 import { AuditService } from "@/services/audit.service";
+import { mapPayoutRequirementAccounts } from "@/services/payments/payout-requirement-accounts";
+import { enrichCounterpartyProviderAccounts } from "@/services/payments/provider-account-enrichment";
 import { assertRampProviderSurfaced } from "@/services/provider-availability.service";
 import {
   type AppContext,
@@ -277,12 +280,8 @@ export const getCounterpartyRequirements = async (c: AppContext) => {
       provider: "lightspark",
       fiatCurrency: query.data.fiatCurrency,
     });
-    payoutAccounts = rows.map((row) => {
-      if (row.destination_country === null || row.provider_status === null) {
-        throw internalError("Lightspark external-account row is missing corridor data.");
-      }
-      return { destinationCountry: row.destination_country, status: row.provider_status };
-    });
+    const enriched = await enrichCounterpartyProviderAccounts(rampRuntime(c), rows);
+    payoutAccounts = mapPayoutRequirementAccounts(rows, enriched);
   }
 
   if (query.data.direction === "onramp") {

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -82,6 +82,8 @@ import { getCounterpartiesRepository } from "@/routes/counterparties/context";
 import { describeError, logEvent } from "@/runtime/money-path-events";
 import { isSentryEnabled } from "@/runtime/observability";
 import { rampTransferTokenMint } from "@/services/payment-operation.service";
+import { mapPayoutRequirementAccounts } from "@/services/payments/payout-requirement-accounts";
+import { enrichCounterpartyProviderAccounts } from "@/services/payments/provider-account-enrichment";
 import { beginApprovedWalletOperationEffect } from "@/services/policy/approved-operation-replay";
 import { walletOperationActorFromAuth } from "@/services/policy/enforcement.service";
 import {
@@ -630,15 +632,11 @@ async function advanceLightsparkRequirements(
       provider: "lightspark",
       fiatCurrency: input.fiatCurrency,
     });
+    const enriched = await enrichCounterpartyProviderAccounts(rampRuntime(c), rows);
     return lightsparkCollectAccountRequirements(
       cryptoRail,
       input.fiatCurrency,
-      rows.map((row) => {
-        if (row.destination_country === null || row.provider_status === null) {
-          throw internalError("Lightspark external-account row is missing corridor data.");
-        }
-        return { destinationCountry: row.destination_country, status: row.provider_status };
-      })
+      mapPayoutRequirementAccounts(rows, enriched)
     );
   }
   if (!isCountryCode(collectedData.destinationCountry)) {

--- a/apps/sdp-api/src/services/payments/payout-requirement-accounts.ts
+++ b/apps/sdp-api/src/services/payments/payout-requirement-accounts.ts
@@ -1,0 +1,43 @@
+import type { RampExternalAccountDetails } from "@sdp/payments/ramps/types";
+import type { PayoutRequirementAccount } from "@sdp/types/ramp-requirements";
+import type { CounterpartyProviderAccountRow } from "@/db/repositories/counterparty-provider-account.repository";
+import { internalError } from "@/lib/errors";
+
+/**
+ * Maps parent-scoped provider-account rows and sanitized provider details into
+ * payout requirements accounts.
+ *
+ * @param rows - Parent-scoped provider-account rows.
+ * @param enriched - Sanitized provider details indexed by row id.
+ * @returns Completed payout accounts for the requirements tree.
+ */
+export function mapPayoutRequirementAccounts(
+  rows: readonly CounterpartyProviderAccountRow[],
+  enriched: ReadonlyMap<string, RampExternalAccountDetails>
+): PayoutRequirementAccount[] {
+  const accounts: PayoutRequirementAccount[] = [];
+  for (const row of rows) {
+    if (row.external_account_reference === null || row.provider_status === null) {
+      continue;
+    }
+    if (row.destination_country === null) {
+      throw internalError("Lightspark external-account row is missing corridor data.");
+    }
+
+    const detail = enriched.get(row.id);
+    const account: PayoutRequirementAccount = {
+      id: row.id,
+      destinationCountry: row.destination_country,
+      paymentRail: row.payment_rail,
+      status: row.provider_status,
+    };
+    if (detail !== undefined && detail.bankName !== undefined) {
+      account.bankName = detail.bankName;
+    }
+    if (detail !== undefined && detail.accountNumberLast4 !== undefined) {
+      account.accountNumberLast4 = detail.accountNumberLast4;
+    }
+    accounts.push(account);
+  }
+  return accounts;
+}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/offramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/offramp-step-content.tsx
@@ -78,7 +78,7 @@ export function OfframpStepContent({ wizard }: { wizard: OfframpWizard }) {
     setField,
     handlePairChange,
     requirementFields,
-    existingPayoutAccount,
+    existingPayoutAccounts,
     collectedData,
     setCollectedField,
     requirementsBlocker,
@@ -166,7 +166,7 @@ export function OfframpStepContent({ wizard }: { wizard: OfframpWizard }) {
         fields={requirementFields}
         values={collectedData}
         onChange={setCollectedField}
-        existingPayoutAccount={existingPayoutAccount}
+        existingPayoutAccounts={existingPayoutAccounts}
       />
     );
   }

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/requirements-fields.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/requirements-fields.tsx
@@ -465,7 +465,7 @@ function AddressRequirementField({
  * @param fields - Fields currently required by the provider and local selections.
  * @param values - Collected values keyed by requirement field.
  * @param onChange - Callback for updating a collected value.
- * @param existingPayoutAccount - Active corridor account selected for reuse.
+ * @param existingPayoutAccounts - Active corridor accounts available for reuse.
  * @returns The requirement field group.
  */
 export function RequirementsFields({
@@ -473,13 +473,13 @@ export function RequirementsFields({
   fields,
   values,
   onChange,
-  existingPayoutAccount,
+  existingPayoutAccounts,
 }: {
   provider: RampProviderId | null;
   fields: RequirementField[];
   values: CollectedFieldData;
   onChange: (key: string, value: string) => void;
-  existingPayoutAccount?: PayoutRequirementAccount | null;
+  existingPayoutAccounts?: PayoutRequirementAccount[];
 }) {
   const t = useTranslations();
   const providerCopy = provider === null ? undefined : REQUIREMENT_GROUP_COPY[provider];
@@ -526,7 +526,7 @@ export function RequirementsFields({
           </Card>
         );
       })}
-      {existingPayoutAccount !== undefined && existingPayoutAccount !== null ? (
+      {existingPayoutAccounts !== undefined && existingPayoutAccounts.length > 0 ? (
         <Card>
           <CardContent className="space-y-2">
             <p className="font-medium text-primary">

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-counterparty-requirements.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-counterparty-requirements.ts
@@ -27,22 +27,21 @@ export interface PayoutRequirementFieldLabels {
 }
 
 /**
- * Finds the active corridor account for a selected destination.
+ * Finds active corridor accounts for a selected destination.
  *
  * @param payout - Provider payout decision tree.
  * @param destinationCountry - Selected destination country code.
- * @returns The active account for the destination, or null when one is not available.
+ * @returns Active accounts for the destination.
  */
-export function findActivePayoutAccount(
+export function activePayoutAccounts(
   payout: PayoutRequirementTree,
   destinationCountry: string
-): PayoutRequirementAccount | null {
-  const account = payout.accounts.find(
+): PayoutRequirementAccount[] {
+  return payout.accounts.filter(
     (candidate) =>
       candidate.destinationCountry === destinationCountry &&
       candidate.status.toUpperCase() === "ACTIVE"
   );
-  return account === undefined ? null : account;
 }
 
 /**
@@ -115,7 +114,7 @@ export function derivePayoutRequirementFields(
   }
 
   const rails = payoutRailsForCountry(payout.countryRails, destinationCountry);
-  if (findActivePayoutAccount(payout, destinationCountry) !== null) {
+  if (activePayoutAccounts(payout, destinationCountry).length > 0) {
     return [destinationCountryField];
   }
 
@@ -239,8 +238,8 @@ export interface CounterpartyRequirementsParams extends AdvanceRequirementsPaylo
 export interface CounterpartyRequirementsState {
   /** Fields the client must collect; empty unless the provider returned `collect`. */
   fields: RequirementField[];
-  /** Active corridor account selected for reuse, when the payout country has one. */
-  existingPayoutAccount: PayoutRequirementAccount | null;
+  /** Active corridor accounts available for reuse in the selected payout country. */
+  existingPayoutAccounts: PayoutRequirementAccount[];
   collectedData: CollectedFieldData;
   setField: (key: string, value: string) => void;
   /** The chosen provider needs fields collected for this counterparty. */
@@ -424,11 +423,11 @@ export function useCounterpartyRequirements(
     return [];
   }, [collectedData, data, payout, payoutLabels]);
 
-  const existingPayoutAccount = useMemo(
+  const existingPayoutAccounts = useMemo(
     () =>
       payout === null || collectedData.destinationCountry === undefined
-        ? null
-        : findActivePayoutAccount(payout, collectedData.destinationCountry),
+        ? []
+        : activePayoutAccounts(payout, collectedData.destinationCountry),
     [collectedData.destinationCountry, payout]
   );
 
@@ -451,7 +450,7 @@ export function useCounterpartyRequirements(
 
   return {
     fields,
-    existingPayoutAccount,
+    existingPayoutAccounts,
     collectedData,
     setField,
     needsCollection:

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-counterparty-requirements.unit.test.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-counterparty-requirements.unit.test.ts
@@ -1,6 +1,9 @@
 import type { PayoutRequirementTree, RequirementField } from "@sdp/types/ramp-requirements";
 import { describe, expect, it } from "vitest";
-import { derivePayoutRequirementFields } from "./use-counterparty-requirements";
+import {
+  activePayoutAccounts,
+  derivePayoutRequirementFields,
+} from "./use-counterparty-requirements";
 
 const labels = {
   destinationCountry: "Destination country",
@@ -47,7 +50,14 @@ const payout = {
       },
     ],
   },
-  accounts: [{ destinationCountry: "CA", status: "ACTIVE" }],
+  accounts: [
+    {
+      id: "account_ca",
+      destinationCountry: "CA",
+      paymentRail: "SWIFT",
+      status: "ACTIVE",
+    },
+  ],
 } satisfies PayoutRequirementTree;
 
 describe("derivePayoutRequirementFields", () => {
@@ -99,5 +109,33 @@ describe("derivePayoutRequirementFields", () => {
       "bankAccount.accountNumber",
     ]);
     expect(fields[2]).toMatchObject({ required: true });
+  });
+});
+
+describe("activePayoutAccounts", () => {
+  it("returns every active account for the selected country", () => {
+    const accounts = activePayoutAccounts(
+      {
+        ...payout,
+        accounts: [
+          ...payout.accounts,
+          {
+            id: "account_ca_second",
+            destinationCountry: "CA",
+            paymentRail: "SEPA",
+            status: "ACTIVE",
+          },
+          {
+            id: "account_ca_archived",
+            destinationCountry: "CA",
+            paymentRail: "ACH",
+            status: "ARCHIVED",
+          },
+        ],
+      },
+      "CA"
+    );
+
+    expect(accounts.map((account) => account.id)).toEqual(["account_ca", "account_ca_second"]);
   });
 });

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-ramp-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-ramp-wizard.ts
@@ -487,7 +487,7 @@ export function useRampWizard<TId extends string>(
     collectedData: requirements.collectedData,
     setCollectedField: requirements.setField,
     requirementFields: requirements.fields,
-    existingPayoutAccount: requirements.existingPayoutAccount,
+    existingPayoutAccounts: requirements.existingPayoutAccounts,
     requirementsBlocker: requirements.blockReason,
     liveWallets,
     walletsLoading,

--- a/packages/sdp-types/src/ramp-requirements.ts
+++ b/packages/sdp-types/src/ramp-requirements.ts
@@ -72,9 +72,13 @@ export type CollectedFieldData = Record<string, string>;
 
 /** An existing payout external account for the corridor's fiat currency. */
 export interface PayoutRequirementAccount {
+  id: string;
   destinationCountry: CountryCode;
+  paymentRail: string | null;
   /** Provider-reported external-account status (e.g. Grid's CREATED/ACTIVE). */
   status: string;
+  bankName?: string;
+  accountNumberLast4?: string;
 }
 
 /**


### PR DESCRIPTION
Implements PRO-1808 (PRO-1804 epic). Stacked on #1587.

**Payout tree accounts carry real display info**

- `PayoutRequirementAccount`: `{ destinationCountry, status }` → `{ id, destinationCountry, paymentRail, status, bankName?, accountNumberLast4? }` (`paymentRail` nullable until a legacy row's lazy backfill runs).
- New `services/payments/payout-requirement-accounts.ts` maps repo rows + the shared Grid enrichment (one call per provider/currency/customer group, masked last-4 from the provider module); replaces the previously copy-pasted inline mapping in BOTH the GET requirements handler and the POST advance path.
- `lightsparkPayoutRequirementTree` stays a pure passthrough — enrichment lives in handlers only.
- Web: `findActivePayoutAccount` → `activePayoutAccounts` (per-country list), `existingPayoutAccount` → `existingPayoutAccounts`. Behavior parity: a corridor with any active account still skips collection; the chooser UI consumes the list in the next ticket.

**before** — payout tree account entry:

1. `{ destinationCountry: "MY", status: "ACTIVE" }` — nothing to render a choice with
2. wizard can only detect "an account exists", never which

**after** (live response, real Grid enrichment):

```jsonc
{ "id": "counterparty_provider_account_5e5b…", "destinationCountry": "MY",
  "paymentRail": "SWIFT", "status": "ACTIVE",
  "bankName": "Maybank", "accountNumberLast4": "5678" }
```

**Verification**

- typecheck + biome clean; counterparties contract + OpenAPI snapshot suites 42/42; web hook unit tests 5/5; CI gates the full suites
- live API: `GET /v1/counterparties/:id/requirements?provider=lightspark&direction=offramp…` returns the enriched account above against real Grid sandbox
- no schema/migration changes; no new endpoints (tenant scoping unchanged — same parent-scoped reads)
