### PR TITLE
feat(api): offramp quote accepts explicit provider-account selection

### DIFF
--- a/apps/sdp-api/src/routes/payments.ramps.test.ts
+++ b/apps/sdp-api/src/routes/payments.ramps.test.ts
@@ -1533,4 +1533,251 @@ describe("Payments routes — ramps", () => {
       expect(body.error.message).toContain("expired");
     });
   });
+
+  describe("lightspark offramp quote account selection", () => {
+    /**
+     * Inserts one counterparty provider-account row with explicit values.
+     *
+     * @param input - Row values for the fixture.
+     * @returns The inserted row id.
+     */
+    async function seedLightsparkProviderAccount(input: {
+      id: string;
+      counterpartyId: string;
+      providerCustomerReference: string;
+      externalAccountReference: string | null;
+      fiatCurrency: string | null;
+      destinationCountry: string | null;
+      paymentRail: string | null;
+      providerStatus: string | null;
+    }): Promise<string> {
+      await getDb(env)
+        .prepare(
+          `INSERT INTO counterparty_provider_accounts (
+             id, organization_id, project_id, counterparty_id, provider,
+             provider_customer_reference, external_account_reference, fiat_currency,
+             destination_country, payment_rail, provider_status, status, metadata
+           ) VALUES (?, ?, ?, ?, 'lightspark', ?, ?, ?, ?, ?, ?, 'active', '{}')`
+        )
+        .bind(
+          input.id,
+          TEST_ORG.id,
+          TEST_PROJECT.id,
+          input.counterpartyId,
+          input.providerCustomerReference,
+          input.externalAccountReference,
+          input.fiatCurrency,
+          input.destinationCountry,
+          input.paymentRail,
+          input.providerStatus
+        )
+        .run();
+      return input.id;
+    }
+
+    /**
+     * Seeds a lightspark counterparty with a Grid customer link and payout accounts.
+     *
+     * @param accounts - Corridor account fixtures to insert for the counterparty.
+     * @returns The counterparty id.
+     */
+    async function seedLightsparkCounterparty(
+      accounts: readonly {
+        id: string;
+        externalAccountReference: string;
+        paymentRail: string;
+      }[]
+    ): Promise<string> {
+      const counterpartyId = await seedCounterparty({
+        providerData: { lightspark: { purposeOfPayment: "SELF" } },
+      });
+      await seedLightsparkProviderAccount({
+        id: `${counterpartyId}_customer_link`,
+        counterpartyId,
+        providerCustomerReference: "Customer:cus_quote_test",
+        externalAccountReference: null,
+        fiatCurrency: null,
+        destinationCountry: null,
+        paymentRail: null,
+        providerStatus: null,
+      });
+      for (const account of accounts) {
+        await seedLightsparkProviderAccount({
+          id: account.id,
+          counterpartyId,
+          providerCustomerReference: "Customer:cus_quote_test",
+          externalAccountReference: account.externalAccountReference,
+          fiatCurrency: "USD",
+          destinationCountry: "MY",
+          paymentRail: account.paymentRail,
+          providerStatus: "ACTIVE",
+        });
+      }
+      return counterpartyId;
+    }
+
+    /**
+     * Mocks the Grid quote endpoint with a valid locked-sending quote.
+     *
+     * @returns The installed fetch spy.
+     */
+    function mockGridQuote() {
+      const quotePage = JSON.stringify({
+        id: "Quote:qt_selection_test",
+        quoteStatus: "CREATED",
+        exchangeRate: 4.2,
+        totalSendingAmount: 25000000,
+        sendingCurrency: { code: "USDC", decimals: 6 },
+        totalReceivingAmount: 105,
+        receivingCurrency: { code: "USD", decimals: 2 },
+        feesIncluded: 0,
+        expiresAt: "2099-01-01T00:00:00.000Z",
+      });
+      return vi.spyOn(globalThis, "fetch").mockImplementation(() =>
+        Promise.resolve(
+          new Response(quotePage, {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      );
+    }
+
+    const quoteRequest = (body: Record<string, unknown>) =>
+      app.request(
+        "/v1/payments/ramps/offramp/quote",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TEST_API_KEY.raw}`,
+          },
+          body: JSON.stringify({
+            provider: "lightspark",
+            sourceWallet: TEST_WALLET_ID,
+            cryptoToken: "USDC",
+            cryptoAmount: "25",
+            fiatCurrency: "USD",
+            destinationCountry: "MY",
+            ...body,
+          }),
+        },
+        env
+      );
+
+    it("resolves an explicit providerAccountId and records it on the transfer", async () => {
+      const counterpartyId = await seedLightsparkCounterparty([
+        {
+          id: "cpa_quote_ach",
+          externalAccountReference: "ExternalAccount:ach",
+          paymentRail: "ACH",
+        },
+        {
+          id: "cpa_quote_swift",
+          externalAccountReference: "ExternalAccount:swift",
+          paymentRail: "SWIFT",
+        },
+      ]);
+      const fetchSpy = mockGridQuote();
+
+      const res = await quoteRequest({ counterpartyId, providerAccountId: "cpa_quote_swift" });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { data: { quote: { id: string }; transferId: string } };
+      expect(body.data.quote.id).toBe("Quote:qt_selection_test");
+      const gridBody = JSON.parse(String(fetchSpy.mock.calls[0][1]?.body)) as {
+        destination: { accountId: string };
+      };
+      expect(gridBody.destination.accountId).toBe("ExternalAccount:swift");
+
+      const transfer = await getDb(env)
+        .prepare("SELECT provider_data FROM payment_transfers WHERE id = ?")
+        .bind(body.data.transferId)
+        .first<{ provider_data: unknown }>();
+      expect(transfer).not.toBeNull();
+      const providerData =
+        typeof transfer?.provider_data === "string"
+          ? (JSON.parse(transfer.provider_data) as Record<string, unknown>)
+          : (transfer?.provider_data as Record<string, unknown>);
+      expect(providerData.payoutProviderAccountId).toBe("cpa_quote_swift");
+      fetchSpy.mockRestore();
+    });
+
+    it("rejects a providerAccountId owned by another counterparty", async () => {
+      const counterpartyId = await seedLightsparkCounterparty([
+        {
+          id: "cpa_quote_own",
+          externalAccountReference: "ExternalAccount:own",
+          paymentRail: "ACH",
+        },
+      ]);
+      const otherCounterpartyId = await seedCounterparty({
+        providerData: { lightspark: { purposeOfPayment: "SELF" } },
+      });
+      await seedLightsparkProviderAccount({
+        id: "cpa_quote_foreign",
+        counterpartyId: otherCounterpartyId,
+        providerCustomerReference: "Customer:cus_other",
+        externalAccountReference: "ExternalAccount:foreign",
+        fiatCurrency: "USD",
+        destinationCountry: "MY",
+        paymentRail: "SWIFT",
+        providerStatus: "ACTIVE",
+      });
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+      const res = await quoteRequest({ counterpartyId, providerAccountId: "cpa_quote_foreign" });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: { code: string; message: string } };
+      expect(body.error.code).toBe("BAD_REQUEST");
+      expect(body.error.message).toContain("providerAccountId");
+      expect(fetchSpy).not.toHaveBeenCalled();
+      fetchSpy.mockRestore();
+    });
+
+    it("rejects an ambiguous corridor when no providerAccountId is given", async () => {
+      const counterpartyId = await seedLightsparkCounterparty([
+        {
+          id: "cpa_quote_multi_a",
+          externalAccountReference: "ExternalAccount:multi_a",
+          paymentRail: "ACH",
+        },
+        {
+          id: "cpa_quote_multi_b",
+          externalAccountReference: "ExternalAccount:multi_b",
+          paymentRail: "SWIFT",
+        },
+      ]);
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+      const res = await quoteRequest({ counterpartyId });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: { message: string } };
+      expect(body.error.message).toContain("explicit external-account selection is required");
+      expect(fetchSpy).not.toHaveBeenCalled();
+      fetchSpy.mockRestore();
+    });
+
+    it("keeps implicit resolution for a single-account corridor", async () => {
+      const counterpartyId = await seedLightsparkCounterparty([
+        {
+          id: "cpa_quote_single",
+          externalAccountReference: "ExternalAccount:single",
+          paymentRail: "SWIFT",
+        },
+      ]);
+      const fetchSpy = mockGridQuote();
+
+      const res = await quoteRequest({ counterpartyId });
+
+      expect(res.status).toBe(200);
+      const gridBody = JSON.parse(String(fetchSpy.mock.calls[0][1]?.body)) as {
+        destination: { accountId: string };
+      };
+      expect(gridBody.destination.accountId).toBe("ExternalAccount:single");
+      fetchSpy.mockRestore();
+    });
+  });
 });

--- a/apps/sdp-api/src/routes/payments.ramps.test.ts
+++ b/apps/sdp-api/src/routes/payments.ramps.test.ts
@@ -1736,6 +1736,47 @@ describe("Payments routes — ramps", () => {
       fetchSpy.mockRestore();
     });
 
+    it("rejects an explicitly selected account that is pending or provider-inactive", async () => {
+      const counterpartyId = await seedLightsparkCounterparty([
+        {
+          id: "cpa_quote_active",
+          externalAccountReference: "ExternalAccount:active",
+          paymentRail: "SWIFT",
+        },
+      ]);
+      await seedLightsparkProviderAccount({
+        id: "cpa_quote_pending",
+        counterpartyId,
+        providerCustomerReference: "Customer:cus_quote_test",
+        externalAccountReference: null,
+        fiatCurrency: "USD",
+        destinationCountry: "MY",
+        paymentRail: "ACH",
+        providerStatus: null,
+      });
+      await seedLightsparkProviderAccount({
+        id: "cpa_quote_created",
+        counterpartyId,
+        providerCustomerReference: "Customer:cus_quote_test",
+        externalAccountReference: "ExternalAccount:created",
+        fiatCurrency: "USD",
+        destinationCountry: "MY",
+        paymentRail: "ACH",
+        providerStatus: "CREATED",
+      });
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+      for (const providerAccountId of ["cpa_quote_pending", "cpa_quote_created"]) {
+        const res = await quoteRequest({ counterpartyId, providerAccountId });
+        expect(res.status).toBe(400);
+        const body = (await res.json()) as { error: { code: string; message: string } };
+        expect(body.error.code).toBe("BAD_REQUEST");
+        expect(body.error.message).toContain("providerAccountId");
+      }
+      expect(fetchSpy).not.toHaveBeenCalled();
+      fetchSpy.mockRestore();
+    });
+
     it("rejects an ambiguous corridor when no providerAccountId is given", async () => {
       const counterpartyId = await seedLightsparkCounterparty([
         {

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -1196,7 +1196,10 @@ export async function createOfframpQuote(c: AppContext): Promise<Response> {
           selected === null ||
           selected.status !== "active" ||
           selected.fiat_currency !== input.fiatCurrency ||
-          selected.destination_country !== input.destinationCountry
+          selected.destination_country !== input.destinationCountry ||
+          selected.external_account_reference === null ||
+          selected.provider_status === null ||
+          !isLightsparkExternalAccountActive(selected.provider_status)
         ) {
           throw badRequest(
             "providerAccountId does not reference an active lightspark payout account for this corridor."

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -56,6 +56,7 @@ import {
   isRampTransferType,
 } from "@/db/repositories";
 import type { CounterpartyRow } from "@/db/repositories/counterparty.repository";
+import type { CounterpartyProviderAccountRow } from "@/db/repositories/counterparty-provider-account.repository";
 import {
   generatePaymentTransferId,
   type PaymentTransferRow,
@@ -1092,6 +1093,7 @@ export async function createOfframpQuote(c: AppContext): Promise<Response> {
   let quote: PaymentRampQuote;
   let precreatedTransferId: string | undefined;
   let pendingTransfer: PaymentTransferRow | undefined;
+  let transferProviderData: Record<string, unknown> | undefined;
   switch (input.provider) {
     case "moonpay": {
       const apiKey = c.get("apiKey");
@@ -1165,22 +1167,43 @@ export async function createOfframpQuote(c: AppContext): Promise<Response> {
       }
       const customerId = await lightsparkProviderCustomerId(c, counterparty, projectId);
       const purposeOfPayment = readLightsparkPurposeOfPayment(counterparty.provider_data);
-      const payoutAccounts = await createPostgresCounterpartyProviderAccountsRepository(
-        getDb(c.env)
-      ).listActiveExternalAccounts({
-        organizationId: scope.auth.organizationId,
-        projectId,
-        counterpartyId: counterparty.id,
-        provider: "lightspark",
-        fiatCurrency: input.fiatCurrency,
-        destinationCountry: input.destinationCountry,
-      });
-      const payoutAccount = selectLightsparkPayoutAccount(
-        payoutAccounts,
-        undefined,
-        input.fiatCurrency,
-        input.destinationCountry
-      );
+      const accountsRepository = createPostgresCounterpartyProviderAccountsRepository(getDb(c.env));
+      let payoutAccount: CounterpartyProviderAccountRow | null;
+      if (input.providerAccountId === undefined) {
+        const payoutAccounts = await accountsRepository.listActiveExternalAccounts({
+          organizationId: scope.auth.organizationId,
+          projectId,
+          counterpartyId: counterparty.id,
+          provider: "lightspark",
+          fiatCurrency: input.fiatCurrency,
+          destinationCountry: input.destinationCountry,
+        });
+        payoutAccount = selectLightsparkPayoutAccount(
+          payoutAccounts,
+          undefined,
+          input.fiatCurrency,
+          input.destinationCountry
+        );
+      } else {
+        const selected = await accountsRepository.getExternalAccountById({
+          organizationId: scope.auth.organizationId,
+          projectId,
+          counterpartyId: counterparty.id,
+          provider: "lightspark",
+          id: input.providerAccountId,
+        });
+        if (
+          selected === null ||
+          selected.status !== "active" ||
+          selected.fiat_currency !== input.fiatCurrency ||
+          selected.destination_country !== input.destinationCountry
+        ) {
+          throw badRequest(
+            "providerAccountId does not reference an active lightspark payout account for this corridor."
+          );
+        }
+        payoutAccount = selected;
+      }
       if (
         customerId === null ||
         purposeOfPayment === null ||
@@ -1191,6 +1214,7 @@ export async function createOfframpQuote(c: AppContext): Promise<Response> {
       ) {
         throw counterpartyNotProvisioned("lightspark", "offramp");
       }
+      transferProviderData = { payoutProviderAccountId: payoutAccount.id };
       quote = await RAMP_PROVIDER_CLIENTS.lightspark.createOfframpQuote(rampRuntime(c), {
         cryptoToken: input.cryptoToken,
         fiatCurrency: input.fiatCurrency,
@@ -1304,6 +1328,7 @@ export async function createOfframpQuote(c: AppContext): Promise<Response> {
       fiatCurrency: input.fiatCurrency ? input.fiatCurrency : null,
       fiatAmount: null,
       rampsMemo: input.rampsMemo,
+      providerData: transferProviderData,
     });
   }
 

--- a/apps/sdp-api/src/routes/payments/schemas.ts
+++ b/apps/sdp-api/src/routes/payments/schemas.ts
@@ -742,6 +742,7 @@ export const createOfframpQuoteSchema = z.discriminatedUnion("provider", [
     ...offrampQuoteBaseShape,
     fiatCurrency: rampFiatCurrencySchema,
     destinationCountry: z.enum(COUNTRY_CODES),
+    providerAccountId: z.string().min(1).optional(),
   }),
   z.object({
     provider: z.enum(["moonpay", "bvnk", "moneygram", "mural", "coinbase", "stripe"]),


### PR DESCRIPTION
Implements PRO-1809 (PRO-1804 epic). Stacked on #1588.

**Explicit payout-account selection on offramp quotes**

- Offramp quote request (lightspark variant): optional `providerAccountId` (`counterparty_provider_account_…` row id).
- Resolution: id given → parent-scoped `getExternalAccountById` + ownership/corridor verification (active + same provider + fiatCurrency + destinationCountry; anything else → 400, never a silent fallback to another account). No id → existing behavior: one active account → use it; multiple → 400 naming the ambiguity; none → `counterpartyNotProvisioned`.
- The selected row's Grid reference goes into `createOfframpQuote`'s `payoutAccountId` (Grid locks the payout destination to the quote), and the transfer records `provider_data.payoutProviderAccountId` = our row id so the settling account is attributable.

**before**:

1. quote resolves the corridor's single account implicitly
2. multiple accounts per corridor (legal since #1586) → 400 with no way through

**after**:

1. `providerAccountId` picks the account; cross-counterparty/corridor ids are rejected with 400
2. omitted id stays backward-compatible for single-account counterparties

## API before/after (live against local API + real Grid sandbox)

```jsonc
// POST /v1/payments/ramps/offramp/quote  { provider: "lightspark", …, providerAccountId: "counterparty_provider_account_5e5b…" }
// → 200: { quote: { id: "Quote:01a06000-b3d1-…", status: "pending", deliveryMode: "manual_instructions" },
//          transferId: "xfr_bbc0ab9c-…" }
// transfer row: provider_data.payoutProviderAccountId = "counterparty_provider_account_5e5b…" (verified in DB)

// same request with a providerAccountId that is not this counterparty's
// → 400 BAD_REQUEST "providerAccountId does not reference an active lightspark payout account for this corridor."
```

**Verification**

- typecheck + biome clean; new contract tests (explicit selection recorded on transfer, cross-counterparty rejection, ambiguity 400, single-account back-compat) — payments.ramps suite 35/35; CI gates the rest
- live: real Grid sandbox quote created via explicit selection (above); foreign-id rejection verified before any Grid call
- note: the offramp quote endpoint is absent from the OpenAPI spec entirely (pre-existing gap — only `onramp/quote` is documented); left untouched, worth its own ticket
