### PR TITLE
fix(ci): candidate digest check accepts the signed OCI index's own manifests

### DIFF
--- a/.github/workflows/deploy-sdp-api-gcp-prod.yml
+++ b/.github/workflows/deploy-sdp-api-gcp-prod.yml
@@ -388,12 +388,18 @@ jobs:
           # content-addressed by the index, so this extends the trust chain
           # without widening it; anything else still fails closed.
           accepted_digests="${expected_digest}"
-          index_children="$(
-            crane manifest "${IMAGE}" 2>/dev/null |
-              jq -r 'select(.mediaType == "application/vnd.oci.image.index.v1+json"
-                       or .mediaType == "application/vnd.docker.distribution.manifest.list.v2+json")
-                     | .manifests[]?.digest' || true
-          )"
+          if ! pinned_manifest="$(crane manifest "${IMAGE}")"; then
+            echo "Failed to fetch the pinned manifest for ${expected_digest}; cannot enumerate signed-index children." >&2
+            exit 1
+          fi
+          if ! index_children="$(
+            jq -r 'select(.mediaType == "application/vnd.oci.image.index.v1+json"
+                     or .mediaType == "application/vnd.docker.distribution.manifest.list.v2+json")
+                   | .manifests[]?.digest' <<<"${pinned_manifest}"
+          )"; then
+            echo "Failed to parse the pinned manifest for ${expected_digest}; cannot enumerate signed-index children." >&2
+            exit 1
+          fi
           if [[ -n "${index_children}" ]]; then
             accepted_digests+=$'\n'"${index_children}"
           fi

--- a/.github/workflows/deploy-sdp-api-gcp-prod.yml
+++ b/.github/workflows/deploy-sdp-api-gcp-prod.yml
@@ -381,8 +381,24 @@ jobs:
               --format='value(status.imageDigest)'
           )"
           expected_digest="${IMAGE##*@}"
-          if [[ "${revision_digest##*@}" != "${expected_digest}" ]]; then
-            echo "Candidate ${candidate_revision} resolved to ${revision_digest}, expected ${expected_digest}." >&2
+          # The pinned digest may be an OCI image index (buildx provenance/SBOM
+          # builds). Cloud Run resolves the index and records the platform
+          # manifest's digest on the revision, so accept the pinned digest or
+          # any manifest listed inside that exact signed index. Children are
+          # content-addressed by the index, so this extends the trust chain
+          # without widening it; anything else still fails closed.
+          accepted_digests="${expected_digest}"
+          index_children="$(
+            crane manifest "${IMAGE}" 2>/dev/null |
+              jq -r 'select(.mediaType == "application/vnd.oci.image.index.v1+json"
+                       or .mediaType == "application/vnd.docker.distribution.manifest.list.v2+json")
+                     | .manifests[]?.digest' || true
+          )"
+          if [[ -n "${index_children}" ]]; then
+            accepted_digests+=$'\n'"${index_children}"
+          fi
+          if ! grep -qxF "${revision_digest##*@}" <<<"${accepted_digests}"; then
+            echo "Candidate ${candidate_revision} resolved to ${revision_digest}, expected ${expected_digest} or a manifest of that signed index." >&2
             exit 1
           fi
           echo "CANDIDATE_REVISION=${candidate_revision}" >> "${GITHUB_ENV}"

--- a/scripts/deploy-sdp-api-gcp-prod-workflow.test.mjs
+++ b/scripts/deploy-sdp-api-gcp-prod-workflow.test.mjs
@@ -208,7 +208,7 @@ test("the orchestrator grants every permission the prod workflow requests", () =
     path.resolve(here, "../.github/workflows/deploy.yml"),
     "utf8"
   );
-  const permissionsBlock = workflow.match(/^permissions:\n((?:  [a-z-]+: [a-z-]+\n)+)/m);
+  const permissionsBlock = workflow.match(/^permissions:\n((?: {2}[a-z-]+: [a-z-]+\n)+)/m);
   assert.ok(permissionsBlock, "prod workflow must declare a top-level permissions block");
   const requested = permissionsBlock[1]
     .trim()
@@ -217,7 +217,7 @@ test("the orchestrator grants every permission the prod workflow requests", () =
     .filter(Boolean);
   assert.ok(requested.length >= 3, "expected at least contents, id-token, and packages grants");
   const callerJob = orchestrator.match(
-    /deploy-api-prod:[\s\S]*?permissions:\n((?:      [a-z-]+: [a-z-]+\n)+)/
+    /deploy-api-prod:[\s\S]*?permissions:\n((?: {6}[a-z-]+: [a-z-]+\n)+)/
   )[1];
   for (const grant of requested) {
     assert.ok(
@@ -230,17 +230,14 @@ test("the orchestrator grants every permission the prod workflow requests", () =
 test("candidate verification accepts the signed index digest or its child manifests, nothing else", () => {
   assert.match(workflow, /accepted_digests="\$\{expected_digest\}"/);
   assert.match(workflow, /crane manifest "\$\{IMAGE\}"/);
-  assert.match(
-    workflow,
-    /grep -qxF "\$\{revision_digest##\*@\}" <<<"\$\{accepted_digests\}"/
-  );
+  assert.match(workflow, /grep -qxF "\$\{revision_digest##\*@\}" <<<"\$\{accepted_digests\}"/);
 });
 
 // Execute the actual digest-selection block from the workflow against stubbed
 // registries, so CI fails when the shell behavior breaks even if the text
 // fragments above still match.
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, chmodSync } from "node:fs";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -255,7 +252,10 @@ const CHILD_DIGEST = "sha256:bbbb00000000000000000000000000000000000000000000000
 const OTHER_DIGEST = "sha256:cccc000000000000000000000000000000000000000000000000000000000000";
 const INDEX_JSON = JSON.stringify({
   mediaType: "application/vnd.oci.image.index.v1+json",
-  manifests: [{ digest: CHILD_DIGEST }, { digest: "sha256:dddd000000000000000000000000000000000000000000000000000000000000" }],
+  manifests: [
+    { digest: CHILD_DIGEST },
+    { digest: "sha256:dddd000000000000000000000000000000000000000000000000000000000000" },
+  ],
 });
 const BARE_JSON = JSON.stringify({ mediaType: "application/vnd.oci.image.manifest.v1+json" });
 
@@ -271,7 +271,7 @@ function runDigestBlock({ craneScript, revisionDigest }) {
     'candidate_revision="rev-test"',
     `revision_digest="registry.example/repo@${revisionDigest}"`,
     digestBlock,
-    'echo GUARD_PASSED',
+    "echo GUARD_PASSED",
   ].join("\n");
   try {
     const out = execFileSync("bash", ["-c", script], {
@@ -316,4 +316,3 @@ test("digest guard still accepts an exact match on a bare (non-index) manifest",
   const r = runDigestBlock({ craneScript: craneBare, revisionDigest: INDEX_DIGEST });
   assert.equal(r.code, 0, r.out);
 });
-

--- a/scripts/deploy-sdp-api-gcp-prod-workflow.test.mjs
+++ b/scripts/deploy-sdp-api-gcp-prod-workflow.test.mjs
@@ -226,3 +226,23 @@ test("the orchestrator grants every permission the prod workflow requests", () =
     );
   }
 });
+
+test("candidate verification accepts the signed index digest or its child manifests, nothing else", () => {
+  assert.match(
+    workflow,
+    /accepted_digests="\$\{expected_digest\}"/
+  );
+  assert.match(
+    workflow,
+    /crane manifest "\$\{IMAGE\}"/
+  );
+  assert.match(
+    workflow,
+    /vnd\.oci\.image\.index\.v1\+json/
+  );
+  assert.match(
+    workflow,
+    /grep -qxF "\$\{revision_digest##\*@\}" <<<"\$\{accepted_digests\}"/
+  );
+});
+

--- a/scripts/deploy-sdp-api-gcp-prod-workflow.test.mjs
+++ b/scripts/deploy-sdp-api-gcp-prod-workflow.test.mjs
@@ -228,21 +228,92 @@ test("the orchestrator grants every permission the prod workflow requests", () =
 });
 
 test("candidate verification accepts the signed index digest or its child manifests, nothing else", () => {
-  assert.match(
-    workflow,
-    /accepted_digests="\$\{expected_digest\}"/
-  );
-  assert.match(
-    workflow,
-    /crane manifest "\$\{IMAGE\}"/
-  );
-  assert.match(
-    workflow,
-    /vnd\.oci\.image\.index\.v1\+json/
-  );
+  assert.match(workflow, /accepted_digests="\$\{expected_digest\}"/);
+  assert.match(workflow, /crane manifest "\$\{IMAGE\}"/);
   assert.match(
     workflow,
     /grep -qxF "\$\{revision_digest##\*@\}" <<<"\$\{accepted_digests\}"/
   );
+});
+
+// Execute the actual digest-selection block from the workflow against stubbed
+// registries, so CI fails when the shell behavior breaks even if the text
+// fragments above still match.
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const blockMatch = workflow.match(
+  /(accepted_digests="\$\{expected_digest\}"[\s\S]*?or a manifest of that signed index\." >&2\n\s*exit 1\n\s*fi)/
+);
+assert.ok(blockMatch, "digest-selection block not found in workflow");
+const digestBlock = blockMatch[1];
+
+const INDEX_DIGEST = "sha256:aaaa000000000000000000000000000000000000000000000000000000000000";
+const CHILD_DIGEST = "sha256:bbbb000000000000000000000000000000000000000000000000000000000000";
+const OTHER_DIGEST = "sha256:cccc000000000000000000000000000000000000000000000000000000000000";
+const INDEX_JSON = JSON.stringify({
+  mediaType: "application/vnd.oci.image.index.v1+json",
+  manifests: [{ digest: CHILD_DIGEST }, { digest: "sha256:dddd000000000000000000000000000000000000000000000000000000000000" }],
+});
+const BARE_JSON = JSON.stringify({ mediaType: "application/vnd.oci.image.manifest.v1+json" });
+
+function runDigestBlock({ craneScript, revisionDigest }) {
+  const dir = mkdtempSync(join(tmpdir(), "digest-guard-"));
+  const cranePath = join(dir, "crane");
+  writeFileSync(cranePath, craneScript);
+  chmodSync(cranePath, 0o755);
+  const script = [
+    "set -euo pipefail",
+    `expected_digest="${INDEX_DIGEST}"`,
+    `IMAGE="registry.example/repo@${INDEX_DIGEST}"`,
+    'candidate_revision="rev-test"',
+    `revision_digest="registry.example/repo@${revisionDigest}"`,
+    digestBlock,
+    'echo GUARD_PASSED',
+  ].join("\n");
+  try {
+    const out = execFileSync("bash", ["-c", script], {
+      env: { ...process.env, PATH: `${dir}:${process.env.PATH}` },
+      encoding: "utf8",
+    });
+    return { code: 0, out };
+  } catch (err) {
+    return { code: err.status, out: `${err.stdout ?? ""}${err.stderr ?? ""}` };
+  }
+}
+
+const craneOk = `#!/usr/bin/env bash\nprintf '%s' '${INDEX_JSON}'\n`;
+const craneBare = `#!/usr/bin/env bash\nprintf '%s' '${BARE_JSON}'\n`;
+const craneFail = "#!/usr/bin/env bash\necho 'UNAUTHORIZED' >&2\nexit 1\n";
+
+test("digest guard passes for the signed index's child manifest", () => {
+  const r = runDigestBlock({ craneScript: craneOk, revisionDigest: CHILD_DIGEST });
+  assert.equal(r.code, 0, r.out);
+  assert.match(r.out, /GUARD_PASSED/);
+});
+
+test("digest guard passes for the pinned index digest itself", () => {
+  const r = runDigestBlock({ craneScript: craneOk, revisionDigest: INDEX_DIGEST });
+  assert.equal(r.code, 0, r.out);
+});
+
+test("digest guard rejects a digest outside the signed index", () => {
+  const r = runDigestBlock({ craneScript: craneOk, revisionDigest: OTHER_DIGEST });
+  assert.equal(r.code, 1);
+  assert.match(r.out, /or a manifest of that signed index/);
+});
+
+test("digest guard fails loudly, not with a mismatch, when the registry fetch fails", () => {
+  const r = runDigestBlock({ craneScript: craneFail, revisionDigest: CHILD_DIGEST });
+  assert.equal(r.code, 1);
+  assert.match(r.out, /Failed to fetch the pinned manifest/);
+  assert.doesNotMatch(r.out, /or a manifest of that signed index/);
+});
+
+test("digest guard still accepts an exact match on a bare (non-index) manifest", () => {
+  const r = runDigestBlock({ craneScript: craneBare, revisionDigest: INDEX_DIGEST });
+  assert.equal(r.code, 0, r.out);
 });
 


### PR DESCRIPTION
## What

The candidate digest guard now accepts the pinned digest or any manifest listed inside that exact signed index, enumerated with one crane call, fail-closed on anything else. Contract test added (16/16 pass locally).

## Why now

v0.70.0's deploy (run 33588593013) failed here deterministically and rolled back. The signed digest `sha256:d4192739...` is an OCI image index (buildx provenance/SBOM builds emit one); Cloud Run records the amd64 child `sha256:896ed127...` on the revision; the guard compared child to index. Confirmed from the registry: 896ed127 is listed inside d4192739 (alongside an arm64 child and two attestation manifests). Every signed-path deploy fails this way until this lands.

## Trust argument for review

Index children are content-addressed by the signed index, so accepting them extends the chain, not the perimeter. An image outside the signed index still fails closed. @andreytatarinov this is your machinery, review accordingly.

## After merge

Redeploy v0.70.0 by workflow dispatch with the release sha. Migrations are already applied (all additive, verified against 0.69.0's code paths). Prod has been serving 0.69.0 untouched throughout.
