### PR TITLE
fix(ci): accept platform-manifest digests in the candidate identity check

### DIFF
--- a/.github/workflows/deploy-sdp-api-gcp-prod.yml
+++ b/.github/workflows/deploy-sdp-api-gcp-prod.yml
@@ -381,8 +381,18 @@ jobs:
               --format='value(status.imageDigest)'
           )"
           expected_digest="${IMAGE##*@}"
-          if [[ "${revision_digest##*@}" != "${expected_digest}" ]]; then
-            echo "Candidate ${candidate_revision} resolved to ${revision_digest}, expected ${expected_digest}." >&2
+          accepted_digests="${expected_digest}"
+          registry_host="${IMAGE%%/*}"
+          repo_path="${IMAGE#*/}"; repo_path="${repo_path%@*}"
+          child_digests="$(
+            curl -fsS -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+              -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json" \
+              "https://${registry_host}/v2/${repo_path}/manifests/${expected_digest}" \
+              | jq -r '.manifests[]?.digest // empty'
+          )" || child_digests=""
+          accepted_digests="${accepted_digests}"$'\n'"${child_digests}"
+          if ! grep -qx "${revision_digest##*@}" <<<"${accepted_digests}"; then
+            echo "Candidate ${candidate_revision} resolved to ${revision_digest}, expected ${expected_digest} or one of its platform manifests." >&2
             exit 1
           fi
           echo "CANDIDATE_REVISION=${candidate_revision}" >> "${GITHUB_ENV}"

--- a/scripts/deploy-sdp-api-gcp-prod-workflow.test.mjs
+++ b/scripts/deploy-sdp-api-gcp-prod-workflow.test.mjs
@@ -190,6 +190,24 @@ test("merge mode skips the internal smoke gate but requires the caller's", () =>
   );
 });
 
+test("candidate identity accepts the index digest or its platform manifests", () => {
+  assert.match(
+    workflow,
+    /accepted_digests="\$\{expected_digest\}"/,
+    "the verified digest itself must stay accepted"
+  );
+  assert.match(
+    workflow,
+    /\.manifests\[\]\?\.digest/,
+    "multi-arch child manifests must be resolved from the index"
+  );
+  assert.match(
+    workflow,
+    /grep -qx "\$\{revision_digest##\*@\}" <<<"\$\{accepted_digests\}"/,
+    "the served digest must match the index or one of its children exactly"
+  );
+});
+
 test("rollback verification accepts release-tag and merge-to-main identities", () => {
   assert.match(
     workflow,
@@ -208,7 +226,7 @@ test("the orchestrator grants every permission the prod workflow requests", () =
     path.resolve(here, "../.github/workflows/deploy.yml"),
     "utf8"
   );
-  const permissionsBlock = workflow.match(/^permissions:\n((?:  [a-z-]+: [a-z-]+\n)+)/m);
+  const permissionsBlock = workflow.match(/^permissions:\n((?: {2}[a-z-]+: [a-z-]+\n)+)/m);
   assert.ok(permissionsBlock, "prod workflow must declare a top-level permissions block");
   const requested = permissionsBlock[1]
     .trim()
@@ -217,7 +235,7 @@ test("the orchestrator grants every permission the prod workflow requests", () =
     .filter(Boolean);
   assert.ok(requested.length >= 3, "expected at least contents, id-token, and packages grants");
   const callerJob = orchestrator.match(
-    /deploy-api-prod:[\s\S]*?permissions:\n((?:      [a-z-]+: [a-z-]+\n)+)/
+    /deploy-api-prod:[\s\S]*?permissions:\n((?: {6}[a-z-]+: [a-z-]+\n)+)/
   )[1];
   for (const grant of requested) {
     assert.ok(


### PR DESCRIPTION
The v0.70.0 release deploy (run 33588593013) failed its post-deploy candidate identity check and auto-rolled back — correctly executed rollback, wrong reason. Release images are multi-arch: verify-and-promote records the **OCI index** digest (`d419…`), but Cloud Run pins and reports the **platform manifest** it serves — the index's linux/amd64 child (`896e…`, confirmed against the registry). Comparing those two levels can never succeed, so every multi-arch release would roll back. v0.69.0 predated the signed-artifacts path; v0.70.0 was its first live run.

The check now fetches the verified index's child list from the registry (same authenticated AR endpoint the deploy uses) and accepts the served digest only if it is exactly the verified index digest or one of its platform-manifest children — still a closed allowlist derived from the cryptographically verified digest, so the security property is unchanged.

Contract test added pinning the allowlist construction; 124/124 pass.

After merge: re-run the v0.70.0 deploy (workflow_dispatch on deploy-sdp-api-gcp-prod with the release sha) to ship the release that was rolled back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)