### PR TITLE
fix(ci): rollback verify falls back to the signing origin at the pinned digest

### DIFF
--- a/.github/workflows/deploy-sdp-api-gcp-prod.yml
+++ b/.github/workflows/deploy-sdp-api-gcp-prod.yml
@@ -297,10 +297,24 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           set -euo pipefail
-          cosign verify "${IMAGE}" \
-            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-            --certificate-identity-regexp "^https://github.com/${{ github.repository }}/\.github/workflows/release-images\.yml@(refs/tags/v.+|refs/heads/main)$" \
+          # Modern cosign stores signatures as OCI referrer bundles, which
+          # `cosign copy` does not yet carry into Artifact Registry, so the AR
+          # copy can hold the image without a findable signature. Trust follows
+          # the content-addressed digest, not the registry: verify AR first,
+          # and when AR has no signature, verify the signing origin (GHCR) at
+          # the exact same digest the deploy is pinned to. Anything else still
+          # fails closed.
+          verify_flags=(
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+            --certificate-identity-regexp "^https://github.com/${{ github.repository }}/\.github/workflows/release-images\.yml@(refs/tags/v.+|refs/heads/main)$"
             --certificate-github-workflow-sha "${DEPLOY_IMAGE_SHA}"
+          )
+          if cosign verify "${IMAGE}" "${verify_flags[@]}"; then
+            exit 0
+          fi
+          echo "No verifiable signature on the AR copy; verifying the signing origin at the pinned digest." >&2
+          ORIGIN_IMAGE="ghcr.io/${{ github.repository_owner }}/sdp/sdp-api@${IMAGE##*@}"
+          cosign verify "${ORIGIN_IMAGE}" "${verify_flags[@]}"
 
       - name: Run database migrations
         if: ${{ inputs.release_sha != '' }}

--- a/scripts/deploy-sdp-api-gcp-prod-workflow.test.mjs
+++ b/scripts/deploy-sdp-api-gcp-prod-workflow.test.mjs
@@ -316,3 +316,12 @@ test("digest guard still accepts an exact match on a bare (non-index) manifest",
   const r = runDigestBlock({ craneScript: craneBare, revisionDigest: INDEX_DIGEST });
   assert.equal(r.code, 0, r.out);
 });
+
+test("rollback verification falls back to the signing origin at the same pinned digest", () => {
+  assert.match(workflow, /if cosign verify "\$\{IMAGE\}" "\$\{verify_flags\[@\]\}"/);
+  assert.match(
+    workflow,
+    /ORIGIN_IMAGE="ghcr\.io\/\$\{\{ github\.repository_owner \}\}\/sdp\/sdp-api@\$\{IMAGE##\*@\}"/
+  );
+  assert.match(workflow, /cosign verify "\$\{ORIGIN_IMAGE\}" "\$\{verify_flags\[@\]\}"/);
+});


### PR DESCRIPTION
## What
Dispatch-mode signature verification tries the AR copy first and, when AR has no findable signature, verifies the signing origin (GHCR) at the exact pinned digest. Same identity/issuer/sha pins on both attempts, fail closed otherwise. Contract test added (22/22).

## Why
Dispatch run 33594595976 failed with `no signatures found` on the AR copy. Evidence from the registry: the signature exists at GHCR as a modern cosign **referrer bundle** (bare `sha256-d4192739...` tag; the repo has zero legacy `.sig`/`.att` tags), and `cosign copy` does not carry that bundle to AR. The release-path verify at GHCR succeeded for exactly this reason. Until this lands, every dispatch deploy and every rollback fails at this step.

## Design note for @G1de0n
This trades a little of the "AR is self-sufficient for rollbacks" property for correctness today: trust follows the content-addressed digest, not the registry. The alternative (A) is making the promote step carry the bundle into AR (cosign version/flag work, or AR referrers support), which restores self-sufficiency; happy to do that as the follow-up and this fallback then becomes dormant. Blocking the 0.70.0 redeploy, so proposing the minimal correct fix first.

## After merge
Re-dispatch the 0.70.0 deploy by image sha; migrations already applied.