### PR TITLE
fix(ramps): re-pin MoneyGram SDK to upstream c3ae7247

### DIFF
--- a/.github/vendor-assets.json
+++ b/.github/vendor-assets.json
@@ -2,7 +2,7 @@
   {
     "name": "moneygram-sdk",
     "url": "https://playground.xramps.moneygram.com/sdk/index.global.js",
-    "sha256": "7fb658f3553036d8eaf1788ea9ad6ef4b51b27e922c212d54d84c0c454c534c6",
+    "sha256": "c3ae724777935c9b2d5ed8b87aa465988915a53283efb56b254a148ec5777436",
     "pinnedIn": "apps/sdp-web/src/lib/moneygram-sdk.ts"
   }
 ]

--- a/apps/sdp-web/src/lib/moneygram-sdk.ts
+++ b/apps/sdp-web/src/lib/moneygram-sdk.ts
@@ -1,4 +1,4 @@
 export const MONEYGRAM_SDK_VERSION =
-  "7fb658f3553036d8eaf1788ea9ad6ef4b51b27e922c212d54d84c0c454c534c6";
+  "c3ae724777935c9b2d5ed8b87aa465988915a53283efb56b254a148ec5777436";
 
 export const MONEYGRAM_SDK_URL = `/api/vendor/moneygram/sdk/${MONEYGRAM_SDK_VERSION}`;


### PR DESCRIPTION
## Summary
The pinned MoneyGram SDK drifted from upstream (`7fb658f3…` → `c3ae7247…`), so the content-addressed vendor proxy has been 502ing the sandbox widget and `vendor-asset-drift` has fired every 6h since 12:02 AM. This bumps the pin in both places (`apps/sdp-web/src/lib/moneygram-sdk.ts` and `.github/vendor-assets.json`).

## Review of the new bundle
Fetched `https://playground.xramps.moneygram.com/sdk/index.global.js` (sha256 verified `c3ae724777935c9b2d5ed8b87aa465988915a53283efb56b254a148ec5777436`, 9,955 bytes, unminified) and read it in full:
- postMessage is origin-locked in both directions; `RAMPS_OPEN_URL` only opens `https://` with `noopener,noreferrer`; no eval/atob/dynamic script/storage/network beyond the widget iframe.
- Changes vs the pinned build: iOS keyboard-viewport relay (`RAMPS_VIEWPORT`), a custodial `RAMPS_DEPOSIT_ADDRESS` event (SDP wires no handler — SDK warns, harmless), verbose signing-error logging.
- The SDK's default widget URL is now the production host, but SDP always passes `widgetUrl` from the quote and validates it against `MONEYGRAM_WIDGET_APPROVED_HOSTS` (still playground-only), so behavior is unchanged.

## Testing
- `node --test scripts/vendor-assets.test.mjs` — 2/2 pass
- no other references to the old hash in the repo

Second drift in a week — the standing fix remains a tagged/versioned artifact from MoneyGram instead of a mutable URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)