### PR TITLE
feat(web): guard ramp providers behind per-provider feature flags

### DIFF
--- a/apps/sdp-web/src/app/dashboard/payments/payments-command-center.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-command-center.tsx
@@ -12,8 +12,12 @@ import Link from "next/link";
 import { Suspense } from "react";
 import { TokenMark } from "@/components/token-mark";
 import { Badge, type BadgeVariant } from "@/components/ui/badge";
+import { getEnabledRampProviders } from "@/flags/ramps";
 import { getRequestLocale, getTranslations } from "@/i18n/server";
-import { fetchProviderAvailability } from "@/lib/provider-availability";
+import {
+  fetchProviderAvailability,
+  filterEnabledRampProviderAccess,
+} from "@/lib/provider-availability";
 import { createTimedTrace } from "@/lib/request-tracing";
 import type { SdpApiClient } from "@/lib/sdp-api";
 import { fetchCounterparties } from "./counterparty/counterparty-page.data";
@@ -442,16 +446,19 @@ async function PaymentNetwork({
 }) {
   const [{ request }, t] = await Promise.all([apiClientPromise, getTranslations()]);
   const trace = createTimedTrace("dashboard.payments.overview.network");
-  const [result, providerAccess] = await trace.step("fetch_network_summary", () =>
-    Promise.all([
-      fetchCounterparties(request, { page: 1, pageSize: 1 }),
-      fetchProviderAvailability(request, organizationId).catch(() => null),
-    ])
-  );
+  const [[result, providerAccess], enabledRampProviders] = await Promise.all([
+    trace.step("fetch_network_summary", () =>
+      Promise.all([
+        fetchCounterparties(request, { page: 1, pageSize: 1 }),
+        fetchProviderAvailability(request, organizationId).catch(() => null),
+      ])
+    ),
+    getEnabledRampProviders(),
+  ]);
   const enabledProviderCount = providerAccess
-    ? Object.values(providerAccess.rampProviderAccess).filter(
-        (provider) => provider.entitled && provider.configured && provider.enabled
-      ).length
+    ? Object.values(
+        filterEnabledRampProviderAccess(providerAccess.rampProviderAccess, enabledRampProviders)
+      ).filter((access) => access.entitled && access.configured && access.enabled).length
     : null;
   trace.log({
     ok: result.ok || providerAccess !== null,

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/offramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/offramp-step-content.tsx
@@ -66,6 +66,7 @@ export function OfframpStepContent({ wizard }: { wizard: OfframpWizard }) {
   const t = useTranslations();
   const {
     currentStepId,
+    enabledRampProviders,
     rampProviderAccess,
     selectedCounterparty,
     liveWallets,
@@ -130,6 +131,7 @@ export function OfframpStepContent({ wizard }: { wizard: OfframpWizard }) {
       <div className="space-y-4">
         <RampPairProviderSelector
           direction="offramp"
+          enabledRampProviders={enabledRampProviders}
           rampProviderAccess={rampProviderAccess}
           selectedCounterparty={selectedCounterparty}
           wallets={liveWallets}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
@@ -33,6 +33,7 @@ export function OnrampStepContent({ wizard }: { wizard: OnrampWizard }) {
   const t = useTranslations();
   const {
     currentStepId,
+    enabledRampProviders,
     rampProviderAccess,
     selectedCounterparty,
     fields,
@@ -78,6 +79,7 @@ export function OnrampStepContent({ wizard }: { wizard: OnrampWizard }) {
       <div className="space-y-4">
         <RampPairProviderSelector
           direction="onramp"
+          enabledRampProviders={enabledRampProviders}
           rampProviderAccess={rampProviderAccess}
           selectedCounterparty={selectedCounterparty}
           wallets={liveWallets}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/ramp-pair-provider-selector.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/ramp-pair-provider-selector.tsx
@@ -4,6 +4,7 @@ import type {
   Counterparty,
   CounterpartyEntityType,
   PaymentsDashboardWallet,
+  RampProviderId,
   SdpEnvironment,
 } from "@sdp/types";
 import { RAMP_PROVIDER_SUPPORT_DETAILS, type RampFiatCurrency } from "@sdp/types/generated/ramp";
@@ -12,7 +13,7 @@ import {
   getCryptoRailAssetLabel,
   type RampProviderDirectionSupport,
 } from "@sdp/types/payment-rails";
-import type { ProviderAvailabilityEntry, RampProviderId } from "@sdp/types/provider-access";
+import type { ProviderAvailabilityEntry } from "@sdp/types/provider-access";
 import { AnimatePresence, motion } from "motion/react";
 import Image from "next/image";
 import { useCallback, useMemo, useState } from "react";
@@ -39,6 +40,7 @@ import { RampSelectionProvider } from "./ramp-selection-context";
 
 interface RampPairProviderSelectorProps {
   direction: RampDirection;
+  enabledRampProviders: readonly RampProviderId[];
   rampProviderAccess: RampProviderAccess | null;
   selectedCounterparty: Counterparty | null;
   wallets: readonly PaymentsDashboardWallet[];
@@ -72,15 +74,24 @@ function getDirectionSupport(
   return RAMP_PROVIDER_SUPPORT_DETAILS[provider][direction];
 }
 
+/**
+ * Returns the available ramp pairs for a direction.
+ *
+ * @param direction - The ramp direction.
+ * @param environment - The dashboard environment.
+ * @param enabledRampProviders - The providers enabled for the current request.
+ * @returns The available ramp pairs.
+ */
 function pairsForDirection(
   direction: RampDirection,
-  environment: SdpEnvironment
+  environment: SdpEnvironment,
+  enabledRampProviders: readonly RampProviderId[]
 ): readonly RampPair[] {
   switch (direction) {
     case "onramp":
-      return onrampPairs(environment);
+      return onrampPairs(environment, enabledRampProviders);
     case "offramp":
-      return offrampPairs(environment);
+      return offrampPairs(environment, enabledRampProviders);
     default: {
       const exhaustive: never = direction;
       return exhaustive;
@@ -208,6 +219,7 @@ function buildProviderExclusion(args: {
 
 export function RampPairProviderSelector({
   direction,
+  enabledRampProviders,
   rampProviderAccess,
   selectedCounterparty,
   wallets,
@@ -226,17 +238,17 @@ export function RampPairProviderSelector({
   const { sdpEnvironment } = useDashboardWorkspace();
   const t = useTranslations();
   const [unavailableDialogOpen, setUnavailableDialogOpen] = useState(false);
-  const pairs = pairsForDirection(direction, sdpEnvironment);
+  const pairs = pairsForDirection(direction, sdpEnvironment, enabledRampProviders);
   const selectedPairSupport = useMemo(
     () => findRampPair(pairs, selectedPair),
     [pairs, selectedPair]
   );
   const directionProviderOptions = useMemo(
     () =>
-      surfacedRampProviderOptions(sdpEnvironment).filter(
+      surfacedRampProviderOptions(sdpEnvironment, enabledRampProviders).filter(
         (option) => Object.keys(getDirectionSupport(option.id, direction).currencies).length > 0
       ),
-    [direction, sdpEnvironment]
+    [direction, enabledRampProviders, sdpEnvironment]
   );
   const providerExclusions = useMemo(
     () =>

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-offramp-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-offramp-wizard.ts
@@ -94,7 +94,7 @@ export function useOfframpWizard(props: UseRampWizardProps) {
   );
 
   const wizard = useRampWizard<OfframpStepId>(props, {
-    pairs: offrampPairs(sdpEnvironment),
+    pairs: offrampPairs(sdpEnvironment, props.enabledRampProviders),
     steps: getOfframpSteps(t),
     stepSchemas: { WALLET: sourceWalletSchema, WITHDRAW: withdrawAmountSchema },
     quoteStepId: "MEMO",

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-onramp-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-onramp-wizard.ts
@@ -68,7 +68,7 @@ export function useOnrampWizard(props: UseRampWizardProps) {
   const [quoteSimulationSucceeded, setQuoteSimulationSucceeded] = useState(false);
 
   const wizard = useRampWizard<OnrampStepId>(props, {
-    pairs: onrampPairs(sdpEnvironment),
+    pairs: onrampPairs(sdpEnvironment, props.enabledRampProviders),
     steps: getOnrampSteps(t),
     stepSchemas: { DEPOSIT: depositAmountSchema },
     quoteStepId: "MEMO",

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-ramp-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-ramp-wizard.ts
@@ -114,6 +114,7 @@ async function createRampQuote(
 export interface UseRampWizardProps {
   wallets: PaymentsDashboardWallet[];
   walletsError: string | null;
+  enabledRampProviders: RampProviderId[];
   rampProviderAccess: RampProviderAccess | null;
   counterpartiesResult: CounterpartiesResult;
   selectedCounterparty: Counterparty | null;
@@ -127,6 +128,7 @@ export function useRampWizard<TId extends string>(
   {
     wallets,
     walletsError,
+    enabledRampProviders,
     rampProviderAccess,
     counterpartiesResult,
     selectedCounterparty,
@@ -475,6 +477,7 @@ export function useRampWizard<TId extends string>(
   };
 
   return {
+    enabledRampProviders,
     rampProviderAccess,
     selectedCounterparty,
     stepIndex,

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/offramp-rail.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/offramp-rail.tsx
@@ -30,6 +30,7 @@ function offrampPrimaryLabel(wizard: OfframpWizard, t: ReturnType<typeof useTran
 export function OfframpRail({
   wallets,
   walletsError,
+  enabledRampProviders,
   rampProviderAccess,
   counterpartiesResult,
   selectedCounterparty,
@@ -43,6 +44,7 @@ export function OfframpRail({
   const wizard = useOfframpWizard({
     wallets,
     walletsError,
+    enabledRampProviders,
     rampProviderAccess,
     counterpartiesResult,
     selectedCounterparty,

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/onramp-rail.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/onramp-rail.tsx
@@ -49,6 +49,7 @@ function onrampPrimaryAction(
 export function OnrampRail({
   wallets,
   walletsError,
+  enabledRampProviders,
   rampProviderAccess,
   counterpartiesResult,
   selectedCounterparty,
@@ -62,6 +63,7 @@ export function OnrampRail({
   const wizard = useOnrampWizard({
     wallets,
     walletsError,
+    enabledRampProviders,
     rampProviderAccess,
     counterpartiesResult,
     selectedCounterparty,

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/payments-action-page.server.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/payments-action-page.server.ts
@@ -3,7 +3,11 @@ import "server-only";
 import type { OnboardingStatusResponse } from "@/app/dashboard/onboarding-status";
 import { fetchCounterparties } from "@/app/dashboard/payments/counterparty/counterparty-page.data";
 import { fetchPaymentsIssuedTokenSymbols } from "@/app/dashboard/payments/payments-page.data";
-import { fetchProviderAvailability } from "@/lib/provider-availability";
+import { getEnabledRampProviders } from "@/flags/ramps";
+import {
+  fetchProviderAvailability,
+  filterEnabledRampProviderAccess,
+} from "@/lib/provider-availability";
 import { createOrgSdpApiClient, createSdpApiClient } from "@/lib/sdp-api";
 
 const UNLINKED_ONBOARDING_STATUS = {
@@ -23,18 +27,23 @@ export async function loadPaymentsActionPageData() {
         )
       : null
   );
-  const [issuedTokenSymbolsResult, counterpartiesResult, providerAccess] = await Promise.all([
-    fetchPaymentsIssuedTokenSymbols(apiClient.request),
-    fetchCounterparties(apiClient.request),
-    providerAccessPromise,
-  ]);
+  const [issuedTokenSymbolsResult, counterpartiesResult, providerAccess, enabledRampProviders] =
+    await Promise.all([
+      fetchPaymentsIssuedTokenSymbols(apiClient.request),
+      fetchCounterparties(apiClient.request),
+      providerAccessPromise,
+      getEnabledRampProviders(),
+    ]);
 
   return {
     issuedTokenSymbolsByMint: Object.fromEntries(
       (issuedTokenSymbolsResult.data ?? []).map((token) => [token.mintAddress, token.symbol])
     ),
     enabledComplianceProviders: providerAccess?.enabledComplianceProviders ?? [],
-    rampProviderAccess: providerAccess ? providerAccess.rampProviderAccess : null,
+    enabledRampProviders,
+    rampProviderAccess: providerAccess
+      ? filterEnabledRampProviderAccess(providerAccess.rampProviderAccess, enabledRampProviders)
+      : null,
     counterpartiesResult,
   };
 }

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/payments-action-page.server.unit.test.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/payments-action-page.server.unit.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   fetchCounterparties: vi.fn(),
   fetchPaymentsIssuedTokenSymbols: vi.fn(),
   fetchProviderAvailability: vi.fn(),
+  getEnabledRampProviders: vi.fn(),
 }));
 
 vi.mock("server-only", () => ({}));
@@ -19,8 +20,15 @@ vi.mock("@/app/dashboard/payments/counterparty/counterparty-page.data", () => ({
 vi.mock("@/app/dashboard/payments/payments-page.data", () => ({
   fetchPaymentsIssuedTokenSymbols: mocks.fetchPaymentsIssuedTokenSymbols,
 }));
-vi.mock("@/lib/provider-availability", () => ({
-  fetchProviderAvailability: mocks.fetchProviderAvailability,
+vi.mock(import("@/lib/provider-availability"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    fetchProviderAvailability: mocks.fetchProviderAvailability,
+  };
+});
+vi.mock("@/flags/ramps", () => ({
+  getEnabledRampProviders: mocks.getEnabledRampProviders,
 }));
 
 import { loadPaymentsActionPageData } from "./payments-action-page.server";
@@ -45,7 +53,11 @@ describe("loadPaymentsActionPageData", () => {
     const counterpartiesResult = { ok: true as const, data: [], total: 0 as const };
     const providerAvailability = {
       enabledComplianceProviders: [],
-      rampProviderAccess: {},
+      rampProviderAccess: {
+        moonpay: { entitled: true, configured: true, enabled: true },
+        mural: { entitled: true, configured: true, enabled: true },
+        stripe: { entitled: true, configured: true, enabled: true },
+      },
     };
 
     mocks.createOrgSdpApiClient.mockResolvedValue({
@@ -59,6 +71,7 @@ describe("loadPaymentsActionPageData", () => {
     mocks.fetchPaymentsIssuedTokenSymbols.mockReturnValue(issuedTokens.promise);
     mocks.fetchCounterparties.mockReturnValue(counterparties.promise);
     mocks.fetchProviderAvailability.mockResolvedValue(providerAvailability);
+    mocks.getEnabledRampProviders.mockResolvedValue(["moonpay", "stripe"]);
 
     const resultPromise = loadPaymentsActionPageData();
 
@@ -77,7 +90,11 @@ describe("loadPaymentsActionPageData", () => {
     await expect(resultPromise).resolves.toEqual({
       issuedTokenSymbolsByMint: { mint_usdc: "USDC" },
       enabledComplianceProviders: [],
-      rampProviderAccess: {},
+      enabledRampProviders: ["moonpay", "stripe"],
+      rampProviderAccess: {
+        moonpay: { entitled: true, configured: true, enabled: true },
+        stripe: { entitled: true, configured: true, enabled: true },
+      },
       counterpartiesResult,
     });
   });

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/ramp-action-page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/ramp-action-page.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import type { ComplianceProviderId, Counterparty, PaymentsDashboardWallet } from "@sdp/types";
+import type {
+  ComplianceProviderId,
+  Counterparty,
+  PaymentsDashboardWallet,
+  RampProviderId,
+} from "@sdp/types";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 import useSWR, { preload } from "swr";
@@ -34,6 +39,7 @@ interface PaymentsActionPageProps {
   walletsError: string | null;
   issuedTokenSymbolsByMint: Record<string, string>;
   enabledComplianceProviders: ComplianceProviderId[];
+  enabledRampProviders: RampProviderId[];
   rampProviderAccess: RampProviderAccess | null;
   counterpartiesResult: CounterpartiesResult;
 }
@@ -44,6 +50,7 @@ export interface RailProps {
   wallets: PaymentsDashboardWallet[];
   walletsError: string | null;
   issuedTokenSymbolsByMint: Record<string, string>;
+  enabledRampProviders: RampProviderId[];
   rampProviderAccess: RampProviderAccess | null;
   counterpartiesResult: CounterpartiesResult;
   selectedCounterparty: Counterparty | null;
@@ -147,6 +154,7 @@ export function PaymentsActionPage(props: PaymentsActionPageProps) {
       wallets: props.wallets,
       walletsError: props.walletsError,
       issuedTokenSymbolsByMint: props.issuedTokenSymbolsByMint,
+      enabledRampProviders: props.enabledRampProviders,
       rampProviderAccess,
       counterpartiesResult: liveCounterparties,
       selectedCounterparty,

--- a/apps/sdp-web/src/flags/index.ts
+++ b/apps/sdp-web/src/flags/index.ts
@@ -1,4 +1,5 @@
 import { vercelAdapter } from "@flags-sdk/vercel";
+import type { RampProviderId } from "@sdp/types";
 import { dedupe, flag } from "flags/next";
 import { getSdpAuth } from "@/lib/sdp-api";
 
@@ -51,6 +52,27 @@ const identifyDashboardEntities = dedupe(async (): Promise<DashboardFlagEntities
     user: { email },
   };
 });
+
+/**
+ * Creates a Vercel flag for one ramp provider.
+ *
+ * @param provider - The ramp provider identifier.
+ * @param title - The provider's display title.
+ * @returns The provider feature flag definition.
+ */
+function rampProviderFlag(provider: RampProviderId, title: string) {
+  return flag<boolean, DashboardFlagEntities>({
+    key: `ramp-provider-${provider}`,
+    adapter: vercelAdapter(),
+    identify: identifyDashboardEntities,
+    defaultValue: flagDefault(`RAMP_PROVIDER_${provider.toUpperCase()}_ENABLED`, true),
+    description: `Show ${title} as a selectable provider in the onramp and offramp wizards.`,
+    options: [
+      { value: false, label: "Hidden" },
+      { value: true, label: "Enabled" },
+    ],
+  });
+}
 
 export const homepageOpenSignup = flag<boolean, DashboardFlagEntities>({
   key: "homepage-open-signup",
@@ -169,3 +191,11 @@ export const earn = flag<boolean, DashboardFlagEntities>({
     { value: true, label: "Enabled" },
   ],
 });
+
+export const rampProviderMoonpay = rampProviderFlag("moonpay", "MoonPay");
+export const rampProviderLightspark = rampProviderFlag("lightspark", "Lightspark");
+export const rampProviderBvnk = rampProviderFlag("bvnk", "BVNK");
+export const rampProviderMoneygram = rampProviderFlag("moneygram", "MoneyGram");
+export const rampProviderCoinbase = rampProviderFlag("coinbase", "Coinbase");
+export const rampProviderMural = rampProviderFlag("mural", "Mural Pay");
+export const rampProviderStripe = rampProviderFlag("stripe", "Stripe");

--- a/apps/sdp-web/src/flags/ramps.ts
+++ b/apps/sdp-web/src/flags/ramps.ts
@@ -1,0 +1,34 @@
+import type { RampProviderId } from "@sdp/types";
+import { RAMP_PROVIDERS } from "@sdp/types";
+import {
+  rampProviderBvnk,
+  rampProviderCoinbase,
+  rampProviderLightspark,
+  rampProviderMoneygram,
+  rampProviderMoonpay,
+  rampProviderMural,
+  rampProviderStripe,
+} from "@/flags";
+
+const RAMP_PROVIDER_FLAGS = {
+  moonpay: rampProviderMoonpay,
+  lightspark: rampProviderLightspark,
+  bvnk: rampProviderBvnk,
+  moneygram: rampProviderMoneygram,
+  coinbase: rampProviderCoinbase,
+  mural: rampProviderMural,
+  stripe: rampProviderStripe,
+} as const satisfies Record<RampProviderId, typeof rampProviderMoonpay>;
+
+/**
+ * Resolves the ramp providers enabled for the current request.
+ *
+ * @returns The enabled ramp providers in canonical provider order.
+ */
+export async function getEnabledRampProviders(): Promise<RampProviderId[]> {
+  const enabled = await Promise.all(
+    RAMP_PROVIDERS.map((provider) => RAMP_PROVIDER_FLAGS[provider]())
+  );
+
+  return RAMP_PROVIDERS.filter((_, index) => enabled[index]);
+}

--- a/apps/sdp-web/src/lib/provider-availability.ts
+++ b/apps/sdp-web/src/lib/provider-availability.ts
@@ -34,6 +34,21 @@ export function hasEnabledRampProvider(access: RampProviderAccess | null): boole
   return Object.values(access).some((entry) => entry.entitled && entry.configured && entry.enabled);
 }
 
+/**
+ * Restricts a ramp provider access record to the feature-flag-enabled providers.
+ *
+ * @param access - The provider access record reported for the organization.
+ * @param enabledProviders - The ramp providers enabled by feature flags.
+ * @returns The access record without flagged-off providers.
+ */
+export function filterEnabledRampProviderAccess(
+  access: RampProviderAccess,
+  enabledProviders: readonly RampProviderId[]
+): RampProviderAccess {
+  const enabled = new Set<string>(enabledProviders);
+  return Object.fromEntries(Object.entries(access).filter(([provider]) => enabled.has(provider)));
+}
+
 export async function fetchProviderAvailability(
   request: SdpApiClient["request"],
   organizationId: string

--- a/apps/sdp-web/src/lib/ramps.ts
+++ b/apps/sdp-web/src/lib/ramps.ts
@@ -1,7 +1,7 @@
-import type { SdpEnvironment } from "@sdp/types";
+import type { RampProviderId, SdpEnvironment } from "@sdp/types";
 import { OFFRAMP_SUPPORT, ONRAMP_SUPPORT, type RampFiatCurrency } from "@sdp/types/generated/ramp";
 import type { CryptoRailId } from "@sdp/types/payment-rails";
-import { isRampProviderSurfaced, type RampProviderId } from "@sdp/types/provider-access";
+import { isRampProviderSurfaced } from "@sdp/types/provider-access";
 
 export type RampDirection = "onramp" | "offramp";
 
@@ -51,13 +51,39 @@ export const RAMP_PROVIDER_OPTIONS: RampProviderOption[] = [
   { id: "stripe", title: "Stripe" },
 ];
 
-export function surfacedRampProviderOptions(environment: SdpEnvironment): RampProviderOption[] {
-  return RAMP_PROVIDER_OPTIONS.filter((option) => isRampProviderSurfaced(option.id, environment));
+/**
+ * Returns the ramp providers surfaced for an environment and enabled by feature flags.
+ *
+ * @param environment - The dashboard environment.
+ * @param enabledProviders - The providers enabled for the current request.
+ * @returns The selectable provider options.
+ */
+export function surfacedRampProviderOptions(
+  environment: SdpEnvironment,
+  enabledProviders: readonly RampProviderId[]
+): RampProviderOption[] {
+  return RAMP_PROVIDER_OPTIONS.filter(
+    (option) =>
+      isRampProviderSurfaced(option.id, environment) && enabledProviders.includes(option.id)
+  );
 }
 
-export function onrampPairs(environment: SdpEnvironment): RampPair[] {
+/**
+ * Returns on-ramp currency pairs with only surfaced and enabled providers.
+ *
+ * @param environment - The dashboard environment.
+ * @param enabledProviders - The providers enabled for the current request.
+ * @returns The available on-ramp pairs.
+ */
+export function onrampPairs(
+  environment: SdpEnvironment,
+  enabledProviders: readonly RampProviderId[]
+): RampPair[] {
   return ONRAMP_SUPPORT.flatMap(({ source, dest, providers }) => {
-    const surfaced = providers.filter((p) => isRampProviderSurfaced(p, environment));
+    const surfaced = providers.filter(
+      (provider) =>
+        isRampProviderSurfaced(provider, environment) && enabledProviders.includes(provider)
+    );
     if (surfaced.length === 0) return [];
     return [{ fiatCurrency: source, assetRail: dest, providers: surfaced }];
   });
@@ -65,9 +91,22 @@ export function onrampPairs(environment: SdpEnvironment): RampPair[] {
 
 // Offramp support is keyed crypto -> fiat (source is the asset rail, dest is the fiat
 // currency), the reverse of onramp. Normalize into the same RampPair shape.
-export function offrampPairs(environment: SdpEnvironment): RampPair[] {
+/**
+ * Returns off-ramp currency pairs with only surfaced and enabled providers.
+ *
+ * @param environment - The dashboard environment.
+ * @param enabledProviders - The providers enabled for the current request.
+ * @returns The available off-ramp pairs.
+ */
+export function offrampPairs(
+  environment: SdpEnvironment,
+  enabledProviders: readonly RampProviderId[]
+): RampPair[] {
   return OFFRAMP_SUPPORT.flatMap(({ source, dest, providers }) => {
-    const surfaced = providers.filter((p) => isRampProviderSurfaced(p, environment));
+    const surfaced = providers.filter(
+      (provider) =>
+        isRampProviderSurfaced(provider, environment) && enabledProviders.includes(provider)
+    );
     if (surfaced.length === 0) return [];
     return [{ fiatCurrency: dest, assetRail: source, providers: surfaced }];
   });


### PR DESCRIPTION
**Flags**

- Adds 7 Vercel flags `ramp-provider-<id>` (moonpay, lightspark, bvnk, moneygram, coinbase, mural, stripe) in `src/flags/index.ts` via one local factory; email targeting reuses the existing Clerk-claim identify.
- Default ON everywhere (`flagDefault("RAMP_PROVIDER_<ID>_ENABLED", true)`) — this deploy is behavior-preserving; rollout = flip flags per environment/email in the Vercel Flags Explorer.
- New `src/flags/ramps.ts` resolver `getEnabledRampProviders()` — one `Promise.all` pass, canonical `RAMP_PROVIDERS` order.

**Gating**

- `loadPaymentsActionPageData()` resolves flags server-side, returns `enabledRampProviders`, and filters `rampProviderAccess` via the new `filterEnabledRampProviderAccess` helper — so `hasEnabledRampProvider` (which gates the fiat method step) respects flags with zero client logic.
- `surfacedRampProviderOptions` / `onrampPairs` / `offrampPairs` now require the enabled list — a flagged-off provider disappears entirely: no card, no pair, no row in the "unavailable providers" modal.
- `enabledRampProviders` rides the same prop path as `rampProviderAccess` (rails → wizard hooks → selector); the wizard's existing pair-membership reset clears `?provider=` deep links to flagged-off providers.
- Command-center network count uses the same helper, so the overview matches the wizards.

**before** — provider visibility per org:

1. static per-env surfacing ∩ pair support ∩ org provider-access
2. no way to hide a provider for rollout without touching entitlements

**after**:

1. same chain ∩ per-provider flag, resolved server-side per request
2. flag off → provider absent from wizards, method step, and overview count; flag on → behavior unchanged

**Verification**

- `pnpm --filter sdp-web exec tsc --noEmit` — clean
- `vitest run` ramps unit tests (server loader incl. flag filtering, schema, memo) — 12/12 passed
- `biome check` on changed files — clean
- local app: not exercised in the browser for this PR — flags default ON so runtime behavior is unchanged; the flag-off path is covered by the server-loader unit test

**Deliberate exceptions**

- Integrations page (credentials surface) and the transactions provider *filter* (historical data) stay unflagged.
- Flags gate UI rollout only; API-side entitlement (provider-access) remains the enforcement layer.
