### PR TITLE
feat(deploy): shadow stage deploy on every merge to main

### DIFF
--- a/.github/workflows/deploy-sdp-api-gcp-stage.yml
+++ b/.github/workflows/deploy-sdp-api-gcp-stage.yml
@@ -1,0 +1,105 @@
+name: Deploy sdp-api to Cloud Run (stage)
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: sdp-api-gcp-deploy-stage
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build and deploy
+    if: github.repository == 'solana-foundation/solana-developer-platform'
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_ID: solana-developer-platform-stg
+      REGION: us-central1
+      REPO: sdp-stage
+      SERVICE: sdp-stage-api-public
+      JOB: sdp-stage-api-public-cron
+      WORKER_SERVICE: sdp-stage-worker
+      MIGRATE_JOB: sdp-stage-api-public-migrate
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.STAGE_DEPLOY_WIF_PROVIDER }}
+          service_account: ${{ vars.STAGE_DEPLOY_SA }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+
+      - name: Build and push image
+        run: |
+          set -euo pipefail
+          IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/sdp-api-public:${GITHUB_SHA}"
+          docker build -f apps/sdp-api/Dockerfile --build-arg GIT_SHA="${GITHUB_SHA}" -t "${IMAGE}" .
+          docker push "${IMAGE}"
+          echo "IMAGE=${IMAGE}" >> "${GITHUB_ENV}"
+
+      - name: Run database migrations
+        run: |
+          gcloud run jobs update "${MIGRATE_JOB}" \
+            --region "${REGION}" --project "${PROJECT_ID}" --image "${IMAGE}"
+          gcloud run jobs execute "${MIGRATE_JOB}" \
+            --region "${REGION}" --project "${PROJECT_ID}" --wait
+
+      - name: Deploy service
+        run: |
+          gcloud run services update "${SERVICE}" \
+            --region "${REGION}" --project "${PROJECT_ID}" --image "${IMAGE}"
+
+      - name: Verify revision readiness
+        run: |
+          set -euo pipefail
+          REVISION=$(gcloud run services describe "${SERVICE}" \
+            --region "${REGION}" --project "${PROJECT_ID}" \
+            --format='value(status.latestCreatedRevisionName)')
+          echo "candidate revision: ${REVISION}"
+          for attempt in $(seq 1 12); do
+            READY=$(gcloud run revisions describe "${REVISION}" \
+              --region "${REGION}" --project "${PROJECT_ID}" --format=json \
+              | jq -r '.status.conditions[] | select(.type == "Ready") | .status')
+            if [ "${READY}" = "True" ]; then
+              echo "revision ${REVISION} is ready"
+              exit 0
+            fi
+            echo "attempt ${attempt}/12: revision ${REVISION} not ready yet (${READY:-unknown})"
+            sleep 10
+          done
+          echo "revision ${REVISION} never became ready" >&2
+          exit 1
+
+      - name: Update cron job image
+        run: |
+          node .github/scripts/verify-managed-reconciliation-cadence.mjs \
+            "${JOB}" "${REGION}" "${PROJECT_ID}"
+          gcloud run jobs update "${JOB}" \
+            --region "${REGION}" --project "${PROJECT_ID}" --image "${IMAGE}"
+
+      - name: Update worker image
+        run: |
+          describe_err="$(mktemp)"
+          if gcloud run services describe "${WORKER_SERVICE}" \
+            --region "${REGION}" --project "${PROJECT_ID}" >/dev/null 2>"${describe_err}"; then
+            gcloud run services update "${WORKER_SERVICE}" \
+              --region "${REGION}" --project "${PROJECT_ID}" --image "${IMAGE}"
+          elif grep -qiE "NOT_FOUND|could not be found" "${describe_err}"; then
+            echo "worker service ${WORKER_SERVICE} not created yet; skipping image update"
+          else
+            cat "${describe_err}" >&2
+            exit 1
+          fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
             none) ;;
             api) api=true ;;
             auto|*)
-              if match "^(apps/sdp-api/|packages/|package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|\.github/workflows/deploy(-sdp-api-gcp(-prod)?)?\.yml|\.github/workflows/sdp-dev-smoke\.yml)"; then
+              if match "^(apps/sdp-api/|packages/|package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|\.github/workflows/deploy(-sdp-api-gcp(-prod|-stage)?)?\.yml|\.github/workflows/sdp-dev-smoke\.yml)"; then
                 api=true
               fi
               ;;
@@ -182,6 +182,15 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/deploy-sdp-api-gcp.yml
+
+  deploy-api-stage:
+    name: sdp-api + worker + cron — stage (shadow)
+    needs: changes
+    if: needs.changes.outputs.api == 'true' && vars.STAGE_DEPLOY_WIF_PROVIDER != ''
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/deploy-sdp-api-gcp-stage.yml
 
   deploy-api-prod:
     name: sdp-api + worker + cron — prod

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -186,7 +186,7 @@ jobs:
   deploy-api-stage:
     name: sdp-api + worker + cron — stage (shadow)
     needs: changes
-    if: needs.changes.outputs.api == 'true' && vars.STAGE_DEPLOY_WIF_PROVIDER != ''
+    if: needs.changes.outputs.api == 'true' && vars.STAGE_DEPLOY_WIF_PROVIDER != '' && vars.STAGE_DEPLOY_SA != ''
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
First slice of the dev→stage cutover (PRO-1767), now that sdp-infra #111 is merged and applied.

## What this does
- New `deploy-sdp-api-gcp-stage.yml`: clone of the dev deploy against `solana-developer-platform-stg` (`sdp-stage-*` service/jobs), plus a revision-readiness gate (`gcloud run revisions describe` Ready poll — stage ingress is LB-only and api-stage DNS isn't live, so no HTTP probe yet).
- `deploy.yml` gets a `deploy-api-stage` job in **shadow mode**: `continue-on-error` inside the called workflow, and the job **skips entirely until `STAGE_DEPLOY_WIF_PROVIDER` / `STAGE_DEPLOY_SA` repo variables are set**. Dev and prod paths are untouched.

## Activation (after merge)
```
gh variable set STAGE_DEPLOY_WIF_PROVIDER --body "$(terraform -chdir=terraform/envs/stage output -raw sdp_api_public_deploy_wif_provider 2>/dev/null || echo '<from stage outputs>')"
gh variable set STAGE_DEPLOY_SA --body "sdp-stage-api-public-deploy@solana-developer-platform-stg.iam.gserviceaccount.com"
```
(exact WIF provider resource name comes from the stage terraform outputs / WIF pool `sdp-stage-api-public-gha`, provider `github`)

## Cutover plan (not in this PR)
1. **Shadow bake (~1 week):** stage deploys on every merge, failures visible but non-blocking; Monday masked-prod refreshes keep running; watch migrate-job behavior against prod-shaped data.
2. **Flip the gate:** point the prod promotion smoke at stage instead of dev, drop `continue-on-error`. Prereqs: api-stage DNS + a stage smoke fixture org (masked DB purges sessions and scrambles api_keys, so a fresh Clerk canary org self-provisions on first login).
3. **Open dev:** any-user/any-branch deploys (#1520 ephemerals), dev leaves the promotion path.

Tests: `pnpm test:scripts` 128/128, actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)