### PR TITLE
fix(issuance): stop pre-selecting scaledUiAmount on tokenized securities

### DIFF
--- a/apps/sdp-web/src/app/dashboard/issuance/create/draft-mapping.unit.test.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/create/draft-mapping.unit.test.ts
@@ -7,6 +7,7 @@ import {
   getAssetDetailsErrors,
   getDefaultPublicFields,
   getPublicFieldCandidates,
+  sanitizeAdvancedSettings,
   togglePublicField,
 } from "./draft-mapping";
 import { createInitialDraft, type DraftState } from "./issuance-draft-wizard.types";
@@ -301,5 +302,38 @@ describe("buildIssuanceMetadata visibility", () => {
     expect(buildIssuanceMetadata(draft).visibility).toEqual({
       public: ["asset.pegCurrency", "asset.name", "chain.decimals"],
     });
+  });
+});
+
+describe("sanitizeAdvancedSettings and scaledUiAmount on securities", () => {
+  // Pins the behaviour that forced STORAGE_VERSION to 3 in use-issuance-draft.ts.
+  //
+  // scaledUiAmount is "available" on a tokenized security: still offered, just no
+  // longer pre-selected, because a mint carrying it is rejected by the DvP
+  // settlement program. Available means still ALLOWED, so hydration keeps it —
+  // right for someone who deliberately ticked it, wrong for a draft where the old
+  // default ticked it for them.
+  //
+  // The draft records no provenance, so this function cannot tell those apart.
+  // Teaching it to strip the setting would silently revert a deliberate choice on
+  // every reload. Discarding pre-change drafts via the version bump is the only
+  // fix that does neither. If this starts failing because sanitize learned to drop
+  // it, re-read that before "fixing" the test.
+  it("keeps a deliberately selected scaledUiAmount on a security", () => {
+    const kept = sanitizeAdvancedSettings("tokenized_security", "equity", {
+      scaledUiAmount: { params: { multiplier: "1" } },
+    });
+
+    expect(kept).toHaveProperty("scaledUiAmount");
+  });
+
+  it("still drops settings the asset type genuinely disallows", () => {
+    const kept = sanitizeAdvancedSettings("tokenized_security", "equity", {
+      transferFee: {},
+      scaledUiAmount: {},
+    });
+
+    expect(kept).not.toHaveProperty("transferFee");
+    expect(kept).toHaveProperty("scaledUiAmount");
   });
 });

--- a/apps/sdp-web/src/app/dashboard/issuance/create/setting-combos.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/create/setting-combos.ts
@@ -62,7 +62,12 @@ export const SETTING_COMBOS: readonly SettingCombo[] = [
     category: "tokenized_security",
     labelKey: cfg("comboRegulatedSecurity"),
     descriptionKey: cfg("comboRegulatedSecurityDescription"),
-    settings: ["scaledUiAmount"],
+    // No scaledUiAmount. This is the DEFAULT preset for a tokenized security, so
+    // anything listed here lands on every security issued without the wizard
+    // being touched — and a mint carrying scaledUiAmount is rejected outright by
+    // the DvP settlement program. It was never part of this preset's stated
+    // purpose either, which is the compliance base described below.
+    settings: [],
     capacities: ["kyc", "transferApprovals", "investorReporting", "restrictTradingHours"],
     // The compliance base every tokenized security needs: verified investors on an
     // on-chain allowlist, reviewed transfers, market-hours trading, and reporting.
@@ -73,7 +78,11 @@ export const SETTING_COMBOS: readonly SettingCombo[] = [
     category: "tokenized_security",
     labelKey: cfg("comboFundOperations"),
     descriptionKey: cfg("comboFundOperationsDescription"),
-    settings: ["scaledUiAmount"],
+    // No scaledUiAmount here either, same reason. This preset is opt-in rather
+    // than default, but balance-display scaling is not part of subscriptions and
+    // redemptions, and bundling it would make picking this preset quietly cost
+    // the issuer DvP settlement. Still reachable as an advanced setting.
+    settings: [],
     capacities: ["kyc", "redemptionApprovals", "issueRetireControls"],
     // A complementary lifecycle layer — subscriptions/redemptions with issuer-managed
     // supply. Same allowlist as the base, so it stacks onto regulatedSecurity (giving a

--- a/apps/sdp-web/src/app/dashboard/issuance/create/setting-combos.unit.test.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/create/setting-combos.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { getMessages, type MessageKey, translate } from "@/i18n/messages";
+import { getRecommendedAdvancedSettings } from "./draft-mapping";
 import { createInitialCapacities } from "./issuance-draft-wizard.types";
 import {
   applyCombo,
@@ -31,6 +32,37 @@ describe("getDefaultCombo", () => {
 
   it("leaves generic without a default so it starts blank", () => {
     expect(getDefaultCombo("generic")).toBeUndefined();
+  });
+
+  // The capability registry no longer recommends scaledUiAmount for securities,
+  // but that alone is not enough: picking a security type also auto-applies this
+  // preset (steps/step-classification.tsx), which used to add the setting straight
+  // back. A mint carrying scaledUiAmount is rejected by the DvP settlement program
+  // with BlockedMintExtension, so the default flow must not produce one.
+  it("does not turn on scaledUiAmount anywhere in the default security flow", () => {
+    const combo = getDefaultCombo("tokenized_security");
+    const applied = applyCombo(
+      combo as SettingCombo,
+      getRecommendedAdvancedSettings("tokenized_security", "equity"),
+      createInitialCapacities(),
+      "allowlist"
+    );
+
+    expect(Object.keys(applied.settings)).not.toContain("scaledUiAmount");
+  });
+
+  // Iterates SETTING_COMBOS directly rather than getCombosForCategory, which
+  // filters the default combo out — and the default is exactly the one that has
+  // to be checked here.
+  it("keeps scaledUiAmount out of every tokenized-security preset", () => {
+    const securityCombos = SETTING_COMBOS.filter(
+      (combo) => combo.category === "tokenized_security"
+    );
+
+    expect(securityCombos.length).toBeGreaterThan(1);
+    for (const combo of securityCombos) {
+      expect(combo.settings, `combo "${combo.key}"`).not.toContain("scaledUiAmount");
+    }
   });
 });
 
@@ -161,11 +193,14 @@ describe("getComboConflict", () => {
     expect(() => translate(messages, conflict?.reasonKey as MessageKey)).not.toThrow();
   });
 
+  // Driven from the interestBearing side because no security preset bundles
+  // scaledUiAmount any more (it blocks DvP settlement, so it is opt-in only).
+  // Same pair, detected from the other direction.
   it("detects the balance-display conflict (interestBearing ↔ scaledUiAmount)", () => {
-    const conflict = getComboConflict(comboByKey("regulatedSecurity"), {
-      interestBearing: {},
+    const conflict = getComboConflict(comboByKey("yieldNote"), {
+      scaledUiAmount: {},
     });
-    expect(conflict?.withLabelKey).toBe("DashboardIssuance.config.interestBearing");
+    expect(conflict?.withLabelKey).toBe("DashboardIssuance.config.scaledUiAmount");
     expect(conflict?.reasonKey).toBe("DashboardIssuance.config.comboConflictReasonBalanceDisplay");
   });
 

--- a/apps/sdp-web/src/app/dashboard/issuance/create/use-issuance-draft.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/create/use-issuance-draft.ts
@@ -27,7 +27,14 @@ const STORAGE_KEY = "sdp:issuance:create-draft:v1";
 // hydrated into an inconsistent state. v2: advanced settings are combo-driven and
 // reset per category, so pre-combo drafts (e.g. security extensions left on a
 // generic asset) must not carry over.
-const STORAGE_VERSION = 2;
+// v3: tokenized securities no longer auto-select scaledUiAmount, because a mint
+// carrying it is rejected by the DvP settlement program. A v2 security draft has
+// it turned on without the issuer ever choosing it, and sanitizeAdvancedSettings
+// cannot strip it — the setting is still allowed (opt-in), and the draft records
+// no provenance, so that code cannot tell the old default from a deliberate
+// choice. Discarding the draft is the only option that does not either ship an
+// unsettleable mint or silently revert someone who genuinely wants the extension.
+const STORAGE_VERSION = 3;
 
 interface WizardState {
   draft: DraftState;

--- a/packages/sdp-issuance/src/capabilities/SUPPORT_MATRIX.md
+++ b/packages/sdp-issuance/src/capabilities/SUPPORT_MATRIX.md
@@ -30,10 +30,10 @@ Legend: `req` = locked (forced on) · `rec` = recommended (default on) · `opt` 
 | stablecoin/fiat_backed | stablecoin | req | req | req | — | — | — | — | — |
 | stablecoin/crypto_backed | stablecoin | req | req | req | — | — | — | — | — |
 | stablecoin/generic | stablecoin | req | req | req | — | — | — | — | — |
-| tokenized_security/generic | tokenized-security | req | req | req | — | — | rec | — | — |
-| tokenized_security/equity | tokenized-security | req | req | req | — | — | rec | — | — |
-| tokenized_security/debt | tokenized-security | req | req | req | — | — | rec | — | — |
-| tokenized_security/fund | tokenized-security | req | req | req | — | — | rec | — | — |
+| tokenized_security/generic | tokenized-security | req | req | req | — | — | opt | — | — |
+| tokenized_security/equity | tokenized-security | req | req | req | — | — | opt | — | — |
+| tokenized_security/debt | tokenized-security | req | req | req | — | — | opt | — | — |
+| tokenized_security/fund | tokenized-security | req | req | req | — | — | opt | — | — |
 
 ## Unsupported gaps
 

--- a/packages/sdp-issuance/src/capabilities/capabilities.test.ts
+++ b/packages/sdp-issuance/src/capabilities/capabilities.test.ts
@@ -63,8 +63,10 @@ describe("advanced settings capability registry", () => {
     assert.ok(stablecoin.includes("freezeAccounts"));
     assert.ok(stablecoin.includes("permanentDelegate"));
 
-    // securities additionally recommend scaledUiAmount (in their template).
-    assert.ok(getRecommendedSettings("tokenized_security", "debt").includes("scaledUiAmount"));
+    // Securities pre-select only what their template forces. scaledUiAmount is
+    // NOT among them: a mint carrying it is rejected by the DvP settlement
+    // program, so pre-ticking it would issue unsettleable securities.
+    assert.ok(!getRecommendedSettings("tokenized_security", "debt").includes("scaledUiAmount"));
 
     // generic assets force nothing on.
     assert.deepEqual(getRecommendedSettings("generic", "generic"), []);
@@ -87,10 +89,12 @@ describe("advanced settings capability registry", () => {
     assert.equal(isSettingAllowed("stablecoin", "fiat_backed", "permanentDelegate"), true);
     assert.ok(getRecommendedSettings("stablecoin", "fiat_backed").includes("permanentDelegate"));
 
-    // scaledUiAmount is conditional in the security builder, so it stays
-    // recommended (deselectable), not locked.
+    // scaledUiAmount is conditional in the security builder, so it is never
+    // locked. It is "available" rather than "recommended" because DvP rejects a
+    // mint that carries it, and a default nobody chose should not decide that.
     const security = resolveAssetCapability("tokenized_security", "equity");
-    assert.equal(security?.settings.scaledUiAmount, "recommended");
+    assert.equal(security?.settings.scaledUiAmount, "available");
+    assert.equal(isSettingAllowed("tokenized_security", "equity", "scaledUiAmount"), true);
     assert.equal(security?.settings.permanentDelegate, "locked");
 
     // generic assets deploy as custom (nothing forced) — no locked settings.

--- a/packages/sdp-issuance/src/capabilities/capabilities.ts
+++ b/packages/sdp-issuance/src/capabilities/capabilities.ts
@@ -34,7 +34,12 @@ const SECURITY_SETTINGS = settings({
   pauseTransfers: "locked",
   freezeAccounts: "locked",
   permanentDelegate: "locked",
-  scaledUiAmount: "recommended",
+  // Available rather than recommended: a mint carrying ScaledUiAmount cannot be
+  // traded through the DvP settlement program, which rejects it at CreateDvp
+  // with BlockedMintExtension. Pre-selecting it meant every security issued on
+  // the defaults was born unsettleable. Still offered, because share splits and
+  // redenomination are a real use for it, but the issuer opts in knowingly.
+  scaledUiAmount: "available",
   transferFee: "unsupported",
   interestBearing: "unsupported",
   nonTransferable: "unsupported",


### PR DESCRIPTION
A tokenized security issued on our defaults can't be traded through DvP. `CreateDvp` rejects any mint carrying ScaledUiAmount, and securities pre-tick it.

Proven on devnet against `dvp34bdbcEm4f4FCUjGV4mDAkDshaQR4LkK8fdcsyZq`, two mints identical apart from that one extension. With it: rejected, `Custom(10)` BlockedMintExtension. Without it: trade creates fine.

It was never locked, just pre-selected, since `getRecommendedSettings` feeds the create wizard's draft. This flips it to `available`, so it stays offered but off unless the issuer picks it.

Deliberately not `unsupported`, even though the other three extensions DvP blocks already are. Scaled UI amounts are a real feature on a security (splits, redenomination), and dropping the capability to suit one integration is the wrong trade. Push back in review if you disagree.

Doesn't make securities tradeable on its own. They also carry `defaultAccountState: frozen`, so the escrow is born frozen and funding bounces. That's PRO-1795.

`SUPPORT_MATRIX.md` is regenerated via `matrix:generate`, not hand-edited.

PRO-1828