### PR TITLE
fix(earn): pre-fund Veda AllowedUser rent so sponsored first deposits pass

### DIFF
--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -461,12 +461,19 @@ organization's own custody wallets.
     log searches; unrecognized shapes fall back to the capped raw JSON. Callers
     holding simulation LOGS pass them too: a bare `Custom: 1` is refined from
     the failing program's own log line into rent-shortfall prose naming the
-    missing SOL (sponsor-fault under sponsorship) or token-balance prose,
-    because the variant alone is the System program's "insufficient lamports",
-    the Token program's "insufficient funds" and every non-Anchor program's
-    first error code at once. A
-    failure the helper attributes to SDP's fee sponsor surfaces as a retryable
-    5xx (with no sponsor detail in the body), never a caller-fault 400.
+    missing SOL or token-balance prose, because the variant alone is the
+    System program's "insufficient lamports", the Token program's
+    "insufficient funds" and every non-Anchor program's first error code at
+    once. A rent shortfall's ATTRIBUTION follows the failing frame: inside a
+    top-level ATA create the funding payer is the plan's (the sponsor under
+    sponsorship, after the provider payer swap), while a shortfall inside any
+    other program is that program spending the WALLET's lamports, which a
+    sponsored plan should have pre-funded (the Veda allowed-user prefund in
+    `@sdp/veda`). Sponsor faults therefore carry `sponsorCause`: "balance"
+    (broke sponsor wallet) keeps the retryable "retry shortly" 5xx, while
+    "prefund" (a plan defect) gets a 5xx that does not promise a retry will
+    help. Neither leaks sponsor detail in the body, and neither is ever a
+    caller-fault 400.
   - **The signed outbox is recorded BEFORE broadcast.** `signVaultPlan` signs
     without sending; one transaction stores the signature, base64 wire bytes,
     last-valid block height, movement and activated claim while still `pending`.

--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -465,8 +465,9 @@ organization's own custody wallets.
     System program's "insufficient lamports", the Token program's
     "insufficient funds" and every non-Anchor program's first error code at
     once. A rent shortfall's ATTRIBUTION follows the failing frame: inside a
-    top-level ATA create the funding payer is the plan's (the sponsor under
-    sponsorship, after the provider payer swap), while a shortfall inside any
+    top-level ATA create or a top-level System transfer the paying account is
+    the plan's own choice (the sponsor under sponsorship, via the provider
+    payer swap and the allowed-user prefund), while a shortfall inside any
     other program is that program spending the WALLET's lamports, which a
     sponsored plan should have pre-funded (the Veda allowed-user prefund in
     `@sdp/veda`). Sponsor faults therefore carry `sponsorCause`: "balance"

--- a/apps/sdp-api/src/services/earn/vault-execution.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-execution.service.ts
@@ -469,7 +469,14 @@ export async function simulateVaultPlan(
       /** Compute units the simulation consumed, when the RPC reports them. */
       unitsConsumed?: bigint;
     }
-  | { ok: false; error: string; fault: "caller" | "sponsor"; logs: readonly string[] }
+  | {
+      ok: false;
+      error: string;
+      fault: "caller" | "sponsor";
+      /** See `VaultSimulationVerdict.sponsorCause`; present on sponsor faults. */
+      sponsorCause?: "balance" | "prefund";
+      logs: readonly string[];
+    }
 > {
   assertExpectedPlan(input.plan, input.cluster, input.expectedAssetIdentity);
   let instructions: EarnVaultTransactionPlan["instructions"];
@@ -536,6 +543,7 @@ export async function simulateVaultPlan(
       ok: false,
       error: verdict.message,
       fault: verdict.fault,
+      ...(verdict.sponsorCause === undefined ? {} : { sponsorCause: verdict.sponsorCause }),
       logs: result.value.logs ?? [],
     };
   }

--- a/apps/sdp-api/src/services/earn/vault-intent-execution.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-intent-execution.service.ts
@@ -89,16 +89,32 @@ export async function executeSignedVaultIntent<TResult extends SignedVaultIntent
     });
     if (!simulation.ok) {
       getLogger().error(
-        { error: simulation.error, fault: simulation.fault, logs: simulation.logs.slice(-5) },
+        {
+          error: simulation.error,
+          fault: simulation.fault,
+          ...(simulation.sponsorCause === undefined
+            ? {}
+            : { sponsorCause: simulation.sponsorCause }),
+          logs: simulation.logs.slice(-5),
+        },
         `vault ${operation}: simulation failed before signing`
       );
-      // A broke sponsor is SDP's operational problem: a 400 would tell client
+      // A sponsor fault is SDP's operational problem: a 400 would tell client
       // retry middleware the caller is at fault (permanent), and would leak
       // SDP's sponsor funding state as a pollable signal. The detail is in the
-      // log line above; the caller gets a retryable 5xx with no internals.
-      // "Network costs" rather than "fee": the sponsor also funds the rent of
-      // accounts a sponsored movement creates, and both shortfalls land here.
+      // log line above; the caller gets a 5xx with no internals. The two
+      // flavours part on the RETRY HINT only: a broke sponsor genuinely
+      // clears with a refill, while a missing prefund is a plan defect and
+      // "retry shortly" would be a false promise.
       if (simulation.fault === "sponsor") {
+        if (simulation.sponsorCause === "prefund") {
+          throw internalError(
+            `Vault ${operation} simulation failed: SDP did not fund an account this ` +
+              `${operation} creates. This needs an SDP-side fix; retrying will not clear it`
+          );
+        }
+        // "Network costs" rather than "fee": the sponsor also funds the rent
+        // of accounts a sponsored movement creates, and both land here.
         throw internalError(
           `Vault ${operation} simulation failed: SDP could not sponsor the network costs. Retry shortly`
         );

--- a/apps/sdp-api/src/services/earn/vault-simulation-error.test.ts
+++ b/apps/sdp-api/src/services/earn/vault-simulation-error.test.ts
@@ -178,6 +178,27 @@ describe("log-refined instruction failures", () => {
     expect(sponsorCause).toBe("prefund");
   });
 
+  // The prefund transfer itself is a TOP-LEVEL System instruction whose
+  // source is the SPONSOR. A short sponsor there is a refillable balance
+  // problem: labelling it a plan defect would tell operators the plan is
+  // broken while the actual fix is the same refill as any broke fee payer.
+  it("treats a shortfall in the plan's own prefund transfer as sponsor balance", () => {
+    const prefundLogs = [
+      "Program 11111111111111111111111111111111 invoke [1]",
+      "Transfer: insufficient lamports 500000, need 1287600",
+      "Program 11111111111111111111111111111111 failed: custom program error: 0x1",
+    ];
+    const { message, fault, sponsorCause } = describeVaultSimulationError(
+      custom1,
+      sponsored,
+      prefundLogs
+    );
+    expect(message).toContain("SDP's fee sponsor could not fund the rent");
+    expect(message).not.toContain("did not pre-fund");
+    expect(fault).toBe("sponsor");
+    expect(sponsorCause).toBe("balance");
+  });
+
   it("tells a wallet-pays caller about the program-created account in its own terms", () => {
     const { message, fault } = describeVaultSimulationError(custom1, walletPays, programRentLogs);
     expect(message).toContain(

--- a/apps/sdp-api/src/services/earn/vault-simulation-error.test.ts
+++ b/apps/sdp-api/src/services/earn/vault-simulation-error.test.ts
@@ -136,12 +136,73 @@ describe("log-refined instruction failures", () => {
     expect(fault).toBe("caller");
   });
 
-  it("blames the sponsor for a rent shortfall under sponsorship", () => {
-    const { message, fault } = describeVaultSimulationError(custom1, sponsored, rentLogs);
+  it("blames the sponsor for an ATA-create rent shortfall under sponsorship", () => {
+    const { message, fault, sponsorCause } = describeVaultSimulationError(
+      custom1,
+      sponsored,
+      rentLogs
+    );
     expect(message).toContain("SDP's fee sponsor could not fund the rent");
     expect(message).toContain("not with the wallet");
     expect(message).not.toContain("Send SOL to the wallet");
     expect(fault).toBe("sponsor");
+    expect(sponsorCause).toBe("balance");
+  });
+
+  // The tail smoky produced AFTER the ATA swap shipped (2026-09-02): the
+  // vault program itself creating the depositor's AllowedUser record and
+  // charging the zero-SOL SIGNER for it. The sponsor's balance is fine here;
+  // the plan failed to pre-fund the wallet. The two must not share a
+  // verdict, because "sponsor balance" sends operators refilling a healthy
+  // wallet while "retry shortly" promises customers a fix that never comes.
+  const programRentLogs = [
+    "Program ASN8Cz36kQSZf2ZrgUbRShaKUpN4CJoTGdv6C5uMsy3J invoke [1]",
+    "Program log: Instruction: Deposit",
+    "Program 11111111111111111111111111111111 invoke [2]",
+    "Transfer: insufficient lamports 0, need 1171605",
+    "Program 11111111111111111111111111111111 failed: custom program error: 0x1",
+    "Program ASN8Cz36kQSZf2ZrgUbRShaKUpN4CJoTGdv6C5uMsy3J failed: custom program error: 0x1",
+  ];
+
+  it("calls an in-program rent shortfall under sponsorship a missing prefund, not sponsor balance", () => {
+    const { message, fault, sponsorCause } = describeVaultSimulationError(
+      custom1,
+      sponsored,
+      programRentLogs
+    );
+    expect(message).toContain("did not pre-fund the wallet");
+    expect(message).toContain("0.001171605 SOL short");
+    expect(message).toContain("not the sponsor's balance");
+    expect(message).not.toContain("fee sponsor could not fund");
+    expect(fault).toBe("sponsor");
+    expect(sponsorCause).toBe("prefund");
+  });
+
+  it("tells a wallet-pays caller about the program-created account in its own terms", () => {
+    const { message, fault } = describeVaultSimulationError(custom1, walletPays, programRentLogs);
+    expect(message).toContain(
+      "does not hold enough SOL to fund an account the vault program creates on first use"
+    );
+    expect(message).toContain("Send SOL to the wallet and retry.");
+    expect(fault).toBe("caller");
+  });
+
+  it("stays neutral about the created account when no top-level frame is in the logs", () => {
+    const truncated = ["Transfer: insufficient lamports 0, need 1171605"];
+    const sponsor = describeVaultSimulationError(custom1, sponsored, truncated);
+    expect(sponsor.message).toContain("an account this transaction creates");
+    expect(sponsor.fault).toBe("sponsor");
+    expect(sponsor.sponsorCause).toBe("balance");
+    const wallet = describeVaultSimulationError(custom1, walletPays, truncated);
+    expect(wallet.message).toContain("an account this transaction");
+    expect(wallet.fault).toBe("caller");
+  });
+
+  it("tags a sponsored fee-payer failure as a balance cause", () => {
+    const { sponsorCause } = describeVaultSimulationError("AccountNotFound", sponsored);
+    expect(sponsorCause).toBe("balance");
+    const wallet = describeVaultSimulationError("AccountNotFound", walletPays);
+    expect(wallet.sponsorCause).toBeUndefined();
   });
 
   it("uses neutral rent-payer wording when the fee mode is unknown", () => {

--- a/apps/sdp-api/src/services/earn/vault-simulation-error.ts
+++ b/apps/sdp-api/src/services/earn/vault-simulation-error.ts
@@ -36,11 +36,21 @@ import type { VaultFeeMode } from "./vault-sponsorship";
 export interface VaultSimulationVerdict {
   message: string;
   /**
-   * "sponsor" when the failing account is SDP's fee sponsor: that is SDP's
-   * operational problem, so callers surface it as a retryable 5xx instead of a
-   * caller-fault 400 a client would treat as permanent.
+   * "sponsor" when the failure is SDP's operational problem rather than the
+   * caller's, so callers surface it as a 5xx instead of a caller-fault 400 a
+   * client would treat as permanent.
    */
   fault: "caller" | "sponsor";
+  /**
+   * Present on every sponsor fault, because the two flavours retry
+   * differently: "balance" means SDP's sponsor wallet itself came up short (a
+   * refill genuinely clears it, so "retry shortly" is honest), while
+   * "prefund" means a program charged the WALLET rent the plan should have
+   * pre-funded: a plan defect no retry clears (see the Veda allowed-user
+   * prefund in @sdp/veda). Blaming the sponsor's balance for the second
+   * flavour is exactly the misattribution this field exists to prevent.
+   */
+  sponsorCause?: "balance" | "prefund";
 }
 
 function stringifyRaw(err: unknown): string {
@@ -73,24 +83,52 @@ const INSTRUCTION_ERROR_DETAILS = new Map<string, string>([
 /**
  * The System program's log inside a failed account creation or transfer:
  * `Transfer: insufficient lamports <have>, need <need>`. In a vault plan this
- * is the rent payer coming up short on the token accounts a first deposit (or
- * first exit) creates — the failure the bare variant renders as `Custom: 1`.
+ * is a rent source coming up short on an account the transaction creates —
+ * the failure the bare variant renders as `Custom: 1`.
  */
 const INSUFFICIENT_LAMPORTS_LOG = /Transfer: insufficient lamports (\d+), need (\d+)/;
 
 /** The SPL Token processors' log for a transfer exceeding the balance. */
 const INSUFFICIENT_TOKENS_LOG = "Error: insufficient funds";
 
-function rentShortfallLamports(logs: readonly string[]): bigint | undefined {
-  for (const line of logs) {
+/** `Program <address> invoke [1]` — a TOP-LEVEL instruction entering. */
+const TOP_LEVEL_INVOKE_LOG = /^Program ([1-9A-HJ-NP-Za-km-z]{32,44}) invoke \[1\]$/;
+
+const ASSOCIATED_TOKEN_PROGRAM =
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL";
+
+interface RentShortfall {
+  lamports: bigint;
+  /**
+   * The top-level program whose instruction the shortfall happened inside:
+   * the nearest preceding `invoke [1]` frame. It decides WHOSE money was
+   * short: a top-level ATA create's funding payer is chosen by the PLAN (the
+   * sponsor under sponsorship, after the providers' payer swap), while a
+   * shortfall inside any other program is that program moving lamports from
+   * an account IT names: for the vault programs SDP fronts, the depositing
+   * wallet, which no transaction-level sponsorship can reach. Undefined when
+   * the logs carry no top-level frame (e.g. a truncated tail).
+   */
+  topLevelProgram: string | undefined;
+}
+
+function rentShortfall(logs: readonly string[]): RentShortfall | undefined {
+  for (const [index, line] of logs.entries()) {
     const match = INSUFFICIENT_LAMPORTS_LOG.exec(line);
     if (!match) continue;
+    let lamports: bigint;
     try {
-      const shortfall = BigInt(match[2] as string) - BigInt(match[1] as string);
-      return shortfall > 0n ? shortfall : undefined;
+      lamports = BigInt(match[2] as string) - BigInt(match[1] as string);
     } catch {
       return undefined;
     }
+    if (lamports <= 0n) return undefined;
+    for (let frame = index - 1; frame >= 0; frame -= 1) {
+      const invoke = TOP_LEVEL_INVOKE_LOG.exec(logs[frame] as string);
+      if (invoke) return { lamports, topLevelProgram: invoke[1] as string };
+    }
+    return { lamports, topLevelProgram: undefined };
   }
   return undefined;
 }
@@ -113,18 +151,51 @@ function describeInstructionFailureFromLogs(
   raw: string,
   fee?: Pick<VaultFeeMode, "kind">
 ): VaultSimulationVerdict | undefined {
-  const shortfall = rentShortfallLamports(logs);
+  const shortfall = rentShortfall(logs);
   if (shortfall !== undefined) {
+    const sol = formatSol(shortfall.lamports);
+    const insideAtaCreate = shortfall.topLevelProgram === ASSOCIATED_TOKEN_PROGRAM;
+    // Words matched to the failing frame: only the ATA program's create is
+    // known to make a TOKEN account; other programs create their own records
+    // (Veda's per-user AllowedUser, for one) with the payer as funder rather
+    // than creator, and an unattributable frame gets the neutral phrase.
+    let created: string;
+    let callerPhrase: string;
+    if (insideAtaCreate) {
+      created = "a token account this transaction creates";
+      callerPhrase = "to create a token account this transaction needs";
+    } else if (shortfall.topLevelProgram === undefined) {
+      created = "an account this transaction creates";
+      callerPhrase = "to create an account this transaction needs";
+    } else {
+      created = "an account the vault program creates on first use";
+      callerPhrase = "to fund an account the vault program creates on first use";
+    }
     if (fee?.kind === "sponsored") {
-      // Post-PRO-1736 the sponsor funds rent alongside the fee, so a rent
-      // shortfall under sponsorship is SDP's operational problem, exactly like
-      // a broke fee payer — callers turn "sponsor" into a retryable 5xx.
+      // Post-PRO-1736 the sponsor funds rent alongside the fee, but only the
+      // rent the PLAN charges it (the ATA creates, payer-swapped by the
+      // provider). A shortfall inside another program is that program
+      // spending the WALLET's lamports, which the plan should have pre-funded
+      // and did not: still SDP's fault, but a plan defect, not a broke
+      // sponsor. The two must not share a message, because "sponsor
+      // balance" sends operators refilling a wallet that is fine.
+      if (insideAtaCreate || shortfall.topLevelProgram === undefined) {
+        return {
+          message:
+            `SDP's fee sponsor could not fund the rent for ${created} ` +
+            `(${sol} SOL short). This is a problem on SDP's side, ` +
+            `not with the wallet. (${raw})`,
+          fault: "sponsor",
+          sponsorCause: "balance",
+        };
+      }
       return {
         message:
-          `SDP's fee sponsor could not fund the rent for a token account this transaction ` +
-          `creates (${formatSol(shortfall)} SOL short). This is a problem on SDP's side, ` +
-          `not with the wallet. (${raw})`,
+          `the vault program charges the wallet rent for an account it creates on first use, ` +
+          `and this movement did not pre-fund the wallet for it (${sol} SOL short). This is ` +
+          `an SDP-side plan defect, not the sponsor's balance and not the wallet. (${raw})`,
         fault: "sponsor",
+        sponsorCause: "prefund",
       };
     }
     const noun = fee === undefined ? "the rent payer" : "the wallet";
@@ -134,8 +205,8 @@ function describeInstructionFailureFromLogs(
         : "Send SOL to the wallet and retry.";
     return {
       message:
-        `${noun} does not hold enough SOL to create a token account this transaction ` +
-        `needs: rent requires ${formatSol(shortfall)} more SOL. ${remedy} (${raw})`,
+        `${noun} does not hold enough SOL ${callerPhrase}: ` +
+        `rent requires ${sol} more SOL. ${remedy} (${raw})`,
       fault: "caller",
     };
   }
@@ -188,6 +259,9 @@ export function describeVaultSimulationError(
       ? "It needs SOL before this can be retried."
       : "Send SOL to the wallet and retry.";
   const feeFault = sponsored ? "sponsor" : "caller";
+  // A fee-payer failure under sponsorship is always the sponsor's own
+  // balance: simulation charges the fee to the sponsor and nothing else.
+  const feeCause = sponsored ? ({ sponsorCause: "balance" } as const) : {};
 
   if (typeof err === "string") {
     switch (err) {
@@ -195,11 +269,13 @@ export function describeVaultSimulationError(
         return {
           message: `${feePayerNoun} holds no SOL, so it cannot pay the network fee. ${feeRemedy} (${raw})`,
           fault: feeFault,
+          ...feeCause,
         };
       case "InsufficientFundsForFee":
         return {
           message: `${feePayerNoun} does not hold enough SOL to pay the network fee. ${feeRemedy} (${raw})`,
           fault: feeFault,
+          ...feeCause,
         };
       case "ProgramAccountNotFound":
         return {

--- a/apps/sdp-api/src/services/earn/vault-simulation-error.ts
+++ b/apps/sdp-api/src/services/earn/vault-simulation-error.ts
@@ -98,13 +98,16 @@ const ASSOCIATED_TOKEN_PROGRAM =
   // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
   "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL";
 
+const SYSTEM_PROGRAM = "11111111111111111111111111111111";
+
 interface RentShortfall {
   lamports: bigint;
   /**
    * The top-level program whose instruction the shortfall happened inside:
    * the nearest preceding `invoke [1]` frame. It decides WHOSE money was
-   * short: a top-level ATA create's funding payer is chosen by the PLAN (the
-   * sponsor under sponsorship, after the providers' payer swap), while a
+   * short: a top-level ATA create's funding payer and a top-level System
+   * transfer's source are chosen by the PLAN (the sponsor under sponsorship,
+   * via the providers' payer swap and the allowed-user prefund), while a
    * shortfall inside any other program is that program moving lamports from
    * an account IT names: for the vault programs SDP fronts, the depositing
    * wallet, which no transaction-level sponsorship can reach. Undefined when
@@ -155,6 +158,13 @@ function describeInstructionFailureFromLogs(
   if (shortfall !== undefined) {
     const sol = formatSol(shortfall.lamports);
     const insideAtaCreate = shortfall.topLevelProgram === ASSOCIATED_TOKEN_PROGRAM;
+    // A shortfall in a TOP-LEVEL System instruction is a transfer the PLAN
+    // authored, whose source the plan chose: under sponsorship that is the
+    // sponsor itself running short on the allowed-user prefund it fronts, a
+    // refillable balance problem, never a missing prefund. Only a shortfall
+    // inside a NON-System, non-ATA program is that program spending an
+    // account the plan could not redirect.
+    const insidePlanTransfer = shortfall.topLevelProgram === SYSTEM_PROGRAM;
     // Words matched to the failing frame: only the ATA program's create is
     // known to make a TOKEN account; other programs create their own records
     // (Veda's per-user AllowedUser, for one) with the payer as funder rather
@@ -164,7 +174,7 @@ function describeInstructionFailureFromLogs(
     if (insideAtaCreate) {
       created = "a token account this transaction creates";
       callerPhrase = "to create a token account this transaction needs";
-    } else if (shortfall.topLevelProgram === undefined) {
+    } else if (insidePlanTransfer || shortfall.topLevelProgram === undefined) {
       created = "an account this transaction creates";
       callerPhrase = "to create an account this transaction needs";
     } else {
@@ -173,13 +183,14 @@ function describeInstructionFailureFromLogs(
     }
     if (fee?.kind === "sponsored") {
       // Post-PRO-1736 the sponsor funds rent alongside the fee, but only the
-      // rent the PLAN charges it (the ATA creates, payer-swapped by the
-      // provider). A shortfall inside another program is that program
-      // spending the WALLET's lamports, which the plan should have pre-funded
-      // and did not: still SDP's fault, but a plan defect, not a broke
-      // sponsor. The two must not share a message, because "sponsor
-      // balance" sends operators refilling a wallet that is fine.
-      if (insideAtaCreate || shortfall.topLevelProgram === undefined) {
+      // rent the PLAN charges it: the ATA creates (payer-swapped by the
+      // provider) and its own top-level prefund transfer. A shortfall inside
+      // any OTHER program is that program spending the WALLET's lamports,
+      // which the plan should have pre-funded and did not: still SDP's
+      // fault, but a plan defect, not a broke sponsor. The two must not
+      // share a message, because "sponsor balance" sends operators refilling
+      // a wallet that is fine.
+      if (insideAtaCreate || insidePlanTransfer || shortfall.topLevelProgram === undefined) {
         return {
           message:
             `SDP's fee sponsor could not fund the rent for ${created} ` +

--- a/packages/sdp-veda/CLAUDE.md
+++ b/packages/sdp-veda/CLAUDE.md
@@ -171,6 +171,26 @@ The deposit build also reads the share ATA's existence (`src/accounts.ts`) and
 reports `createsShareAccount`, so the API's `share_ata_rent_funder` records
 the party that truly paid — which is what the eventual exit refunds.
 
+There is a SECOND rent the swap cannot reach (found on smoky 2026-09-02 right
+after the swap shipped): the vault program itself lazily creates the
+depositor's `AllowedUser` PDA inside the `deposit` instruction on a wallet's
+first deposit into a vault, with the SIGNER hardcoded as the lamport source
+(one signer in the account table, no payer knob, emitted even with compliance
+mode off). `src/allowed-user.ts` therefore PREPENDS one System transfer of
+exactly that account's rent-exempt minimum from `rentPayer` to the owner when
+the plan is sponsored and the PDA does not exist yet; the program's create
+consumes it in the same transaction, so the owner nets zero. The amount comes
+from a live `getMinimumBalanceForRentExemption(57)` read, never a hardcoded
+lamport figure: rent parameters are cluster state, and devnet's have already
+moved once during this integration. The ABI facts behind it (the deposit
+discriminator, `allowed_user` at account index 14, the 57-byte size) are
+pinned to the committed IDL by `allowed-user.test.ts`, in the same falsifiable
+style as `idl-layout.test.ts`.
+
+Withdrawals deliberately skip the prefund: the withdraw instruction reads the
+same PDA, but a wallet can only redeem shares it deposited, so the record
+always exists by exit time.
+
 ## Positions are read in base units, and the valuation may be absent
 
 `getUserPosition` returns an exact atomic `bigint` for the share balance —

--- a/packages/sdp-veda/src/accounts.ts
+++ b/packages/sdp-veda/src/accounts.ts
@@ -27,3 +27,25 @@ export async function accountExists(rpcUrl: string, account: Address): Promise<b
     });
   }
 }
+
+/**
+ * The rent-exempt minimum for an account of `bytes`, read from the chain the
+ * plan targets rather than computed locally: rent parameters are cluster
+ * state, and a hardcoded rate silently under-funds the day they change
+ * (devnet's has already moved once during this integration).
+ */
+export async function minimumBalanceForRentExemption(
+  rpcUrl: string,
+  bytes: number
+): Promise<bigint> {
+  const rpc = createVedaRpc(rpcUrl);
+  try {
+    return BigInt(await rpc.getMinimumBalanceForRentExemption(BigInt(bytes)).send());
+  } catch (cause) {
+    throw new SdpVedaError(
+      "VAULT_UNREADABLE",
+      `Veda could not read the rent-exempt minimum for a ${bytes}-byte account`,
+      { cause }
+    );
+  }
+}

--- a/packages/sdp-veda/src/allowed-user.test.ts
+++ b/packages/sdp-veda/src/allowed-user.test.ts
@@ -1,0 +1,125 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { type Address, address, type Instruction } from "@solana/kit";
+import { describe, expect, it } from "vitest";
+import {
+  allowedUserAccountForDeposit,
+  prefundOwnerRentInstruction,
+  VEDA_ALLOWED_USER_ACCOUNT_SIZE,
+  VEDA_DEPOSIT_ALLOWED_USER_ACCOUNT_INDEX,
+  VEDA_DEPOSIT_DISCRIMINATOR,
+} from "./allowed-user";
+
+const VAULT_PROGRAM = address("5J76xGGXn5op9S48pMqWV6Ex48ZxsKsRs4bGeDzSHEVc");
+const OWNER = address("11111111111111111111111111111112");
+const SPONSOR = address("SysvarRecentB1ockHashes11111111111111111111");
+const ALLOWED_USER = address("SysvarRent111111111111111111111111111111111");
+const SYSTEM = "11111111111111111111111111111111";
+
+/** A deposit-shaped instruction: right discriminator, allowed_user in place. */
+function depositInstruction(overrides?: {
+  programAddress?: Address;
+  data?: Uint8Array;
+  accountCount?: number;
+}): Instruction {
+  const count = overrides?.accountCount ?? 20;
+  const accounts = Array.from({ length: count }, (_, index) => ({
+    address: index === VEDA_DEPOSIT_ALLOWED_USER_ACCOUNT_INDEX ? ALLOWED_USER : OWNER,
+    role: index === 0 ? 3 : 1,
+  }));
+  return {
+    programAddress: overrides?.programAddress ?? VAULT_PROGRAM,
+    accounts,
+    data: overrides?.data ?? new Uint8Array([...VEDA_DEPOSIT_DISCRIMINATOR, 7, 7, 7]),
+  } as Instruction;
+}
+
+/**
+ * The constants are ABI claims about the deployed program; the committed IDL
+ * is what makes them falsifiable (same pattern as `idl-layout.test.ts`). If
+ * Veda ships a new IDL, these fail before a build misreads an account or
+ * under-funds a prefund.
+ */
+describe("the committed IDL pins the deposit ABI constants", () => {
+  const idlPath = join(
+    dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "idl",
+    "boring_vault_svm.json"
+  );
+  const idl = JSON.parse(readFileSync(idlPath, "utf8")) as {
+    instructions: { name: string; discriminator: number[]; accounts: { name: string }[] }[];
+    types: { name: string; type: { kind: string; fields?: { name: string; type: unknown }[] } }[];
+  };
+  const deposit = idl.instructions.find((instruction) => instruction.name === "deposit");
+
+  it("matches the deposit discriminator", () => {
+    expect(deposit?.discriminator).toEqual([...VEDA_DEPOSIT_DISCRIMINATOR]);
+  });
+
+  it("finds allowed_user at the pinned account index", () => {
+    expect(deposit?.accounts[VEDA_DEPOSIT_ALLOWED_USER_ACCOUNT_INDEX]?.name).toBe("allowed_user");
+  });
+
+  it("recomputes the AllowedUser account size from the IDL's own fields", () => {
+    const sizes: Record<string, number> = { bool: 1, u8: 1, u64: 8, i64: 8, pubkey: 32 };
+    const struct = idl.types.find((type) => type.name === "AllowedUser");
+    const fields = struct?.type.fields ?? [];
+    expect(fields.length).toBeGreaterThan(0);
+    const size = fields.reduce((total, field) => {
+      const fieldSize = sizes[String(field.type)];
+      if (fieldSize === undefined) throw new Error(`unsized AllowedUser field ${field.name}`);
+      return total + fieldSize;
+    }, 8); // the 8-byte Anchor account discriminator
+    expect(size).toBe(VEDA_ALLOWED_USER_ACCOUNT_SIZE);
+  });
+});
+
+describe("allowedUserAccountForDeposit", () => {
+  it("reads the allowed_user account off the deposit instruction", () => {
+    expect(allowedUserAccountForDeposit([depositInstruction()], VAULT_PROGRAM)).toBe(ALLOWED_USER);
+  });
+
+  it("ignores instructions of other programs and other discriminators", () => {
+    expect(
+      allowedUserAccountForDeposit(
+        [depositInstruction({ programAddress: address(SYSTEM) })],
+        VAULT_PROGRAM
+      )
+    ).toBeUndefined();
+    expect(
+      allowedUserAccountForDeposit(
+        [depositInstruction({ data: new Uint8Array([183, 18, 70, 156, 148, 109, 161, 34]) })],
+        VAULT_PROGRAM
+      )
+    ).toBeUndefined();
+    expect(
+      allowedUserAccountForDeposit([depositInstruction({ data: new Uint8Array() })], VAULT_PROGRAM)
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when the account table is shorter than the pinned index", () => {
+    expect(
+      allowedUserAccountForDeposit(
+        [depositInstruction({ accountCount: VEDA_DEPOSIT_ALLOWED_USER_ACCOUNT_INDEX })],
+        VAULT_PROGRAM
+      )
+    ).toBeUndefined();
+  });
+});
+
+describe("prefundOwnerRentInstruction", () => {
+  it("encodes one System transfer from the sponsor to the owner", () => {
+    const instruction = prefundOwnerRentInstruction(SPONSOR, OWNER, 1_171_605n);
+    expect(String(instruction.programAddress)).toBe(SYSTEM);
+    expect(instruction.accounts?.[0]).toMatchObject({ address: SPONSOR, role: 3 });
+    expect(instruction.accounts?.[1]).toMatchObject({ address: OWNER, role: 1 });
+
+    const data = instruction.data as Uint8Array;
+    expect(data).toHaveLength(12);
+    const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+    expect(view.getUint32(0, true)).toBe(2); // System Transfer
+    expect(view.getBigUint64(4, true)).toBe(1_171_605n);
+  });
+});

--- a/packages/sdp-veda/src/allowed-user.ts
+++ b/packages/sdp-veda/src/allowed-user.ts
@@ -1,0 +1,106 @@
+import { AccountRole, type Address, address, type Instruction } from "@solana/kit";
+
+/**
+ * The per-user account Veda's deposit creates, and the prefund that pays for
+ * it under sponsorship.
+ *
+ * `boring_vault_svm`'s `deposit` lazily creates the depositor's `AllowedUser`
+ * PDA on a wallet's FIRST deposit into a vault: a System `createAccount` CPI
+ * whose lamports come from the SIGNER, hardcoded by the program's account
+ * table (one signer, no payer knob), and emitted even with the vault's
+ * compliance mode off. That is rent the ATA payer swap in `./rent.ts` cannot
+ * reach: it happens inside the vault program's own CPI, not in a top-level
+ * ATA create. A custody wallet deliberately holding zero SOL therefore failed
+ * its first deposit in simulation even with the fee and the ATA rent
+ * sponsored (measured on smoky 2026-09-02: `Transfer: insufficient lamports
+ * 0, need 1171605` inside the deposit instruction).
+ *
+ * The mechanism here is a PREFUND, not a payer swap: when the plan is
+ * sponsored and the AllowedUser account does not exist yet, the build
+ * prepends one System transfer of exactly that account's rent-exempt minimum
+ * from the sponsor to the owner, which the program's create consumes in the
+ * same transaction, so the owner nets zero. The sponsor signs nothing new: it
+ * is already the transaction fee payer, and one `signAsFeePayer` covers the
+ * transfer's source account too. Prepending never disturbs a protected
+ * instruction group: groups stay contiguous, and the program's own
+ * sysvar-relative checks are unaffected by instructions in front of them.
+ *
+ * Known residual, accepted: if something else creates the AllowedUser account
+ * between build and execution, the program's idempotent create is skipped and
+ * the owner keeps the prefund as dust, bounded by one 57-byte account's rent
+ * and by how rarely one wallet's first deposits race each other.
+ *
+ * The three constants below are ABI facts about the deployed program, pinned
+ * to the committed IDL by `allowed-user.test.ts` exactly as
+ * `idl-layout.test.ts` pins `@sdp/earn`'s offset table: if Veda ships a
+ * different ABI, a test fails before a build misreads an account.
+ */
+
+/** Anchor discriminator of `boring_vault_svm`'s `deposit` instruction. */
+export const VEDA_DEPOSIT_DISCRIMINATOR: readonly number[] = [242, 35, 198, 137, 82, 225, 242, 182];
+
+/** Position of `allowed_user` in the deposit instruction's account table. */
+export const VEDA_DEPOSIT_ALLOWED_USER_ACCOUNT_INDEX = 14;
+
+/**
+ * Size in bytes of the `AllowedUser` account the deposit may create: the
+ * 8-byte Anchor discriminator plus the struct fields in the committed IDL.
+ * The prefund is sized from THIS number via a live rent read, never from a
+ * hardcoded lamport figure — rent parameters are cluster state.
+ */
+export const VEDA_ALLOWED_USER_ACCOUNT_SIZE = 57;
+
+const SYSTEM_PROGRAM_ADDRESS = address("11111111111111111111111111111111");
+
+/** The System program's `Transfer` instruction index, u32 little-endian. */
+const SYSTEM_TRANSFER_INSTRUCTION = 2;
+
+function isVedaDepositInstruction(instruction: Instruction, vaultProgram: Address): boolean {
+  if (instruction.programAddress !== vaultProgram) return false;
+  const data = instruction.data;
+  if (data === undefined || data.length < VEDA_DEPOSIT_DISCRIMINATOR.length) return false;
+  return VEDA_DEPOSIT_DISCRIMINATOR.every((byte, index) => data[index] === byte);
+}
+
+/**
+ * The `allowed_user` account the plan's deposit instruction names, read from
+ * the instruction itself (same rule as `createdAtaAddressForMint`): the
+ * answer is about the plan that will execute, not PDA arithmetic this package
+ * repeats. Undefined when the plan carries no recognizable deposit
+ * instruction.
+ */
+export function allowedUserAccountForDeposit(
+  instructions: readonly Instruction[],
+  vaultProgram: Address
+): Address | undefined {
+  for (const instruction of instructions) {
+    if (!isVedaDepositInstruction(instruction, vaultProgram)) continue;
+    return instruction.accounts?.[VEDA_DEPOSIT_ALLOWED_USER_ACCOUNT_INDEX]?.address;
+  }
+  return undefined;
+}
+
+/**
+ * One System transfer of `lamports` from `rentPayer` to `owner`: the prefund
+ * a sponsored first deposit prepends. Plain instruction data with no signer
+ * objects: the paymaster supplies the payer's signature after compilation,
+ * exactly as on the ATA payer swap.
+ */
+export function prefundOwnerRentInstruction(
+  rentPayer: Address,
+  owner: Address,
+  lamports: bigint
+): Instruction {
+  const data = new Uint8Array(12);
+  const view = new DataView(data.buffer);
+  view.setUint32(0, SYSTEM_TRANSFER_INSTRUCTION, true);
+  view.setBigUint64(4, lamports, true);
+  return {
+    programAddress: SYSTEM_PROGRAM_ADDRESS,
+    accounts: [
+      { address: rentPayer, role: AccountRole.WRITABLE_SIGNER },
+      { address: owner, role: AccountRole.WRITABLE },
+    ],
+    data,
+  };
+}

--- a/packages/sdp-veda/src/sdk.test.ts
+++ b/packages/sdp-veda/src/sdk.test.ts
@@ -2,6 +2,10 @@ import { wellKnownMint } from "@sdp/types";
 import type { VedaDeployment } from "@sdp/types/veda-programs";
 import { address } from "@solana/kit";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  VEDA_DEPOSIT_ALLOWED_USER_ACCOUNT_INDEX,
+  VEDA_DEPOSIT_DISCRIMINATOR,
+} from "./allowed-user";
 import { toClusterConfig } from "./programs";
 import type { VedaRuntime } from "./types";
 
@@ -31,6 +35,7 @@ const mocks = vi.hoisted(() => ({
   validateDeployment: vi.fn(),
   readMintDecimals: vi.fn(),
   accountExists: vi.fn(),
+  minimumBalanceForRentExemption: vi.fn(),
 }));
 
 vi.mock("@vedatech/svm-sdk", () => ({
@@ -49,7 +54,10 @@ vi.mock("@vedatech/svm-sdk", () => ({
   },
 }));
 vi.mock("./mint", () => ({ readMintDecimals: mocks.readMintDecimals }));
-vi.mock("./accounts", () => ({ accountExists: mocks.accountExists }));
+vi.mock("./accounts", () => ({
+  accountExists: mocks.accountExists,
+  minimumBalanceForRentExemption: mocks.minimumBalanceForRentExemption,
+}));
 // The RPC client is only handed to the (mocked) SDK; keep it inert.
 vi.mock("./rpc", () => ({ createVedaRpc: vi.fn(() => ({})) }));
 
@@ -343,6 +351,90 @@ describe("rent attribution and share-account truth", () => {
     // No share account is ever created on the way out, so nothing is claimed.
     expect("createsShareAccount" in plan).toBe(false);
     expect(mocks.accountExists).not.toHaveBeenCalled();
+  });
+});
+
+describe("a sponsored first deposit pre-funds the allowed-user rent", () => {
+  const input = { vault: VAULT, owner: OWNER, amount: "1.5", minSharesOut: "1.4" };
+  const SPONSOR = address("SysvarRecentB1ockHashes11111111111111111111");
+  const ALLOWED_USER = address("SysvarEpochSchedu1e111111111111111111111111");
+  const SYSTEM = "11111111111111111111111111111111";
+
+  /**
+   * A deposit instruction as the SDK actually emits it: the vault program,
+   * the real Anchor discriminator, allowed_user at its IDL-pinned index.
+   */
+  function vedaDeposit() {
+    const accounts = Array.from({ length: 20 }, (_, index) => ({
+      address: index === VEDA_DEPOSIT_ALLOWED_USER_ACCOUNT_INDEX ? ALLOWED_USER : OWNER,
+      role: index === 0 ? 3 : 1,
+    }));
+    return {
+      programAddress: config.vaultProgramAddress,
+      accounts,
+      data: new Uint8Array([...VEDA_DEPOSIT_DISCRIMINATOR, 1, 2, 3]),
+    };
+  }
+
+  function primeFirstDeposit(allowedUserExists: boolean): void {
+    primeVault([{ mint: USDC_DEVNET, allowDeposits: true }]);
+    mocks.vault.buildDeposit.mockResolvedValue({
+      instructions: [vedaDeposit()],
+      requiredSignerAddresses: [OWNER],
+      protectedInstructionGroups: [],
+    });
+    mocks.accountExists.mockImplementation(
+      async (_rpcUrl: string, account: unknown) =>
+        String(account) !== String(ALLOWED_USER) || allowedUserExists
+    );
+    mocks.minimumBalanceForRentExemption.mockResolvedValue(1_171_605n);
+  }
+
+  /**
+   * THE PROGRAM-RENT GAP (smoky 2026-09-02, second layer). The vault program
+   * creates the depositor's AllowedUser record inside the deposit instruction
+   * and charges the SIGNER — a payer the ATA swap cannot reach — so a
+   * sponsored plan must hand the owner exactly that rent first, or a zero-SOL
+   * custody wallet fails its first deposit with everything else sponsored.
+   */
+  it("prepends one System transfer of the account's live rent", async () => {
+    primeFirstDeposit(false);
+
+    const plan = await buildVedaDepositPlan(runtime, config, { ...input, rentPayer: SPONSOR });
+
+    expect(plan.instructions).toHaveLength(2);
+    const [prefund, deposit] = plan.instructions;
+    expect(String(prefund?.programAddress)).toBe(SYSTEM);
+    expect(prefund?.accounts?.[0]).toMatchObject({ address: SPONSOR, role: 3 });
+    expect(prefund?.accounts?.[1]).toMatchObject({ address: OWNER, role: 1 });
+    const data = prefund?.data as Uint8Array;
+    const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+    expect(view.getUint32(0, true)).toBe(2);
+    expect(view.getBigUint64(4, true)).toBe(1_171_605n);
+    // The deposit instruction itself survives verbatim, still after the prefund.
+    expect(deposit).toEqual(vedaDeposit());
+    // Sized from the chain the plan targets, never a hardcoded lamport figure.
+    expect(mocks.minimumBalanceForRentExemption).toHaveBeenCalledWith(runtime.rpcUrl, 57);
+  });
+
+  it("adds nothing when the allowed-user record already exists", async () => {
+    primeFirstDeposit(true);
+
+    const plan = await buildVedaDepositPlan(runtime, config, { ...input, rentPayer: SPONSOR });
+
+    expect(plan.instructions).toHaveLength(1);
+    expect(mocks.minimumBalanceForRentExemption).not.toHaveBeenCalled();
+  });
+
+  it("adds nothing without a sponsor: the owner funds its own record", async () => {
+    primeFirstDeposit(false);
+
+    const plan = await buildVedaDepositPlan(runtime, config, input);
+
+    expect(plan.instructions).toHaveLength(1);
+    // Unsponsored builds never even ask: the answer could not change the plan.
+    expect(mocks.accountExists).not.toHaveBeenCalledWith(runtime.rpcUrl, ALLOWED_USER);
+    expect(mocks.minimumBalanceForRentExemption).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/sdp-veda/src/sdk.ts
+++ b/packages/sdp-veda/src/sdk.ts
@@ -1,7 +1,12 @@
 import { isVedaDepositMint } from "@sdp/types/veda-programs";
-import { type Address, address } from "@solana/kit";
+import { type Address, address, type Instruction } from "@solana/kit";
 import { createVedaClient, VedaSdkError } from "@vedatech/svm-sdk";
-import { accountExists } from "./accounts";
+import { accountExists, minimumBalanceForRentExemption } from "./accounts";
+import {
+  allowedUserAccountForDeposit,
+  prefundOwnerRentInstruction,
+  VEDA_ALLOWED_USER_ACCOUNT_SIZE,
+} from "./allowed-user";
 import { acceptPositiveAtMintScale, mintDecimals } from "./amounts";
 import { SdpVedaError, vaultUnreadable } from "./errors";
 import { assertPlanTargetsCluster } from "./guards";
@@ -302,10 +307,12 @@ export async function buildVedaDepositPlan(
   // reordering anything. The swap is the only way to honour `rentPayer` here:
   // the SDK names the owner as every create's funding payer and offers no
   // alternative (see ./rent.ts).
+  const sponsor =
+    input.rentPayer === undefined || input.rentPayer === input.owner ? undefined : input.rentPayer;
   const instructions =
-    input.rentPayer === undefined || input.rentPayer === input.owner
+    sponsor === undefined
       ? [...plan.instructions]
-      : [...chargeAtaCreationRentTo([...plan.instructions], input.rentPayer)];
+      : [...chargeAtaCreationRentTo([...plan.instructions], sponsor)];
 
   // Whether rent is actually charged is chain state, not plan shape: the
   // create is idempotent, so only this read can say. The caller records the
@@ -315,10 +322,33 @@ export async function buildVedaDepositPlan(
   const createsShareAccount =
     shareAta === undefined ? undefined : !(await accountExists(runtime.rpcUrl, shareAta));
 
+  // The OTHER rent a first deposit owes, which the ATA swap above cannot
+  // reach: the vault program lazily creates the depositor's AllowedUser
+  // record INSIDE the deposit instruction and charges the SIGNER for it:
+  // the payer is fixed by the program's own account table, so no
+  // transaction-level sponsorship can substitute one. A sponsored plan
+  // therefore pre-funds the owner with exactly that account's rent, which
+  // the program's create consumes in the same transaction (mechanism and
+  // residuals in ./allowed-user.ts). Wallet-pays plans change nothing: the
+  // owner funds its own record, as the program intends.
+  const allowedUser = allowedUserAccountForDeposit(instructions, config.vaultProgramAddress);
+  let finalInstructions: readonly Instruction[] = instructions;
+  if (
+    sponsor !== undefined &&
+    allowedUser !== undefined &&
+    !(await accountExists(runtime.rpcUrl, allowedUser))
+  ) {
+    const rent = await minimumBalanceForRentExemption(
+      runtime.rpcUrl,
+      VEDA_ALLOWED_USER_ACCOUNT_SIZE
+    );
+    finalInstructions = [prefundOwnerRentInstruction(sponsor, input.owner, rent), ...instructions];
+  }
+
   return assertPlanTargetsCluster(
     {
       cluster: config.cluster,
-      instructions,
+      instructions: finalInstructions,
       lookupTables: [],
       assetIdentity: {
         depositTokenMint: asset.mint,

--- a/packages/sdp-veda/src/types.ts
+++ b/packages/sdp-veda/src/types.ts
@@ -115,15 +115,19 @@ export interface VedaDepositInput {
    */
   owner: Address;
   /**
-   * Who funds rent for the token accounts this plan creates. Omitted means the
+   * Who funds rent for the accounts this plan creates. Omitted means the
    * owner pays, which is what an unsponsored deposit wants.
    *
    * Veda's SDK offers no payer knob — it names the owner as the funding payer
    * of every ATA create it emits — so honoring this means REWRITING those
-   * creates' funding account after the build (`./rent.ts`). NOT the
-   * transaction fee payer: this address lands inside the instruction accounts
-   * as writable+signer, and the API's paymaster supplies its signature after
-   * compilation, exactly as on the Kamino client.
+   * creates' funding account after the build (`./rent.ts`). The vault program
+   * ALSO charges the owner, inside the deposit instruction itself, for the
+   * AllowedUser record a first deposit creates; that payer cannot be swapped,
+   * so a sponsored build prepends a transfer pre-funding the owner with
+   * exactly that rent (`./allowed-user.ts`). NOT the transaction fee payer:
+   * this address lands inside the instruction accounts as writable+signer,
+   * and the API's paymaster supplies its signature after compilation, exactly
+   * as on the Kamino client.
    */
   rentPayer?: Address;
   /** Deposit amount in the vault asset's own units, as a decimal string. */


### PR DESCRIPTION
Smokey Veda deposits still failed after #1611: the ATA payer swap fixed the share-ATA rent, but `boring_vault_svm` also lazily creates the depositor's `AllowedUser` PDA inside the deposit instruction with the SIGNER hardcoded as rent source, and custody wallets hold zero SOL by design. Sponsored builds now prepend one System transfer of exactly that account's rent from the sponsor to the owner, consumed in-tx by the program's create, and the simulation classifier stops blaming the sponsor's balance for it.

**What changed**

- `@sdp/veda` `allowed-user.ts` (new): reads `allowed_user` off the built deposit ix; when sponsored and missing, prepends a sponsor->owner transfer sized by a live `getMinimumBalanceForRentExemption(57)` read (devnet's rent rate already moved once this year). The ABI constants are pinned to the committed IDL by `allowed-user.test.ts`.
- `vault-simulation-error.ts`: rent shortfalls are attributed by the failing frame. Top-level ATA create keeps the sponsor-balance copy; a shortfall inside another program becomes `sponsorCause: "prefund"`, worded as an SDP-side plan defect.
- `vault-intent-execution.service.ts`: the 5xx says "Retry shortly" only for the balance flavour; a prefund gap says it needs an SDP-side fix.
- Wallet-pays and withdraw paths unchanged (a withdrawing wallet always deposited first, so its PDA exists).

**before**: fee and share-ATA rent sponsored -> Veda deposit ix CPIs createAccount for AllowedUser from the zero-SOL owner -> `insufficient lamports 0, need 1171605` -> "SDP could not sponsor the network costs. Retry shortly" (sponsor was fine; retrying never helps).

**after**: build reads AllowedUser existence -> missing + sponsored prepends the rent transfer, consumed in the same tx (owner nets zero) -> sim passes; a future prefund gap is named as such instead of promising a retry.

**Reviewer notes**

- The prefund needs no new signature (sponsor already signs as fee payer) and no infra change: System is allowlisted and devnet Kora has `system.allow_transfer = true`; ~3.1M lamports per first deposit vs the 9.9M per-tx cap.
- Known residual: a build-to-broadcast race leaves the owner one account's rent as dust (documented in `allowed-user.ts`).
- Mainnet (PRO-1777) unaffected: Kora's mainnet `allow_transfer` stays CI-pinned false; the real ask there is a payer knob from Veda.

**Verification**

- `pnpm --filter @sdp/veda test` passed (106); typecheck and biome clean.
- `pnpm --filter @sdp/api exec vitest run src/services/earn/` passed (188); earn.vault + vault-withdrawals routes passed (96); typecheck clean.
- Surfpool devnet fork, real vault `3wbKP...`, real `buildVedaDepositPlan`, owner holding USDC and zero SOL: `simulateTransaction` returns `err: null` (prefund at ix0, AllowedUser create passes, shares mint). The full local app was not exercised (needs the devnet Kora sponsorship stack); the changed seam was driven directly.
