### PR TITLE
ci(smoke): stage smoke target with readiness heartbeat

### DIFF
--- a/.github/workflows/deploy-sdp-api-gcp-stage.yml
+++ b/.github/workflows/deploy-sdp-api-gcp-stage.yml
@@ -103,3 +103,19 @@ jobs:
             cat "${describe_err}" >&2
             exit 1
           fi
+
+  smoke:
+    name: Dispatch stage smoke (shadow)
+    needs: deploy
+    if: github.repository == 'solana-foundation/solana-developer-platform'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    continue-on-error: true
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Trigger the stage smoke run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run sdp-dev-smoke.yml --repo "${{ github.repository }}" --ref main -f target=stage

--- a/.github/workflows/sdp-dev-smoke.yml
+++ b/.github/workflows/sdp-dev-smoke.yml
@@ -57,14 +57,6 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      - name: Probe API readiness
-        id: health
-        run: |
-          set -euo pipefail
-          READY=$(curl -sS -m 15 "${PLAYWRIGHT_API_URL}/health/ready")
-          echo "$READY"
-          echo "$READY" | jq -e '.status == "ready" and .checks.database == "ok" and .checks.redis == "ok"' >/dev/null
-
       - name: Pin the smoke flag posture
         run: jq -r 'to_entries[] | .value.env + "=" + (.value.value|tostring)' apps/sdp-web/smoke-flags.json >> "$GITHUB_ENV"
 
@@ -76,6 +68,14 @@ jobs:
           oidc_jwt=$(curl -sf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
             "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/solana-foundation" | jq -r '.value')
           doppler oidc login --scope=. --identity="${{ vars.DOPPLER_CI_IDENTITY_ID }}" --token="${oidc_jwt}"
+
+      - name: Probe API readiness
+        id: health
+        run: |
+          set -euo pipefail
+          READY=$(curl -sS -m 15 "${PLAYWRIGHT_API_URL}/health/ready")
+          echo "$READY"
+          echo "$READY" | jq -e '.status == "ready" and .checks.database == "ok" and .checks.redis == "ok"' >/dev/null
 
       - name: Install Playwright browser
         run: pnpm --filter sdp-web exec playwright install --with-deps chromium

--- a/.github/workflows/sdp-dev-smoke.yml
+++ b/.github/workflows/sdp-dev-smoke.yml
@@ -2,7 +2,17 @@ name: SDP smoke canary
 
 on:
   workflow_dispatch:
+    inputs:
+      target:
+        description: "Environment to smoke"
+        type: choice
+        default: dev
+        options: [dev, stage]
   workflow_call:
+    inputs:
+      target:
+        type: string
+        default: dev
 
 permissions:
   contents: read
@@ -14,13 +24,14 @@ concurrency:
 
 jobs:
   smoke:
-    name: GCP dev dashboard smoke
+    name: GCP ${{ inputs.target || 'dev' }} dashboard smoke
     runs-on: ubuntu-latest
     timeout-minutes: 20
     if: github.repository == 'solana-foundation/solana-developer-platform'
     env:
       DOPPLER_PRESERVE_ENV: PLAYWRIGHT_API_URL,PLAYWRIGHT_USE_EXTERNAL_API,PLAYWRIGHT_USE_NEXT_START,PLAYWRIGHT_NEXT_DIST_DIR,SDP_API_BASE_URL,NEXT_PUBLIC_SDP_API_BASE_URL,NEXT_PUBLIC_SENTRY_DSN,NODE_ENV,SENTRY_AUTH_TOKEN,VERCEL_ENV,SDP_FLAG_HOMEPAGE_OPEN_SIGNUP,SDP_FLAG_ORGANIZATION_ONBOARDING,SDP_FLAG_PRIVY_BYOK,SDP_FLAG_ASSET_PROFILES,PRIVATE_CHANNELS_ENABLED,HELIUS_RINGS_ENABLED,PAYMENTS_ENABLED,MARKETS_ENABLED,EARN_ENABLED
-      PLAYWRIGHT_API_URL: https://api-dev.solana.com
+      SMOKE_TARGET: ${{ inputs.target || 'dev' }}
+      PLAYWRIGHT_API_URL: ${{ (inputs.target || 'dev') == 'stage' && 'https://api-stage.solana.com' || 'https://api-dev.solana.com' }}
       PLAYWRIGHT_USE_EXTERNAL_API: "1"
       PLAYWRIGHT_USE_NEXT_START: "1"
       PLAYWRIGHT_NEXT_DIST_DIR: .next-playwright
@@ -46,6 +57,14 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
+      - name: Probe API readiness
+        id: health
+        run: |
+          set -euo pipefail
+          READY=$(curl -sS -m 15 "${PLAYWRIGHT_API_URL}/health/ready")
+          echo "$READY"
+          echo "$READY" | jq -e '.status == "ready" and .checks.database == "ok" and .checks.redis == "ok"' >/dev/null
+
       - name: Pin the smoke flag posture
         run: jq -r 'to_entries[] | .value.env + "=" + (.value.value|tostring)' apps/sdp-web/smoke-flags.json >> "$GITHUB_ENV"
 
@@ -61,7 +80,8 @@ jobs:
       - name: Install Playwright browser
         run: pnpm --filter sdp-web exec playwright install --with-deps chromium
 
-      - name: Build web app against the dev API
+      - name: Build web app against the target API
+        if: env.SMOKE_TARGET != 'stage' || vars.STAGE_SMOKE_READY == 'true'
         env:
           DOPPLER_CONFIG: dev_ci
           SDP_API_BASE_URL: ${{ env.PLAYWRIGHT_API_URL }}
@@ -70,6 +90,7 @@ jobs:
         run: scripts/doppler/run-with-config.sh node scripts/run-with-healthy-solana-rpc.mjs pnpm --filter sdp-web build
 
       - name: Run GCP read-only smoke
+        if: env.SMOKE_TARGET != 'stage' || vars.STAGE_SMOKE_READY == 'true'
         id: smoke
         env:
           DOPPLER_CONFIG: dev_ci
@@ -78,6 +99,7 @@ jobs:
         run: scripts/doppler/run-with-config.sh pnpm --filter sdp-web run test:e2e:gcp-smoke
 
       - name: Private-channels vendor sandbox smoke
+        if: env.SMOKE_TARGET == 'dev'
         run: pnpm test:private-channels
 
       - name: Report run to Loki
@@ -86,8 +108,7 @@ jobs:
         env:
           DOPPLER_PROJECT: solana-developer-platform
           DOPPLER_CONFIG: dev_ci
-          SMOKE_OUTCOME: ${{ steps.smoke.outcome }}
-          SMOKE_TARGET: dev
+          SMOKE_OUTCOME: ${{ steps.smoke.outcome == 'skipped' && steps.health.outcome || steps.smoke.outcome }}
           RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: doppler run --scope=. --project "$DOPPLER_PROJECT" --config "$DOPPLER_CONFIG" --preserve-env=SMOKE_OUTCOME,SMOKE_TARGET,RUN_ID,RUN_URL -- ./scripts/report-smoke-to-loki.sh

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ apps/sdp-web/test-results/
 *.tsbuildinfo
 .vercel
 private/
+infra/kora/terraform/

--- a/apps/sdp-web/playwright/env.ts
+++ b/apps/sdp-web/playwright/env.ts
@@ -4,7 +4,12 @@ import path from "node:path";
 const DEFAULT_CLERK_TEST_ORG_NAME = "Solana";
 const DEFAULT_CLERK_TEST_EMAIL = "e2e-smoke+sdp-web@example.com";
 const BASE_URL = "http://localhost:3100";
-const GCP_DEV_API_URL = "https://api-dev.solana.com";
+const GCP_EXTERNAL_API_URLS = [
+  "https://api-dev.solana.com",
+  "https://api-stage.solana.com",
+  "https://api-preview.solana.com",
+];
+const GCP_DEV_API_URL = GCP_EXTERNAL_API_URLS[0];
 
 type E2EEnvCommon = {
   baseURL: string;
@@ -121,9 +126,9 @@ export function getE2EEnv(): E2EEnv {
   const explicitExternalApiUrl = useExternalApi
     ? resolveExplicitEnvValue("PLAYWRIGHT_API_URL").replace(/\/$/, "")
     : null;
-  if (explicitExternalApiUrl && explicitExternalApiUrl !== GCP_DEV_API_URL) {
+  if (explicitExternalApiUrl && !GCP_EXTERNAL_API_URLS.includes(explicitExternalApiUrl)) {
     throw new Error(
-      `External GCP smoke only accepts ${GCP_DEV_API_URL}; received ${explicitExternalApiUrl}`
+      `External GCP smoke only accepts ${GCP_EXTERNAL_API_URLS.join(", ")}; received ${explicitExternalApiUrl}`
     );
   }
 

--- a/apps/sdp-web/playwright/tests/gcp-read-only-smoke.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/gcp-read-only-smoke.e2e.spec.ts
@@ -103,7 +103,11 @@ test.describe("GCP dev dashboard read-only smoke", () => {
     if (!env.useExternalApi) {
       throw new Error("GCP smoke must run in explicit external mode");
     }
-    expect(env.sdpApiBaseUrl).toBe("https://api-dev.solana.com");
+    expect([
+      "https://api-dev.solana.com",
+      "https://api-stage.solana.com",
+      "https://api-preview.solana.com",
+    ]).toContain(env.sdpApiBaseUrl);
 
     fixture = await provisionWithAdminSession(browser, async (session) => {
       expect(session.identity.email).toBe(env.clerkTestEmail);


### PR DESCRIPTION
Phase-2 app half of the stage rollout (infra half: sdp-infra #124). Gives stage a per-deploy verification heartbeat today and a pre-wired path to the full authed suite, without touching dev or prod behavior.

- `sdp-dev-smoke.yml` gains a `target` input (`dev` default, `stage`); every existing caller is unchanged.
- New always-on **readiness probe** step asserts `/health/ready` reports `ready` + db/redis `ok` against the target before anything builds.
- For `target=stage` the Playwright build/suite is gated behind repo var `STAGE_SMOKE_READY` (unset today) — the run still probes readiness and reports to Loki, so stage gets a heartbeat before fixtures exist.
- Loki line now carries `target` from the input; `SMOKE_OUTCOME` falls back to the probe outcome when the suite is skipped. Feeds the new `sdp-smoke-consecutive-failures-stage` rule (sdp-infra #124).
- Stage deploys dispatch the smoke fire-and-forget (`gh workflow run`, `continue-on-error`) — a stage smoke failure cannot red a main deploy while stage shadows. The private-channels vendor smoke stays dev-only to avoid double vendor runs per merge.

**before** — stage deploy verification:
1. shadow deploy → gcloud revision-Ready poll
2. no HTTP-level check, no smoke event → `target=stage` absent from Loki
3. a stage env broken above the revision layer (LB, WAF, auth, DB perms on the masked copy) goes unnoticed

**after** — stage deploy verification:
1. shadow deploy → revision-Ready poll → dispatches smoke `target=stage`
2. smoke probes `https://api-stage.solana.com/health/ready` (flips to api-preview once DNS lands — one line), asserts ready+db+redis
3. outcome lands in Loki as `sdp_smoke_run{target="stage"}` → consecutive-failure alert; when `STAGE_SMOKE_READY=true` is set the full authed Playwright suite activates with zero further workflow changes

**Verification**
- `actionlint` on both workflows — clean
- `node --test scripts/*.test.mjs` — 128/128 (workflow-shape tests)
- exact probe command against live stage: `curl /health/ready | jq -e '.status=="ready" and .checks.database=="ok" and .checks.redis=="ok"'` → `ready`, revision `sdp-stage-api-public-00012-kfk`
- end-to-end dispatch path exercises on the first merge-triggered shadow deploy (cannot run pre-merge; shadow `continue-on-error` bounds the blast radius)

Known gaps
- Stage fixtures (Clerk canary org) are the activation key for the authed suite — separate ops task, then set `STAGE_SMOKE_READY=true`.
- Probe URL flips to `api-preview.solana.com` after sdp-infra #124 applies + DNS lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)