### PR TITLE
feat(deploy): stage replaces dev in the merge pipeline; dev deploys by PR label

### DIFF
--- a/.github/workflows/deploy-dev-on-label.yml
+++ b/.github/workflows/deploy-dev-on-label.yml
@@ -1,0 +1,25 @@
+name: Deploy PR to dev (label-triggered)
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: sdp-api-gcp-deploy-dev
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy this PR branch to dev
+    if: >-
+      github.repository == 'solana-foundation/solana-developer-platform' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'deploy-dev')
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/deploy-sdp-api-gcp.yml

--- a/.github/workflows/deploy-sdp-api-gcp-prod.yml
+++ b/.github/workflows/deploy-sdp-api-gcp-prod.yml
@@ -76,12 +76,14 @@ jobs:
           ./scripts/notify-slack.sh
 
   smoke:
-    name: Gate on dev smoke
+    name: Gate on stage smoke
     if: >-
       github.repository == 'solana-foundation/solana-developer-platform' &&
       github.event_name != 'workflow_dispatch' &&
       inputs.image_sha == ''
     uses: ./.github/workflows/sdp-dev-smoke.yml
+    with:
+      target: stage
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/deploy-sdp-api-gcp-stage.yml
+++ b/.github/workflows/deploy-sdp-api-gcp-stage.yml
@@ -16,7 +16,6 @@ jobs:
   deploy:
     name: Build and deploy
     if: github.repository == 'solana-foundation/solana-developer-platform'
-    continue-on-error: true
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: solana-developer-platform-stg
@@ -105,17 +104,11 @@ jobs:
           fi
 
   smoke:
-    name: Dispatch stage smoke (shadow)
+    name: Post-deploy stage smoke
     needs: deploy
-    if: github.repository == 'solana-foundation/solana-developer-platform'
-    runs-on: ubuntu-latest
-    timeout-minutes: 3
-    continue-on-error: true
     permissions:
       contents: read
-      actions: write
-    steps:
-      - name: Trigger the stage smoke run
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh workflow run sdp-dev-smoke.yml --repo "${{ github.repository }}" --ref main -f target=stage
+      id-token: write
+    uses: ./.github/workflows/sdp-dev-smoke.yml
+    with:
+      target: stage

--- a/.github/workflows/deploy-sdp-api-gcp.yml
+++ b/.github/workflows/deploy-sdp-api-gcp.yml
@@ -85,11 +85,3 @@ jobs:
             exit 1
           fi
 
-  smoke:
-    name: Post-deploy dev smoke
-    needs: deploy
-    permissions:
-      contents: read
-      id-token: write
-    uses: ./.github/workflows/sdp-dev-smoke.yml
-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,8 +115,8 @@ jobs:
           curl -sS --fail-with-body -X POST -H 'Content-Type: application/json' --data "$PAYLOAD" "$SLACK" || true
 
   notify-end:
-    needs: [changes, deploy-api-dev, deploy-api-prod]
-    if: always() && needs.deploy-api-dev.result != 'skipped' && vars.CONTINUOUS_PROD_DEPLOY == 'true'
+    needs: [changes, deploy-api-stage, deploy-api-prod]
+    if: always() && needs.deploy-api-stage.result != 'skipped' && vars.CONTINUOUS_PROD_DEPLOY == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     continue-on-error: true
@@ -137,8 +137,8 @@ jobs:
         env:
           SERVICES: api
           OUTCOME: >-
-            ${{ (needs.deploy-api-dev.result == 'failure' || needs.deploy-api-prod.result == 'failure') && 'FAILED' ||
-                (needs.deploy-api-dev.result == 'cancelled' || needs.deploy-api-prod.result == 'cancelled') && 'CANCELLED' ||
+            ${{ (needs.deploy-api-stage.result == 'failure' || needs.deploy-api-prod.result == 'failure') && 'FAILED' ||
+                (needs.deploy-api-stage.result == 'cancelled' || needs.deploy-api-prod.result == 'cancelled') && 'CANCELLED' ||
                 'SUCCESS' }}
           ACTOR: ${{ github.actor }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -174,17 +174,8 @@ jobs:
             }')
           curl -sS --fail-with-body -X POST -H 'Content-Type: application/json' --data "$PAYLOAD" "$SLACK" || true
 
-  deploy-api-dev:
-    name: sdp-api + worker + cron — dev + smoke
-    needs: changes
-    if: needs.changes.outputs.api == 'true'
-    permissions:
-      contents: read
-      id-token: write
-    uses: ./.github/workflows/deploy-sdp-api-gcp.yml
-
   deploy-api-stage:
-    name: sdp-api + worker + cron — stage (shadow)
+    name: sdp-api + worker + cron — stage + smoke
     needs: changes
     if: needs.changes.outputs.api == 'true' && vars.STAGE_DEPLOY_WIF_PROVIDER != '' && vars.STAGE_DEPLOY_SA != ''
     permissions:
@@ -194,7 +185,7 @@ jobs:
 
   deploy-api-prod:
     name: sdp-api + worker + cron — prod
-    needs: [changes, deploy-api-dev]
+    needs: [changes, deploy-api-stage]
     if: >-
       needs.changes.outputs.api == 'true' &&
       github.event_name == 'push' &&


### PR DESCRIPTION
Executes the PRO-1767 cutover: stage becomes the bake env on every merge; dev becomes the labeled playground.

**Pipeline**
- `deploy.yml`: merge → **stage** (blocking; `deploy-api-prod` now needs it); dev job removed from the push path; Slack notify aggregation follows stage.
- `deploy-sdp-api-gcp-stage.yml`: shadow posture removed (`continue-on-error` gone); the dispatch-smoke job becomes a blocking `uses:` call with `target: stage`.
- `deploy-sdp-api-gcp-prod.yml`: promotion gate = stage smoke.

**Dev as playground**
- New `deploy-dev-on-label.yml`: label `deploy-dev` on a **same-repo** PR deploys that branch to the dev project (shared/expendable, last-writer-wins, concurrency-serialized). Fork PRs are excluded by the head-repo guard and by GitHub's fork id-token rules.
- Dev deploy workflow keeps `workflow_dispatch`; its post-deploy smoke is retired with the promotion role (smoke stays dispatchable with `target: dev`).

**before** — merge to main:
1. deploy dev → authed dev smoke → (release) prod gate on dev smoke
2. stage shadows, non-blocking

**after** — merge to main:
1. deploy stage → stage smoke (readiness today, authed later) → prod gate on stage
2. dev untouched by merges; any PR reaches dev via one label

**Called-out regression (temporary)**: the prod gate drops from the authed 13-endpoint dev smoke to a stage readiness probe until the authed stage suite lands — stage runs **prod Clerk**, so it needs the canary's sign-in-ticket flow rather than `@clerk/testing`; the existing SDP Canary org's identity survives in the masked stage DB, so the fixture already exists. That port is the top follow-up.

**Requires before label-deploys work**: sdp-infra pairs this with loosening dev's app-repo WIF from `repository + refs/heads/main` to repository-only (dev is expendable by design; prod/stage stay ref-pinned).

**Verification**: actionlint clean on all five changed workflows; `pnpm test:scripts` 128/128. The pipeline itself proves on the first post-merge run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)