### PR TITLE
ci: enforceable branch controls — always-run security checks, rules-drift watch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,25 @@
 *    @solana-foundation/sdp-maintainers
+
+# Custody and signing
+/packages/sdp-custody/                                  @GuiBibeau @G1de0n
+/apps/sdp-api/src/services/adapters/signing/            @GuiBibeau @G1de0n
+/apps/sdp-api/src/services/domain/signing/              @GuiBibeau @G1de0n
+
+# Payments and ramps
+/packages/sdp-payments/                                 @multipletwigs @GuiBibeau
+/apps/sdp-api/src/routes/payments/                      @multipletwigs @GuiBibeau
+
+# Issuance
+/packages/sdp-issuance/                                 @arseniy-nikitochkin @multipletwigs
+/apps/sdp-api/src/routes/issuance/                      @arseniy-nikitochkin @multipletwigs
+
+# Authentication and authorization
+/apps/sdp-api/src/middleware/                           @GuiBibeau @G1de0n
+/apps/sdp-api/src/lib/auth.ts                           @GuiBibeau @G1de0n
+
+# Database migrations
+/apps/sdp-api/src/db/migrations/                        @G1de0n @niks3089
+
+# CI/CD, release, and deploy machinery
+/.github/                                               @G1de0n @niks3089
+/scripts/                                               @G1de0n @niks3089

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 *    @solana-foundation/sdp-maintainers
 
 # Custody and signing
-/packages/sdp-custody/                                  @GuiBibeau @G1de0n
-/apps/sdp-api/src/services/adapters/signing/            @GuiBibeau @G1de0n
-/apps/sdp-api/src/services/domain/signing/              @GuiBibeau @G1de0n
+/packages/sdp-custody/                                  @GuiBibeau
+/apps/sdp-api/src/services/adapters/signing/            @GuiBibeau
+/apps/sdp-api/src/services/domain/signing/              @GuiBibeau
 
 # Payments and ramps
 /packages/sdp-payments/                                 @multipletwigs @GuiBibeau
@@ -14,8 +14,8 @@
 /apps/sdp-api/src/routes/issuance/                      @arseniy-nikitochkin @multipletwigs
 
 # Authentication and authorization
-/apps/sdp-api/src/middleware/                           @GuiBibeau @G1de0n
-/apps/sdp-api/src/lib/auth.ts                           @GuiBibeau @G1de0n
+/apps/sdp-api/src/middleware/                           @GuiBibeau
+/apps/sdp-api/src/lib/auth.ts                           @GuiBibeau
 
 # Database migrations
 /apps/sdp-api/src/db/migrations/                        @pashpashkin @multipletwigs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,7 @@
 /apps/sdp-api/src/lib/auth.ts                           @GuiBibeau @G1de0n
 
 # Database migrations
-/apps/sdp-api/src/db/migrations/                        @G1de0n @niks3089
+/apps/sdp-api/src/db/migrations/                        @pashpashkin @multipletwigs
 
 # CI/CD, release, and deploy machinery
 /.github/                                               @G1de0n @niks3089

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,21 +1,21 @@
 *    @solana-foundation/sdp-maintainers
 
 # Custody and signing
-/packages/sdp-custody/                                  @GuiBibeau
-/apps/sdp-api/src/services/adapters/signing/            @GuiBibeau
-/apps/sdp-api/src/services/domain/signing/              @GuiBibeau
+/packages/sdp-custody/                                  @multipletwigs @pashpashkin
+/apps/sdp-api/src/services/adapters/signing/            @multipletwigs @pashpashkin
+/apps/sdp-api/src/services/domain/signing/              @multipletwigs @pashpashkin
 
 # Payments and ramps
-/packages/sdp-payments/                                 @multipletwigs @GuiBibeau
-/apps/sdp-api/src/routes/payments/                      @multipletwigs @GuiBibeau
+/packages/sdp-payments/                                 @multipletwigs @pashpashkin
+/apps/sdp-api/src/routes/payments/                      @multipletwigs @pashpashkin
 
 # Issuance
 /packages/sdp-issuance/                                 @arseniy-nikitochkin @multipletwigs
 /apps/sdp-api/src/routes/issuance/                      @arseniy-nikitochkin @multipletwigs
 
 # Authentication and authorization
-/apps/sdp-api/src/middleware/                           @GuiBibeau
-/apps/sdp-api/src/lib/auth.ts                           @GuiBibeau
+/apps/sdp-api/src/middleware/                           @multipletwigs @pashpashkin
+/apps/sdp-api/src/lib/auth.ts                           @multipletwigs @pashpashkin
 
 # Database migrations
 /apps/sdp-api/src/db/migrations/                        @pashpashkin @multipletwigs

--- a/.github/branch-rules-baseline.json
+++ b/.github/branch-rules-baseline.json
@@ -7,10 +7,7 @@
   },
   {
     "parameters": {
-      "allowed_merge_methods": [
-        "squash",
-        "rebase"
-      ],
+      "allowed_merge_methods": ["squash", "rebase"],
       "dismiss_stale_reviews_on_push": true,
       "require_code_owner_review": false,
       "require_extra_approval_for_unattributed_changes": true,

--- a/.github/branch-rules-baseline.json
+++ b/.github/branch-rules-baseline.json
@@ -1,0 +1,27 @@
+[
+  {
+    "type": "deletion"
+  },
+  {
+    "type": "non_fast_forward"
+  },
+  {
+    "parameters": {
+      "allowed_merge_methods": [
+        "squash",
+        "rebase"
+      ],
+      "dismiss_stale_reviews_on_push": true,
+      "require_code_owner_review": false,
+      "require_extra_approval_for_unattributed_changes": true,
+      "require_last_push_approval": true,
+      "required_approving_review_count": 1,
+      "required_review_thread_resolution": false,
+      "required_reviewers": []
+    },
+    "type": "pull_request"
+  },
+  {
+    "type": "required_signatures"
+  }
+]

--- a/.github/workflows/branch-rules-drift.yml
+++ b/.github/workflows/branch-rules-drift.yml
@@ -1,0 +1,75 @@
+name: Branch rules drift
+
+on:
+  schedule:
+    - cron: "23 */6 * * *"
+  pull_request:
+    paths:
+      - '.github/branch-rules-baseline.json'
+      - '.github/workflows/branch-rules-drift.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: branch-rules-drift
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+
+      - name: Compare live branch rules against the committed baseline
+        id: drift
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${{ github.repository }}/rules/branches/main" \
+            | jq -S 'map(del(.ruleset_id, .ruleset_source, .ruleset_source_type)) | sort_by(.type)' > /tmp/live.json
+          if ! diff -u .github/branch-rules-baseline.json /tmp/live.json > /tmp/drift.diff; then
+            echo "::error::branch protection rules for main diverged from the reviewed baseline"
+            cat /tmp/drift.diff
+            {
+              echo "diff<<__EOF__"
+              head -c 3000 /tmp/drift.diff
+              echo
+              echo "__EOF__"
+            } >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          echo "branch rules match the baseline" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Install Doppler CLI
+        if: failure() && github.event_name != 'pull_request'
+        uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4.0.1
+
+      - name: Doppler OIDC login
+        if: failure() && github.event_name != 'pull_request'
+        run: |
+          oidc_jwt=$(curl -sf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/solana-foundation" | jq -r '.value')
+          doppler oidc login --scope=. --identity="${{ vars.DOPPLER_CI_IDENTITY_ID }}" --token="${oidc_jwt}"
+
+      - name: Notify Slack on drift
+        if: failure() && github.event_name != 'pull_request'
+        continue-on-error: true
+        env:
+          DRIFT: ${{ steps.drift.outputs.diff }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          SLACK=$(doppler secrets get SLACK_ALERT_WEBHOOK_URL --plain --scope=. --project solana-developer-platform --config dev_ci 2>/dev/null || true)
+          if [ -z "$SLACK" ]; then echo "::warning::SLACK_ALERT_WEBHOOK_URL missing — skipping notification"; exit 0; fi
+          echo "::add-mask::$SLACK"
+          PAYLOAD=$(jq -n --arg drift "$DRIFT" --arg run "$RUN_URL" \
+            '{ text: "*[FIRING] branch-rules-drift [solana-developer-platform]*",
+               attachments: [ { color: "#cc0000", blocks: [
+                 {type: "section", text: {type: "mrkdwn", text: "*Branch protection for main no longer matches the reviewed baseline.*\nEither revert the ruleset change or land a reviewed baseline update.\n```\($drift)```\n<\($run)|drift run>"}} ] } ] }')
+          curl -sS --fail-with-body -X POST -H 'Content-Type: application/json' --data "$PAYLOAD" "$SLACK"

--- a/.github/workflows/branch-rules-drift.yml
+++ b/.github/workflows/branch-rules-drift.yml
@@ -33,7 +33,9 @@ jobs:
           set -euo pipefail
           gh api "repos/${{ github.repository }}/rules/branches/main" \
             | jq -S 'map(del(.ruleset_id, .ruleset_source, .ruleset_source_type)) | sort_by(.type)' > /tmp/live.json
-          if ! diff -u .github/branch-rules-baseline.json /tmp/live.json > /tmp/drift.diff; then
+          jq -S . .github/branch-rules-baseline.json > /tmp/baseline.json
+          if ! diff -u /tmp/baseline.json /tmp/live.json > /tmp/drift.diff; then
+            echo "drifted=true" >> "$GITHUB_OUTPUT"
             echo "::error::branch protection rules for main diverged from the reviewed baseline"
             cat /tmp/drift.diff
             {
@@ -47,18 +49,18 @@ jobs:
           echo "branch rules match the baseline" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Install Doppler CLI
-        if: failure() && github.event_name != 'pull_request'
+        if: failure() && steps.drift.outputs.drifted == 'true' && github.event_name != 'pull_request'
         uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4.0.1
 
       - name: Doppler OIDC login
-        if: failure() && github.event_name != 'pull_request'
+        if: failure() && steps.drift.outputs.drifted == 'true' && github.event_name != 'pull_request'
         run: |
           oidc_jwt=$(curl -sf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
             "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/solana-foundation" | jq -r '.value')
           doppler oidc login --scope=. --identity="${{ vars.DOPPLER_CI_IDENTITY_ID }}" --token="${oidc_jwt}"
 
       - name: Notify Slack on drift
-        if: failure() && github.event_name != 'pull_request'
+        if: failure() && steps.drift.outputs.drifted == 'true' && github.event_name != 'pull_request'
         continue-on-error: true
         env:
           DRIFT: ${{ steps.drift.outputs.diff }}

--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -2,14 +2,8 @@ name: Workflow Security
 
 on:
   pull_request:
-    paths:
-      - ".github/**"
-      - "scripts/ci/**"
   push:
     branches: [main]
-    paths:
-      - ".github/**"
-      - "scripts/ci/**"
 
 permissions:
   contents: read

--- a/docs/ops/branch-controls.md
+++ b/docs/ops/branch-controls.md
@@ -1,0 +1,44 @@
+# Branch controls
+
+How branch protection for this repository is owned, enforced, and changed
+(SDLC §§3.2.5, 3.4.1–3.4.2, 4).
+
+## What is enforced on `main`
+
+Rules come from the organization-level ruleset and are snapshotted in
+`.github/branch-rules-baseline.json`:
+
+- no direct pushes: every change lands through a pull request with at least one
+  approving review, re-approval after the last push, and an extra approval for
+  unattributed changes;
+- no force pushes, no branch deletion;
+- verified commit signatures;
+- squash or rebase merges only.
+
+Required status checks and code-owner review are configured in the same ruleset;
+the baseline file is the reviewed record of the full rule set.
+
+## Control owner
+
+The SDP security owner holds this control. Ruleset changes are made by an
+organization administrator at the security owner's request — never ad hoc.
+
+## Changing the rules
+
+1. Open a pull request updating `.github/branch-rules-baseline.json` to the
+   intended state and describing why.
+2. After that PR is approved, an organization administrator applies the matching
+   ruleset change.
+3. The `branch-rules-drift` workflow verifies live rules against the baseline
+   every six hours and on baseline PRs; a mismatch pages the alerts channel and
+   fails until the ruleset and the baseline agree again.
+
+An unannounced ruleset change therefore surfaces within six hours as a drift
+alert, and the git history of the baseline file is the control's audit evidence.
+
+## Security-relevant checks
+
+`workflow-security.yml` (actionlint, full-SHA action pins, the changed-packages
+injection fixture) runs on every pull request so it can be a required check —
+path filtering was removed deliberately; a check that does not run cannot be
+required.


### PR DESCRIPTION
First half of HOO-1397 (SDLC §§3.2.5, 3.4.1–3.4.2, 4) — the parts enforceable from inside the repo. The ruleset changes themselves need an org admin and are listed at the end.

## What
- **workflow-security.yml runs on every PR** — path filters removed. Its three jobs (actionlint, full-SHA action pins, changed-packages injection fixture) are seconds-cheap, and a check that doesn't run can't be made required.
- **branch-rules-drift.yml** — every 6h (and on baseline PRs), fetches the live `rules/branches/main` rule set, normalizes it, and diffs against the committed `.github/branch-rules-baseline.json`. A mismatch fails the run and fires a `[FIRING]` alert to the alerts webhook — an unannounced ruleset change surfaces within six hours, and the baseline file's git history becomes the control's audit evidence.
- **docs/ops/branch-controls.md** — control owner, the change process (baseline PR first, then the org-admin ruleset change), and what is enforced today.
- `.github/branch-rules-baseline.json` — the reviewed snapshot of the current rules (verified matching live at commit time).

## For the org admin (separate, after this merges)
1. Add **required status checks** to the main ruleset — today nothing is required at merge time: CI core jobs + the three workflow-security checks.
2. Flip **require_code_owner_review** on once the critical-path CODEOWNERS lands (follow-up PR, owner mapping under discussion).
3. Confirm the ruleset's **bypass actors** list is empty (not readable with repo-scoped tokens).
Each of those changes lands as a baseline-file PR here first, per the doc.