### PR TITLE
docs(skills): refresh ramp skills for the requirements event model

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -30,15 +30,10 @@ Explicitly invoke **`integrate-ramp-provider`** first. Pass the provider docs UR
 | `integrate-offramp` | Crypto→fiat quote |
 | `integrate-webhook` | Signature verification + settlement events |
 
-Capability work is parallel after registration. For an unsupported direction, declare empty support and implement the required interface methods as typed rejections; only `createOnrampQuote` is optional in the current `RampProvider` contract.
+Capability work is parallel after registration. For an unsupported direction, declare empty support and implement the required interface methods as typed rejections; only `createOnrampQuote` and `listExternalAccountDetails` are optional in the current `RampProvider` contract.
 
 ## Choose the closest reference
 
-| Integration shape | Reference |
-|---|---|
-| Manual instructions + counterparty provisioning | `packages/sdp-payments/src/ramps/providers/lightspark/client.ts` |
-| Hosted redirect/widget | `packages/sdp-payments/src/ramps/providers/moonpay/client.ts` |
-| Embedded session widget | `packages/sdp-payments/src/ramps/providers/stripe/client.ts` |
-| Multi-step KYC, accounts, and provider-specific DB state | BVNK or Mural package client plus `apps/sdp-api/src/routes/payments/handlers/ramps/<provider>.ts` |
+Every integration shape is represented under `packages/sdp-payments/src/ramps/providers/` (with API-side DB helpers in `apps/sdp-api/src/routes/payments/handlers/ramps/<provider>.ts`): manual instructions + counterparty provisioning, hosted redirect/widget, embedded session widget, and multi-step KYC with provider-side account state. Read the existing client whose shape matches yours.
 
 The type system catches many missing registrations, but not every schema, public type, translation, or UI catalog. Use `register-provider` as the complete checklist.

--- a/.agents/skills/counterparty-requirements/SKILL.md
+++ b/.agents/skills/counterparty-requirements/SKILL.md
@@ -1,16 +1,44 @@
 ---
 name: counterparty-requirements
-description: Implement a ramp provider's pure validateCounterparty decision in @sdp/payments plus the API-side collected-field advance flow, schemas, and provider-data persistence.
+description: Implement a ramp provider's pure validateCounterparty decision in @sdp/payments plus the API-side requirements event flow — status events out, advance submissions in, provider state as counterparty_provider_accounts rows. PII is JIT pass-through only.
 disable-model-invocation: true
 ---
 
 # Counterparty requirements
 
-Before a quote, the platform asks your provider what a counterparty still needs — KYC, a payout account, or nothing at all. `validateCounterparty` answers that. It is **pure and synchronous**: it reads the counterparty + its `provider_data` and returns a `CounterpartyRequirements`. No HTTP, no DB — the actual provisioning happens later, in the advance flow.
+Before a quote, the platform asks your provider what a counterparty still needs — KYC, a payout account, or nothing at all. `validateCounterparty` answers that. It is **pure and synchronous**: it reads the counterparty + handler-resolved state and returns a `CounterpartyRequirements`. No HTTP, no DB — the actual provisioning happens later, in the advance flow.
 
 Use this skill for every provider, including providers that always return `ready`. The dashboard calls the requirements GET and POST flow before requesting a quote, so both schemas and an `advanceCounterpartyRequirements` branch must admit the provider even when there is no KYC or provisioning work to perform.
 
-Canonical examples live in `packages/sdp-payments/src/ramps/providers/`: Lightspark and BVNK for collected fields, Mural for hosted onboarding states, and MoonPay for an inline ready decision.
+Canonical examples live in `packages/sdp-payments/src/ramps/providers/` — before writing yours, read the existing provider whose lifecycle is closest: inline ready decisions, collected-field KYC, customer-link → payout-tree provisioning, and hosted onboarding lifecycles are all represented.
+
+## The event model
+
+The requirements flow is a set of event streams, each a closed union discriminated on `(provider, status/kind)`. Adding a provider means declaring exactly which events it emits and accepts in each stream:
+
+- **Status events out** (`GET /v1/counterparties/:counterpartyId/requirements`): `validateCounterparty` emits one arm of `CounterpartyRequirements` (`packages/sdp-types/src/ramp-requirements.ts`).
+- **Advance submissions in** (`POST …/requirements`): one `submitCounterpartyRequirementsSchema` arm per provider (nested `discriminatedUnion("direction", …)` when payloads differ per direction). `collectedData` on the submission is the **only PII channel** in the platform.
+- **Webhook auto-advance** (optional): providers with async provisioning also move requirement state from typed webhook events — see `integrate-webhook`.
+
+## Provider state: `counterparty_provider_accounts`
+
+All provider-side counterparty state is rows in this table — one row per provider resource. The row schema is `counterpartyProviderAccountRowSchema` in `apps/sdp-api/src/db/repositories/counterparty-provider-account.repository.ts`; every repo method is tenant-scoped and parent-scoped.
+
+| Column | What it is and how to use it |
+|---|---|
+| `id` | `counterparty_provider_account_<uuid>`. Sent upstream as the platform-side account id on JIT creation where the provider accepts one, which makes creation idempotent (the provider rejects a duplicate id). |
+| `organization_id`, `project_id`, `counterparty_id` | Tenant + parent scope. Every read and write takes all three — get/update/archive too, never just list. |
+| `provider` | The ramp provider id; part of every lookup key. |
+| `kind` | What the row represents: `customer_link` (the provider-side customer; one active per `(counterparty, provider)`, enforced by partial unique index), `payout_account` (off-ramp destination account), `funding_wallet` (on-ramp funding resource), `merchant_wallet` (merchant-owned provider wallet). Pick the kind that matches the resource; do not invent parallel storage. |
+| `provider_customer_reference` | The provider's customer id the resource belongs to. Required on every row. |
+| `external_account_reference` | The provider's own id for the resource (account/wallet id). `null` on `customer_link` rows. This is the value quote calls pass upstream. |
+| `fiat_currency`, `destination_country`, `payment_rail` | The corridor. Set on corridor-scoped kinds; `null` where not applicable. Multiple active rows per corridor — including per rail — are legal; there is no corridor uniqueness, so selection is explicit (`providerAccountId`), never assumed. |
+| `provider_status` | The provider-reported lifecycle status, stored verbatim. Gate on it with a provider-side predicate before using the row in a quote; treat unknown values as not-ready. |
+| `status` | SDP soft delete: `active` / `archived`. Replacement = archive + create a new row; never hard-delete, never update in place to repoint a resource. |
+| `metadata` | Kind-discriminated JSON, schema-validated on write against the per-kind metadata schemas in the repository file. Provider references and state only — **never PII, never bank details**. |
+| `created_at`, `updated_at` | Row timestamps; also the display timestamps when the provider reports none on the resource. |
+
+**`counterparties.provider_data` is deprecated.** Do not add a provider key to it; new provider state must be a row here under the right `kind`. PII lands in neither place — it flows through advance-submission `collectedData`, JIT to the provider, and is discarded.
 
 ## Contract
 
@@ -18,51 +46,70 @@ Canonical examples live in `packages/sdp-payments/src/ramps/providers/`: Lightsp
 validateCounterparty(counterparty: Counterparty, options: ValidateCounterpartyOptions): CounterpartyRequirements
 ```
 
-`options` = `{ direction, providerData, cryptoToken?, fiatCurrency?, destinationWalletAddress? }`. Trivial bodies (`readyCounterparty(...)`, or an `unsupported` guard) stay inline in the client; non-trivial decisions delegate to `providers/<id>/counterparty.ts`.
+`ValidateCounterpartyOptions` is direction-discriminated (`packages/sdp-payments/src/ramps/types.ts`): both arms carry `providerData` (legacy), `providerCustomerReference` (the handler-resolved `customer_link` reference), `cryptoToken?`, and `fiatCurrency?`; the offramp arm adds `cryptoRail?` and `payoutAccounts?` (handler-listed active corridor accounts). Trivial bodies (`readyCounterparty(...)`, or an `unsupported` guard) stay inline in the client; non-trivial decisions delegate to `providers/<id>/counterparty.ts`.
 
-`CounterpartyRequirements` is discriminated by `provider`; the `status` union (`packages/sdp-types/src/ramp-requirements.ts`). Every provider gets these three:
+Status events every provider gets:
 
-- `{ status: "ready" }` — good to quote.
+- `{ status: "ready"; providerAccountId? }` — good to quote. An offramp advance that resolved a payout account echoes its row id so the client can pass it back for explicit quote selection.
 - `{ status: "collect"; fields: RequirementField[] }` — need input first.
 - `{ status: "unsupported"; reason }` — this counterparty/corridor can't be served, and why.
-- provider-specific onboarding states currently cover Lightspark, BVNK, and Mural, including verification URLs, terms-of-service URLs, verification progress/failure, and funding-account provisioning. Read the authoritative union in `packages/sdp-types/src/ramp-requirements.ts`; extend it only when generic `ready` / `collect` / `unsupported` cannot represent the provider.
 
-`RequirementField` is a discriminated union (same module):
+The full status union, discriminated on `(provider, status)`:
 
-- `{ kind: "text"; key; label; required; pattern?; minLength?; maxLength?; placeholder?; mask? }`
-- `{ kind: "select"; key; label; required; options: { value; label }[] }`
-
-Build fields with `textField`, `selectField`, and `readyCounterparty` from `packages/sdp-payments/src/ramps/requirements.ts`; don't hand-roll the shape.
-
-## The decision (variety)
-
-| Provider | validateCounterparty |
+| Provider | Statuses |
 |---|---|
-| MoonPay | always `readyCounterparty(...)` — no KYC gating |
-| Lightspark | on-ramp ready; off-ramp `ready` if an active payout account exists, else `collect` payout fields (per-currency spec), else `unsupported` |
-| BVNK | off-ramp ready; on-ramp `ready` if a verified customer exists, else `collect` KYC fields, else `unsupported` (business entity / missing country) |
-| Mural | provider-hosted organization/KYC/ToS lifecycle with account provisioning |
+| every provider | `ready` (may carry `providerAccountId`), `collect(fields)`, `unsupported(reason)` |
+| lightspark | `onboarding_not_started`, `collect_counterparty(fields)`, `collect_account(payout: PayoutRequirementTree)` |
+| bvnk | `onboarding_not_started`, `customer_verification_required(verificationUrl)`, `customer_verifying`, `customer_verification_failed`, `funding_account_provisioning`, `provisioning_failed` |
+| mural | `onboarding_not_started`, `terms_of_service_required(termsOfServiceUrl)`, `customer_verification_required(verificationUrl)`, `customer_verifying`, `customer_verification_failed`, `funding_account_provisioning` |
+
+The authoritative union is `CounterpartyRequirements` in `packages/sdp-types/src/ramp-requirements.ts` — re-read it before editing; this table goes stale. Extend it only when generic `ready` / `collect` / `unsupported` cannot represent the provider.
+
+`RequirementField` kinds (same module): `text`, `select`, `country`, `date`, and `address` (nested dotted-key parts). `country` is codes-only on the wire — the server never inlines a country option list; the client renders its own dropdown from `COUNTRIES` with flag labels; values are ISO 3166-1 alpha-2 both ways. Build fields with `textField`, `selectField`, `countryField`, `dateField`, and `readyCounterparty` from `packages/sdp-payments/src/ramps/requirements.ts`; don't hand-roll the shape.
+
+## The payout tree (offramp account reuse)
+
+`collect_account` carries a `PayoutRequirementTree` — destination-first collection:
+
+- `countryRails`: destination country → rail options for the corridor.
+- `railFields`: rail → fields with true per-rail requiredness.
+- `accounts`: the counterparty's existing active accounts for the corridor, `{ id, destinationCountry, paymentRail, status, bankName?, accountNumberLast4? }`, so the client offers reuse instead of silently re-collecting bank fields.
+
+Display info (`bankName`, `accountNumberLast4`) comes from JIT provider enrichment via the optional `listExternalAccountDetails` provider method — masked server-side, never persisted; absent fields stay absent (typed optional), never defaulted.
+
+## The decision (archetypes)
+
+Simplest first — pick the closest and mirror its decision function:
+
+- Always `readyCounterparty(...)` — no KYC gating.
+- `collect` KYC fields, `ready` once the provider verifies the customer.
+- Customer link first (`collect_counterparty`), then per-corridor payout collection (`collect_account` with the payout tree; existing accounts offered for reuse), then `ready`.
+- Provider-hosted onboarding (ToS/verification URLs) advanced to `ready` by webhook events.
 
 ## The advance / submit flow
 
 Both requirement routes must admit the provider before its client can run:
 
 - `GET /v1/counterparties/:counterpartyId/requirements`: update the direction-specific provider lists in `apps/sdp-api/src/routes/counterparties/schemas.ts`.
-- `POST /v1/counterparties/:counterpartyId/requirements`: add a provider arm to `submitCounterpartyRequirementsSchema` in `apps/sdp-api/src/routes/payments/schemas.ts`.
+- `POST /v1/counterparties/:counterpartyId/requirements`: add a provider arm to `submitCounterpartyRequirementsSchema` in `apps/sdp-api/src/routes/payments/schemas.ts`. An offramp arm may also take `providerAccountId?` — an advance that selects an existing corridor account instead of collecting bank fields.
 
-The POST handler re-runs `validateCounterparty`, validates submitted `collectedData`, then calls `advanceCounterpartyRequirements` in `apps/sdp-api/src/routes/payments/handlers/ramps.ts`, which dispatches to the DB-side `ensure*` helper.
+The POST handler re-runs `validateCounterparty`, validates submitted `collectedData`, then calls `advanceCounterpartyRequirements` in `apps/sdp-api/src/routes/payments/handlers/ramps.ts`, which dispatches to the DB-side `ensure*` helper. The helper's job: provider HTTP with the collected PII, then persist the *result* as a `counterparty_provider_accounts` row.
 
-**Hard rule: collected KYC is never persisted.** `collectedData` (SSN, IBAN, CDD, tax id) flows into the provider API call only. What lands in `provider_data` is metadata — customer id, account id, status, timestamps. Raw secrets are transient. (`GET /v1/counterparties/:id/requirements` exposes the current requirements for the client wizard.)
+**Hard rule: collected KYC is never persisted.** `collectedData` (SSN, IBAN, CDD, tax id) flows into the provider API call only. What lands in the account row is metadata — provider references, status, corridor, rail. Raw secrets are transient.
+
+## Listing accounts
+
+`GET /v1/counterparties/:id/provider-accounts` (own route module, `apps/sdp-api/src/routes/counterparty-provider-accounts/`) lists the rows with JIT enrichment (`enrichCounterpartyProviderAccounts`): providers implementing `listExternalAccountDetails` contribute `bankName` / `accountNumberLast4` / `paymentRails` per request; nothing enriched is written back. The surface is provider-generic — never special-case a provider in the endpoint, response schema, or UI.
 
 ## Gating
 
-Quotes consume the provisioned state: a Lightspark quote needs `customerId` + an active payout account; a BVNK quote needs a verified customer + ready rule. If it's not there, the quote throws `counterpartyNotProvisioned` — it does not fall back to an ungated quote.
+Quotes consume the provisioned state: an offramp quote resolves the payout account explicitly (`providerAccountId`) or from the corridor's active rows; a verification-gated provider needs its active `customer_link` and any required resource rows. If it's not there, the quote throws `counterpartyNotProvisioned` — it does not fall back to an ungated quote.
 
 ## Rules + verify
 
 Shared rules live in `integrate-ramp-provider`. Hot here:
 
-- `validateCounterparty` is pure — no HTTP, no DB; read only `counterparty` + `providerData`.
+- `validateCounterparty` is pure — no HTTP, no DB; read only the counterparty + handler-resolved options.
 - No fallbacks — `unsupported` with a reason beats a silent empty requirement; never persist collected KYC.
-- Status + field types are discriminated unions — return exactly one arm; no `any`.
+- Status + field types are discriminated unions — return exactly one arm; no `any`. No new `counterparties.provider_data` keys.
 - Verify `@sdp/payments` typecheck/lint/tests plus focused API GET/POST requirement tests. Test the pure decision table and prove raw collected KYC is not persisted.

--- a/.agents/skills/integrate-estimate/SKILL.md
+++ b/.agents/skills/integrate-estimate/SKILL.md
@@ -8,7 +8,7 @@ disable-model-invocation: true
 
 An estimate is a rate preview: "how much USDC for 100 EUR?" It hits the provider's live rate API and nothing else — no counterparty, no wallet, no DB. That makes it the first capability to build: if `estimateOnramp` works, your `register-provider` config reader and credentials are correct.
 
-Choose the closest implementation in `packages/sdp-payments/src/ramps/providers/`: Lightspark for decimal/minor-unit conversion, MoonPay for hosted-provider quote APIs, Stripe for on-ramp-only support, or BVNK for POST-based estimates.
+Choose the closest implementation in `packages/sdp-payments/src/ramps/providers/` — GET- and POST-based estimate APIs, hosted-provider quote APIs, minor-unit conversion, and single-direction support are all represented.
 
 ## Contract
 
@@ -38,7 +38,7 @@ Output `PaymentRampEstimate` (`@sdp/types`, `packages/sdp-types/src/payments.ts`
 
 `ctx` is `{ env, mode }` — read your config with the mode-keyed reader from `register-provider`, then HTTP only. Convert the asset rail with `getCryptoRailAssetLabel` from `@sdp/types/payment-rails`; convert minor units with `parseDecimalAmount` / `formatDecimalAmount` from `@sdp/solana/amount`.
 
-Lightspark's shape: GET the corridor's `exchange-rates` once to learn decimals, again with the amount to get the quote, then map into `PaymentRampEstimate`.
+A common shape: GET the corridor's exchange rate once to learn decimals, again with the amount to get the quote, then map into `PaymentRampEstimate`.
 
 ## Fail loud
 
@@ -58,11 +58,7 @@ The dashboard runtime routes are `POST /v1/payments/ramps/{onramp|offramp}/estim
 
 ## Variety
 
-| Provider | How estimate is sourced |
-|---|---|
-| Lightspark | `GET exchange-rates?sourceCurrency=…&destinationCurrency=…` (corridor, then with amount) |
-| MoonPay | `GET /v3/currencies/{code}/buy_quote` (on) / `sell_quote` (off) |
-| BVNK | `POST` quote with `estimate=true` |
+Estimate sourcing differs per upstream: corridor exchange-rate GETs (once for decimals, again with the amount), per-currency buy/sell quote GETs, or a `POST` quote flagged as estimate-only. Map whichever the upstream offers into `PaymentRampEstimate`.
 
 ## Rules + verify
 

--- a/.agents/skills/integrate-offramp/SKILL.md
+++ b/.agents/skills/integrate-offramp/SKILL.md
@@ -8,9 +8,9 @@ disable-model-invocation: true
 
 Off-ramp = a counterparty sells crypto from an SDP wallet for fiat paid to a payout account. Implement `createOfframpQuote` and add a branch to the API dispatch. There is no `executeOfframp` method in the current provider contract.
 
-`createOfframpQuote` is **required** on `RampProvider` (unlike `createOnrampQuote`, which is optional) — even a provider that doesn't support off-ramp must implement it; the dispatch `case` for that provider can throw instead of calling it (Mural, Coinbase, and Stripe all currently throw "not supported" from the handler rather than reaching the client method).
+`createOfframpQuote` is **required** on `RampProvider` (unlike `createOnrampQuote`, which is optional) — even a provider that doesn't support off-ramp must implement it; the dispatch `case` for that provider can throw instead of calling it (several registered providers do exactly that today rather than reaching the client method).
 
-Choose the closest package client under `packages/sdp-payments/src/ramps/providers/`: Lightspark/BVNK for manual instructions and payout provisioning, or MoonPay for a hosted off-ramp.
+Choose the closest package client under `packages/sdp-payments/src/ramps/providers/` by delivery mode: manual instructions with payout provisioning, a hosted widget, or a session widget.
 
 ## Contract
 
@@ -22,22 +22,21 @@ Output `PaymentRampQuote` is closed by `provider` and `deliveryMode`; add the pr
 
 1. **Source wallet.** The shared policy extraction resolves `sourceWallet` to an SDP wallet/address and gates the value-moving operation through `policyGate`. Do not accept a provider account id in place of the SDP source wallet.
 
-2. **Payout account.** The fiat needs a destination bank account. Lightspark resolves `payoutAccountId` from the counterparty's most recent active account (`latestLightsparkPayoutAccount`), JIT-created by `ensureLightsparkPayoutAccount` — content-addressed by a hash of the collected bank details, and **the raw bank details are sent to the provider and never stored**. That provisioning is `counterparty-requirements`; the quote consumes the resolved id and throws `counterpartyNotProvisioned` if it's missing or inactive.
+2. **Payout account.** The fiat needs a destination bank account, and a counterparty may hold several active accounts per corridor (per rail). The quote request takes an optional `providerAccountId` (the `counterparty_provider_accounts` row id): when present, the handler resolves it parent-scoped and rejects a mismatched corridor; when absent, it lists the corridor's active rows and applies the provider's selection helper. Accounts are JIT-created by the requirements advance flow — **the raw bank details are sent to the provider and never stored**. Missing/inactive account throws `counterpartyNotProvisioned`; the transfer records the chosen row id as `payoutProviderAccountId` in its provider data.
 
 ## Handler wiring (the DB side)
 
-Add a branch to `apps/sdp-api/src/routes/payments/handlers/ramps.ts`. The handler resolves counterparty + source wallet + payout account, calls the HTTP-only package method, and persists via `persistRampQuoteTransfer` (off-ramp writes `sourceAddress` + `cryptoAmount`, `direction: "outbound"`).
+Add a branch to `apps/sdp-api/src/routes/payments/handlers/ramps.ts`. The handler resolves counterparty + source wallet + payout account, calls the HTTP-only package method, and persists the transfer. A `reservedTransferId` is minted before the provider call so it can travel upstream as the reference (pass it in a description/reference field where the upstream accepts one); persistence then takes one of two paths: default `persistRampQuoteTransfer` after the quote (off-ramp writes `sourceAddress` + `cryptoAmount`, `direction: "outbound"`, plus `providerData` such as `payoutProviderAccountId`), or a pending transfer created **before** the provider call and completed/failed after it (a `createPending*` → `completePending*` helper pair) when the provider call must be attributable to a row even on failure.
 
 Dashboard runtime route: `POST /v1/payments/ramps/offramp/quote`, gated by provider availability, metered quota, permissions, and `policyGate`. It is not currently in public OpenAPI; do not advertise it as public unless the OpenAPI policy changes.
 
 ## Variety
 
-| Provider | deliveryMode | Off-ramp quote shape |
-|---|---|---|
-| Lightspark | `manual_instructions` | `REALTIME_FUNDING` quote: customer sends crypto to the instructions, the provider auto-executes into the payout account |
-| BVNK | `manual_instructions` | estimate → accept; carries `bvnkCompliance` (requester IP, etc.) |
-| MoonPay | `hosted` | signed `sell.moonpay.com` widget `hostedUrl` |
-| MoneyGram | `session_widget` | short-lived session JWT + `widgetUrl` |
+| deliveryMode | Off-ramp quote shape |
+|---|---|
+| `manual_instructions` | on-chain funding instructions: the customer sends crypto to the instructions and the provider executes into the advance-provisioned payout destination (missing provisioning throws `counterpartyNotProvisioned`; some upstreams also require compliance party details on the quote) |
+| `hosted` | signed provider widget `hostedUrl` |
+| `session_widget` | short-lived session credentials + widget URL |
 
 ## Rules + verify
 

--- a/.agents/skills/integrate-onramp/SKILL.md
+++ b/.agents/skills/integrate-onramp/SKILL.md
@@ -10,7 +10,7 @@ On-ramp = a counterparty buys crypto with fiat, delivered to an SDP-known wallet
 
 `createOnrampQuote` is **optional** on `RampProvider` — implement it only if your provider has a lockable quote step.
 
-Choose the closest package client: Lightspark/BVNK/Mural for manual instructions, MoonPay/Coinbase for hosted URLs, or Stripe/MoneyGram for session widgets. Provider-specific DB helpers live in `apps/sdp-api/src/routes/payments/handlers/ramps/<id>.ts`.
+Choose the closest package client by delivery mode: manual instructions, hosted URL, or session widget — all three are represented under `packages/sdp-payments/src/ramps/providers/`. Provider-specific DB helpers live in `apps/sdp-api/src/routes/payments/handlers/ramps/<id>.ts`.
 
 ## Contract
 
@@ -18,9 +18,9 @@ Read the current `RampOnrampQuoteInput` from `packages/sdp-payments/src/ramps/ty
 
 `PaymentRampQuote` is a closed union discriminated by both `provider` and `deliveryMode` in `packages/sdp-types/src/payments.ts`. Add the provider-specific quote arm, and add a `PaymentRampInstruction` arm for new manual instruction fields:
 
-- `deliveryMode: "manual_instructions"` — return `paymentInstructions` (bank/wire or on-chain funding details). Lightspark, BVNK, Mural.
-- `deliveryMode: "hosted"` — return a `hostedUrl` the client renders (widget/redirect). MoonPay.
-- `deliveryMode: "session_widget"` — return the session fields required by an embedded SDK/frame. Stripe, MoneyGram.
+- `deliveryMode: "manual_instructions"` — return `paymentInstructions` (bank/wire or on-chain funding details).
+- `deliveryMode: "hosted"` — return a `hostedUrl` the client renders (widget/redirect).
+- `deliveryMode: "session_widget"` — return the session fields required by an embedded SDK/frame.
 
 Prefer the upstream quote/session id. If the upstream does not mint one, use `rampId("ramp_quote")` from `@sdp/payments/ramps/shared` and pass that reference upstream. The webhook or reconciliation path must return the same reference.
 
@@ -29,27 +29,25 @@ Prefer the upstream quote/session id. If the upstream does not mint one, use `ra
 Add a branch to `apps/sdp-api/src/routes/payments/handlers/ramps.ts`. The handler owns all DB work:
 
 - resolves the counterparty + destination wallet,
-- ensures any provider-side customer/account exists (DB-touching `ensure*` helpers live in `apps/sdp-api/src/routes/payments/handlers/ramps/<id>.ts`, like `ensureLightsparkCustomer`),
+- ensures any provider-side customer/account exists (DB-touching `ensure*` helpers live in `apps/sdp-api/src/routes/payments/handlers/ramps/<id>.ts`),
 - calls your HTTP-only `createOnrampQuote` with pre-resolved inputs,
-- persists the transfer via `persistRampQuoteTransfer` (dedups by `(provider, providerReference)`; `rampQuoteTransferStatus` maps a `manual_instructions` + `pending` quote to `awaiting_payment`).
+- persists the transfer via `persistRampQuoteTransfer` (dedups by `(provider, providerReference)`; `rampQuoteTransferStatus` maps a `manual_instructions` + `pending` quote to `awaiting_payment`). A `reservedTransferId` is minted before the provider call so it can travel upstream as the reference; a provider whose failed calls must still be attributable to a row pre-creates the pending transfer instead and skips the post-quote persist.
 
 Runtime route: `POST /v1/payments/ramps/onramp/quote`, gated by provider availability, metered quota, permissions, and `policyGate`. This route is public OpenAPI today; update `apps/sdp-api/src/openapi/**` when the new provider changes its request/response shape and regenerate owned artifacts.
 
-For `hosted`, decide whether the upstream permits iframe embedding or requires a top-level redirect. Check the provider's CSP / `frame-ancestors` policy and return/render the URL accordingly; the dashboard's generic non-Coinbase hosted path currently uses `MoonpayRampFrame`, so a redirect-only provider needs an explicit renderer instead of inheriting that path.
+For `hosted`, decide whether the upstream permits iframe embedding or requires a top-level redirect. Check the provider's CSP / `frame-ancestors` policy and return/render the URL accordingly; the dashboard's default hosted path assumes iframe embedding, so a redirect-only provider needs an explicit renderer instead of inheriting that path.
 
 ## Variety
 
-| Provider | deliveryMode | On-ramp quote shape |
-|---|---|---|
-| Lightspark | `manual_instructions` | `REALTIME_FUNDING` quote; funding `paymentInstructions` |
-| BVNK | `manual_instructions` | bank pay-in instructions built from the provisioned rule |
-| Mural | `manual_instructions` | pay-in instructions for the resolved account |
-| MoonPay | `hosted` | signed `buy.moonpay.com` widget `hostedUrl` |
-| Stripe / MoneyGram | `session_widget` | embedded provider session credentials |
+| deliveryMode | On-ramp quote shape |
+|---|---|
+| `manual_instructions` | bank pay-in or funding instructions built from the provisioned customer/resource |
+| `hosted` | signed provider widget `hostedUrl` |
+| `session_widget` | embedded provider session credentials |
 
 ## Gating — throw, don't fallback
 
-A provider that needs provisioning must fail loud when it's missing: Lightspark throws if `customerId` is absent; BVNK throws `counterpartyNotProvisioned` if the customer isn't verified or the rule isn't ready. Getting the counterparty to a ready state is `counterparty-requirements` — never substitute a default.
+A provider that needs provisioning must fail loud when it's missing: a missing customer link, unverified customer, or unprovisioned funding resource throws `counterpartyNotProvisioned`. Getting the counterparty to a ready state is `counterparty-requirements` — never substitute a default.
 
 ## Rules + verify
 

--- a/.agents/skills/integrate-ramp-provider/SKILL.md
+++ b/.agents/skills/integrate-ramp-provider/SKILL.md
@@ -18,7 +18,7 @@ Complete the [ramp intake](https://solanafoundation.typeform.com/to/sxTGbwXt) an
 
 ## Sequence
 
-Do them in this order. For unsupported directions, skip business-flow implementation but still satisfy the required `RampProvider` methods with empty rail/entity support and explicit typed rejection; only `createOnrampQuote` is optional today.
+Do them in this order. For unsupported directions, skip business-flow implementation but still satisfy the required `RampProvider` methods with empty rail/entity support and explicit typed rejection; only `createOnrampQuote` and `listExternalAccountDetails` are optional today.
 
 1. **register-provider** — add the id, package client, API schemas/dispatch, availability, setup registry, mode-keyed config, webhook registration decision, and dashboard catalog. Make the skeleton compile.
 2. **rail-discovery** — declare which fiat/crypto rails you support.
@@ -29,12 +29,25 @@ Do them in this order. For unsupported directions, skip business-flow implementa
 
 Adding the id breaks exhaustive registries and switches. Fix those failures without adding fallbacks, then follow `register-provider` for the non-exhaustive schemas, public quote types, translations, and UI catalogs the compiler cannot discover from the new union member alone.
 
+## Everything is discriminated on events
+
+Every provider-facing surface is a closed union keyed by provider id + event kind; integrating a provider means declaring exactly which events it emits and accepts in each family:
+
+1. **Requirement statuses** — `CounterpartyRequirements` arms per `(provider, status)` (`counterparty-requirements`).
+2. **Advance submissions** — `submitCounterpartyRequirementsSchema` arms, `collectedData` = the only PII channel (`counterparty-requirements`).
+3. **Webhook events** — `RampSettlementEvent` kinds, plus provider-specific provisioning events that auto-advance requirements (`integrate-webhook`).
+4. **Client session events** — `POST /v1/payments/ramps/<id>/events` kinds for `session_widget` providers.
+
+Provider-side state is `counterparty_provider_accounts` rows discriminated by `kind` (`customer_link`, `payout_account`, `funding_wallet`, `merchant_wallet`). **`counterparties.provider_data` is deprecated** — never add a provider key to it; PII flows only through advance-submission `collectedData`, JIT to the provider, never persisted.
+
 ## Reference selection
 
-- `lightspark`: manual instructions plus customer/payout provisioning.
-- `moonpay`: hosted quote with no provider-side counterparty provisioning.
-- `stripe` or `moneygram`: session-widget quote.
-- `bvnk` or `mural`: multi-step onboarding and provider-specific API-side state.
+Pick the existing provider closest to yours by archetype — all live under `packages/sdp-payments/src/ramps/providers/`:
+
+- manual instructions plus customer/payout provisioning;
+- hosted quote with no provider-side counterparty provisioning;
+- session-widget quote;
+- multi-step onboarding and provider-specific API-side state.
 
 ## Rules that aren't optional (shared by every step)
 

--- a/.agents/skills/integrate-webhook/SKILL.md
+++ b/.agents/skills/integrate-webhook/SKILL.md
@@ -12,7 +12,7 @@ Webhooks drive a transfer's lifecycle after the quote: `awaiting_payment → set
 - `parse(payload)` — pure wire-format → `RampSettlementEvent` mapping.
 - `process(c, environment, event)` — DB orchestration; calls `applyRampSettlementEvent`.
 
-Canonical example: `LightsparkWebhookProcessor` in `apps/sdp-api/src/routes/webhooks/ramps/lightspark.ts`.
+Canonical examples: the registered processors in `apps/sdp-api/src/routes/webhooks/ramps/` — read the closest one before writing yours.
 
 ## Mount + flow
 
@@ -41,7 +41,7 @@ Signature variety across the six registered webhook providers:
 
 `(payload: Payload) → Event`, typically `RampSettlementEvent` from `@sdp/payments/ramps/types`. Narrow the payload with `readString` / `readRecord` / `readNumber` from `@sdp/payments/json`. Map upstream event types to `kind`, and set `reference` to the quote id persisted by SDP; that is how settlement finds the transfer. Anything legitimately signed but irrelevant maps to `{ provider, kind: "ignore", reason }`.
 
-`parse` runs synchronously **before** the 2xx ack, so it must be total over every payload the provider can legitimately sign: unknown event types and transactions the platform didn't create (sandbox tests, manual payments on the same account) must map to an `ignore` event or an absent reference — never a throw, which turns into a non-2xx and a provider retry loop. Reserve throws for payloads that violate the provider's own guaranteed envelope (e.g. a missing event type), where a loud deterministic failure is the point. Example: BVNK channel references not minted by SDP return `undefined` from `readBvnkOfframpReference` and get logged-and-skipped in `process`.
+`parse` runs synchronously **before** the 2xx ack, so it must be total over every payload the provider can legitimately sign: unknown event types and transactions the platform didn't create (sandbox tests, manual payments on the same account) must map to an `ignore` event or an absent reference — never a throw, which turns into a non-2xx and a provider retry loop. Reserve throws for payloads that violate the provider's own guaranteed envelope (e.g. a missing event type), where a loud deterministic failure is the point. Example: references not minted by SDP return `undefined` from the processor's reference reader and get logged-and-skipped in `process`.
 
 `RampSettlementEvent` (`packages/sdp-payments/src/ramps/types.ts`):
 
@@ -69,9 +69,9 @@ async process(c: AppContext, _environment: SdpEnvironment, event: RampSettlement
 
 Then register the class in `RAMP_PROVIDER_WEBHOOK_PROCESSOR` in `apps/sdp-api/src/routes/webhooks/handlers.ts`, or explicitly extend the excluded no-webhook provider union. `applyRampSettlementEvent` finds the transfer by `(provider, reference)`, skips terminal rows on redelivery, maps `kind → status`, persists received amounts for the relevant direction plus settlement economics, and records failed/expired errors.
 
-## Beyond settlement (advanced)
+## Beyond settlement: provisioning auto-advance
 
-BVNK also receives customer/wallet/provisioning events: its `parse` returns a wider `BvnkWebhookEvent` union, and `process` switches on `event.kind`, routing settlement kinds to `applyRampSettlementEvent`-based helpers and the rest to background provisioning helpers. That's an extension — the standard contract a new provider implements is the settlement path above.
+A provider whose counterparty provisioning is async (KYC verification, wallet creation) also moves requirement state from webhooks: `parse` returns a wider provider event union — one event kind per upstream type (customer status changes, wallet creation/status changes, payment status changes) — and `process` switches exhaustively on `event.kind`, routing settlement kinds to `applyRampSettlementEvent`-based helpers and provisioning kinds to helpers that update `counterparty_provider_accounts` rows (never `counterparties.provider_data` — it's deprecated). The requirements GET then reflects the advanced state (`counterparty-requirements`). The standard contract a new provider implements is the settlement path above; add provisioning kinds only when the upstream provisions asynchronously.
 
 ## Rules + verify
 

--- a/.agents/skills/rail-discovery/SKILL.md
+++ b/.agents/skills/rail-discovery/SKILL.md
@@ -13,7 +13,7 @@ Implement rail support in `packages/sdp-payments`; the codegen (`apps/sdp-api/sc
 1. **Upstream discovery API:** add `RAMP_RAIL_DUMPS.<id>` in `packages/sdp-payments/src/ramps/shared.ts`; `_discoverRails` writes raw responses; `distillRailSupport` reads and normalizes them.
 2. **No discovery API:** make `_discoverRails` a no-op and return an explicit, tested snapshot from `distillRailSupport`. Do not invent a network endpoint or dump.
 
-Both paths declare `<PROVIDER>_DECLARED_RAIL_SUPPORT` for entity types and country support not discovered in the snapshot. Reference Lightspark for one dump, BVNK for multiple endpoints, Mural for discovered country support, and Stripe for static support; all live under `packages/sdp-payments/src/ramps/providers/`.
+Both paths declare `<PROVIDER>_DECLARED_RAIL_SUPPORT` for entity types and country support not discovered in the snapshot. Reference the existing providers under `packages/sdp-payments/src/ramps/providers/` — single-dump, multi-endpoint, discovered-country-support, and static-support variants are all represented.
 
 ## The data flow
 
@@ -51,7 +51,7 @@ async _discoverRails({ env, fetchJson, writeDump }: Parameters<RampProvider["_di
 }
 ```
 
-Use the provider's most public/anonymous discovery endpoints where possible (see BVNK's anon `/api/currency/*?offset=0&max=1000` paging). `_discoverRails` is `@internal` — only the discovery script ever calls it.
+Use the provider's most public/anonymous discovery endpoints where possible (some upstreams expose anonymous paged catalog endpoints). `_discoverRails` is `@internal` — only the discovery script ever calls it.
 
 ## Step 3 — `distillRailSupport`
 
@@ -87,7 +87,7 @@ Mapping rules (helpers live in `shared.ts`):
 - **Fiat code → currency key** — validate with `isActiveIso4217CurrencyCode(code)`; codes that fail are dropped into `droppedCurrencyCodes`, not added to the snapshot. Uppercase ISO 4217 only.
 - **Country code** — validate with `isIso3166Alpha2CountryCode(code)`; failures go into `droppedCountryCodes`.
 - **Limits** — `{ min, max }` are major-unit decimal strings when the provider reports bounds; use `unreportedCurrencyLimit()` (`{ min: null, max: null }`) when it doesn't.
-- Only populate `countrySupport` on the snapshot if you're genuinely discovering it from the dump (Mural derives per-currency country lists this way). If your provider doesn't report country coverage, leave it `undefined` here and declare it instead (step 4).
+- Only populate `countrySupport` on the snapshot if you're genuinely discovering it from the dump (one existing provider derives per-currency country lists this way). If your provider doesn't report country coverage, leave it `undefined` here and declare it instead (step 4).
 
 ## Step 4 — declare what you don't discover
 

--- a/.agents/skills/register-provider/SKILL.md
+++ b/.agents/skills/register-provider/SKILL.md
@@ -38,7 +38,7 @@ export class <Id>RampClient implements RampProvider {
 }
 ```
 
-`RampProvider` currently requires both estimates, rail discovery/distillation, counterparty validation, and an off-ramp method. An unsupported direction must use empty declared/discovered support plus a typed unsupported requirement or payments error; it must not pretend to work. `createOnrampQuote` remains optional.
+`RampProvider` currently requires both estimates, rail discovery/distillation, counterparty validation, and an off-ramp method. An unsupported direction must use empty declared/discovered support plus a typed unsupported requirement or payments error; it must not pretend to work. `createOnrampQuote` and `listExternalAccountDetails` are optional — implement the latter when the provider JIT-creates external accounts, so the provider-accounts list endpoint and the offramp payout tree can show display info (`bankName`, masked `accountNumberLast4`; fetched per request, never persisted).
 
 Use one mode-aware config reader over the passed `env`. Provider code performs HTTP only and imports neither `AppContext` nor database modules. Use `providerFetchJson` for provider requests and payments-package errors such as `providerNotConfigured`, `providerUnavailable`, and `estimateNotAvailable`.
 
@@ -70,6 +70,8 @@ isConfigured: (env, testMode) => {
 ```
 
 Do not add obsolete `executeOnramp` / `executeOfframp` branches; those methods are not part of the current provider contract.
+
+Provider-side counterparty state is `counterparty_provider_accounts` rows discriminated by `kind` (`customer_link`, `payout_account`, `funding_wallet`, `merchant_wallet`). **Never add a key to `counterparties.provider_data`** — it is deprecated; PII arrives only through requirements-advance `collectedData` and is passed JIT to the provider, never persisted.
 
 ## 4. Extend shared contracts
 


### PR DESCRIPTION
Refreshes the 8 ramp-provider integration skills to match the current requirements flow: event-discriminated surfaces, `counterparty_provider_accounts` as the only provider state, and PII as JIT pass-through.

**Event model**
- `counterparty-requirements` now documents the flow as event streams discriminated on `(provider, status/kind)`: requirement statuses out (full per-provider status table), advance submissions in (`submitCounterpartyRequirementsSchema` arms, `collectedData` as the only PII channel), and webhook auto-advance.
- `integrate-ramp-provider` gains an "Everything is discriminated on events" section enumerating the four event families (statuses, advance submissions, webhook events, client session events).

**Provider state**
- Column-by-column reference for `counterparty_provider_accounts` (kind semantics, idempotent `id`, corridor columns with explicit selection, `provider_status` gating, soft delete, kind-validated `metadata`).
- `counterparties.provider_data` documented as deprecated: no new provider keys; state rows only.

**Flow updates (PRO-1804)**
- `country` / `date` / `address` requirement-field kinds; `country` is codes-only on the wire.
- Payout tree with existing-account reuse; offramp quote takes explicit `providerAccountId`; `GET /v1/counterparties/:id/provider-accounts` with JIT enrichment via optional `listExternalAccountDetails`.
- Reserved/pending transfer persistence paths replace the stale single-path description.

**Genericization**
- Provider-specific examples replaced with archetype descriptions everywhere except two deliberate reference tables: the requirement-status union and the webhook signature schemes.

**before** — what the skills taught:

1. Two requirement field kinds (`text`, `select`); country lists inlined as options.
2. Payout account resolved implicitly from "the most recent active account"; one account per corridor assumed.
3. Provider state described as `provider_data` blobs; per-provider helper names cited as the contract.

**after** — what they teach now:

1. Five field kinds; countries collected as codes, rendered client-side.
2. Multi-account corridors with explicit `providerAccountId` selection and account-reuse in the payout tree.
3. State as kind-discriminated rows; every provider surface declared as closed-union events; PII never persisted.

**Verification**
- `grep -ri` over the 8 skills + README: provider names remain only in the two kept tables — result confirmed.
- Skill claims spot-checked against `packages/sdp-types/src/ramp-requirements.ts`, `counterparty-provider-account.repository.ts`, and `handlers/ramps.ts` on `main`.
