### PR TITLE
chore: route all code ownership through the foundation product team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,25 +1,25 @@
-*    @solana-foundation/sdp-maintainers
+*                                                       @solana-foundation/foundation-product-team
 
 # Custody and signing
-/packages/sdp-custody/                                  @multipletwigs @resourcefulmind
-/apps/sdp-api/src/services/adapters/signing/            @multipletwigs @resourcefulmind
-/apps/sdp-api/src/services/domain/signing/              @multipletwigs @resourcefulmind
+/packages/sdp-custody/                                  @solana-foundation/foundation-product-team
+/apps/sdp-api/src/services/adapters/signing/            @solana-foundation/foundation-product-team
+/apps/sdp-api/src/services/domain/signing/              @solana-foundation/foundation-product-team
 
 # Payments and ramps
-/packages/sdp-payments/                                 @multipletwigs @resourcefulmind
-/apps/sdp-api/src/routes/payments/                      @multipletwigs @resourcefulmind
+/packages/sdp-payments/                                 @solana-foundation/foundation-product-team
+/apps/sdp-api/src/routes/payments/                      @solana-foundation/foundation-product-team
 
 # Issuance
-/packages/sdp-issuance/                                 @arseniy-nikitochkin @multipletwigs
-/apps/sdp-api/src/routes/issuance/                      @arseniy-nikitochkin @multipletwigs
+/packages/sdp-issuance/                                 @solana-foundation/foundation-product-team
+/apps/sdp-api/src/routes/issuance/                      @solana-foundation/foundation-product-team
 
 # Authentication and authorization
-/apps/sdp-api/src/middleware/                           @multipletwigs @resourcefulmind
-/apps/sdp-api/src/lib/auth.ts                           @multipletwigs @resourcefulmind
+/apps/sdp-api/src/middleware/                           @solana-foundation/foundation-product-team
+/apps/sdp-api/src/lib/auth.ts                           @solana-foundation/foundation-product-team
 
 # Database migrations
-/apps/sdp-api/src/db/migrations/                        @resourcefulmind @multipletwigs
+/apps/sdp-api/src/db/migrations/                        @solana-foundation/foundation-product-team
 
 # CI/CD, release, and deploy machinery
-/.github/                                               @G1de0n @niks3089
-/scripts/                                               @G1de0n @niks3089
+/.github/                                               @solana-foundation/foundation-product-team
+/scripts/                                               @solana-foundation/foundation-product-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,24 +1,24 @@
 *    @solana-foundation/sdp-maintainers
 
 # Custody and signing
-/packages/sdp-custody/                                  @multipletwigs @pashpashkin
-/apps/sdp-api/src/services/adapters/signing/            @multipletwigs @pashpashkin
-/apps/sdp-api/src/services/domain/signing/              @multipletwigs @pashpashkin
+/packages/sdp-custody/                                  @multipletwigs @resourcefulmind
+/apps/sdp-api/src/services/adapters/signing/            @multipletwigs @resourcefulmind
+/apps/sdp-api/src/services/domain/signing/              @multipletwigs @resourcefulmind
 
 # Payments and ramps
-/packages/sdp-payments/                                 @multipletwigs @pashpashkin
-/apps/sdp-api/src/routes/payments/                      @multipletwigs @pashpashkin
+/packages/sdp-payments/                                 @multipletwigs @resourcefulmind
+/apps/sdp-api/src/routes/payments/                      @multipletwigs @resourcefulmind
 
 # Issuance
 /packages/sdp-issuance/                                 @arseniy-nikitochkin @multipletwigs
 /apps/sdp-api/src/routes/issuance/                      @arseniy-nikitochkin @multipletwigs
 
 # Authentication and authorization
-/apps/sdp-api/src/middleware/                           @multipletwigs @pashpashkin
-/apps/sdp-api/src/lib/auth.ts                           @multipletwigs @pashpashkin
+/apps/sdp-api/src/middleware/                           @multipletwigs @resourcefulmind
+/apps/sdp-api/src/lib/auth.ts                           @multipletwigs @resourcefulmind
 
 # Database migrations
-/apps/sdp-api/src/db/migrations/                        @pashpashkin @multipletwigs
+/apps/sdp-api/src/db/migrations/                        @resourcefulmind @multipletwigs
 
 # CI/CD, release, and deploy machinery
 /.github/                                               @G1de0n @niks3089


### PR DESCRIPTION
Per the team's direction: every code-owner entry now points at @solana-foundation/foundation-product-team. The critical-path list is kept enumerated (rather than collapsed into the `*` rule) so the paths the SDLC treats as critical stay documented and can be re-granularized per-team later — @solana-foundation/hoodies is available if we want the CI/CD or migrations paths routed there instead.

**Hold merge** until membership of foundation-product-team is confirmed complete — with `require_code_owner_review` enforced later, a missing member means their PRs wait on someone else's approval on every owned path.