### PR TITLE
feat(deploy): release PRs refresh dev with the candidate

### DIFF
--- a/.github/workflows/deploy-dev-on-label.yml
+++ b/.github/workflows/deploy-dev-on-label.yml
@@ -1,8 +1,8 @@
-name: Deploy PR to dev (label-triggered)
+name: Deploy PR to dev (label or release PR)
 
 on:
   pull_request:
-    types: [labeled, synchronize]
+    types: [labeled, synchronize, opened]
 
 permissions:
   contents: read
@@ -15,10 +15,14 @@ concurrency:
 jobs:
   deploy:
     name: Deploy this PR branch to dev
+    # Release PRs always refresh dev so the web preview pass runs against the
+    # release candidate API (previews build with dev Clerk and cannot target
+    # stage, which trusts only the prod Clerk issuer).
     if: >-
       github.repository == 'solana-foundation/solana-developer-platform' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      contains(github.event.pull_request.labels.*.name, 'deploy-dev')
+      (contains(github.event.pull_request.labels.*.name, 'deploy-dev') ||
+       github.event.pull_request.head.ref == 'sdp/release-main')
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Fixes the gate gap Opeyemi hit on 0.71.0: since #1622, dev doesn't deploy on merge, so the Vercel web preview pass ran against a stale dev API.

**Why not point previews at stage**: previews build with the **dev Clerk** instance; stage trusts only the **prod Clerk issuer**, so every authed BFF call 401s. The alternative — prod Clerk keys in the preview env — requires allowing `*.vercel.app` origins on the prod Clerk instance, i.e. PR previews that can authenticate real users. Not a trade worth making.\n\n**Fix**: the release PR branch (`sdp/release-main`) now triggers the dev deploy on open and every update — the preview pass always runs web-candidate against api-candidate, with dev Clerk, no config changes anywhere. Ad-hoc refreshes keep working via the `deploy-dev` label or `gh workflow run deploy-sdp-api-gcp.yml --ref main`.\n\n**Longer-term**: per-PR preview backends are #1520 (ephemeral envs) — this is the bridge until that lands.\n\nVerification: actionlint clean; behavior proves on the next release PR update.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)