### PR TITLE
build(deps): bump the fast-uri pnpm override to 3.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
       "brace-expansion": "5.0.9",
       "bigint-buffer": "workspace:*",
       "esbuild": "0.28.1",
-      "fast-uri": "3.1.5",
+      "fast-uri": "3.1.7",
       "js-yaml": "4.3.0",
       "postcss>nanoid": "3.3.18",
       "postcss": "^8.5.22",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ overrides:
   brace-expansion: 5.0.9
   bigint-buffer: workspace:*
   esbuild: 0.28.1
-  fast-uri: 3.1.5
+  fast-uri: 3.1.7
   js-yaml: 4.3.0
   postcss>nanoid: 3.3.18
   postcss: ^8.5.22
@@ -7137,8 +7137,8 @@ packages:
   fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fastestsmallesttextencoderdecoder@1.0.22:
     resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
@@ -15854,7 +15854,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -16943,7 +16943,7 @@ snapshots:
 
   fast-stable-stringify@1.0.0: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fastestsmallesttextencoderdecoder@1.0.22: {}
 


### PR DESCRIPTION
- Bumps the root `pnpm.overrides` pin for `fast-uri` from 3.1.5 to 3.1.7 and refreshes the two lockfile entries that carry it; nothing else in the lockfile moves.
- Closes Dependabot alerts 150, 151, 152, 153 (CVE-2026-75975, CVE-2026-75899, CVE-2026-76172, CVE-2026-75931). All four are HIGH on paper and build-time only here.
- Dependabot cannot open this PR itself: it does not edit `pnpm.overrides`, so the alerts have no fix PR and would sit open indefinitely.
- 3.1.7 is the npm `three` dist-tag (3.1.6 was the first patched release). 4.x is a major and is not taken.

**before** — where fast-uri runs today:

1. `pnpm.overrides` pins `fast-uri` to 3.1.5 for the whole workspace.
2. The only consumer is `ajv@8` under `schema-utils` under `webpack`, pulled in by `@sentry/webpack-plugin` in `apps/sdp-web`; it executes during `next build` option validation.
3. `apps/sdp-api` (Hono + zod) has no `ajv` or `fast-uri` in its install closure (`pnpm install --filter @sdp/api...` in its Dockerfile), so the API image never contains it. No request data reaches `fast-uri` anywhere.

**after** — same shape, patched version:

1. The override resolves to 3.1.7; the lockfile importer and package entries follow.
2. Build-time behaviour is unchanged; the four advisories (URL normalize/resolve SSRF and host-confusion paths) no longer apply to the resolved version.
3. Dependabot closes the four alerts on merge.

**Verification**

- `pnpm install --lockfile-only` on the branch, then the lockfile reduced to the fast-uri hunks only (pnpm 10.16.0 also rewrote an unrelated `eslint-plugin-import` peer key, which was dropped to keep the diff to this change) — 2 files, +6/-6.
- `pnpm install --frozen-lockfile --lockfile-only` — `Done`, so the committed lockfile matches the manifests.
- Not run locally: `next build` for `apps/sdp-web`; CI's web build, Dependency Review, and Pinned Dependency Policy checks cover it.

Known gaps
- The override itself stays. Dropping it would let ajv's own `^3` range resolve and Dependabot manage the package from then on; kept as the smaller diff. Worth revisiting the next time this package gets an advisory (four in one week).
