### PR TITLE
refactor(payments): derive ramp terminal and cancelable statuses from shared records

### DIFF
--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -37,7 +37,9 @@ import type { RampRuntimeContext } from "@sdp/payments/ramps/types";
 import { redactCredentialString } from "@sdp/redaction";
 import { parseDecimalAmount } from "@sdp/solana/amount";
 import {
+  CANCELABLE_RAMP_TRANSFER_STATUSES,
   getCryptoRailAssetLabel,
+  isCancelableRampTransferStatus,
   isCountryCode,
   type PaymentRampEstimate,
   type PaymentRampInstruction,
@@ -1417,8 +1419,7 @@ export async function cancelRampTransfer(c: ValidatedBodyContext<typeof cancelRa
   if (!isRampTransferType(transfer.type)) {
     throw badRequest("Only ramp transfers can be canceled through this endpoint.");
   }
-  const cancelableStatuses: readonly PaymentTransferStatus[] = ["pending", "awaiting_payment"];
-  if (!cancelableStatuses.includes(transfer.status)) {
+  if (!isCancelableRampTransferStatus(transfer.status)) {
     throw badRequest(`Transfer can no longer be canceled (status: ${transfer.status}).`);
   }
 
@@ -1426,7 +1427,7 @@ export async function cancelRampTransfer(c: ValidatedBodyContext<typeof cancelRa
     transferId: transfer.id,
     organizationId: scope.auth.organizationId,
     projectId,
-    fromStatuses: cancelableStatuses,
+    fromStatuses: CANCELABLE_RAMP_TRANSFER_STATUSES,
     toStatus: "canceled",
     updatedAt: new Date().toISOString(),
   });

--- a/apps/sdp-api/src/routes/payments/handlers/ramps/events.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps/events.ts
@@ -1,6 +1,6 @@
 import { compareDecimalAmounts } from "@sdp/payments/decimal";
-import type { MoneygramRampEvent } from "@sdp/types";
-import type { PaymentTransferRow, PaymentTransferStatus } from "@/db/repositories";
+import { isTerminalRampTransferStatus, type MoneygramRampEvent } from "@sdp/types";
+import type { PaymentTransferRow } from "@/db/repositories";
 import { getAuth, requireProjectId } from "@/lib/auth";
 import { badRequest, conflict, internalError, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
@@ -9,17 +9,6 @@ import { type AppContext, getPaymentsRepository } from "../../context";
 import { mapTransferRow } from "../../mappers";
 import type { coinbaseRampEventSchema, moneygramRampEventSchema } from "../../schemas";
 import { isRampQuoteBindingExpired } from "./quote-binding";
-
-const TERMINAL_RAMP_STATUSES = [
-  "completed",
-  "failed",
-  "expired",
-  "canceled",
-] as const satisfies readonly PaymentTransferStatus[];
-
-function isTerminalRampStatus(status: PaymentTransferStatus): boolean {
-  return (TERMINAL_RAMP_STATUSES as readonly PaymentTransferStatus[]).includes(status);
-}
 
 function readMoneygramData(transfer: PaymentTransferRow): Record<string, unknown> {
   const value = transfer.provider_data.moneygram;
@@ -133,7 +122,7 @@ export async function recordCoinbaseRampEvent(
   if (transfer.type !== "onramp") {
     throw badRequest("Coinbase events only apply to on-ramp transfers.");
   }
-  if (isTerminalRampStatus(transfer.status)) {
+  if (isTerminalRampTransferStatus(transfer.status)) {
     return success(c, { transfer: mapTransferRow(transfer) });
   }
 
@@ -178,7 +167,7 @@ export async function recordMoneygramRampEvent(
   if (!transfer) {
     throw notFound("Ramp transfer");
   }
-  if (isTerminalRampStatus(transfer.status)) {
+  if (isTerminalRampTransferStatus(transfer.status)) {
     return success(c, { transfer: mapTransferRow(transfer) });
   }
 

--- a/apps/sdp-api/src/routes/payments/schemas.ts
+++ b/apps/sdp-api/src/routes/payments/schemas.ts
@@ -8,6 +8,7 @@ import {
   MURAL_SANDBOX_PAYIN_CURRENCIES,
   OFFRAMP_CRYPTO_RAILS,
   ONRAMP_CRYPTO_RAILS,
+  PAYMENT_TRANSFER_STATUSES,
   type PolicyRule,
   type PrivateTransferRequest,
   RAMP_PROVIDERS,
@@ -521,18 +522,7 @@ export const createTransferSchema = z.strictObject({
 
 export const transferDirectionSchema = z.enum(["inbound", "outbound"]);
 
-export const transferStatusSchema = z.enum([
-  "pending",
-  "processing",
-  "confirmed",
-  "finalized",
-  "failed",
-  "awaiting_payment",
-  "settling",
-  "completed",
-  "canceled",
-  "expired",
-]);
+export const transferStatusSchema = z.enum(PAYMENT_TRANSFER_STATUSES);
 
 const transferFilterTimestampSchema = z
   .string()

--- a/apps/sdp-api/src/services/payments/ramp-settlements.ts
+++ b/apps/sdp-api/src/services/payments/ramp-settlements.ts
@@ -1,4 +1,5 @@
 import type { RampSettlementEvent } from "@sdp/payments/ramps";
+import { isTerminalRampTransferStatus } from "@sdp/types";
 import { asTransactionalClient, getDb } from "@/db";
 import type {
   PaymentsRepository,
@@ -23,15 +24,13 @@ const RAMP_SETTLEMENT_STATUS = {
   expired: "expired",
 } as const satisfies Record<Exclude<RampSettlementEvent["kind"], "ignore">, PaymentTransferStatus>;
 
-// `expired` is deliberately absent: it is derived from provider ABSENCE (an
-// abandoned checkout the provider never saw), and a provider event proving
-// activity must be able to revive it — signed widget URLs do not expire, so a
-// customer can complete checkout after the abandonment horizon.
-const TERMINAL_RAMP_TRANSFER_STATUSES = [
-  "completed",
-  "failed",
-  "canceled",
-] as const satisfies readonly PaymentTransferStatus[];
+// `expired` is carved out of the shared terminal set: it is derived from provider
+// ABSENCE (an abandoned checkout the provider never saw), and a provider event
+// proving activity must be able to revive it — signed widget URLs do not expire,
+// so a customer can complete checkout after the abandonment horizon.
+function isSettlementFinalStatus(status: PaymentTransferStatus): boolean {
+  return status !== "expired" && isTerminalRampTransferStatus(status);
+}
 
 // awaiting_payment self-transition is allowed: a provider may issue a NEW
 // deposit wallet while still awaiting payment (MoonPay does on sale
@@ -64,10 +63,6 @@ const ALLOWED_RAMP_SETTLEMENT_SOURCE_STATUSES = {
   Exclude<RampSettlementEvent["kind"], "ignore">,
   readonly PaymentTransferStatus[]
 >;
-
-function isTerminalRampTransferStatus(status: PaymentTransferStatus): boolean {
-  return (TERMINAL_RAMP_TRANSFER_STATUSES as readonly PaymentTransferStatus[]).includes(status);
-}
 
 /**
  * Builds the guarded transfer update one settlement event produces.
@@ -156,7 +151,7 @@ export async function applyRampSettlementEvent(env: Env, event: RampSettlementEv
   }
   // Out-of-order or redelivered events must not regress a settled transfer
   // (e.g. a retried PENDING arriving after COMPLETED).
-  if (isTerminalRampTransferStatus(transfer.status)) {
+  if (isSettlementFinalStatus(transfer.status)) {
     return;
   }
 

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/ramp-transfer-state.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/ramp-transfer-state.ts
@@ -1,24 +1,15 @@
-import { isTerminalRampTransferStatus, type PaymentTransferStatus } from "@sdp/types";
-
-const RAMP_TRANSFER_CANCELABLE = {
-  pending: true,
-  awaiting_payment: true,
-  processing: false,
-  confirmed: false,
-  finalized: false,
-  settling: false,
-  completed: false,
-  failed: false,
-  canceled: false,
-  expired: false,
-} as const satisfies Record<PaymentTransferStatus, boolean>;
+import {
+  isCancelableRampTransferStatus,
+  isTerminalRampTransferStatus,
+  type PaymentTransferStatus,
+} from "@sdp/types";
 
 export function getRampTransferState(status: PaymentTransferStatus | undefined) {
   if (status === undefined) {
     return { cancelable: false, terminal: false };
   }
   return {
-    cancelable: RAMP_TRANSFER_CANCELABLE[status],
+    cancelable: isCancelableRampTransferStatus(status),
     terminal: isTerminalRampTransferStatus(status),
   };
 }

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/ramp-transfer-state.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/ramp-transfer-state.ts
@@ -1,25 +1,24 @@
-import type { PaymentTransferStatus } from "@sdp/types";
+import { isTerminalRampTransferStatus, type PaymentTransferStatus } from "@sdp/types";
 
-type RampTransferState =
-  | { cancelable: true; terminal: false }
-  | { cancelable: false; terminal: boolean };
-
-const RAMP_TRANSFER_STATE = {
-  pending: { cancelable: true, terminal: false },
-  awaiting_payment: { cancelable: true, terminal: false },
-  processing: { cancelable: false, terminal: false },
-  confirmed: { cancelable: false, terminal: false },
-  finalized: { cancelable: false, terminal: false },
-  settling: { cancelable: false, terminal: false },
-  completed: { cancelable: false, terminal: true },
-  failed: { cancelable: false, terminal: true },
-  canceled: { cancelable: false, terminal: true },
-  expired: { cancelable: false, terminal: true },
-} as const satisfies Record<PaymentTransferStatus, RampTransferState>;
+const RAMP_TRANSFER_CANCELABLE = {
+  pending: true,
+  awaiting_payment: true,
+  processing: false,
+  confirmed: false,
+  finalized: false,
+  settling: false,
+  completed: false,
+  failed: false,
+  canceled: false,
+  expired: false,
+} as const satisfies Record<PaymentTransferStatus, boolean>;
 
 export function getRampTransferState(status: PaymentTransferStatus | undefined) {
   if (status === undefined) {
     return { cancelable: false, terminal: false };
   }
-  return RAMP_TRANSFER_STATE[status];
+  return {
+    cancelable: RAMP_TRANSFER_CANCELABLE[status],
+    terminal: isTerminalRampTransferStatus(status),
+  };
 }

--- a/packages/sdp-types/src/payments.ts
+++ b/packages/sdp-types/src/payments.ts
@@ -119,6 +119,25 @@ export const SUCCESSFUL_PAYMENT_TRANSFER_STATUSES = [
   "finalized",
 ] as const satisfies readonly PaymentTransferStatus[];
 
+/** Whether each status ends a ramp transfer's lifecycle. Scoped to ramps — onchain sends terminate at `finalized`. */
+export const RAMP_TRANSFER_STATUS_TERMINAL = {
+  pending: false,
+  processing: false,
+  confirmed: false,
+  finalized: false,
+  failed: true,
+  awaiting_payment: false,
+  settling: false,
+  completed: true,
+  canceled: true,
+  expired: true,
+} as const satisfies Record<PaymentTransferStatus, boolean>;
+
+/** Reports whether a ramp transfer can never leave the given status. */
+export function isTerminalRampTransferStatus(status: PaymentTransferStatus): boolean {
+  return RAMP_TRANSFER_STATUS_TERMINAL[status];
+}
+
 export interface LightsparkGridAmount {
   amount: number;
   currencyCode: string;

--- a/packages/sdp-types/src/payments.ts
+++ b/packages/sdp-types/src/payments.ts
@@ -101,17 +101,20 @@ export interface PaymentWalletPolicyAuditEntry {
   evaluatedAt: string;
 }
 
-export type PaymentTransferStatus =
-  | "pending"
-  | "processing"
-  | "confirmed"
-  | "finalized"
-  | "failed"
-  | "awaiting_payment"
-  | "settling"
-  | "completed"
-  | "canceled"
-  | "expired";
+export const PAYMENT_TRANSFER_STATUSES = [
+  "pending",
+  "processing",
+  "confirmed",
+  "finalized",
+  "failed",
+  "awaiting_payment",
+  "settling",
+  "completed",
+  "canceled",
+  "expired",
+] as const;
+
+export type PaymentTransferStatus = (typeof PAYMENT_TRANSFER_STATUSES)[number];
 
 export const SUCCESSFUL_PAYMENT_TRANSFER_STATUSES = [
   "completed",
@@ -137,6 +140,30 @@ export const RAMP_TRANSFER_STATUS_TERMINAL = {
 export function isTerminalRampTransferStatus(status: PaymentTransferStatus): boolean {
   return RAMP_TRANSFER_STATUS_TERMINAL[status];
 }
+
+/** Whether a ramp transfer in each status can still be canceled: only before the customer has funded it. */
+export const RAMP_TRANSFER_STATUS_CANCELABLE = {
+  pending: true,
+  processing: false,
+  confirmed: false,
+  finalized: false,
+  failed: false,
+  awaiting_payment: true,
+  settling: false,
+  completed: false,
+  canceled: false,
+  expired: false,
+} as const satisfies Record<PaymentTransferStatus, boolean>;
+
+/** Reports whether a ramp transfer in the given status can still be canceled. */
+export function isCancelableRampTransferStatus(status: PaymentTransferStatus): boolean {
+  return RAMP_TRANSFER_STATUS_CANCELABLE[status];
+}
+
+/** The statuses a ramp transfer can be canceled from, for status-guarded updates. */
+export const CANCELABLE_RAMP_TRANSFER_STATUSES = PAYMENT_TRANSFER_STATUSES.filter(
+  (status) => RAMP_TRANSFER_STATUS_CANCELABLE[status]
+);
 
 export interface LightsparkGridAmount {
   amount: number;


### PR DESCRIPTION
Independent hand-kept lists of ramp status semantics — which statuses are terminal, and which are cancelable — now derive from exhaustive records in `@sdp/types`.

*(Previously stacked on #1574; rebased onto `main` and no longer depends on it. #1574's `isTerminalTransferStatus` helper move left this PR with that rebase — it rejoins #1574.)*

**Shared source**

- `RAMP_TRANSFER_STATUS_TERMINAL` and `RAMP_TRANSFER_STATUS_CANCELABLE` in `packages/sdp-types/src/payments.ts`: exhaustive `Record<PaymentTransferStatus, boolean>`, so adding a status forces both decisions at compile time.
- Lookups: `isTerminalRampTransferStatus`, `isCancelableRampTransferStatus`; `CANCELABLE_RAMP_TRANSFER_STATUSES` (derived array) for status-guarded updates. Scoped to ramps — onchain sends terminate at `finalized`.
- `PaymentTransferStatus` is now derived from a `PAYMENT_TRANSFER_STATUSES` const (same union, enables deriving the arrays without casts).

**Call sites now derive instead of re-list**

- `apps/sdp-api` ramp events handler: local `TERMINAL_RAMP_STATUSES` array deleted, identical set.
- `apps/sdp-api` ramp settlements: `isSettlementFinalStatus` = shared set minus `expired` — the documented carve-out stays (expiry is derived from provider absence, a provider event proving activity must revive it).
- `apps/sdp-api` cancel-transfer handler: inline `["pending", "awaiting_payment"]` replaced by the shared cancelable set for both the guard and `fromStatuses`.
- `apps/sdp-api` `routes/payments/schemas.ts`: `transferStatusSchema` now `z.enum(PAYMENT_TRANSFER_STATUSES)` instead of re-listing all ten statuses.
- `sdp-web` `ramp-transfer-state.ts`: both `terminal` and `cancelable` derived from the shared records; the local record is deleted.

**before** — five lists, drift by omission:

1. Each surface keeps its own status array/set.
2. A new `PaymentTransferStatus` compiles everywhere; any list that forgot it silently treats the status as non-terminal or non-cancelable (webhook events keep mutating a settled transfer, or the dashboard offers cancel on a transfer the API refuses).

**after** — two records, forced decisions:

1. All surfaces call the shared lookups.
2. A new status fails `sdp-types` compilation until its terminality and cancelability are declared, then every surface picks both up.
3. The intentional deviation (`expired` revivable in settlements) is an explicit one-line carve-out at its call site, not a divergent copy.

**Verification**

- `pnpm turbo typecheck --filter @sdp/types --filter @sdp/api --filter sdp-web` — 21 tasks pass
- `vitest run` on `ramp-transfer-state` (sdp-web) — 11 tests pass
- `vitest run` on `ramp-settlements`, `payments.ramps`, openapi routes (sdp-api) — 11 + 40 + snapshot tests pass
- Behavior-preserving: each derived set is value-identical to the list it replaces
