### PR TITLE
ci: run unit tests on the self-hosted dev-project VM runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
 
   test:
     name: Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted", "sdp-dev-vm"]') || 'ubuntu-latest' }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
- Routes the `Unit Tests` job to the new self-hosted runner `gha-sdp-dev-1` (label `sdp-dev-vm`) — an e2-standard-8 VM in the dev GCP project (`solana-developer-platform-dev`, us-central1-a), registered at the org level and running as a systemd service.
- **Fork PRs never touch the VM**: `runs-on` is conditional — only pushes and same-repo PRs get `[self-hosted, sdp-dev-vm]`; fork PRs fall back to `ubuntu-latest`. This is the standard public-repo guard against arbitrary fork code executing on our infrastructure.
- No step changes: Docker is installed on the VM, so the postgres/redis `services:` containers, pnpm/node setup, and Doppler OIDC all work unchanged.

**before** — every Unit Tests run:
1. queues on a GitHub-hosted `ubuntu-latest` runner (2 vCPU)

**after**:
1. push / same-repo PR → `gha-sdp-dev-1` in the dev project (8 vCPU, warm pnpm store after first runs)
2. fork PR → `ubuntu-latest` exactly as before

**Verification**
- runner service log on the VM: `√ Connected to GitHub … Listening for Jobs` (v2.337.0)
- `actionlint` — clean for this change (one pre-existing shellcheck info elsewhere in the file)

Known gaps
- The runner sits in the org **Default** runner group; an org admin should restrict that group (or a new group) to this repository so other org repos can't schedule onto the VM.
- Single runner ⇒ one concurrent Unit Tests job; add a second VM/runner with the same label if queueing shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)