### PR TITLE
fix(payments): refetch counterparty requirements on every provider selection

### DIFF
--- a/apps/sdp-web/src/app/dashboard/payments/payments-query-key.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-query-key.ts
@@ -13,6 +13,8 @@ export const paymentsQueryKeys = {
     ["offramp-transfer-status", transferId] as const,
   requirementsStatusPoll: ({ subjectKey }: { subjectKey: string }) =>
     ["counterparty-requirements-status-poll", subjectKey] as const,
+  isCounterpartyRequirementsKey: (key: unknown) =>
+    Array.isArray(key) && key[0] === "counterparty-requirements",
   counterpartyRequirements: ({
     counterpartyId,
     provider,

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/offramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/offramp-step-content.tsx
@@ -76,6 +76,7 @@ export function OfframpStepContent({ wizard }: { wizard: OfframpWizard }) {
     quote,
     transferStatus,
     setField,
+    selectProvider,
     handlePairChange,
     requirementFields,
     selectedProviderAccountId,
@@ -152,7 +153,7 @@ export function OfframpStepContent({ wizard }: { wizard: OfframpWizard }) {
           onAmountBlur={() => {}}
           onWalletChange={(walletId) => setField("walletId", walletId)}
           onPairChange={handlePairChange}
-          onProviderSelect={(nextProvider) => setField("provider", nextProvider)}
+          onProviderSelect={selectProvider}
         />
         {requirementsBlocker ? (
           <div className="rounded-2xl border border-error-border bg-error-bg px-4 py-3 text-sm text-error">

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
@@ -37,6 +37,7 @@ export function OnrampStepContent({ wizard }: { wizard: OnrampWizard }) {
     selectedCounterparty,
     fields,
     setField,
+    selectProvider,
     liveWallets,
     walletsLoading,
     selectedWallet,
@@ -93,7 +94,7 @@ export function OnrampStepContent({ wizard }: { wizard: OnrampWizard }) {
           onAmountBlur={() => {}}
           onWalletChange={(walletId) => setField("walletId", walletId)}
           onPairChange={handlePairChange}
-          onProviderSelect={(nextProvider) => setField("provider", nextProvider)}
+          onProviderSelect={selectProvider}
         />
         {requirementsBlocker ? (
           <div className="rounded-2xl border border-error-border bg-error-bg px-4 py-3 text-sm text-error">

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-counterparty-requirements.behavior.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-counterparty-requirements.behavior.unit.test.tsx
@@ -3,8 +3,9 @@
 import type { CounterpartyRequirements, PayoutRequirementTree } from "@sdp/types/ramp-requirements";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { SWRConfig } from "swr";
+import { SWRConfig, useSWRConfig } from "swr";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { paymentsQueryKeys } from "@/app/dashboard/payments/payments-query-key";
 import { getMessages } from "@/i18n/messages";
 import { I18nProvider } from "@/i18n/provider";
 import {
@@ -477,5 +478,71 @@ describe("useCounterpartyRequirements — subject-addressed responses", () => {
     await secondSubmit;
 
     expect(rendered.result.current.onboarding).toEqual(provisioning);
+  });
+
+  /**
+   * Mirrors the wizard's `selectProvider` purge (use-ramp-wizard.ts): every
+   * provider-card click clears all cached requirements answers before setting
+   * the provider field.
+   */
+  function usePurgeHarness(params: CounterpartyRequirementsParams) {
+    const requirements = useCounterpartyRequirements(params);
+    const { mutate } = useSWRConfig();
+    const purgeRequirements = () => {
+      void mutate(paymentsQueryKeys.isCounterpartyRequirementsKey, undefined, {
+        revalidate: true,
+      });
+    };
+    return { requirements, purgeRequirements };
+  }
+
+  it("re-selecting the same provider refetches a subject the cache already answered", async () => {
+    const rendered = renderHook((props: CounterpartyRequirementsParams) => usePurgeHarness(props), {
+      wrapper,
+      initialProps: OFFRAMP_PARAMS,
+    });
+    await release("GET", COLLECT_COUNTERPARTY);
+    await waitFor(() => expect(rendered.result.current.requirements.needsCollection).toBe(true));
+
+    // The frozen SWR options serve the cached answer on re-render — this is the
+    // stale state a provider click must not trust.
+    rendered.rerender(OFFRAMP_PARAMS);
+    expect(held).toHaveLength(0);
+
+    act(() => {
+      rendered.result.current.purgeRequirements();
+    });
+    await waitFor(() => expect(held).toHaveLength(1));
+    await release("GET", READY_US_ADVANCE);
+
+    await waitFor(() => expect(rendered.result.current.requirements.needsCollection).toBe(false));
+    expect(rendered.result.current.requirements.isResolved).toBe(true);
+  });
+
+  it("returning to a previously answered provider refetches after the purge", async () => {
+    const bvnkParams: CounterpartyRequirementsParams = { ...OFFRAMP_PARAMS, provider: "bvnk" };
+    const rendered = renderHook((props: CounterpartyRequirementsParams) => usePurgeHarness(props), {
+      wrapper,
+      initialProps: OFFRAMP_PARAMS,
+    });
+    await release("GET", COLLECT_COUNTERPARTY);
+
+    rendered.rerender(bvnkParams);
+    const bvnkRequest = await release("GET", COLLECT_COUNTERPARTY);
+    expect(bvnkRequest.url).toContain("provider=bvnk");
+
+    act(() => {
+      rendered.result.current.purgeRequirements();
+    });
+    rendered.rerender(OFFRAMP_PARAMS);
+    // The purge revalidates the still-mounted bvnk key, then the switch back to
+    // lightspark finds an empty cache and must fetch — two requests, in order.
+    await waitFor(() => expect(held).toHaveLength(2));
+    const revalidatedBvnk = await release("GET", COLLECT_COUNTERPARTY);
+    expect(revalidatedBvnk.url).toContain("provider=bvnk");
+    const lightsparkRequest = await release("GET", READY_US_ADVANCE);
+    expect(lightsparkRequest.url).toContain("provider=lightspark");
+
+    await waitFor(() => expect(rendered.result.current.requirements.needsCollection).toBe(false));
   });
 });

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-ramp-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-ramp-wizard.ts
@@ -14,7 +14,7 @@ import type {
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
-import useSWR from "swr";
+import useSWR, { useSWRConfig } from "swr";
 import type { z } from "zod";
 import { paymentsQueryKeys } from "@/app/dashboard/payments/payments-query-key";
 import {
@@ -165,6 +165,14 @@ export function useRampWizard<TId extends string>(
     provider: null,
     counterpartyId: initialCounterpartyId,
   });
+
+  const { mutate: mutateSwrCache } = useSWRConfig();
+  const selectProvider = (provider: RampProviderId) => {
+    void mutateSwrCache(paymentsQueryKeys.isCounterpartyRequirementsKey, undefined, {
+      revalidate: true,
+    });
+    setField("provider", provider);
+  };
 
   const selectedProviderField = fields.provider;
   useEffect(() => {
@@ -518,6 +526,7 @@ export function useRampWizard<TId extends string>(
     selectedRampPair,
     fields,
     setField,
+    selectProvider,
     quote,
     quoteTransferId,
     memoRows,


### PR DESCRIPTION
- The ramp wizard's requirements GET is deliberately non-revalidating (`revalidateIfStale`/`onFocus`/`onReconnect` all false) so the step list can't flip mid-flow — but SWR's session-global cache then served stale `collect` answers forever, so re-entering the wizard re-asked for KYC data the provider already had.
- Clicking a provider card now goes through `selectProvider`, which purges every cached requirements entry via a global SWR key-filter `mutate` (`revalidate: true`) before setting the field — every selection issues a real GET, including re-clicking the already-selected provider.
- Mid-flow semantics are unchanged: the SWR options stay frozen; freshness lives entirely on the click event.
- New `paymentsQueryKeys.isCounterpartyRequirementsKey` predicate sits next to the key factory; both onramp and offramp step contents wire `onProviderSelect` to it.

**before** — stale requirements served from session cache:

1. Wizard fetches requirements once per (counterparty, provider, corridor, wallet) key
2. Counterparty completes provisioning (advance + webhook) out-of-band
3. Re-entering the wizard or re-selecting the provider serves the cached `collect` answer — no request — and the wizard re-collects PII the provider already has

**after** — provider click is the freshness event:

1. Provider card click → global `mutate(isCounterpartyRequirementsKey, undefined, { revalidate: true })` → all cached requirements entries purged, mounted key refetched
2. Fresh answer reports `ready` for a provisioned customer → requirements step skipped, quote uses the existing provider customer
3. Mid-flow, nothing revalidates — the inserted requirements step never vanishes under the user

**Verification**

- `tsc --noEmit` (sdp-web) — clean
- `vitest run src/app/dashboard/payments/ramps/hooks` — 17/17 pass
- `biome check` on the four changed files — clean
- local app: deposit wizard with a counterparty holding an existing Lightspark customer — two Lightspark clicks produced two `GET /requirements` (200 each, previously zero on re-selection); PII step skipped; quote created against the reused provider customer with no duplicate `customer_link` row

**Known gaps**

- The requirements fetch keeps SWR's default error retry (`shouldRetryOnError`); a failed GET still background-retries. Pre-existing; one-line tightening if wanted.