### PR TITLE
fix(earn): improve wallet empty states and balance refresh

### DIFF
--- a/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-funding-wallets.ts
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-funding-wallets.ts
@@ -65,6 +65,14 @@ const fundingWalletsResponseSchema = z.object({
   }),
 });
 
+const fundingWalletBalanceResponseSchema = z.object({
+  data: z.object({
+    walletBalances: z.object({
+      balances: z.array(walletTokenBalanceSchema),
+    }),
+  }),
+});
+
 export type EarnFundingWallet = z.infer<typeof earnFundingWalletSchema>;
 
 /**
@@ -88,11 +96,67 @@ export async function fetchFundingWallets(): Promise<EarnFundingWallet[]> {
   return parsed.data.data.wallets.filter((wallet) => wallet.status === "active");
 }
 
+/**
+ * Read one wallet directly from the uncached Payments balance endpoint.
+ *
+ * The collection endpoint intentionally keeps a short API-side cache for
+ * normal dashboard reads. That cache is the wrong source immediately after a
+ * vault movement settles: both the submit refresh and the settlement refresh
+ * can otherwise land inside the same cache window and leave Treasury frozen
+ * on the pre-transaction balance.
+ */
+export async function fetchLiveFundingWalletBalance(
+  walletId: string
+): Promise<NonNullable<EarnFundingWallet["balances"]>> {
+  const response = await fetch(
+    `/api/dashboard/payments/wallets/${encodeURIComponent(walletId)}/balances`,
+    { cache: "no-store" }
+  );
+  if (!response.ok) {
+    throw new Error(`Request failed (${response.status})`);
+  }
+  const parsed = fundingWalletBalanceResponseSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    throw new Error("Invalid custody wallet balance response");
+  }
+  return parsed.data.data.walletBalances.balances;
+}
+
+/**
+ * Refresh every visible wallet independently. A failed live read preserves
+ * that wallet's previous observation, including `undefined`; it never turns
+ * unavailable into an invented zero and it does not block healthy wallets
+ * from updating.
+ */
+export async function refreshFundingWalletBalances(
+  wallets: readonly EarnFundingWallet[]
+): Promise<EarnFundingWallet[]> {
+  return Promise.all(
+    wallets.map(async (wallet) => {
+      try {
+        const balances = await fetchLiveFundingWalletBalance(wallet.walletId);
+        return { ...wallet, balances };
+      } catch {
+        return wallet;
+      }
+    })
+  );
+}
+
 export function useEarnFundingWallets() {
   const { data, error, isLoading, mutate } = useSWR(earnQueryKeys.fundingWallets(), () =>
     fetchFundingWallets()
   );
-  return { wallets: data, error, isLoading, refresh: () => void mutate() };
+  return {
+    wallets: data,
+    error,
+    isLoading,
+    refresh: () => void mutate(),
+    refreshBalances: () =>
+      void mutate(async () => refreshFundingWalletBalances(await fetchFundingWallets()), {
+        revalidate: false,
+      }),
+  };
 }
 
 // --- Display helpers -------------------------------------------------------

--- a/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-funding-wallets.unit.test.ts
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-funding-wallets.unit.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { type EarnFundingWallet, fetchFundingWallets } from "./earn-funding-wallets";
+import {
+  type EarnFundingWallet,
+  fetchFundingWallets,
+  fetchLiveFundingWalletBalance,
+  refreshFundingWalletBalances,
+} from "./earn-funding-wallets";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -44,5 +49,71 @@ describe("fetchFundingWallets", () => {
     });
 
     await expect(fetchFundingWallets()).resolves.toEqual([active]);
+  });
+});
+
+describe("live funding wallet balances", () => {
+  it("bypasses the cached collection and reads the wallet balance endpoint", async () => {
+    const balances = [
+      {
+        token: "USDC",
+        mint: "USDC111111111111111111111111111111111111111",
+        amount: "425000000",
+        uiAmount: "425",
+        decimals: 6,
+      },
+    ];
+    const fetchMock = vi.fn(async () => Response.json({ data: { walletBalances: { balances } } }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchLiveFundingWalletBalance("wallet/live")).resolves.toEqual(balances);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/dashboard/payments/wallets/wallet%2Flive/balances",
+      { cache: "no-store" }
+    );
+  });
+
+  it("updates healthy wallets while preserving an unavailable wallet observation", async () => {
+    const first = wallet({
+      id: "first",
+      balances: [
+        {
+          token: "USDC",
+          mint: "USDC111111111111111111111111111111111111111",
+          amount: "1000000",
+          uiAmount: "1",
+          decimals: 6,
+        },
+      ],
+    });
+    const unavailable = wallet({ id: "unavailable", balances: undefined });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input).includes("provider-unavailable")) {
+          return Response.json({ error: { message: "RPC unavailable" } }, { status: 503 });
+        }
+        return Response.json({
+          data: {
+            walletBalances: {
+              balances: [
+                {
+                  token: "USDC",
+                  mint: "USDC111111111111111111111111111111111111111",
+                  amount: "500000",
+                  uiAmount: "0.5",
+                  decimals: 6,
+                },
+              ],
+            },
+          },
+        });
+      })
+    );
+
+    const refreshed = await refreshFundingWalletBalances([first, unavailable]);
+    expect(refreshed[0]?.balances?.[0]?.uiAmount).toBe("0.5");
+    expect(refreshed[1]).toBe(unavailable);
+    expect(refreshed[1]?.balances).toBeUndefined();
   });
 });

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.tsx
@@ -353,6 +353,7 @@ function DepositWalletPicker({
   const locale = useLocale();
   const workspace = useOptionalDashboardWorkspace();
   const custodyEnabled = workspace?.flags.custody ?? true;
+  const canManageCustody = workspace?.dashboardAccess.capabilities.canManageCustody ?? true;
 
   let walletContent: ReactNode;
   if (walletsLoading && wallets === undefined) {
@@ -380,7 +381,7 @@ function DepositWalletPicker({
         <p className="mt-1 text-sm leading-5 text-secondary">
           {t("DashboardEarn.deposit.walletsEmptyBody")}
         </p>
-        {custodyEnabled ? (
+        {custodyEnabled && canManageCustody ? (
           <Button asChild className="mt-3" size="sm" variant="outline">
             <Link href="/dashboard/wallets/setup">{t("DashboardCustody.createWallet")}</Link>
           </Button>

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.tsx
@@ -10,6 +10,7 @@ import {
   WELL_KNOWN_TOKEN_BY_MINT,
 } from "@sdp/types";
 import { ExternalLinkIcon, Loader2Icon } from "lucide-react";
+import Link from "next/link";
 import { type ChangeEvent, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { Badge, type BadgeVariant } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -381,7 +382,7 @@ function DepositWalletPicker({
         </p>
         {custodyEnabled ? (
           <Button asChild className="mt-3" size="sm" variant="outline">
-            <a href="/dashboard/wallets">{t("DashboardEarn.deposit.goToWallets")}</a>
+            <Link href="/dashboard/wallets/setup">{t("DashboardCustody.createWallet")}</Link>
           </Button>
         ) : null}
       </div>

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.unit.test.tsx
@@ -45,6 +45,7 @@ const copy = vi.hoisted<Record<string, string>>(() => ({
   "DashboardEarn.deposit.walletsEmptyTitle": "No active custody wallets",
   "DashboardEarn.deposit.walletsEmptyBody": "Create a wallet before depositing.",
   "DashboardEarn.deposit.goToWallets": "Open Wallets",
+  "DashboardCustody.createWallet": "Create wallet",
   "DashboardEarn.deposit.walletUnnamed": "Unnamed wallet",
   "DashboardEarn.deposit.strategyAssetUnavailable": "Strategy asset unavailable.",
   "DashboardEarn.deposit.vaultWalletTitle": "Funding wallet",
@@ -735,6 +736,19 @@ describe("EarnVaultDepositModal", () => {
       (screen.getByRole("button", { name: "Confirm deposit" }) as HTMLButtonElement).disabled
     ).toBe(true);
     expect(mocks.createEarnVaultDeposit).not.toHaveBeenCalled();
+  });
+
+  it("sends an empty wallet state straight to wallet setup", async () => {
+    mocks.useEarnFundingWallets.mockReturnValue({
+      wallets: [],
+      error: undefined,
+      isLoading: false,
+    });
+    render(<EarnVaultDepositModal projectId={PROJECT_ID} strategy={strategy} onClose={vi.fn()} />);
+
+    await screen.findByRole("dialog");
+    const action = screen.getByRole("link", { name: "Create wallet" });
+    expect(action.getAttribute("href")).toBe("/dashboard/wallets/setup");
   });
 
   it("funds a deposit in another stablecoin: source balance, swap fields, distinct key", async () => {

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.unit.test.tsx
@@ -25,6 +25,7 @@ const IDEMPOTENCY_KEY = "11111111-1111-4111-8111-111111111111";
 const PROJECT_ID = "prj_test";
 
 const mocks = vi.hoisted(() => ({
+  canManageCustody: true,
   createEarnVaultDeposit: vi.fn(),
   useEarnFundingWallets: vi.fn(),
   useEarnVaultDepositOutcome: vi.fn(),
@@ -120,6 +121,13 @@ vi.mock("@/i18n/provider", () => ({
   useLocale: () => "en",
 }));
 
+vi.mock("@/contexts/dashboard-workspace-context", () => ({
+  useOptionalDashboardWorkspace: () => ({
+    dashboardAccess: { capabilities: { canManageCustody: mocks.canManageCustody } },
+    flags: { custody: true },
+  }),
+}));
+
 vi.mock("./deposit/earn-funding-wallets", () => ({
   walletDisplayName: (wallet: EarnFundingWallet | undefined, fallback: string) =>
     wallet?.label?.trim() || fallback,
@@ -195,6 +203,7 @@ async function enterDepositAmount(amount = "1.000000") {
 }
 
 beforeEach(() => {
+  mocks.canManageCustody = true;
   mocks.createEarnVaultDeposit.mockReset();
   mocks.fetchEarnVaultDepositByRequestId.mockReset();
   mocks.fetchEarnVaultDepositPreview.mockReset();
@@ -749,6 +758,20 @@ describe("EarnVaultDepositModal", () => {
     await screen.findByRole("dialog");
     const action = screen.getByRole("link", { name: "Create wallet" });
     expect(action.getAttribute("href")).toBe("/dashboard/wallets/setup");
+  });
+
+  it("does not offer wallet setup without custody management permission", async () => {
+    mocks.canManageCustody = false;
+    mocks.useEarnFundingWallets.mockReturnValue({
+      wallets: [],
+      error: undefined,
+      isLoading: false,
+    });
+    render(<EarnVaultDepositModal projectId={PROJECT_ID} strategy={strategy} onClose={vi.fn()} />);
+
+    await screen.findByRole("dialog");
+    expect(screen.getByText("No active custody wallets")).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "Create wallet" })).toBeNull();
   });
 
   it("funds a deposit in another stablecoin: source balance, swap fields, distinct key", async () => {

--- a/apps/sdp-web/src/app/dashboard/markets/treasury-solutions/treasury-solutions-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/treasury-solutions/treasury-solutions-workspace.tsx
@@ -410,11 +410,13 @@ function TreasuryWalletsCard({
         <h2 className="text-[19px] leading-6 font-medium text-primary">
           {t("DashboardMarkets.treasury.connectedWallets")}
         </h2>
-        <Button asChild size="sm" variant="secondary">
-          <Link href={DASHBOARD_SIDE_NAV_HREFS.wallets}>
-            {t("DashboardMarkets.treasury.viewAll")}
-          </Link>
-        </Button>
+        {wallets.length > 0 ? (
+          <Button asChild size="sm" variant="secondary">
+            <Link href={DASHBOARD_SIDE_NAV_HREFS.wallets}>
+              {t("DashboardMarkets.treasury.viewAll")}
+            </Link>
+          </Button>
+        ) : null}
       </div>
       {isLoading ? (
         <div className="grid gap-3 md:grid-cols-3">
@@ -425,11 +427,20 @@ function TreasuryWalletsCard({
       ) : error ? (
         <p className="text-sm text-secondary">{t("DashboardMarkets.treasury.walletsError")}</p>
       ) : wallets.length === 0 ? (
-        <ListEmptyState
-          description={t("DashboardMarkets.treasury.walletsEmptyDescription")}
-          icon={<WalletCardsIcon aria-hidden="true" className="size-5" />}
-          message={t("DashboardMarkets.treasury.walletsEmptyTitle")}
-        />
+        <Card className="overflow-hidden rounded-2xl py-0">
+          <ListEmptyState
+            action={
+              <Button asChild size="sm">
+                <Link href={`${DASHBOARD_SIDE_NAV_HREFS.wallets}/setup`}>
+                  {t("DashboardCustody.createWallet")}
+                </Link>
+              </Button>
+            }
+            description={t("DashboardMarkets.treasury.walletsEmptyDescription")}
+            icon={<WalletCardsIcon aria-hidden="true" className="size-5" />}
+            message={t("DashboardMarkets.treasury.walletsEmptyTitle")}
+          />
+        </Card>
       ) : (
         <div className="grid gap-3 md:grid-cols-3">
           {wallets.map((wallet) => {
@@ -1130,7 +1141,7 @@ export function TreasurySolutionsWorkspace({
     wallets,
     error: walletsError,
     isLoading: walletsLoading,
-    refresh: refreshWallets,
+    refreshBalances: refreshWalletBalances,
   } = useEarnFundingWallets();
   const {
     strategies,
@@ -1377,7 +1388,7 @@ export function TreasurySolutionsWorkspace({
           }
           onDeposit={setDepositStrategy}
           onRefresh={() => {
-            refreshWallets();
+            refreshWalletBalances();
             refreshStrategies();
             // On the default shelf both strategy hooks share one SWR key, and
             // refreshing it twice would run the paged catalogue fetch twice
@@ -1412,13 +1423,13 @@ export function TreasurySolutionsWorkspace({
           onClose={() => setDepositStrategy(null)}
           projectId={selectedProjectId}
           onDeposited={(deposit) => {
-            // Two refreshes, for two different moments. This one shows the
-            // claimed position row and the debited wallet right away; the
-            // watch below is what re-reads them once the chain has actually
-            // decided, which is the only point at which the holding is real.
+            // Two refreshes, for two different moments. This starts an
+            // uncached balance read for a fast landing; the watch below reads
+            // again once the chain has actually decided, which is the only
+            // point at which the holding is real.
             addVaultDepositWatches([deposit]);
             refreshPositions();
-            refreshWallets();
+            refreshWalletBalances();
           }}
           strategy={depositStrategy}
         />
@@ -1443,7 +1454,7 @@ export function TreasurySolutionsWorkspace({
           onWithdrawn={(withdrawal) => {
             addVaultWithdrawalWatches([withdrawal]);
             refreshPositions();
-            refreshWallets();
+            refreshWalletBalances();
           }}
           position={withdrawPosition}
           projectId={selectedProjectId}
@@ -1477,7 +1488,7 @@ export function TreasurySolutionsWorkspace({
             // Only now did the exit change what the org holds: the shares are
             // burned and the proceeds sit in the custody wallet.
             refreshPositions();
-            refreshWallets();
+            refreshWalletBalances();
           }}
         />
       ))}
@@ -1499,7 +1510,7 @@ export function TreasurySolutionsWorkspace({
             // Only NOW is the position real: the shares exist on chain and the
             // wallet balance reflects what left it.
             refreshPositions();
-            refreshWallets();
+            refreshWalletBalances();
           }}
         />
       ))}

--- a/apps/sdp-web/src/app/dashboard/markets/treasury-solutions/treasury-solutions-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/treasury-solutions/treasury-solutions-workspace.tsx
@@ -403,6 +403,7 @@ function TreasuryWalletsCard({
   const locale = useLocale();
   const workspace = useOptionalDashboardWorkspace();
   const custodyEnabled = workspace?.flags.custody ?? true;
+  const canManageCustody = workspace?.dashboardAccess.capabilities.canManageCustody ?? true;
   if (!custodyEnabled) return null;
   return (
     <section>
@@ -430,11 +431,13 @@ function TreasuryWalletsCard({
         <Card className="overflow-hidden rounded-2xl py-0">
           <ListEmptyState
             action={
-              <Button asChild size="sm">
-                <Link href={`${DASHBOARD_SIDE_NAV_HREFS.wallets}/setup`}>
-                  {t("DashboardCustody.createWallet")}
-                </Link>
-              </Button>
+              canManageCustody ? (
+                <Button asChild size="sm">
+                  <Link href={`${DASHBOARD_SIDE_NAV_HREFS.wallets}/setup`}>
+                    {t("DashboardCustody.createWallet")}
+                  </Link>
+                </Button>
+              ) : undefined
             }
             description={t("DashboardMarkets.treasury.walletsEmptyDescription")}
             icon={<WalletCardsIcon aria-hidden="true" className="size-5" />}

--- a/apps/sdp-web/src/app/dashboard/markets/treasury-solutions/treasury-solutions-workspace.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/treasury-solutions/treasury-solutions-workspace.unit.test.tsx
@@ -30,6 +30,7 @@ const mocks = vi.hoisted(() => ({
   refreshStrategies: vi.fn(),
   refreshPositions: vi.fn(),
   refreshPrograms: vi.fn(),
+  refreshWalletBalances: vi.fn(),
   refreshWallets: vi.fn(),
   withdrawalsByProgram: {} as Record<string, Array<{ status: string; withdrawalRef?: string }>>,
   vaultDeposits: [] as Array<{
@@ -49,6 +50,13 @@ const mocks = vi.hoisted(() => ({
   vaultDepositTrackers: {} as Record<
     string,
     {
+      onSettled?: (deposit: {
+        createdAt?: string;
+        failureReason: string | null;
+        movementId: string;
+        positionId: string;
+        status: string;
+      }) => void;
       onUpdated?: (deposit: {
         createdAt?: string;
         failureReason: string | null;
@@ -61,6 +69,13 @@ const mocks = vi.hoisted(() => ({
   vaultWithdrawalTrackers: {} as Record<
     string,
     {
+      onSettled?: (withdrawal: {
+        createdAt: string;
+        failureReason: string | null;
+        movementId: string;
+        positionId: string;
+        status: string;
+      }) => void;
       onUpdated?: (withdrawal: {
         createdAt: string;
         failureReason: string | null;
@@ -97,6 +112,7 @@ const mocks = vi.hoisted(() => ({
   strategiesStaleError: false,
   strategyMissingShareMint: false,
   walletsError: false,
+  walletsEmpty: false,
   corruptStableShareMint: false,
   secondWalletBalances: undefined as
     | Array<{ token: string; mint: string; amount: string; uiAmount: string; decimals: number }>
@@ -117,39 +133,42 @@ vi.mock("../earn/deposit/earn-funding-wallets", () => ({
   useEarnFundingWallets: () => ({
     error: mocks.walletsError ? new Error("wallets unavailable") : undefined,
     isLoading: false,
+    refreshBalances: mocks.refreshWalletBalances,
     refresh: mocks.refreshWallets,
-    wallets: [
-      {
-        id: "cwlt_live",
-        custodyConfigId: "custody_live",
-        isRuntimeExecutionAllowed: true,
-        walletId: "privy_live",
-        publicKey: "LiveWallet111111111111111111111111111111111",
-        label: "Operating treasury",
-        purpose: null,
-        status: "active",
-        createdAt: "2026-08-18T00:00:00.000Z",
-        provider: "privy",
-        balances: mocks.walletBalances,
-      },
-      ...(mocks.secondWalletBalances
-        ? [
-            {
-              id: "cwlt_second",
-              custodyConfigId: "custody_live",
-              isRuntimeExecutionAllowed: true,
-              walletId: "privy_second",
-              publicKey: "SecondWallet1111111111111111111111111111111",
-              label: "Reserve treasury",
-              purpose: null,
-              status: "active",
-              createdAt: "2026-08-18T00:00:00.000Z",
-              provider: "privy",
-              balances: mocks.secondWalletBalances,
-            },
-          ]
-        : []),
-    ],
+    wallets: mocks.walletsEmpty
+      ? []
+      : [
+          {
+            id: "cwlt_live",
+            custodyConfigId: "custody_live",
+            isRuntimeExecutionAllowed: true,
+            walletId: "privy_live",
+            publicKey: "LiveWallet111111111111111111111111111111111",
+            label: "Operating treasury",
+            purpose: null,
+            status: "active",
+            createdAt: "2026-08-18T00:00:00.000Z",
+            provider: "privy",
+            balances: mocks.walletBalances,
+          },
+          ...(mocks.secondWalletBalances
+            ? [
+                {
+                  id: "cwlt_second",
+                  custodyConfigId: "custody_live",
+                  isRuntimeExecutionAllowed: true,
+                  walletId: "privy_second",
+                  publicKey: "SecondWallet1111111111111111111111111111111",
+                  label: "Reserve treasury",
+                  purpose: null,
+                  status: "active",
+                  createdAt: "2026-08-18T00:00:00.000Z",
+                  provider: "privy",
+                  balances: mocks.secondWalletBalances,
+                },
+              ]
+            : []),
+        ],
   }),
 }));
 
@@ -384,6 +403,13 @@ vi.mock("../earn/earn-vault-withdraw-modal", () => ({
   ),
   EarnVaultWithdrawalOutcomeTracker: (props: {
     movementId: string;
+    onSettled?: (withdrawal: {
+      createdAt: string;
+      failureReason: string | null;
+      movementId: string;
+      positionId: string;
+      status: string;
+    }) => void;
     onUpdated?: (withdrawal: {
       createdAt: string;
       failureReason: string | null;
@@ -412,6 +438,13 @@ vi.mock("../earn/earn-vault-deposit-modal", () => ({
   },
   EarnVaultDepositOutcomeTracker: (props: {
     movementId: string;
+    onSettled?: (deposit: {
+      createdAt?: string;
+      failureReason: string | null;
+      movementId: string;
+      positionId: string;
+      status: string;
+    }) => void;
     onUpdated?: (deposit: {
       createdAt?: string;
       failureReason: string | null;
@@ -475,6 +508,7 @@ beforeEach(() => {
   mocks.secondWalletBalances = undefined;
   mocks.strategyMissingShareMint = false;
   mocks.walletsError = false;
+  mocks.walletsEmpty = false;
   mocks.corruptStableShareMint = false;
   vi.clearAllMocks();
 });
@@ -482,6 +516,18 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("TreasurySolutionsWorkspace", () => {
+  it("guides a treasury with no wallet straight into wallet setup", () => {
+    mocks.walletsEmpty = true;
+    mocks.positionsEmpty = true;
+    renderWorkspace();
+
+    expect(screen.getByText("No active custody wallets")).toBeTruthy();
+    const action = screen.getByRole("link", { name: "Create wallet" });
+    expect(action.getAttribute("href")).toBe("/dashboard/wallets/setup");
+    expect(screen.queryByRole("link", { name: "View all" })).toBeNull();
+    expect(screen.getByRole("heading", { name: "Available strategies" })).toBeTruthy();
+  });
+
   it("renders live wallets, vault positions, and existing provider programs", async () => {
     const user = userEvent.setup();
     renderWorkspace();
@@ -685,6 +731,34 @@ describe("TreasurySolutionsWorkspace", () => {
         name: "Deposited: The latest deposit is confirmed on-chain.",
       })
     ).toBeTruthy();
+  });
+
+  it("refreshes uncached wallet balances when a vault movement settles", async () => {
+    const movementId = "earn_vault_movement_live_balance";
+    mocks.vaultDeposits = [
+      {
+        createdAt: "2026-09-01T17:22:00.000Z",
+        failureReason: null,
+        movementId,
+        positionId: "earn_vault_position_live",
+        status: "submitted",
+      },
+    ];
+    renderWorkspace();
+
+    await waitFor(() => expect(mocks.vaultDepositTrackers[movementId]).toBeTruthy());
+    act(() => {
+      mocks.vaultDepositTrackers[movementId]?.onSettled?.({
+        createdAt: "2026-09-01T17:22:00.000Z",
+        failureReason: null,
+        movementId,
+        positionId: "earn_vault_position_live",
+        status: "confirmed",
+      });
+    });
+
+    expect(mocks.refreshWalletBalances).toHaveBeenCalledTimes(1);
+    expect(mocks.refreshWallets).not.toHaveBeenCalled();
   });
 
   it("updates a confirmed withdrawal to final settlement in place", async () => {

--- a/apps/sdp-web/src/app/dashboard/markets/treasury-solutions/treasury-solutions-workspace.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/treasury-solutions/treasury-solutions-workspace.unit.test.tsx
@@ -23,6 +23,7 @@ if (!window.matchMedia) {
 }
 
 const mocks = vi.hoisted(() => ({
+  canManageCustody: true,
   environment: "sandbox" as "sandbox" | "production",
   programProvider: "ground",
   // Every cluster value useEarnStrategies was asked for, across renders.
@@ -126,7 +127,10 @@ const CATALOGUE_SHARE_MINT = "ShareCatalogue11111111111111111111111111111";
 
 vi.mock("@/contexts/dashboard-workspace-context", () => ({
   useDashboardWorkspace: () => ({ sdpEnvironment: mocks.environment }),
-  useOptionalDashboardWorkspace: () => undefined,
+  useOptionalDashboardWorkspace: () => ({
+    dashboardAccess: { capabilities: { canManageCustody: mocks.canManageCustody } },
+    flags: { custody: true },
+  }),
 }));
 
 vi.mock("../earn/deposit/earn-funding-wallets", () => ({
@@ -484,6 +488,7 @@ function renderWorkspace() {
 }
 
 beforeEach(() => {
+  mocks.canManageCustody = true;
   mocks.environment = "sandbox";
   mocks.programProvider = "ground";
   mocks.strategiesClusterRequests = [];
@@ -526,6 +531,16 @@ describe("TreasurySolutionsWorkspace", () => {
     expect(action.getAttribute("href")).toBe("/dashboard/wallets/setup");
     expect(screen.queryByRole("link", { name: "View all" })).toBeNull();
     expect(screen.getByRole("heading", { name: "Available strategies" })).toBeTruthy();
+  });
+
+  it("does not offer wallet setup without custody management permission", () => {
+    mocks.canManageCustody = false;
+    mocks.walletsEmpty = true;
+    mocks.positionsEmpty = true;
+    renderWorkspace();
+
+    expect(screen.getByText("No active custody wallets")).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "Create wallet" })).toBeNull();
   });
 
   it("renders live wallets, vault positions, and existing provider programs", async () => {


### PR DESCRIPTION
- Adds direct Create wallet actions to Treasury and the Earn deposit flow.
- Wraps the Treasury zero-wallet state in a focused card and hides View all until a wallet exists.
- Refreshes visible wallets through the uncached per-wallet balance endpoint after submit, settlement, and manual refresh.
- Preserves each wallet's last observation when its live balance read fails without blocking healthy wallets.

**before**: wallet setup and vault balance feedback

1. Empty states were passive or returned users to the wallet list.
2. Collection-cache refreshes could retain the pre-movement balance.

**after**: wallet setup and vault balance feedback

1. Empty states link directly to `/dashboard/wallets/setup`.
2. Submit and settlement trigger independent `no-store` wallet reads.
3. Failed reads remain unavailable or retain their prior observation.

## How balance refresh works

`reload wallet inventory -> fetch each live balance -> merge successes -> preserve failures`

**Screenshots**

![Treasury no-wallet empty state](https://github.com/user-attachments/assets/fb527695-66a2-4e44-8e50-ee4bc5abda7d)

**Verification**

- Focused Vitest: 76 passed.
- `pnpm --filter sdp-web typecheck`: passed.
- Biome on six changed files: passed.
- Local app: selected a zero-wallet project and verified the Treasury setup CTA on localhost.
