### PR TITLE
feat(web): expire vault deposit quotes and re-quote silently before submit

### DIFF
--- a/apps/sdp-api/src/routes/earn/handlers/vault.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/vault.ts
@@ -342,10 +342,11 @@ export async function extractEarnVaultDepositPolicyCandidate(
   // Kamino's pinned SDK selects the LEGACY deposit instruction when no
   // `minSharesOut` is given — there is no implicit floor, so a vault-state
   // change between signing and inclusion can mint materially fewer shares than
-  // the caller reviewed. The dashboard now derives one from a live quote with
-  // a displayed tolerance (`POST /vault-deposit-previews`) — an expiry is the
-  // piece still missing — but API callers predate the floor, so requiring it
-  // unconditionally today would still break working flows.
+  // the caller reviewed. The dashboard derives one from a live quote with a
+  // displayed tolerance (`POST /vault-deposit-previews`) and refuses to submit
+  // a floor whose quote has aged past its TTL (PRO-1691) — but API callers
+  // predate the floor, so requiring it unconditionally today would still break
+  // working flows.
   //
   // This is scoped to production deliberately, and it is NOT dead code: the
   // environment gate above closes production for a different reason (no exit

--- a/apps/sdp-web/src/app/dashboard/markets/earn/CLAUDE.md
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/CLAUDE.md
@@ -292,14 +292,23 @@ program create still sends the body `requestId` form.
   (fingerprint: project, position, shares, minAmountOut — the derived exit
   floor is in there for the same reason the deposit's is) under its own
   versioned `sessionStorage` key.
-- `earn-vault-slippage.tsx` — the slippage-floor machinery BOTH vault modals
+- `earn-vault-slippage.ts` — the slippage-floor machinery BOTH vault modals
   share: `parseSlippageToleranceBps`, `floorForTolerance` (BigInt at the quoted
   mint's scale, floored, one-atom minimum), `isSlippageExceededRefusal` (the
-  API's `details.reason` seam), the debounced quote hook and the disclosure
-  section. One copy on purpose — two copies of a funds-protection rule is how
-  one drifts, the same reasoning as `earn-idempotency-key-store`. The floor is
-  derived from a LIVE provider quote, never from the caller's own input; an
-  unavailable quote DISABLES the action rather than guessing.
+  API's `details.reason` seam), the debounced quote hook and (in
+  `earn-vault-slippage-section.tsx`) the disclosure section. One copy on
+  purpose — two copies of a funds-protection rule is how one drifts, the same
+  reasoning as `earn-idempotency-key-store`. The floor is derived from a LIVE
+  provider quote, never from the caller's own input; an unavailable quote
+  DISABLES the action rather than guessing. Quotes EXPIRE (PRO-1691): past
+  `VAULT_QUOTE_TTL_MS` the hook re-quotes on its own, silently in place (the
+  standing quote stays on screen and swaps when the fresh one lands — never a
+  loading flicker or a disarmed confirm), and the deposit modal's
+  `floorSafeToSubmit` additionally refuses to SUBMIT a floor whose quote aged
+  past the TTL without re-quoting first: still satisfiable proceeds with the
+  floor the user reviewed, a rate beyond it stops client-side through the
+  blown-floor copy and control. Held floors bypass the check — a replay must
+  carry the floor its key was minted with, verbatim.
 - `earn-idempotency-key-store.ts` — the shared machinery behind BOTH tracking
   modules (storage tiers, quota divergence, approval holds, entry bounds), plus
   `answerRetiresIdempotencyKey`, the shared retire-decision rule. Extracted

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.tsx
@@ -52,6 +52,7 @@ import {
 } from "./earn-vault-deposit-tracking";
 import {
   floorForTolerance,
+  isExpiredQuote,
   isSlippageExceededRefusal,
   isZeroQuote,
   parseSlippageToleranceBps,
@@ -914,6 +915,44 @@ export function EarnVaultDepositModal({
     amountValidation.kind !== "valid" ||
     (slippagePolicy !== null && minSharesOut === undefined);
 
+  /**
+   * EXPIRY BACKSTOP (PRO-1691). The quote hook re-quotes on its own, but
+   * timers throttle in background tabs, so the floor on screen can be older
+   * than the TTL at submit. A floor that fresh — or a HELD floor, which a
+   * replay must carry verbatim — passes straight through. An expired one is
+   * re-quoted first: the floor the user REVIEWED is submitted only once a
+   * fresh rate proves it still satisfiable — never a weaker floor re-derived
+   * from the fresh rate, which could accept up to double the chosen tolerance.
+   * A rate that moved beyond that floor stops the submission on THIS side of
+   * the API, through the same copy and control as a blown floor, and either
+   * way the displayed quote re-syncs. Returns whether to proceed.
+   */
+  async function floorSafeToSubmit(
+    controller: AbortController,
+    amount: string,
+    heldFloor: string | null | undefined,
+    floor: string | null
+  ): Promise<boolean> {
+    if (heldFloor !== undefined || floor === null || !isExpiredQuote(quote)) return true;
+    const fresh = await fetchEarnVaultDepositPreview(
+      { strategyId: strategy.id, amount },
+      controller.signal
+    );
+    if (controller.signal.aborted) return false;
+    const usable = fresh.kind === "quoted" && fresh.preview.blockingIssues.length === 0;
+    if (usable && compareUnsignedDecimals(fresh.preview.sharesOut, floor) !== -1) {
+      return true;
+    }
+    if (usable) setSlippageOpen(true);
+    setQuoteRefreshKey((refresh) => refresh + 1);
+    setSubmitError(
+      usable
+        ? t("DashboardEarn.deposit.vaultSlippageExceeded")
+        : t("DashboardEarn.deposit.vaultQuoteUnavailable")
+    );
+    return false;
+  }
+
   async function submitResolvedIntent(
     controller: AbortController,
     wallet: EarnFundingWallet,
@@ -951,6 +990,8 @@ export function EarnVaultDepositModal({
     // freshly derived floor, and records it for exactly that future replay.
     const heldFloor = resolvedKey.wasHeld ? recallVaultDepositFloor(fingerprint) : undefined;
     const floorForRequest = heldFloor !== undefined ? heldFloor : (minSharesOut ?? null);
+
+    if (!(await floorSafeToSubmit(controller, amount, heldFloor, floorForRequest))) return;
     rememberVaultDepositFloor(fingerprint, floorForRequest);
 
     // The value-moving POST deliberately takes NO abort signal. The server

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.tsx
@@ -309,6 +309,31 @@ function resolveDepositSubmission(
   };
 }
 
+type ExpiredFloorVerdict = "still_satisfiable" | "floor_exceeded" | "quote_unavailable" | "aborted";
+
+/**
+ * EXPIRY BACKSTOP (PRO-1691), the read half: the floor on screen came from a
+ * quote that aged past the TTL, so ask the vault again before sending it. The
+ * floor the user REVIEWED is what a passing verdict submits, never a weaker
+ * floor re-derived from the fresh rate (that would accept up to double the
+ * chosen tolerance).
+ */
+async function revalidateExpiredFloor(
+  strategyId: string,
+  amount: string,
+  floor: string,
+  signal: AbortSignal
+): Promise<ExpiredFloorVerdict> {
+  const fresh = await fetchEarnVaultDepositPreview({ strategyId, amount }, signal);
+  if (signal.aborted) return "aborted";
+  if (fresh.kind !== "quoted" || fresh.preview.blockingIssues.length > 0) {
+    return "quote_unavailable";
+  }
+  return compareUnsignedDecimals(fresh.preview.sharesOut, floor) === -1
+    ? "floor_exceeded"
+    : "still_satisfiable";
+}
+
 type Translation = ReturnType<typeof useTranslations>;
 
 function amountValidationMessage(
@@ -916,16 +941,13 @@ export function EarnVaultDepositModal({
     (slippagePolicy !== null && minSharesOut === undefined);
 
   /**
-   * EXPIRY BACKSTOP (PRO-1691). The quote hook re-quotes on its own, but
-   * timers throttle in background tabs, so the floor on screen can be older
-   * than the TTL at submit. A floor that fresh — or a HELD floor, which a
-   * replay must carry verbatim — passes straight through. An expired one is
-   * re-quoted first: the floor the user REVIEWED is submitted only once a
-   * fresh rate proves it still satisfiable — never a weaker floor re-derived
-   * from the fresh rate, which could accept up to double the chosen tolerance.
-   * A rate that moved beyond that floor stops the submission on THIS side of
-   * the API, through the same copy and control as a blown floor, and either
-   * way the displayed quote re-syncs. Returns whether to proceed.
+   * EXPIRY BACKSTOP (PRO-1691), the state half. The quote hook re-quotes on
+   * its own, but timers throttle in background tabs, so the floor on screen
+   * can be older than the TTL at submit. A fresh floor, or a HELD floor (a
+   * replay must carry it verbatim), passes straight through. An expired one is
+   * revalidated first; a rate that moved beyond it stops the submission on
+   * THIS side of the API, through the same copy and control as a blown floor,
+   * and either way the displayed quote re-syncs. Returns whether to proceed.
    */
   async function floorSafeToSubmit(
     controller: AbortController,
@@ -934,19 +956,13 @@ export function EarnVaultDepositModal({
     floor: string | null
   ): Promise<boolean> {
     if (heldFloor !== undefined || floor === null || !isExpiredQuote(quote)) return true;
-    const fresh = await fetchEarnVaultDepositPreview(
-      { strategyId: strategy.id, amount },
-      controller.signal
-    );
-    if (controller.signal.aborted) return false;
-    const usable = fresh.kind === "quoted" && fresh.preview.blockingIssues.length === 0;
-    if (usable && compareUnsignedDecimals(fresh.preview.sharesOut, floor) !== -1) {
-      return true;
-    }
-    if (usable) setSlippageOpen(true);
+    const verdict = await revalidateExpiredFloor(strategy.id, amount, floor, controller.signal);
+    if (verdict === "still_satisfiable") return true;
+    if (verdict === "aborted") return false;
+    if (verdict === "floor_exceeded") setSlippageOpen(true);
     setQuoteRefreshKey((refresh) => refresh + 1);
     setSubmitError(
-      usable
+      verdict === "floor_exceeded"
         ? t("DashboardEarn.deposit.vaultSlippageExceeded")
         : t("DashboardEarn.deposit.vaultQuoteUnavailable")
     );

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.unit.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import type { EarnStrategy, EarnVaultDeposit, EarnVaultMovementStatus } from "@sdp/types";
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { EarnFundingWallet } from "./deposit/earn-funding-wallets";
@@ -18,6 +18,8 @@ import {
   floorForTolerance,
   isSlippageExceededRefusal,
   parseSlippageToleranceBps,
+  VAULT_QUOTE_DEBOUNCE_MS,
+  VAULT_QUOTE_TTL_MS,
 } from "./earn-vault-slippage";
 
 const USDC_MINT = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
@@ -1019,6 +1021,190 @@ describe("slippage-floored providers", () => {
     expect(
       (screen.getByRole("button", { name: "Confirm deposit" }) as HTMLButtonElement).disabled
     ).toBe(true);
+  });
+
+  describe("quote expiry (PRO-1691)", () => {
+    function quoted(sharesOut: string) {
+      return {
+        kind: "quoted" as const,
+        preview: {
+          strategyId: vedaStrategy.id,
+          sharesOut,
+          shareDecimals: 6,
+          blockingIssues: [] as { code: string; message: string }[],
+        },
+      };
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    async function advanceTimers(ms: number) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(ms);
+      });
+    }
+
+    /** Flush the submit's promise chain without moving any timer. */
+    async function flushSubmission() {
+      await act(async () => {
+        for (let step = 0; step < 25; step += 1) await Promise.resolve();
+      });
+    }
+
+    /** Select the wallet, enter 1 USDC, and wait out the quote debounce. */
+    async function armVedaDeposit() {
+      screen.getByRole("dialog", { name: "Deposit into Institutional USDC Vault" });
+      fireEvent.click(screen.getByRole("radio", { name: /Treasury wallet/ }));
+      fireEvent.change(screen.getByLabelText("Amount (USDC)"), {
+        target: { value: "1.000000" },
+      });
+      await advanceTimers(VAULT_QUOTE_DEBOUNCE_MS);
+      screen.getByText("Minimum shares received");
+    }
+
+    it("re-quotes an aged quote on its own and re-floors in place, without disarming", async () => {
+      let resolveRefresh: (value: ReturnType<typeof quoted>) => void = () => {};
+      mocks.fetchEarnVaultDepositPreview.mockResolvedValueOnce(quoted("1")).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRefresh = resolve;
+          })
+      );
+      render(
+        <EarnVaultDepositModal projectId={PROJECT_ID} strategy={vedaStrategy} onClose={vi.fn()} />
+      );
+      await armVedaDeposit();
+      expect(screen.getByText("0.999")).toBeTruthy();
+
+      // The TTL elapses: the refresh fires on its own and is IN FLIGHT here…
+      // (the second advance fires the re-run's own zero-delay fetch timer)
+      await advanceTimers(VAULT_QUOTE_TTL_MS + 1000);
+      await advanceTimers(1);
+      expect(mocks.fetchEarnVaultDepositPreview).toHaveBeenCalledTimes(2);
+      // …while the standing quote stays on screen — no loading flicker, no
+      // disarmed confirm, no layout shift.
+      expect(screen.getByText("0.999")).toBeTruthy();
+      expect(screen.queryByText(/Fetching the live share quote/)).toBeNull();
+      expect(
+        (screen.getByRole("button", { name: "Confirm deposit" }) as HTMLButtonElement).disabled
+      ).toBe(false);
+
+      await act(async () => {
+        resolveRefresh(quoted("0.9"));
+        await Promise.resolve();
+      });
+      // The fresh rate swaps in place: expected shares and floor both re-derive.
+      expect(screen.getByText("0.9")).toBeTruthy();
+      expect(screen.getByText("0.8991")).toBeTruthy();
+    });
+
+    it("re-quotes a floor older than the TTL at submit, then sends the reviewed floor", async () => {
+      mocks.fetchEarnVaultDepositPreview
+        .mockResolvedValueOnce(quoted("1"))
+        .mockResolvedValueOnce(quoted("0.9995"));
+      mocks.createEarnVaultDeposit.mockResolvedValue({
+        ok: true,
+        status: 200,
+        data: { kind: "submitted", deposit: vaultDeposit("submitted") },
+      });
+      render(
+        <EarnVaultDepositModal projectId={PROJECT_ID} strategy={vedaStrategy} onClose={vi.fn()} />
+      );
+      await armVedaDeposit();
+      // The clock passes the TTL without the auto-refresh timer firing — the
+      // throttled-background-tab case the submit-time check exists for.
+      vi.setSystemTime(Date.now() + VAULT_QUOTE_TTL_MS + 1000);
+
+      fireEvent.click(screen.getByRole("button", { name: "Confirm deposit" }));
+      await flushSubmission();
+
+      // The fresh check ran, BEFORE the money moved…
+      expect(mocks.fetchEarnVaultDepositPreview).toHaveBeenCalledTimes(2);
+      expect(mocks.createEarnVaultDeposit).toHaveBeenCalledTimes(1);
+      expect(mocks.fetchEarnVaultDepositPreview.mock.invocationCallOrder[1]).toBeLessThan(
+        mocks.createEarnVaultDeposit.mock.invocationCallOrder[0]
+      );
+      // …and the floor sent is the one the user REVIEWED, freshly revalidated:
+      // the still-satisfiable 0.999, never a weaker floor off the 0.9995 rate.
+      expect(mocks.createEarnVaultDeposit.mock.calls[0][0]).toEqual({
+        strategyId: strategy.id,
+        custodyWalletId: "wallet_1",
+        amount: "1",
+        minSharesOut: "0.999",
+      });
+      expect(screen.getByText("Deposit submitted")).toBeTruthy();
+    });
+
+    it("stops a stale submit whose fresh rate broke the floor: slippage copy, no POST", async () => {
+      mocks.fetchEarnVaultDepositPreview
+        .mockResolvedValueOnce(quoted("1"))
+        .mockResolvedValue(quoted("0.99"));
+      render(
+        <EarnVaultDepositModal projectId={PROJECT_ID} strategy={vedaStrategy} onClose={vi.fn()} />
+      );
+      await armVedaDeposit();
+      vi.setSystemTime(Date.now() + VAULT_QUOTE_TTL_MS + 1000);
+
+      fireEvent.click(screen.getByRole("button", { name: "Confirm deposit" }));
+      await flushSubmission();
+
+      // The rate moved beyond the chosen tolerance while the quote sat stale:
+      // friction lands HERE, before submit, never as a server refusal after.
+      expect(mocks.createEarnVaultDeposit).not.toHaveBeenCalled();
+      expect(screen.getByText(/Increase the tolerance below/)).toBeTruthy();
+      expect(
+        (screen.getByLabelText("Slippage tolerance (basis points)") as HTMLInputElement).value
+      ).toBe("10");
+      // The displayed quote re-syncs so the retry reviews the fresh floor.
+      await advanceTimers(1);
+      expect(mocks.fetchEarnVaultDepositPreview.mock.calls.length).toBeGreaterThanOrEqual(3);
+      expect(screen.getByText("0.98901")).toBeTruthy();
+    });
+
+    it("replays a held key's floor verbatim, bypassing the expiry check", async () => {
+      mocks.fetchEarnVaultDepositPreview
+        .mockResolvedValueOnce(quoted("1"))
+        .mockResolvedValue(quoted("0.5"));
+      mocks.createEarnVaultDeposit.mockResolvedValue({
+        ok: true,
+        status: 202,
+        data: { kind: "approval_pending", message: "Approval required" },
+      });
+
+      const held = render(
+        <EarnVaultDepositModal projectId={PROJECT_ID} strategy={vedaStrategy} onClose={vi.fn()} />
+      );
+      await armVedaDeposit();
+      fireEvent.click(screen.getByRole("button", { name: "Confirm deposit" }));
+      await flushSubmission();
+      screen.getByText("Approval required");
+      held.unmount();
+
+      render(
+        <EarnVaultDepositModal projectId={PROJECT_ID} strategy={vedaStrategy} onClose={vi.fn()} />
+      );
+      await armVedaDeposit();
+      vi.setSystemTime(Date.now() + VAULT_QUOTE_TTL_MS + 1000);
+      fireEvent.click(screen.getByRole("button", { name: "Confirm deposit" }));
+      await flushSubmission();
+
+      // Had the expiry gate run here, the 0.5 re-quote would have refused the
+      // held 0.999 floor. It must not: an approval's replay carries the floor
+      // its key was MINTED with, verbatim, or the hold is stranded.
+      expect(mocks.createEarnVaultDeposit).toHaveBeenCalledTimes(2);
+      expect(mocks.createEarnVaultDeposit.mock.calls[1][0]).toMatchObject({
+        minSharesOut: "0.999",
+      });
+      expect(mocks.createEarnVaultDeposit.mock.calls[1][1]).toBe(
+        mocks.createEarnVaultDeposit.mock.calls[0][1]
+      );
+    });
   });
 
   it("answers a blown floor with its own copy, opens the control, and re-quotes", async () => {

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-slippage.ts
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-slippage.ts
@@ -90,14 +90,36 @@ export type VaultQuoteState<T> =
   | { kind: "idle" }
   | { kind: "loading" }
   | { kind: "unavailable" }
-  | { kind: "quoted"; key: string; preview: T };
+  | { kind: "quoted"; key: string; preview: T; quotedAt: number };
 
 export const VAULT_QUOTE_DEBOUNCE_MS = 400;
 
 /**
+ * How long a quote may back a floor. A rate is a moving observation, not a
+ * fact: past this age the hook re-quotes on its own, and the deposit submit
+ * refuses to send a floor derived from anything older without re-quoting
+ * first (PRO-1691). Timers throttle in background tabs, which is exactly why
+ * the submit-time check exists alongside the auto-refresh.
+ */
+export const VAULT_QUOTE_TTL_MS = 30_000;
+
+/** True when a quote is older than the TTL — too old to derive a floor from. */
+export function isExpiredQuote<T>(quote: VaultQuoteState<T>): boolean {
+  return quote.kind === "quoted" && Date.now() - quote.quotedAt > VAULT_QUOTE_TTL_MS;
+}
+
+/**
  * The live quote a floor is derived from. Debounced behind typing, aborted on
  * change and unmount, and re-fetched when `refreshKey` bumps — a blown floor
- * retries against a FRESH rate, never the one that just refused.
+ * retries against a FRESH rate, never the one that just refused. A quote that
+ * ages past `VAULT_QUOTE_TTL_MS` re-fetches on its own.
+ *
+ * A re-fetch of a key we already hold a quote for is SILENT: the standing
+ * quote stays on screen and swaps in place when the fresh one lands — no
+ * loading flicker, no layout shift, no disarmed confirm. Only a NEW key drops
+ * to `loading`, debounced behind typing. A silent re-fetch that fails still
+ * lands on `unavailable`: an expired quote must never keep arming the action
+ * just because its replacement could not be read.
  *
  * `key` is the serialized quote input; `null` means "nothing to quote" (no
  * floor policy, or the input is not valid yet) and resolves to `idle` without
@@ -113,42 +135,61 @@ export function useDebouncedVaultQuote<T>(
   refreshKey: number
 ): VaultQuoteState<T> {
   const [state, setState] = useState<VaultQuoteState<T>>({ kind: "idle" });
+  // Bumped when the standing quote ages past the TTL; a dependency of the
+  // fetch effect, so expiry re-runs it without any caller involvement.
+  const [expiryEpoch, setExpiryEpoch] = useState(0);
   const fetchRef = useRef(fetchQuote);
-  // The latest-fetcher write lives in an effect, never in render: React can
+  const stateRef = useRef(state);
+  // The latest-value writes live in an effect, never in render: React can
   // replay or discard render work, and a mutation there leaks from UI that
-  // never commits.
+  // never commits. Declared before the fetch effect so both refs are current
+  // by the time it runs.
   useEffect(() => {
     fetchRef.current = fetchQuote;
+    stateRef.current = state;
   });
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshKey is deliberately unused in the body — bumping it re-runs the quote after a blown floor.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshKey and expiryEpoch are deliberately unused in the body — bumping either re-runs the quote (after a blown floor, or past the TTL).
   useEffect(() => {
     if (key === null) {
       setState({ kind: "idle" });
       return;
     }
+    // Already holding a quote for THIS key means this run is a refresh, not a
+    // new question: keep it on screen and skip the typing debounce.
+    const silent = stateRef.current.kind === "quoted" && stateRef.current.key === key;
     const controller = new AbortController();
-    setState({ kind: "loading" });
-    const timer = setTimeout(() => {
-      fetchRef.current(controller.signal).then(
-        (result) => {
-          if (controller.signal.aborted) return;
-          setState(
-            result.kind === "quoted"
-              ? { kind: "quoted", key, preview: result.preview }
-              : { kind: "unavailable" }
-          );
-        },
-        () => {
-          if (!controller.signal.aborted) setState({ kind: "unavailable" });
-        }
-      );
-    }, VAULT_QUOTE_DEBOUNCE_MS);
+    if (!silent) setState({ kind: "loading" });
+    const timer = setTimeout(
+      () => {
+        fetchRef.current(controller.signal).then(
+          (result) => {
+            if (controller.signal.aborted) return;
+            setState(
+              result.kind === "quoted"
+                ? { kind: "quoted", key, preview: result.preview, quotedAt: Date.now() }
+                : { kind: "unavailable" }
+            );
+          },
+          () => {
+            if (!controller.signal.aborted) setState({ kind: "unavailable" });
+          }
+        );
+      },
+      silent ? 0 : VAULT_QUOTE_DEBOUNCE_MS
+    );
     return () => {
       clearTimeout(timer);
       controller.abort();
     };
-  }, [key, refreshKey]);
+  }, [key, refreshKey, expiryEpoch]);
+
+  useEffect(() => {
+    if (state.kind !== "quoted") return;
+    const remaining = state.quotedAt + VAULT_QUOTE_TTL_MS - Date.now();
+    const timer = setTimeout(() => setExpiryEpoch((epoch) => epoch + 1), Math.max(remaining, 0));
+    return () => clearTimeout(timer);
+  }, [state]);
 
   return state;
 }


### PR DESCRIPTION
Closes PRO-1691. Follow-up to the quote-derived `minSharesOut` floor: the deposit preview carried no timestamp, so a modal left open submitted a floor from a rate the user reviewed arbitrarily long ago.

- `VAULT_QUOTE_TTL_MS` (30s) on the shared vault quote hook: an aged quote re-fetches on its own, silently in place (the standing quote stays on screen and swaps when the fresh one lands; no loading flicker, no disarmed confirm). Both vault modals inherit this.
- `floorSafeToSubmit` in the deposit modal: a floor whose quote aged past the TTL (throttled background tab) is re-quoted inline before the POST. Still satisfiable proceeds in the same click; a rate that moved beyond the reviewed floor stops client-side through the existing blown-floor copy and control, and the displayed quote re-syncs.
- Held floors bypass the check: an approval replay carries the floor its key was minted with, verbatim.

**before**: quote fetched once per input

1. quote at open, floor displayed
2. modal idles
3. submit sends the stale floor; rate drift surfaces only as a server refusal, or lands inside a floor reviewed against a dead rate

**after**: quotes expire

1. re-quote every 30s, in place
2. stale-at-submit re-quotes first; the POST carries a floor a fresh rate proved satisfiable
3. beyond-tolerance movement stops before submit

**Reviewer notes**

- A revalidated stale submit deliberately sends the REVIEWED floor, never one re-derived from the fresh rate (that would accept up to roughly 2x the chosen tolerance); rationale in `floorSafeToSubmit`'s doc comment.
- The `apps/sdp-api` diff is comment-only (removes "an expiry is the piece still missing").

**Verification**

- `pnpm --filter sdp-web exec vitest run src/app/dashboard/markets/earn`: 149/149, 4 new tests (silent TTL re-floor in place, stale-submit re-quote ordered before the POST, beyond-tolerance stop with no POST, held-floor exemption)
- sdp-web `tsc --noEmit` clean; biome clean on the changed files
- Not exercised in the running app: the delta is a 30s timer with deliberately no visual change; the new unit tests drive the real component through fake timers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
