### PR TITLE
fix(api): stamp database identity on the Clerk onboarding middleware

### DIFF
--- a/apps/sdp-api/src/lib/tenant-boundary.test.ts
+++ b/apps/sdp-api/src/lib/tenant-boundary.test.ts
@@ -73,6 +73,9 @@ describe("tenant data-access boundary", () => {
       "job.ts",
       "middleware/auth.ts",
       "middleware/clerk-auth.ts",
+      // Pre-link Clerk surface: resolves the Clerk-org mapping before any
+      // tenant exists, then narrows the request to the mapped organization.
+      "middleware/clerk-onboarding.ts",
       "middleware/session-auth.ts",
       "middleware/database-identity.ts",
       // The audit ledger's hash chain spans every organization by design; its

--- a/apps/sdp-api/src/middleware/clerk-onboarding.ts
+++ b/apps/sdp-api/src/middleware/clerk-onboarding.ts
@@ -1,4 +1,5 @@
 import type { Context, Next } from "hono";
+import { getDb, runWithSystemDatabaseIdentity, runWithTenantDatabaseIdentity } from "@/db";
 import {
   type ClerkJwtPayload,
   extractBearerToken,
@@ -48,6 +49,29 @@ export function clerkOnboardingMiddleware() {
       orgRole: payload.org_role ?? null,
       email,
     });
+
+    // The Clerk-org -> organization mapping lives in an RLS-forced table
+    // (migration 0081) and must be read before a tenant identity exists, so
+    // the lookup runs under the system identity (the same boundary
+    // clerk-auth.ts draws) and the rest of the request narrows to the mapped
+    // organization. An unlinked Clerk org proceeds with the ambient
+    // no-identity context: tenant-table reads stay empty and the handlers
+    // answer linked:false / Organization not found instead of leaking anything.
+    const mapping = await runWithSystemDatabaseIdentity("http:auth", () =>
+      getDb(c.env)
+        .prepare(
+          `SELECT organization_id
+           FROM auth_organization_identities
+           WHERE provider = 'clerk' AND provider_org_id = ?`
+        )
+        .bind(payload.org_id)
+        .first<{ organization_id: string }>()
+    );
+
+    if (mapping) {
+      await runWithTenantDatabaseIdentity({ organizationId: mapping.organization_id }, next);
+      return;
+    }
 
     await next();
   };

--- a/apps/sdp-api/src/routes/onboarding/tenant-isolation-http.test.ts
+++ b/apps/sdp-api/src/routes/onboarding/tenant-isolation-http.test.ts
@@ -1,0 +1,97 @@
+/**
+ * /v1/onboarding runs before clerkAuthMiddleware ever links a session, so its
+ * middleware must resolve the Clerk-org mapping under the system database
+ * identity and narrow the request to the mapped organization. Exercised
+ * through the full HTTP stack under the plain NOSUPERUSER/NOBYPASSRLS runtime
+ * role so the forced RLS policies (migration 0081) actually apply.
+ *
+ * Regression: the middleware verified the Clerk JWT but stamped no database
+ * identity, so the status handler's auth_organization_identities lookup ran
+ * identity-less, RLS returned zero rows, and every linked organization
+ * reported linked:false (the dashboard then failed closed and badged every
+ * treasury vault "Access unavailable").
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getDb } from "@/db";
+import app from "@/index";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+
+const { verifyClerkJwtForRequest } = vi.hoisted(() => ({
+  verifyClerkJwtForRequest: vi.fn(),
+}));
+
+vi.mock("@/lib/clerk-token", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/clerk-token")>()),
+  verifyClerkJwtForRequest,
+}));
+
+const ORGANIZATION_ID = "org_onboarding_isolation";
+const CLERK_ORG_ID = "org_clerk_onboarding_isolation";
+
+function clerkPayload(clerkOrgId: string) {
+  return {
+    sub: "user_clerk_onboarding_isolation",
+    org_id: clerkOrgId,
+    org_slug: "onboarding-isolation",
+    org_role: "org:admin",
+    email: "onboarding-isolation@example.com",
+  };
+}
+
+const getStatus = () =>
+  app.request(
+    "/v1/onboarding/status",
+    { headers: { Authorization: "Bearer clerk-session-token" } },
+    env
+  );
+
+type StatusBody = {
+  data: { linked: boolean; organization: { id: string } | null; setup: unknown };
+};
+
+describe("onboarding status under database tenant isolation", () => {
+  beforeEach(async () => {
+    verifyClerkJwtForRequest.mockReset();
+    await seedTestDatabase(env);
+
+    const db = getDb(env);
+    await db.batch([
+      db
+        .prepare(
+          `INSERT INTO organizations (id, name, slug, tier, status)
+           VALUES (?, 'Onboarding isolation', 'onboarding-isolation', 'individual', 'active')`
+        )
+        .bind(ORGANIZATION_ID),
+      db
+        .prepare(
+          `INSERT INTO auth_organization_identities
+             (id, provider, provider_org_id, organization_id, slug)
+           VALUES ('aoi_onboarding_isolation', 'clerk', ?, ?, 'onboarding-isolation')`
+        )
+        .bind(CLERK_ORG_ID, ORGANIZATION_ID),
+    ]);
+  });
+
+  it("resolves a linked organization through row-level security", async () => {
+    verifyClerkJwtForRequest.mockResolvedValue(clerkPayload(CLERK_ORG_ID));
+
+    const res = await getStatus();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as StatusBody;
+    expect(body.data.linked).toBe(true);
+    expect(body.data.organization?.id).toBe(ORGANIZATION_ID);
+    expect(body.data.setup).not.toBeNull();
+  });
+
+  it("reports unlinked for a Clerk organization with no mapping", async () => {
+    verifyClerkJwtForRequest.mockResolvedValue(clerkPayload("org_clerk_never_linked"));
+
+    const res = await getStatus();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as StatusBody;
+    expect(body.data.linked).toBe(false);
+    expect(body.data.organization).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

`clerkOnboardingMiddleware` verified the Clerk JWT but never stamped a database identity, so once #1447's forced RLS deployed, the onboarding-status handler's `auth_organization_identities` lookup ran identity-less and read zero rows. Every linked org reported `linked: false`, the web's `loadEarnProviderAccess()` failed closed, and the dashboard badged every Treasury vault "Access unavailable" (the smoky regression; org data was untouched).

**before**: verify JWT -> handler queries the Clerk-org mapping with no identity -> RLS returns zero rows -> `linked: false` for every org

**after**: verify JWT -> resolve the mapping under the system identity (the same boundary clerk-auth.ts draws) -> run the rest of the request under the mapped org's tenant identity; an unlinked Clerk org proceeds identity-less and still answers `linked: false`

## Reviewer notes

- **The system-identity grant covers only the one mapping lookup**; everything after narrows to the tenant. Grant site registered in `tenant-boundary.test.ts`.
- `completeOnboarding`'s writes pass under tenant identity: the `organizations` policy keys on `id`, custody/provider reads on `organization_id`.

## Verification

- New full-stack regression test under the NOSUPERUSER/NOBYPASSRLS runtime role: a linked org resolves `linked: true`, an unlinked one stays `false`. The linked case fails on main.
- Onboarding + tenant-isolation suites: 33 passed. `tsc --noEmit` and Biome: clean.
