### PR TITLE
feat(earn): reconcile custody vault shares against recorded positions

### DIFF
--- a/apps/sdp-api/src/db/repositories/earn-movements.repository.ts
+++ b/apps/sdp-api/src/db/repositories/earn-movements.repository.ts
@@ -331,6 +331,19 @@ export interface EarnMovementsRepository {
     limit: number;
     before: EarnMovementCursor | null;
   }): Promise<{ rows: EarnPositionRow[]; hasMore: boolean }>;
+  /**
+   * The COMPLETE set of claims `listVaultPositions` would serve (same
+   * visibility predicate, unpaged — a reconciliation over a page would clear
+   * discrepancies it never looked at), each with whether any of its movements
+   * is still unsettled. Read-only input to share reconciliation (PRO-1741);
+   * empty wallet scope answers empty rather than throwing, because "this key
+   * sees no wallets" is a legitimate reconciliation answer.
+   */
+  listVaultClaimsForReconciliation(params: {
+    organizationId: string;
+    environment: SdpEnvironment;
+    custodyWalletIds: readonly string[];
+  }): Promise<Array<EarnPositionRow & { has_unsettled_movements: boolean }>>;
   /** External-wallet vault claims, exact-project scoped, newest first. */
   listExternalWalletPositions(params: {
     organizationId: string;
@@ -766,6 +779,39 @@ function mapMovementRow(row: Record<string, unknown>): EarnMovementRow {
   };
 }
 
+/**
+ * What makes a custody vault claim VISIBLE to the org: the exact predicate
+ * behind `GET /vault-positions` (activated, open or re-entered, live movement
+ * evidence, wallet-scoped). `listVaultClaimsForReconciliation` shares it by
+ * construction, because the reconciliation report's meaning is "relative to
+ * what the positions read serves": a claim matched by a broader predicate
+ * would mark a holding recorded while `/vault-positions` still hides it, and
+ * the Treasury would understate with reconciliation reporting all clear.
+ *
+ * Binds, in order: organization_id, environment, custody wallet id array.
+ */
+const CUSTODY_VAULT_CLAIM_VISIBILITY_SQL = `organization_id = ?
+               AND environment = ?
+               AND kind = 'vault_direct'
+               AND activated_at IS NOT NULL
+               AND (
+                 closed_at IS NULL
+                 OR EXISTS (
+                   SELECT 1
+                   FROM earn_movements reentry
+                   WHERE reentry.position_id = earn_positions.id
+                     AND reentry.direction = 'deposit'
+                     AND reentry.status IN ('requested', 'submitted')
+                 )
+               )
+               AND custody_wallet_id = ANY (?::text[])
+               AND EXISTS (
+                 SELECT 1
+                 FROM earn_movements movement
+                 WHERE movement.position_id = earn_positions.id
+                   AND movement.status IN ('requested', 'submitted', 'confirmed', 'finalized')
+               )`;
+
 export function createPostgresEarnMovementsRepository(db: AppDb): EarnMovementsRepository {
   return {
     async getMovementById(params) {
@@ -927,27 +973,7 @@ export function createPostgresEarnMovementsRepository(db: AppDb): EarnMovementsR
       const result = await db
         .prepare(
           `SELECT * FROM earn_positions
-             WHERE organization_id = ?
-               AND environment = ?
-               AND kind = 'vault_direct'
-               AND activated_at IS NOT NULL
-               AND (
-                 closed_at IS NULL
-                 OR EXISTS (
-                   SELECT 1
-                   FROM earn_movements reentry
-                   WHERE reentry.position_id = earn_positions.id
-                     AND reentry.direction = 'deposit'
-                     AND reentry.status IN ('requested', 'submitted')
-                 )
-               )
-               AND custody_wallet_id = ANY (?::text[])
-               AND EXISTS (
-                 SELECT 1
-                 FROM earn_movements movement
-                 WHERE movement.position_id = earn_positions.id
-                   AND movement.status IN ('requested', 'submitted', 'confirmed', 'finalized')
-               )
+             WHERE ${CUSTODY_VAULT_CLAIM_VISIBILITY_SQL}
                ${beforeClause}
              ORDER BY created_at DESC, id DESC
              LIMIT ?`
@@ -962,6 +988,33 @@ export function createPostgresEarnMovementsRepository(db: AppDb): EarnMovementsR
         .all<EarnPositionRow>();
       const rows = result.results ?? [];
       return { rows: rows.slice(0, params.limit), hasMore: rows.length > params.limit };
+    },
+
+    async listVaultClaimsForReconciliation(params) {
+      if (params.custodyWalletIds.length === 0) {
+        return [];
+      }
+      // `has_unsettled_movements` uses the vault ledger's NON-TERMINAL set
+      // (finalized|failed are the only terminal statuses). A claim with an
+      // in-flight movement is excluded from zero-share reporting by the
+      // service: the ledger already explains why chain and record disagree,
+      // and the every-minute sweep will settle it either way.
+      const result = await db
+        .prepare(
+          `SELECT *,
+                  EXISTS (
+                    SELECT 1
+                    FROM earn_movements unsettled
+                    WHERE unsettled.position_id = earn_positions.id
+                      AND unsettled.status IN ('requested', 'submitted', 'confirmed')
+                  ) AS has_unsettled_movements
+             FROM earn_positions
+             WHERE ${CUSTODY_VAULT_CLAIM_VISIBILITY_SQL}
+             ORDER BY created_at DESC, id DESC`
+        )
+        .bind(params.organizationId, params.environment, params.custodyWalletIds)
+        .all<EarnPositionRow & { has_unsettled_movements: boolean }>();
+      return result.results ?? [];
     },
 
     async listExternalWalletPositions(params) {

--- a/apps/sdp-api/src/db/repositories/earn.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/earn.repository.postgres.ts
@@ -231,6 +231,20 @@ export function createPostgresEarnRepository(db: AppDb): EarnRepository {
       return row ? mapStrategyRow(row) : null;
     },
 
+    async listShareMintedStrategies(params) {
+      const result = await db
+        .prepare(
+          `SELECT * FROM earn_strategies
+             WHERE environment = ?
+               AND host_cluster = ?
+               AND share_mint IS NOT NULL
+             ORDER BY created_at ASC, id ASC`
+        )
+        .bind(params.environment, params.hostCluster)
+        .all<Record<string, unknown>>();
+      return (result.results ?? []).map(mapStrategyRow);
+    },
+
     async deleteUnlistedStrategies(input: DeleteUnlistedEarnStrategiesInput) {
       // Only `active` rows are deleted. An operator `paused`/`deprecated` is a
       // deliberate human record, and it is load-bearing: upsertStrategy refuses

--- a/apps/sdp-api/src/db/repositories/earn.repository.ts
+++ b/apps/sdp-api/src/db/repositories/earn.repository.ts
@@ -258,6 +258,18 @@ export interface EarnRepository {
   getStrategyById(strategyId: string): Promise<EarnStrategyRow | null>;
   listStrategies(input: ListEarnStrategiesInput): Promise<ListEarnStrategiesResult>;
   /**
+   * Every catalogued strategy that mints a share token on the given cluster,
+   * for share-mint → vault attribution (PRO-1741). The WHOLE stored inventory
+   * on purpose: no status filter and no curation, because a held share of a
+   * paused or hidden vault still identifies real money. Cluster-scoped so a
+   * sandbox environment's browse-only mainnet mirror (PRO-1742) can never
+   * claim a balance read from the environment's own cluster.
+   */
+  listShareMintedStrategies(params: {
+    environment: SdpEnvironment;
+    hostCluster: SolanaCluster;
+  }): Promise<EarnStrategyRow[]>;
+  /**
    * DELETE every `active` strategy for (provider, environment) — optionally
    * narrowed to one cluster's sub-shelf — that the provider no longer lists.
    * Returns the deleted provider references so the caller can log exactly what

--- a/apps/sdp-api/src/openapi/paths/earn.ts
+++ b/apps/sdp-api/src/openapi/paths/earn.ts
@@ -28,6 +28,7 @@ import {
   earnStrategyResponse,
   earnVaultDepositPreviewRequest,
   earnVaultDepositPreviewResponse,
+  earnVaultShareReconciliationResponse,
 } from "../schemas/earn";
 import {
   errorResponses,
@@ -47,6 +48,9 @@ const earnPublicSecurity: Array<Record<string, string[]>> = [{ apiKeyAuth: [] }]
 export function registerEarnPaths(registry: OpenAPIRegistry) {
   registerEarnStrategyPaths(registry, earnConfigurationSecurity);
   registerEarnDepositPreviewPath(registry, earnConfigurationSecurity);
+  // Treasury-facing, so the internal document only: partners hold no custody
+  // wallets for this read to reconcile.
+  registerEarnVaultShareReconciliationPath(registry, earnConfigurationSecurity);
   registerEarnExternalWalletPaths(registry, earnConfigurationSecurity);
 }
 
@@ -142,6 +146,36 @@ function registerEarnDepositPreviewPath(
         content: jsonContent(earnVaultDepositPreviewResponse),
       },
       ...errorResponses(errorResponseSchema, [400, 401, 403, 404, 429, 500, 501, 503]),
+    },
+  });
+}
+
+function registerEarnVaultShareReconciliationPath(
+  registry: OpenAPIRegistry,
+  security: Array<Record<string, string[]>>
+) {
+  registry.registerPath({
+    method: "get",
+    path: "/v1/earn/vault-share-reconciliation",
+    tags: ["Earn"],
+    summary: "Reconcile custody vault shares against recorded positions",
+    operationId: "getEarnVaultShareReconciliation",
+    description:
+      "Report-only comparison of each scoped custody wallet's on-chain share balances against " +
+      "the recorded claim set, both directions: share balances of catalogued vaults with no " +
+      "recorded position (for example, shares acquired by signing outside SDP), and recorded " +
+      "open positions whose wallet holds none of their shares. Writes nothing. Takes the same " +
+      "wallet-binding scope as the positions read and no provider gate.",
+    security,
+    request: {
+      headers: projectScopeHeaders,
+    },
+    responses: {
+      200: {
+        description: "Reconciliation report",
+        content: jsonContent(earnVaultShareReconciliationResponse),
+      },
+      ...errorResponses(errorResponseSchema, [401, 403, 429, 500, 503]),
     },
   });
 }

--- a/apps/sdp-api/src/openapi/schemas/earn.ts
+++ b/apps/sdp-api/src/openapi/schemas/earn.ts
@@ -351,6 +351,72 @@ export const earnVaultDepositPreviewResponse = successResponseSchema(
   })
 );
 
+export const earnVaultShareReconciliationResponse = successResponseSchema(
+  z.object({
+    unrecordedHoldings: z
+      .array(
+        z.object({
+          custodyWalletId: z.string().openapi({ example: "cwlt_example" }),
+          walletAddress: z
+            .string()
+            .openapi({ example: "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM" }),
+          provider: z.string().openapi({ example: "kamino" }),
+          strategyId: z.string().openapi({ example: "earn_strategy_example" }),
+          strategyName: z.string().openapi({ example: "USDC Prime Vault" }),
+          vaultAddress: z.string().openapi({
+            description: "The catalogued vault the held share mint attributes to.",
+          }),
+          shareMint: z.string(),
+          shares: z.string().openapi({
+            description: "Raw share-token amount in base units.",
+            example: "500",
+          }),
+          decimals: z.number().int().openapi({ example: 6 }),
+          uiShares: z.string().openapi({ example: "0.0005" }),
+          ambiguousAttribution: z.boolean().openapi({
+            description:
+              "True when more than one catalogued vault identity claims this share mint, so " +
+              "the attribution is the best candidate rather than the only one.",
+          }),
+        })
+      )
+      .openapi({
+        description:
+          "Share balances the custody wallet holds for catalogued vaults with no recorded " +
+          "open position behind them (for example, shares acquired by signing outside SDP).",
+      }),
+    unbackedPositions: z
+      .array(
+        z.object({
+          positionId: z.string().openapi({ example: "earn_position_example" }),
+          custodyWalletId: z.string().openapi({ example: "cwlt_example" }),
+          walletAddress: z.string(),
+          provider: z.string().openapi({ example: "kamino" }),
+          vaultAddress: z.string().nullable(),
+          shareMint: z.string().nullable(),
+          label: z.string(),
+        })
+      )
+      .openapi({
+        description:
+          "Recorded open positions whose wallet holds none of their shares. Positions with an " +
+          "unsettled movement are excluded: the ledger already explains that disagreement.",
+      }),
+    unreadableWallets: z
+      .array(
+        z.object({
+          custodyWalletId: z.string().openapi({ example: "cwlt_example" }),
+          walletAddress: z.string(),
+        })
+      )
+      .openapi({
+        description:
+          "Wallets whose balance read failed or ran out of the request budget. Their claims " +
+          "are unjudged in this report, never closed or marked unbacked.",
+      }),
+  })
+);
+
 export const earnExternalWalletWithdrawalPreviewResponse = successResponseSchema(
   z.object({
     positionId: z.string().openapi({ example: "earn_position_example" }),

--- a/apps/sdp-api/src/routes/earn.vault-share-reconciliation.test.ts
+++ b/apps/sdp-api/src/routes/earn.vault-share-reconciliation.test.ts
@@ -1,0 +1,362 @@
+import { hashString } from "@sdp/payments/hash";
+import type { CachedApiKey } from "@sdp/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getDb } from "@/db";
+import type { UpsertEarnStrategyInput } from "@/db/repositories/earn.repository";
+import { createPostgresEarnRepository } from "@/db/repositories/earn.repository.postgres";
+import { createPostgresEarnMovementsRepository } from "@/db/repositories/earn-movements.repository";
+import app from "@/index";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import { clearKVStores, seedCachedApiKey } from "@/test/mocks/kv";
+
+const { getSplTokenBalances } = vi.hoisted(() => ({ getSplTokenBalances: vi.fn() }));
+vi.mock("@/routes/payments/token-accounts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/routes/payments/token-accounts")>()),
+  getSplTokenBalances,
+}));
+
+// The endpoint genesis-proof and per-cluster URL resolution are chain-facing;
+// balances themselves come from the mocked read above, so no RPC request is
+// ever issued by these tests.
+const { assertClusterEndpoint, resolveClusterRpcUrl } = vi.hoisted(() => ({
+  assertClusterEndpoint: vi.fn(async () => {}),
+  resolveClusterRpcUrl: vi.fn(() => "http://127.0.0.1:8899"),
+}));
+vi.mock("@/services/earn/execution-registry", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/earn/execution-registry")>()),
+  assertClusterEndpoint,
+  resolveClusterRpcUrl,
+}));
+
+const ORG = "org_share_reconciliation";
+const USER = "usr_share_reconciliation";
+const PROJECT_A = "prj_share_reconciliation_a";
+const PROJECT_B = "prj_share_reconciliation_b";
+const CONFIG_A = "cfg_share_reconciliation_a";
+const CONFIG_A2 = "cfg_share_reconciliation_a2";
+const CONFIG_B = "cfg_share_reconciliation_b";
+const WALLET_A = "cwlt_share_reconciliation_a";
+const WALLET_A2 = "cwlt_share_reconciliation_a2";
+const WALLET_B = "cwlt_share_reconciliation_b";
+const PROVIDER_WALLET_A = "privy_share_reconciliation_a";
+const PROVIDER_WALLET_A2 = "privy_share_reconciliation_a2";
+const PROVIDER_WALLET_B = "privy_share_reconciliation_b";
+const PUBLIC_KEY_A = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+const PUBLIC_KEY_A2 = "mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So";
+const PUBLIC_KEY_B = "3nMFwZXwY1s1M5s8vYAHqd4wGs4iSxXE4LRoUMMYqEgF";
+const TOKEN_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const SHARE_MINT_CATALOGUED = "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN";
+const SHARE_MINT_RECORDED = "So11111111111111111111111111111111111111112";
+const SHARE_MINT_EMPTY = "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263";
+const SHARE_MINT_MIRROR = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB";
+const API_KEY = { id: "key_share_reconciliation", raw: "sk_test_share_reconciliation" };
+
+function cachedKey(): CachedApiKey {
+  return {
+    id: API_KEY.id,
+    organizationId: ORG,
+    projectId: PROJECT_A,
+    role: "api_admin",
+    permissions: ["*"],
+    environment: "sandbox",
+    rateLimitTier: "standard",
+    allowedIps: null,
+    signingWalletId: null,
+    status: "active",
+    expiresAt: null,
+  };
+}
+
+async function seedScope(): Promise<void> {
+  const keyHash = await hashString(API_KEY.raw, env.API_KEY_PEPPER);
+  await seedCachedApiKey(env, keyHash, cachedKey());
+  await getDb(env).batch([
+    getDb(env)
+      .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
+      .bind(ORG, "Share Reconciliation Org", "share-reconciliation", "enterprise", "active"),
+    getDb(env)
+      .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')")
+      .bind(USER, "share-reconciliation@example.com"),
+    ...[PROJECT_A, PROJECT_B].map((projectId, index) =>
+      getDb(env)
+        .prepare(
+          `INSERT INTO projects
+             (id, organization_id, name, slug, environment, status, created_by)
+           VALUES (?, ?, ?, ?, 'sandbox', 'active', ?)`
+        )
+        .bind(projectId, ORG, `Project ${index}`, `share-reconciliation-${index}`, USER)
+    ),
+    getDb(env)
+      .prepare(
+        `INSERT INTO api_keys
+           (id, organization_id, project_id, created_by, name, key_prefix, key_hash, role, permissions, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'api_admin', '["*"]'::jsonb, 'active')`
+      )
+      .bind(API_KEY.id, ORG, PROJECT_A, USER, "Reconciliation key", "sk_test_sha", keyHash),
+    ...[
+      [CONFIG_A, PROJECT_A, WALLET_A, PROVIDER_WALLET_A, PUBLIC_KEY_A],
+      [CONFIG_B, PROJECT_B, WALLET_B, PROVIDER_WALLET_B, PUBLIC_KEY_B],
+    ].flatMap(([configId, projectId, walletId, providerWalletId, publicKey]) => [
+      getDb(env)
+        .prepare(
+          `INSERT INTO custody_configs
+             (id, organization_id, project_id, provider, config_encrypted, status)
+           VALUES (?, ?, ?, 'privy', 'encrypted', 'active')`
+        )
+        .bind(configId, ORG, projectId),
+      getDb(env)
+        .prepare(
+          `INSERT INTO custody_wallets
+             (id, custody_config_id, wallet_id, public_key, status)
+           VALUES (?, ?, ?, ?, 'active')`
+        )
+        .bind(walletId, configId, providerWalletId, publicKey),
+    ]),
+  ]);
+}
+
+/**
+ * A second wallet PROJECT_A can see, through an ORGANIZATION-level config
+ * (`project_id IS NULL` — a second project-level 'privy' config would violate
+ * the (org, project, provider) unique). Same visibility either way:
+ * `listWallets` hands org-level configs to every project.
+ */
+async function seedSecondProjectAWallet(): Promise<void> {
+  await getDb(env).batch([
+    getDb(env)
+      .prepare(
+        `INSERT INTO custody_configs
+           (id, organization_id, project_id, provider, config_encrypted, status)
+         VALUES (?, ?, NULL, 'privy', 'encrypted', 'active')`
+      )
+      .bind(CONFIG_A2, ORG),
+    getDb(env)
+      .prepare(
+        `INSERT INTO custody_wallets
+           (id, custody_config_id, wallet_id, public_key, status)
+         VALUES (?, ?, ?, ?, 'active')`
+      )
+      .bind(WALLET_A2, CONFIG_A2, PROVIDER_WALLET_A2, PUBLIC_KEY_A2),
+  ]);
+}
+
+async function seedStrategy(overrides: Partial<UpsertEarnStrategyInput> = {}) {
+  const strategy = await createPostgresEarnRepository(getDb(env)).upsertStrategy({
+    provider: "kamino",
+    providerReference: `vault-${crypto.randomUUID()}`,
+    name: "Reconciliation USDC Vault",
+    sourceKind: "defi",
+    underlyingSource: "kamino",
+    depositMints: [TOKEN_MINT],
+    shareMint: SHARE_MINT_CATALOGUED,
+    apyType: "variable",
+    currentApy: "0.062",
+    liquidityTerm: "instant",
+    redemptionDelayDays: null,
+    riskMetadata: {},
+    status: "active",
+    hostCluster: "devnet",
+    environment: "sandbox",
+    ...overrides,
+  });
+  if (!strategy) {
+    throw new Error("Failed to seed earn strategy");
+  }
+  return strategy;
+}
+
+async function createPosition(params: {
+  projectId?: string;
+  walletId?: string;
+  providerReference?: string;
+  shareMint?: string;
+}) {
+  const providerReference = params.providerReference ?? `vault_${crypto.randomUUID()}`;
+  return createPostgresEarnMovementsRepository(getDb(env)).createSignedVaultDepositIntent({
+    organizationId: ORG,
+    projectId: params.projectId ?? PROJECT_A,
+    environment: "sandbox",
+    provider: "kamino",
+    vaultAddress: providerReference,
+    custodyWalletId: params.walletId ?? WALLET_A,
+    sourceAddress: PUBLIC_KEY_A,
+    tokenMint: TOKEN_MINT,
+    shareMint: params.shareMint ?? SHARE_MINT_RECORDED,
+    label: `Vault ${providerReference}`,
+    requestedAmount: "1",
+    signature: `sig_${crypto.randomUUID()}`,
+    signedTransaction: "AQ==",
+    lastValidBlockHeight: "12345",
+    requestId: crypto.randomUUID(),
+    idempotencyFingerprint: `fingerprint_${providerReference}`,
+    createdBy: USER,
+  });
+}
+
+async function finalizeMovement(movementId: string): Promise<void> {
+  const now = new Date().toISOString();
+  const advanced = await createPostgresEarnMovementsRepository(getDb(env)).advanceVaultMovement({
+    movementId,
+    organizationId: ORG,
+    toStatus: "finalized",
+    confirmedAt: now,
+    settledAt: now,
+  });
+  if (!advanced) {
+    throw new Error(`Failed to finalize movement ${movementId}`);
+  }
+}
+
+function balance(mint: string, amount: string, decimals = 6) {
+  return { token: "custom", mint, amount, uiAmount: amount, decimals };
+}
+
+function getReconciliation() {
+  return app.request(
+    "/v1/earn/vault-share-reconciliation",
+    { headers: { Authorization: `Bearer ${API_KEY.raw}` } },
+    env
+  );
+}
+
+interface ReportBody {
+  data: {
+    unrecordedHoldings: Array<Record<string, unknown>>;
+    unbackedPositions: Array<Record<string, unknown>>;
+    unreadableWallets: Array<Record<string, unknown>>;
+  };
+}
+
+beforeEach(async () => {
+  env.MARKETS_ENABLED = "true";
+  env.EARN_ENABLED = "true";
+  await seedTestDatabase(env);
+  await clearKVStores(env);
+  await seedScope();
+  vi.clearAllMocks();
+  assertClusterEndpoint.mockResolvedValue(undefined);
+  resolveClusterRpcUrl.mockReturnValue("http://127.0.0.1:8899");
+  getSplTokenBalances.mockResolvedValue([]);
+});
+
+describe("GET /v1/earn/vault-share-reconciliation", () => {
+  it("surfaces a catalogued share balance that has no recorded claim behind it", async () => {
+    const strategy = await seedStrategy();
+    getSplTokenBalances.mockResolvedValue([balance(SHARE_MINT_CATALOGUED, "500")]);
+
+    const response = await getReconciliation();
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as ReportBody;
+
+    expect(body.data.unrecordedHoldings).toEqual([
+      {
+        custodyWalletId: WALLET_A,
+        walletAddress: PUBLIC_KEY_A,
+        provider: "kamino",
+        strategyId: strategy.id,
+        strategyName: strategy.name,
+        vaultAddress: strategy.provider_reference,
+        shareMint: SHARE_MINT_CATALOGUED,
+        shares: "500",
+        decimals: 6,
+        uiShares: "500",
+      },
+    ]);
+    expect(body.data.unbackedPositions).toEqual([]);
+    expect(body.data.unreadableWallets).toEqual([]);
+  });
+
+  it("reports a settled claim whose wallet holds none of its shares, and not one that is backed", async () => {
+    const backed = await createPosition({ shareMint: SHARE_MINT_RECORDED });
+    await finalizeMovement(backed.movement.id);
+    const empty = await createPosition({ shareMint: SHARE_MINT_EMPTY });
+    await finalizeMovement(empty.movement.id);
+    getSplTokenBalances.mockResolvedValue([balance(SHARE_MINT_RECORDED, "250")]);
+
+    const response = await getReconciliation();
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as ReportBody;
+
+    expect(body.data.unbackedPositions).toEqual([
+      expect.objectContaining({
+        positionId: empty.position.id,
+        custodyWalletId: WALLET_A,
+        shareMint: SHARE_MINT_EMPTY,
+      }),
+    ]);
+    // The backed claim's balance is recorded, so it is not an unrecorded
+    // holding — even without a catalogue row for its mint.
+    expect(body.data.unrecordedHoldings).toEqual([]);
+    expect(body.data.unreadableWallets).toEqual([]);
+  });
+
+  it("keeps a claim with an unsettled movement out of the zero-share report", async () => {
+    await createPosition({ shareMint: SHARE_MINT_RECORDED });
+
+    const response = await getReconciliation();
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as ReportBody;
+
+    expect(body.data.unbackedPositions).toEqual([]);
+    expect(body.data.unreadableWallets).toEqual([]);
+  });
+
+  it("never reads or reports a wallet outside the key's binding scope", async () => {
+    await seedSecondProjectAWallet();
+    await seedStrategy();
+    getSplTokenBalances.mockResolvedValue([balance(SHARE_MINT_CATALOGUED, "500")]);
+    const keyHash = await hashString(API_KEY.raw, env.API_KEY_PEPPER);
+    await seedCachedApiKey(env, keyHash, {
+      ...cachedKey(),
+      signingWalletId: PROVIDER_WALLET_A,
+      walletBindings: [{ walletId: PROVIDER_WALLET_A, permissions: ["earn:read"] }],
+    });
+
+    const response = await getReconciliation();
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as ReportBody;
+
+    expect(getSplTokenBalances).toHaveBeenCalledTimes(1);
+    expect(getSplTokenBalances.mock.calls[0]?.[1]).toBe(PUBLIC_KEY_A);
+    expect(body.data.unrecordedHoldings).toEqual([
+      expect.objectContaining({ custodyWalletId: WALLET_A, walletAddress: PUBLIC_KEY_A }),
+    ]);
+  });
+
+  it("names an unreadable wallet, withdraws its zero-share findings, and touches no rows", async () => {
+    const claim = await createPosition({ shareMint: SHARE_MINT_EMPTY });
+    await finalizeMovement(claim.movement.id);
+    getSplTokenBalances.mockRejectedValue(new Error("rpc unavailable"));
+
+    const response = await getReconciliation();
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as ReportBody;
+
+    expect(body.data.unreadableWallets).toEqual([
+      { custodyWalletId: WALLET_A, walletAddress: PUBLIC_KEY_A },
+    ]);
+    expect(body.data.unbackedPositions).toEqual([]);
+    expect(body.data.unrecordedHoldings).toEqual([]);
+
+    const row = await createPostgresEarnMovementsRepository(getDb(env)).getPositionById({
+      organizationId: ORG,
+      environment: "sandbox",
+      positionId: claim.position.id,
+    });
+    expect(row?.closed_at).toBeNull();
+  });
+
+  it("never attributes a balance through the browse-only mirror of the other cluster's shelf", async () => {
+    await seedStrategy({ shareMint: SHARE_MINT_MIRROR, hostCluster: "mainnet-beta" });
+    getSplTokenBalances.mockResolvedValue([balance(SHARE_MINT_MIRROR, "500")]);
+
+    const response = await getReconciliation();
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as ReportBody;
+
+    expect(body.data.unrecordedHoldings).toEqual([]);
+    expect(body.data.unbackedPositions).toEqual([]);
+    expect(body.data.unreadableWallets).toEqual([]);
+  });
+});

--- a/apps/sdp-api/src/routes/earn.vault-share-reconciliation.test.ts
+++ b/apps/sdp-api/src/routes/earn.vault-share-reconciliation.test.ts
@@ -29,6 +29,20 @@ vi.mock("@/services/earn/execution-registry", async (importOriginal) => ({
   resolveClusterRpcUrl,
 }));
 
+// Lets one test shrink the pass budget to prove the deadline posture; null
+// keeps the handler's real default.
+const { deadlineTimeoutOverride } = vi.hoisted(() => ({
+  deadlineTimeoutOverride: { ms: null as number | null },
+}));
+vi.mock("@/services/earn/vault-deadline", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/services/earn/vault-deadline")>();
+  return {
+    ...original,
+    createVaultDeadline: (timeoutMs?: number) =>
+      original.createVaultDeadline(deadlineTimeoutOverride.ms ?? timeoutMs),
+  };
+});
+
 const ORG = "org_share_reconciliation";
 const USER = "usr_share_reconciliation";
 const PROJECT_A = "prj_share_reconciliation_a";
@@ -235,6 +249,7 @@ beforeEach(async () => {
   await clearKVStores(env);
   await seedScope();
   vi.clearAllMocks();
+  deadlineTimeoutOverride.ms = null;
   assertClusterEndpoint.mockResolvedValue(undefined);
   resolveClusterRpcUrl.mockReturnValue("http://127.0.0.1:8899");
   getSplTokenBalances.mockResolvedValue([]);
@@ -261,10 +276,47 @@ describe("GET /v1/earn/vault-share-reconciliation", () => {
         shares: "500",
         decimals: 6,
         uiShares: "500",
+        ambiguousAttribution: false,
       },
     ]);
     expect(body.data.unbackedPositions).toEqual([]);
     expect(body.data.unreadableWallets).toEqual([]);
+  });
+
+  it("prefers the active catalogue row for a duplicated share mint and flags the ambiguity", async () => {
+    const active = await seedStrategy({ providerReference: "vault-active" });
+    await seedStrategy({ providerReference: "vault-superseded", status: "deprecated" });
+    getSplTokenBalances.mockResolvedValue([balance(SHARE_MINT_CATALOGUED, "500")]);
+
+    const response = await getReconciliation();
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as ReportBody;
+
+    expect(body.data.unrecordedHoldings).toEqual([
+      expect.objectContaining({
+        strategyId: active.id,
+        vaultAddress: "vault-active",
+        ambiguousAttribution: true,
+      }),
+    ]);
+  });
+
+  it("reports wallets the request budget could not read instead of hanging or skipping them", async () => {
+    const claim = await createPosition({ shareMint: SHARE_MINT_EMPTY });
+    await finalizeMovement(claim.movement.id);
+    deadlineTimeoutOverride.ms = 1;
+    getSplTokenBalances.mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve([]), 100))
+    );
+
+    const response = await getReconciliation();
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as ReportBody;
+
+    expect(body.data.unreadableWallets).toEqual([
+      { custodyWalletId: WALLET_A, walletAddress: PUBLIC_KEY_A },
+    ]);
+    expect(body.data.unbackedPositions).toEqual([]);
   });
 
   it("reports a settled claim whose wallet holds none of its shares, and not one that is backed", async () => {

--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -677,8 +677,11 @@ organization's own custody wallets.
   `unrecordedHoldings` (held shares of a catalogued vault with no visible claim)
   and `unbackedPositions` (a visible claim whose wallet holds none of its
   shares; a claim with an unsettled movement is excluded — the ledger already
-  explains that disagreement and the sweep settles it). **Report-only in both
-  directions**: it writes, adopts, and closes nothing — an org-level custody
+  explains that disagreement and the sweep settles it). A duplicated share mint
+  attributes to the active-then-newest row and sets `ambiguousAttribution` when
+  the candidates disagree on the vault identity — `share_mint` carries no
+  uniqueness rule, and a re-listed vault leaves its predecessor row behind.
+  **Report-only in both directions**: it writes, adopts, and closes nothing — an org-level custody
   config is shared by sibling projects, so adoption would guess attribution,
   and a scan that writes money records fabricates claims the moment it has a
   bug. Claim visibility is the positions read's EXACT predicate by construction
@@ -688,7 +691,11 @@ organization's own custody wallets.
   org already holds). The endpoint is genesis-proven before any balance read — a
   wrong-cluster RPC would report every position unbacked — and a per-wallet
   read failure degrades to a named `unreadableWallets` entry whose claims go
-  unjudged, never a zero-share finding.
+  unjudged, never a zero-share finding. The whole pass runs under one
+  `VaultDeadline`, so a data-driven wallet count bounds what gets READ, never
+  how long the request runs: an over-budget wallet is unreadable, not a hung
+  request and not a silent skip. Registered in the INTERNAL OpenAPI document
+  only — partners hold no custody wallets for this read to reconcile.
 
 - `POST /vault-withdrawal-previews` — the exit QUOTE the dashboard derives its
   `minAmountOut` floor from (`supportsVaultWithdrawQuote`; 501 for a provider

--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -665,6 +665,31 @@ organization's own custody wallets.
   A failed chain read leaves a position UNHYDRATED rather than zero; reporting
   zero is a claim about someone's money that a failed RPC call cannot support.
 
+- `GET /vault-share-reconciliation` — chain-versus-ledger REPORT for the custody
+  claims above (PRO-1741). The positions read can only serve what SDP recorded,
+  and `self_service` custody credentials make divergence reachable (an org can
+  sign from the same wallet outside SDP). This read enumerates each scoped
+  wallet's SPL balances (`getSplTokenBalances`, both token programs), attributes
+  share mints through the STORED catalogue (`listShareMintedStrategies`: no
+  status filter and no curation — a paused or hidden vault's shares are still
+  money — but cluster-scoped, so the PRO-1742 mirror can never claim a balance
+  read from the environment's own cluster), and reports both disagreements:
+  `unrecordedHoldings` (held shares of a catalogued vault with no visible claim)
+  and `unbackedPositions` (a visible claim whose wallet holds none of its
+  shares; a claim with an unsettled movement is excluded — the ledger already
+  explains that disagreement and the sweep settles it). **Report-only in both
+  directions**: it writes, adopts, and closes nothing — an org-level custody
+  config is shared by sibling projects, so adoption would guess attribution,
+  and a scan that writes money records fabricates claims the moment it has a
+  bug. Claim visibility is the positions read's EXACT predicate by construction
+  (`CUSTODY_VAULT_CLAIM_VISIBILITY_SQL` — a broader match would mark a holding
+  recorded while `/vault-positions` still hides it), and wallet-binding scope is
+  the same `listReadableEarnVaultWallets`. No provider gate (ADR 0002: money the
+  org already holds). The endpoint is genesis-proven before any balance read — a
+  wrong-cluster RPC would report every position unbacked — and a per-wallet
+  read failure degrades to a named `unreadableWallets` entry whose claims go
+  unjudged, never a zero-share finding.
+
 - `POST /vault-withdrawal-previews` — the exit QUOTE the dashboard derives its
   `minAmountOut` floor from (`supportsVaultWithdrawQuote`; 501 for a provider
   without the capability), the deposit preview's mirror with deliberately

--- a/apps/sdp-api/src/routes/earn/handlers/vault-reconciliation.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/vault-reconciliation.ts
@@ -1,0 +1,81 @@
+import { createRpc } from "@sdp/rpc/solana";
+import { assertValidAddress } from "@sdp/solana/address";
+import { getDb } from "@/db";
+import { createPostgresEarnMovementsRepository } from "@/db/repositories/earn-movements.repository";
+import { getAuth, requireProjectId } from "@/lib/auth";
+import { success } from "@/lib/response";
+import { getSplTokenBalances } from "@/routes/payments/token-accounts";
+import {
+  assertClusterEndpoint,
+  earnClusterFor,
+  resolveClusterRpcUrl,
+} from "@/services/earn/execution-registry";
+import { reconcileVaultShareHoldings } from "@/services/earn/vault-share-reconciliation.service";
+import type { AppContext } from "../context";
+import { getEarnRepository, resolveSdpEnvironment } from "../context";
+import { listReadableEarnVaultWallets } from "./vault";
+
+/**
+ * GET /v1/earn/vault-share-reconciliation — custody share balances versus the
+ * recorded claim set, both directions (PRO-1741).
+ *
+ * `GET /vault-positions` can only report what SDP recorded, and the recorded
+ * set can genuinely diverge from chain: `self_service` custody credentials let
+ * an org sign from the same wallet outside SDP. This read enumerates each
+ * scoped wallet's SPL balances, attributes share mints through the stored
+ * catalogue, and reports the two disagreements — a held share balance with no
+ * visible claim, and a claim whose wallet holds none of its shares.
+ *
+ * REPORT-ONLY: it writes nothing, adopts nothing, closes nothing (the service
+ * header carries the why). NO provider gate, same ADR 0002 reason as the
+ * positions read — this reports on money the org already holds. It DOES take
+ * the positions read's exact wallet-binding scope: a bound key that cannot see
+ * wallet B's positions must not learn wallet B's balances here either.
+ *
+ * The endpoint is genesis-proven before any balance read: a misconfigured or
+ * wrong-cluster RPC must fail the whole pass (positions untouched, failure
+ * reported as an error) rather than read the wrong chain and report every
+ * position unbacked. Per-wallet read failures degrade instead to a named
+ * `unreadableWallets` entry, and that wallet's claims go unjudged.
+ */
+export async function getEarnVaultShareReconciliation(c: AppContext) {
+  const environment = resolveSdpEnvironment(c);
+  const auth = getAuth(c);
+  const projectId = requireProjectId(c);
+
+  const scopedWallets = await listReadableEarnVaultWallets(c, auth, projectId);
+  // A wallet can be projected once per custody config; reconcile each row once.
+  const walletsById = new Map<string, { id: string; publicKey: string }>();
+  for (const wallet of scopedWallets) {
+    if (!walletsById.has(wallet.id)) {
+      walletsById.set(wallet.id, { id: wallet.id, publicKey: wallet.publicKey });
+    }
+  }
+  if (walletsById.size === 0) {
+    return success(c, { unrecordedHoldings: [], unbackedPositions: [], unreadableWallets: [] });
+  }
+
+  const cluster = earnClusterFor(environment);
+  const [claims, strategies] = await Promise.all([
+    createPostgresEarnMovementsRepository(getDb(c.env)).listVaultClaimsForReconciliation({
+      organizationId: auth.organizationId,
+      environment,
+      custodyWalletIds: [...walletsById.keys()],
+    }),
+    getEarnRepository(c).listShareMintedStrategies({ environment, hostCluster: cluster }),
+  ]);
+
+  const rpcUrl = resolveClusterRpcUrl(c.env, cluster);
+  await assertClusterEndpoint(c.env, cluster, rpcUrl);
+  const rpc = createRpc(c.env, { rpcUrl });
+
+  const report = await reconcileVaultShareHoldings({
+    wallets: [...walletsById.values()],
+    claims,
+    strategies,
+    readBalances: (ownerAddress) =>
+      getSplTokenBalances(rpc, assertValidAddress(ownerAddress, "custodyWallet")),
+  });
+
+  return success(c, report);
+}

--- a/apps/sdp-api/src/routes/earn/handlers/vault-reconciliation.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/vault-reconciliation.ts
@@ -10,6 +10,7 @@ import {
   earnClusterFor,
   resolveClusterRpcUrl,
 } from "@/services/earn/execution-registry";
+import { createVaultDeadline } from "@/services/earn/vault-deadline";
 import { reconcileVaultShareHoldings } from "@/services/earn/vault-share-reconciliation.service";
 import type { AppContext } from "../context";
 import { getEarnRepository, resolveSdpEnvironment } from "../context";
@@ -36,7 +37,10 @@ import { listReadableEarnVaultWallets } from "./vault";
  * wrong-cluster RPC must fail the whole pass (positions untouched, failure
  * reported as an error) rather than read the wrong chain and report every
  * position unbacked. Per-wallet read failures degrade instead to a named
- * `unreadableWallets` entry, and that wallet's claims go unjudged.
+ * `unreadableWallets` entry, and that wallet's claims go unjudged. The whole
+ * pass shares one `VaultDeadline`, the same absolute budget every vault
+ * workflow runs under, so a data-driven wallet count bounds what gets read,
+ * never how long the request runs.
  */
 export async function getEarnVaultShareReconciliation(c: AppContext) {
   const environment = resolveSdpEnvironment(c);
@@ -75,6 +79,7 @@ export async function getEarnVaultShareReconciliation(c: AppContext) {
     strategies,
     readBalances: (ownerAddress) =>
       getSplTokenBalances(rpc, assertValidAddress(ownerAddress, "custodyWallet")),
+    deadline: createVaultDeadline(),
   });
 
   return success(c, report);

--- a/apps/sdp-api/src/routes/earn/index.ts
+++ b/apps/sdp-api/src/routes/earn/index.ts
@@ -46,6 +46,7 @@ import {
   listEarnVaultPositions,
   listEarnVaultWithdrawals,
 } from "./handlers/vault";
+import { getEarnVaultShareReconciliation } from "./handlers/vault-reconciliation";
 import {
   earnExternalWalletDepositTransactionSchema,
   earnExternalWalletSubmitSchema,
@@ -225,6 +226,17 @@ earn.get(
   "/vault-positions",
   requirePermissions("earn:read", "wallets:read"),
   listEarnVaultPositions
+);
+// Chain-versus-ledger reconciliation for the custody vault claims above
+// (PRO-1741): a REPORT of share balances the positions read cannot see (held
+// with no recorded claim) and claims the chain no longer backs (recorded, zero
+// shares). Report-only — it writes nothing — with no provider gate (it
+// describes money the org already holds) and the positions read's exact
+// wallet-binding scope, which is why it carries the same permission pair.
+earn.get(
+  "/vault-share-reconciliation",
+  requirePermissions("earn:read", "wallets:read"),
+  getEarnVaultShareReconciliation
 );
 
 // External-wallet (caller-signed) vault flows (PRO-1722): the B2B2C money

--- a/apps/sdp-api/src/services/earn/vault-share-reconciliation.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-share-reconciliation.service.ts
@@ -1,0 +1,176 @@
+import { mapSettledWithConcurrency } from "@/lib/concurrency";
+
+/**
+ * Reconcile custody-wallet share balances against recorded vault claims
+ * (PRO-1741).
+ *
+ * REPORT-ONLY by design, in both directions. An unrecorded holding is
+ * surfaced, never adopted into `earn_positions`: a custody wallet may be
+ * shared by sibling projects through an organization-level config, so an
+ * auto-created claim would have to guess attribution, and a scan that writes
+ * money records fabricates claims the moment it has a bug. The reverse
+ * finding never closes a row for the same reason — reporting is recoverable,
+ * a wrong write is not.
+ *
+ * Failure posture per wallet: an unreadable balance read names the wallet and
+ * withdraws every claim it would have judged. Zero-share findings in
+ * particular are claims about someone's money that a failed RPC read cannot
+ * support (the same rule hydration follows).
+ */
+
+/** One wallet's SPL balances; absence of a mint means a zero balance. */
+export type VaultShareBalanceReader = (
+  ownerAddress: string
+) => Promise<ReadonlyArray<{ mint: string; amount: string; decimals: number; uiAmount: string }>>;
+
+export interface ReconcilableVaultWallet {
+  /** `custody_wallets.id` (`cwlt_…`) — the id claim rows are scoped by. */
+  id: string;
+  publicKey: string;
+}
+
+export interface ReconcilableVaultClaim {
+  id: string;
+  custody_wallet_id: string | null;
+  provider: string;
+  vault_address: string | null;
+  share_mint: string | null;
+  label: string;
+  has_unsettled_movements: boolean;
+}
+
+export interface ReconcilableShareMintedStrategy {
+  id: string;
+  provider: string;
+  provider_reference: string;
+  name: string;
+  share_mint: string | null;
+}
+
+export interface UnrecordedVaultHolding {
+  custodyWalletId: string;
+  walletAddress: string;
+  provider: string;
+  strategyId: string;
+  strategyName: string;
+  vaultAddress: string;
+  shareMint: string;
+  /** Raw share-token amount, base units. */
+  shares: string;
+  decimals: number;
+  uiShares: string;
+}
+
+export interface UnbackedVaultPosition {
+  positionId: string;
+  custodyWalletId: string;
+  walletAddress: string;
+  provider: string;
+  vaultAddress: string | null;
+  shareMint: string | null;
+  label: string;
+}
+
+export interface UnreadableVaultWallet {
+  custodyWalletId: string;
+  walletAddress: string;
+}
+
+export interface VaultShareReconciliationReport {
+  unrecordedHoldings: UnrecordedVaultHolding[];
+  unbackedPositions: UnbackedVaultPosition[];
+  unreadableWallets: UnreadableVaultWallet[];
+}
+
+/** Same bound the positions hydration fan-out uses for per-owner reads. */
+const BALANCE_READ_CONCURRENCY = 8;
+
+export async function reconcileVaultShareHoldings(input: {
+  wallets: ReadonlyArray<ReconcilableVaultWallet>;
+  claims: ReadonlyArray<ReconcilableVaultClaim>;
+  strategies: ReadonlyArray<ReconcilableShareMintedStrategy>;
+  readBalances: VaultShareBalanceReader;
+}): Promise<VaultShareReconciliationReport> {
+  // First catalogue row wins a mint. Rows are unique per (provider, reference,
+  // environment) and one vault mints one share token, so a collision would be
+  // a catalogue defect; deterministic first-wins keeps the report stable
+  // rather than flapping between attributions.
+  const strategiesByShareMint = new Map<string, ReconcilableShareMintedStrategy>();
+  for (const strategy of input.strategies) {
+    if (strategy.share_mint && !strategiesByShareMint.has(strategy.share_mint)) {
+      strategiesByShareMint.set(strategy.share_mint, strategy);
+    }
+  }
+
+  const claimsByWalletId = new Map<string, ReconcilableVaultClaim[]>();
+  for (const claim of input.claims) {
+    if (!claim.custody_wallet_id) continue;
+    const walletClaims = claimsByWalletId.get(claim.custody_wallet_id);
+    if (walletClaims) walletClaims.push(claim);
+    else claimsByWalletId.set(claim.custody_wallet_id, [claim]);
+  }
+
+  const report: VaultShareReconciliationReport = {
+    unrecordedHoldings: [],
+    unbackedPositions: [],
+    unreadableWallets: [],
+  };
+
+  const wallets = [...input.wallets];
+  const settled = await mapSettledWithConcurrency(wallets, BALANCE_READ_CONCURRENCY, (wallet) =>
+    input.readBalances(wallet.publicKey)
+  );
+
+  wallets.forEach((wallet, index) => {
+    const outcome = settled[index];
+    const walletClaims = claimsByWalletId.get(wallet.id) ?? [];
+    if (!outcome || outcome.status === "rejected") {
+      report.unreadableWallets.push({
+        custodyWalletId: wallet.id,
+        walletAddress: wallet.publicKey,
+      });
+      return;
+    }
+
+    const balancesByMint = new Map(outcome.value.map((balance) => [balance.mint, balance]));
+    const recordedShareMints = new Set(
+      walletClaims.map((claim) => claim.share_mint).filter((mint) => mint !== null)
+    );
+
+    for (const balance of outcome.value) {
+      const strategy = strategiesByShareMint.get(balance.mint);
+      if (!strategy || recordedShareMints.has(balance.mint)) continue;
+      report.unrecordedHoldings.push({
+        custodyWalletId: wallet.id,
+        walletAddress: wallet.publicKey,
+        provider: strategy.provider,
+        strategyId: strategy.id,
+        strategyName: strategy.name,
+        vaultAddress: strategy.provider_reference,
+        shareMint: balance.mint,
+        shares: balance.amount,
+        decimals: balance.decimals,
+        uiShares: balance.uiAmount,
+      });
+    }
+
+    for (const claim of walletClaims) {
+      // A claim without a share mint cannot be judged against balances, and an
+      // in-flight movement already explains a chain/record disagreement — the
+      // sweep settles it within about a minute either way.
+      if (!claim.share_mint || claim.has_unsettled_movements) continue;
+      if (balancesByMint.has(claim.share_mint)) continue;
+      report.unbackedPositions.push({
+        positionId: claim.id,
+        custodyWalletId: wallet.id,
+        walletAddress: wallet.publicKey,
+        provider: claim.provider,
+        vaultAddress: claim.vault_address,
+        shareMint: claim.share_mint,
+        label: claim.label,
+      });
+    }
+  });
+
+  return report;
+}

--- a/apps/sdp-api/src/services/earn/vault-share-reconciliation.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-share-reconciliation.service.ts
@@ -1,4 +1,5 @@
 import { mapSettledWithConcurrency } from "@/lib/concurrency";
+import type { VaultDeadline } from "@/services/earn/vault-deadline";
 
 /**
  * Reconcile custody-wallet share balances against recorded vault claims
@@ -45,6 +46,8 @@ export interface ReconcilableShareMintedStrategy {
   provider_reference: string;
   name: string;
   share_mint: string | null;
+  status: string;
+  created_at: string;
 }
 
 export interface UnrecordedVaultHolding {
@@ -59,6 +62,13 @@ export interface UnrecordedVaultHolding {
   shares: string;
   decimals: number;
   uiShares: string;
+  /**
+   * True when more than one catalogued vault identity claims this share mint,
+   * so the attribution above is the best candidate rather than the only one.
+   * `share_mint` carries no uniqueness rule, and a paused or deprecated row
+   * stays in the inventory next to its re-listed successor.
+   */
+  ambiguousAttribution: boolean;
 }
 
 export interface UnbackedVaultPosition {
@@ -85,22 +95,63 @@ export interface VaultShareReconciliationReport {
 /** Same bound the positions hydration fan-out uses for per-owner reads. */
 const BALANCE_READ_CONCURRENCY = 8;
 
+/**
+ * All catalogue rows claiming one share mint, with the attribution the report
+ * names resolved up front: an `active` row beats a paused or deprecated one
+ * (the live catalogue truth beats a predecessor kept for its operator record),
+ * newest first within a status, id as the total-order tiebreak. The holding is
+ * flagged ambiguous only when the candidates disagree on the VAULT identity
+ * (provider + reference): a re-listed vault leaves two rows for one identity,
+ * and that is a superseded row, not an ambiguous mint.
+ */
+function resolveShareMintAttributions(
+  strategies: ReadonlyArray<ReconcilableShareMintedStrategy>
+): Map<string, { attributed: ReconcilableShareMintedStrategy; ambiguous: boolean }> {
+  const candidatesByMint = new Map<string, ReconcilableShareMintedStrategy[]>();
+  for (const strategy of strategies) {
+    if (!strategy.share_mint) continue;
+    const candidates = candidatesByMint.get(strategy.share_mint);
+    if (candidates) candidates.push(strategy);
+    else candidatesByMint.set(strategy.share_mint, [strategy]);
+  }
+
+  const attributions = new Map<
+    string,
+    { attributed: ReconcilableShareMintedStrategy; ambiguous: boolean }
+  >();
+  for (const [mint, candidates] of candidatesByMint) {
+    const ranked = [...candidates].sort((a, b) => {
+      const aActive = a.status === "active" ? 0 : 1;
+      const bActive = b.status === "active" ? 0 : 1;
+      if (aActive !== bActive) return aActive - bActive;
+      if (a.created_at !== b.created_at) return b.created_at.localeCompare(a.created_at);
+      return b.id.localeCompare(a.id);
+    });
+    const attributed = ranked[0];
+    if (!attributed) continue;
+    const identities = new Set(
+      candidates.map((candidate) => `${candidate.provider}\n${candidate.provider_reference}`)
+    );
+    attributions.set(mint, { attributed, ambiguous: identities.size > 1 });
+  }
+  return attributions;
+}
+
 export async function reconcileVaultShareHoldings(input: {
   wallets: ReadonlyArray<ReconcilableVaultWallet>;
   claims: ReadonlyArray<ReconcilableVaultClaim>;
   strategies: ReadonlyArray<ReconcilableShareMintedStrategy>;
   readBalances: VaultShareBalanceReader;
+  /**
+   * One absolute budget for the whole pass. The wallet count is data-driven,
+   * so without this a large tenant turns the endpoint into unbounded
+   * request-length RPC waves; with it, a wallet whose read cannot start or
+   * finish inside the budget lands in `unreadableWallets` (claims unjudged),
+   * never a hung request and never a silently skipped wallet.
+   */
+  deadline: VaultDeadline;
 }): Promise<VaultShareReconciliationReport> {
-  // First catalogue row wins a mint. Rows are unique per (provider, reference,
-  // environment) and one vault mints one share token, so a collision would be
-  // a catalogue defect; deterministic first-wins keeps the report stable
-  // rather than flapping between attributions.
-  const strategiesByShareMint = new Map<string, ReconcilableShareMintedStrategy>();
-  for (const strategy of input.strategies) {
-    if (strategy.share_mint && !strategiesByShareMint.has(strategy.share_mint)) {
-      strategiesByShareMint.set(strategy.share_mint, strategy);
-    }
-  }
+  const strategiesByShareMint = resolveShareMintAttributions(input.strategies);
 
   const claimsByWalletId = new Map<string, ReconcilableVaultClaim[]>();
   for (const claim of input.claims) {
@@ -118,7 +169,9 @@ export async function reconcileVaultShareHoldings(input: {
 
   const wallets = [...input.wallets];
   const settled = await mapSettledWithConcurrency(wallets, BALANCE_READ_CONCURRENCY, (wallet) =>
-    input.readBalances(wallet.publicKey)
+    input.deadline.run(`vault share balance read for ${wallet.publicKey}`, () =>
+      input.readBalances(wallet.publicKey)
+    )
   );
 
   wallets.forEach((wallet, index) => {
@@ -138,19 +191,20 @@ export async function reconcileVaultShareHoldings(input: {
     );
 
     for (const balance of outcome.value) {
-      const strategy = strategiesByShareMint.get(balance.mint);
-      if (!strategy || recordedShareMints.has(balance.mint)) continue;
+      const attribution = strategiesByShareMint.get(balance.mint);
+      if (!attribution || recordedShareMints.has(balance.mint)) continue;
       report.unrecordedHoldings.push({
         custodyWalletId: wallet.id,
         walletAddress: wallet.publicKey,
-        provider: strategy.provider,
-        strategyId: strategy.id,
-        strategyName: strategy.name,
-        vaultAddress: strategy.provider_reference,
+        provider: attribution.attributed.provider,
+        strategyId: attribution.attributed.id,
+        strategyName: attribution.attributed.name,
+        vaultAddress: attribution.attributed.provider_reference,
         shareMint: balance.mint,
         shares: balance.amount,
         decimals: balance.decimals,
         uiShares: balance.uiAmount,
+        ambiguousAttribution: attribution.ambiguous,
       });
     }
 


### PR DESCRIPTION
Closes [PRO-1741](https://linear.app/solana-fndn/issue/PRO-1741/reconcile-custody-wallet-vault-shares-against-recorded-positions). New report-only read `GET /v1/earn/vault-share-reconciliation`: custody-wallet share balances versus the recorded claim set, both directions.

**The decision the ticket asked for: surfaced discrepancy, not auto-recorded position.** Org-level custody configs are shared by sibling projects, so adopting a found holding into `earn_positions` would guess attribution, and a scanner that writes money records fabricates claims the moment it has a bug. The reverse direction never closes rows for the same reason.

**before**: divergence is invisible

1. `GET /vault-positions` lists `earn_positions` claims and hydrates each from chain
2. shares acquired outside SDP (reachable via `self_service` custody credentials) have no claim row and are never listed, so Treasury understates
3. a recorded claim whose shares left outside SDP hydrates to zero with no signal

**after**

1. enumerate each scoped wallet's SPL balances (`getSplTokenBalances`, both token programs)
2. attribute share mints through the stored catalogue (`listShareMintedStrategies`: no curation or status filter; cluster-scoped so the PRO-1742 sandbox mirror can never claim a devnet balance)
3. report `unrecordedHoldings` (held, no visible claim) and `unbackedPositions` (visible claim, zero shares; claims with unsettled movements excluded, the ledger already explains those)
4. a failed per-wallet read degrades to a named `unreadableWallets` entry whose claims go unjudged; the endpoint is genesis-proven before any balance read, and the whole pass runs under one `VaultDeadline` so wallet count bounds what gets read, never request length
5. a duplicated share mint attributes to the active-then-newest catalogue row and carries `ambiguousAttribution` when candidates disagree on the vault identity; the route is registered in the internal OpenAPI document

**Reviewer notes**

- **Claim visibility is the positions read's exact predicate**, extracted as `CUSTODY_VAULT_CLAIM_VISIBILITY_SQL` and shared by both queries. A broader match would mark holdings recorded while `/vault-positions` still hides them.
- Same permission pair and wallet-binding scope as `/vault-positions` (`listReadableEarnVaultWallets`); no provider gate (ADR 0002: it reports money the org already holds).
- No ledger writer touched; the movements repository gains two reads.

**Verification**

- New route suite 8/8: unrecorded holding seeded without a row; settled zero-share claim reported while an in-flight one is excluded; bound key reads only its own wallet; unreadable wallet named with rows untouched; cluster-mirror exclusion; ambiguous-mint attribution; over-budget wallet reported unreadable.
- Tenant isolation: the route takes no id; scoping is org + project + wallet binding in SQL, pinned by the sibling-project and binding tests (401 unauthenticated via shared auth middleware).
- 150 tests green across the new suite and five adjacent earn suites (`earn.vault-positions`, `earn.movements`, `earn.repository`, `earn`, `earn.vault`); `tsc` and `biome` clean.
- Live local-API curl evidence not captured (no LOCAL.md key available this session); the route tests drive the full Hono app against real Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

