### PR TITLE
feat(web): add Treasury and Embedded Yield icons to the Markets subnav

### DIFF
--- a/apps/sdp-web/src/components/dashboard-nav.ts
+++ b/apps/sdp-web/src/components/dashboard-nav.ts
@@ -9,7 +9,9 @@ import {
   CoinsIcon,
   FileTextIcon,
   KeyRoundIcon,
+  LandmarkIcon,
   LayoutDashboardIcon,
+  PercentIcon,
   ReceiptTextIcon,
   RepeatIcon,
   ShieldCheckIcon,
@@ -147,12 +149,14 @@ export function getMarketsActions(
     {
       label: t("Shared.dashboardShell.treasurySolutions"),
       href: DASHBOARD_MARKETS_SUBNAV_HREFS.treasurySolutions,
+      icon: LandmarkIcon,
     },
     ...(earnEnabled
       ? [
           {
             label: t("Shared.dashboardShell.earnProgram"),
             href: DASHBOARD_MARKETS_SUBNAV_HREFS.earnProgram,
+            icon: PercentIcon,
           },
         ]
       : []),

--- a/apps/sdp-web/src/components/dashboard-nav.unit.test.tsx
+++ b/apps/sdp-web/src/components/dashboard-nav.unit.test.tsx
@@ -1,3 +1,4 @@
+import { LandmarkIcon, PercentIcon } from "lucide-react";
 import type { ComponentProps } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
@@ -78,10 +79,12 @@ describe("Markets dashboard navigation", () => {
       {
         label: "Shared.dashboardShell.treasurySolutions",
         href: "/dashboard/markets/treasury-solutions",
+        icon: LandmarkIcon,
       },
       {
         label: "Shared.dashboardShell.earnProgram",
         href: "/dashboard/markets/embedded-yield",
+        icon: PercentIcon,
       },
     ]);
   });


### PR DESCRIPTION
Markets subnav rows were the only ones without icons. Treasury now uses `LandmarkIcon` and Embedded Yield uses `PercentIcon`, rendered through the existing `SubNavItem.icon` slot, so no renderer changes.

**before**: Payments children render icons; Treasury and Embedded Yield render text-only rows.

**after**: all subnav children render an icon through the same `child.icon` path in `dashboard-shell`.

**Reviewer notes**

- `LandmarkIcon` matches what the Markets landing card already uses for the Treasury destination.
- The landing card's `UsersRoundIcon` was deliberately not reused for Embedded Yield: it is near-identical to Counterparty's `UsersIcon` two rows up in the same sidebar. `HandCoins` was avoided too since issuance uses it for "seize". `PercentIcon` reads as yield/APY and is unused elsewhere in the app.
- The exact-match children assertion in `dashboard-nav.unit.test.tsx` now pins both icons.

**Screenshots**

![Sidebar with Payments and Markets expanded, every subnav row iconed](https://github.com/user-attachments/assets/719547b3-c617-4d5a-a882-d94a6fdd8c56)

![Markets landing with the new Treasury and Embedded Yield subnav icons](https://github.com/user-attachments/assets/533a684b-ff76-4576-af0c-29b9245b9739)

**Verification**

- `vitest run src/components/` — 15 files, 130 tests pass
- `tsc --noEmit` — clean in `src/` (remaining errors are a pre-existing stale `.next` artifact in the worktree)
- local app on this branch (API :8787 + web :3100): walked /dashboard → Markets in the browser; a Playwright pass signed in as the e2e admin and asserted `svg.lucide-landmark` inside the Treasury link and `svg.lucide-percent` inside the Embedded Yield link
- eslint not run: it currently crashes repo-wide on ESLint 10 + eslint-plugin-react, pre-existing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
