### PR TITLE
fix(compliance): make Chainalysis and Elliptic decisions unambiguous

### DIFF
--- a/apps/sdp-api/src/openapi/schemas/compliance.ts
+++ b/apps/sdp-api/src/openapi/schemas/compliance.ts
@@ -14,7 +14,7 @@ export const complianceProviderNameSchema = z
   .openapi({ description: "Compliance provider identifier.", example: "range" });
 
 export const complianceProviderStatusSchema = z
-  .enum(["ok", "unavailable", "error"])
+  .enum(["ok", "pending", "unavailable", "error"])
   .openapi({ description: "Provider response status.", example: "ok" });
 
 export const addressScreeningRequestSchema = screenAddressSchemaBase
@@ -45,6 +45,11 @@ export const complianceProviderResultSchema = z
     riskLevel: z.string().optional().openapi({
       description: "Provider-specific risk level label.",
       example: "High risk",
+    }),
+    providerStatus: z.string().optional().openapi({
+      description:
+        "The provider's own status word, verbatim, retained for audit; the normalized status field is the decision.",
+      example: "COMPLETE",
     }),
     message: z.string().optional().openapi({
       description: "Optional provider message, such as warnings or error details.",

--- a/apps/sdp-api/src/routes/compliance.test.ts
+++ b/apps/sdp-api/src/routes/compliance.test.ts
@@ -337,10 +337,13 @@ describe("Compliance routes", () => {
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(
+        // The documented synchronous wallet analysis carries risk_score at the
+        // TOP level; the old nested fixture only passed under the deep search
+        // this change removes (a nested per-rule score must never read as the
+        // wallet's verdict).
         JSON.stringify({
-          analysis: {
-            risk_score: 42,
-          },
+          risk_score: 42,
+          risk_level: "high",
         }),
         {
           status: 200,

--- a/apps/sdp-api/src/services/compliance/providers/chainalysis.test.ts
+++ b/apps/sdp-api/src/services/compliance/providers/chainalysis.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ChainalysisComplianceProvider } from "./chainalysis";
+
+const INPUT = { address: "addr1", network: "solana", intent: "unknown" as const };
+
+function provider() {
+  return new ChainalysisComplianceProvider({ apiKey: "key" });
+}
+
+function mockResponse(body: unknown, status = 200) {
+  vi.stubGlobal(
+    "fetch",
+    vi
+      .fn()
+      .mockResolvedValue(
+        new Response(typeof body === "string" ? body : JSON.stringify(body), { status })
+      )
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("ChainalysisComplianceProvider", () => {
+  it("reports a completed screening with a verdict as ok", async () => {
+    mockResponse({ status: "COMPLETE", risk: "Low", riskScore: 2 });
+    const result = await provider().screenAddress(INPUT);
+    expect(result).toMatchObject({
+      status: "ok",
+      riskScore: 2,
+      riskLevel: "Low",
+      providerStatus: "COMPLETE",
+    });
+  });
+
+  it("never reports a non-complete screening as ok", async () => {
+    // The reported defect: IN_PROGRESS used to come back status "ok".
+    mockResponse({ status: "IN_PROGRESS", riskScore: 5 });
+    const result = await provider().screenAddress(INPUT);
+    expect(result.status).toBe("pending");
+    expect(result.providerStatus).toBe("IN_PROGRESS");
+    expect(result.riskScore).toBeNull();
+  });
+
+  it("fails closed on a completed response with no verdict at all", async () => {
+    mockResponse({ status: "COMPLETE" });
+    const result = await provider().screenAddress(INPUT);
+    expect(result.status).toBe("error");
+  });
+
+  it("fails closed on conflicting risk-score aliases instead of guessing", async () => {
+    mockResponse({ status: "COMPLETE", riskScore: 2, risk_score: 9 });
+    const result = await provider().screenAddress(INPUT);
+    expect(result.status).toBe("error");
+    expect(result.message).toContain("conflicting");
+  });
+
+  it("fails closed on a body that is not JSON", async () => {
+    mockResponse("<html>gateway error</html>");
+    const result = await provider().screenAddress(INPUT);
+    expect(result.status).toBe("error");
+  });
+
+  it("reports an HTTP failure as error with the provider detail", async () => {
+    mockResponse({ message: "forbidden" }, 403);
+    const result = await provider().screenAddress(INPUT);
+    expect(result.status).toBe("error");
+    expect(result.message).toContain("403");
+  });
+});

--- a/apps/sdp-api/src/services/compliance/providers/chainalysis.test.ts
+++ b/apps/sdp-api/src/services/compliance/providers/chainalysis.test.ts
@@ -56,6 +56,15 @@ describe("ChainalysisComplianceProvider", () => {
     expect(result.message).toContain("conflicting");
   });
 
+  it("fails closed on a wrong-typed score rather than falling back to the level", async () => {
+    // Ignoring the malformed field and reading the level instead is a guess:
+    // the response says something about the score that we cannot interpret.
+    mockResponse({ status: "COMPLETE", risk: "Low", riskScore: "high" });
+    const result = await provider().screenAddress(INPUT);
+    expect(result.status).toBe("error");
+    expect(result.message).toContain("riskScore");
+  });
+
   it("fails closed on a body that is not JSON", async () => {
     mockResponse("<html>gateway error</html>");
     const result = await provider().screenAddress(INPUT);

--- a/apps/sdp-api/src/services/compliance/providers/chainalysis.ts
+++ b/apps/sdp-api/src/services/compliance/providers/chainalysis.ts
@@ -46,17 +46,23 @@ function extractErrorMessage(body: string): string {
   return body;
 }
 
-function readRiskScore(payload: ChainalysisRiskResponse): number | null {
-  if (typeof payload.riskScore === "number") {
-    return payload.riskScore;
+/**
+ * The numeric score under whichever alias this deployment's Chainalysis
+ * product spells it. Aliases are tolerated, ambiguity is not: two aliases
+ * carrying DIFFERENT numbers is a response we cannot interpret, and guessing
+ * between them would weaken a compliance decision — the caller fails closed.
+ */
+function readRiskScore(payload: ChainalysisRiskResponse): { score: number | null } | "ambiguous" {
+  const candidates = [payload.riskScore, payload.risk_score, payload.score].filter(
+    (value): value is number => typeof value === "number"
+  );
+  if (candidates.length === 0) {
+    return { score: null };
   }
-  if (typeof payload.risk_score === "number") {
-    return payload.risk_score;
+  if (new Set(candidates).size > 1) {
+    return "ambiguous";
   }
-  if (typeof payload.score === "number") {
-    return payload.score;
-  }
-  return null;
+  return { score: candidates[0] };
 }
 
 function readRiskLevel(payload: ChainalysisRiskResponse): string | undefined {
@@ -112,25 +118,67 @@ export class ChainalysisComplianceProvider implements ComplianceProvider {
         };
       }
 
-      const payload = (await response.json().catch(() => ({}))) as ChainalysisRiskResponse;
-      const riskScore = readRiskScore(payload);
+      const payload = (await response.json().catch(() => null)) as ChainalysisRiskResponse | null;
+      if (payload === null) {
+        return {
+          provider: this.name,
+          status: "error",
+          riskScore: null,
+          message: "Chainalysis returned a response that is not valid JSON.",
+          evaluatedAt,
+        };
+      }
+
+      const providerStatus = typeof payload.status === "string" ? payload.status : undefined;
+
+      // A screening the provider itself calls unfinished is NOT a verdict.
+      // Reporting it `ok` let an IN_PROGRESS response read as a pass; it is
+      // `pending`, and the raw status travels along for audit (HOO-1012).
+      if (providerStatus !== undefined && providerStatus !== "COMPLETE") {
+        return {
+          provider: this.name,
+          status: "pending",
+          riskScore: null,
+          providerStatus,
+          message: `Chainalysis screening is not complete (status: ${providerStatus}).`,
+          evaluatedAt,
+        };
+      }
+
+      const read = readRiskScore(payload);
       const riskLevel = readRiskLevel(payload);
-      const result: ComplianceProviderResult = {
+      if (read === "ambiguous") {
+        return {
+          provider: this.name,
+          status: "error",
+          riskScore: null,
+          ...(providerStatus !== undefined ? { providerStatus } : {}),
+          message: "Chainalysis returned conflicting risk-score fields; refusing to guess.",
+          evaluatedAt,
+        };
+      }
+
+      // A completed screening with neither a score nor a level carries no
+      // verdict at all — malformed, so fail closed rather than pass on it.
+      if (read.score === null && !riskLevel) {
+        return {
+          provider: this.name,
+          status: "error",
+          riskScore: null,
+          ...(providerStatus !== undefined ? { providerStatus } : {}),
+          message: "Chainalysis response carried no risk score or risk level.",
+          evaluatedAt,
+        };
+      }
+
+      return {
         provider: this.name,
         status: "ok",
-        riskScore,
+        riskScore: read.score,
+        ...(riskLevel ? { riskLevel } : {}),
+        ...(providerStatus !== undefined ? { providerStatus } : {}),
         evaluatedAt,
       };
-
-      if (riskLevel) {
-        result.riskLevel = riskLevel;
-      }
-
-      if (typeof payload.status === "string" && payload.status !== "COMPLETE") {
-        result.message = `Chainalysis screening status: ${payload.status}`;
-      }
-
-      return result;
     } catch (error) {
       return {
         provider: this.name,

--- a/apps/sdp-api/src/services/compliance/providers/chainalysis.ts
+++ b/apps/sdp-api/src/services/compliance/providers/chainalysis.ts
@@ -1,20 +1,32 @@
+import { z } from "zod";
 import type {
   ComplianceAddressScreeningInput,
   ComplianceProvider,
   ComplianceProviderResult,
 } from "../types";
+import { describeSchemaFailure, extractProviderErrorMessage } from "./provider-response";
 
 const DEFAULT_CHAINALYSIS_API_BASE_URL = "https://api.chainalysis.com";
 
-type ChainalysisRiskResponse = {
-  risk?: unknown;
-  riskLevel?: unknown;
-  risk_score?: unknown;
-  riskScore?: unknown;
-  score?: unknown;
-  status?: unknown;
-  message?: unknown;
-};
+/**
+ * The response is parsed at the boundary, not narrowed field by field further
+ * in. Every documented field is typed, and a field carrying the wrong type is
+ * a response we refuse to interpret rather than quietly ignore — reading past
+ * a malformed score is how an ambiguous screening turns into a verdict
+ * (HOO-1012). Undocumented keys are ignored, so the product's own extra fields
+ * never break a screening.
+ */
+const chainalysisRiskResponseSchema = z.object({
+  risk: z.string().optional(),
+  riskLevel: z.string().optional(),
+  risk_score: z.number().finite().optional(),
+  riskScore: z.number().finite().optional(),
+  score: z.number().finite().optional(),
+  status: z.string().optional(),
+  message: z.string().optional(),
+});
+
+type ChainalysisRiskResponse = z.infer<typeof chainalysisRiskResponseSchema>;
 
 export interface ChainalysisComplianceProviderConfig {
   apiKey?: string;
@@ -26,26 +38,6 @@ function normalizeChainalysisApiBaseUrl(baseUrl: string | undefined): string {
   return value.endsWith("/") ? value.slice(0, -1) : value;
 }
 
-function extractErrorMessage(body: string): string {
-  if (!body) {
-    return "";
-  }
-
-  try {
-    const parsed = JSON.parse(body) as { error?: { message?: unknown }; message?: unknown };
-    if (typeof parsed.error?.message === "string") {
-      return parsed.error.message;
-    }
-    if (typeof parsed.message === "string") {
-      return parsed.message;
-    }
-  } catch {
-    // Fall back to raw body when response is not JSON.
-  }
-
-  return body;
-}
-
 /**
  * The numeric score under whichever alias this deployment's Chainalysis
  * product spells it. Aliases are tolerated, ambiguity is not: two aliases
@@ -54,7 +46,7 @@ function extractErrorMessage(body: string): string {
  */
 function readRiskScore(payload: ChainalysisRiskResponse): { score: number | null } | "ambiguous" {
   const candidates = [payload.riskScore, payload.risk_score, payload.score].filter(
-    (value): value is number => typeof value === "number"
+    (value): value is number => value !== undefined
   );
   if (candidates.length === 0) {
     return { score: null };
@@ -66,13 +58,7 @@ function readRiskScore(payload: ChainalysisRiskResponse): { score: number | null
 }
 
 function readRiskLevel(payload: ChainalysisRiskResponse): string | undefined {
-  if (typeof payload.riskLevel === "string") {
-    return payload.riskLevel;
-  }
-  if (typeof payload.risk === "string") {
-    return payload.risk;
-  }
-  return undefined;
+  return payload.riskLevel ?? payload.risk;
 }
 
 export class ChainalysisComplianceProvider implements ComplianceProvider {
@@ -106,7 +92,7 @@ export class ChainalysisComplianceProvider implements ComplianceProvider {
       });
 
       if (!response.ok) {
-        const body = extractErrorMessage(await response.text().catch(() => ""));
+        const body = extractProviderErrorMessage(await response.text().catch(() => ""));
         return {
           provider: this.name,
           status: "error",
@@ -118,8 +104,8 @@ export class ChainalysisComplianceProvider implements ComplianceProvider {
         };
       }
 
-      const payload = (await response.json().catch(() => null)) as ChainalysisRiskResponse | null;
-      if (payload === null) {
+      const body = await response.json().catch(() => undefined);
+      if (body === undefined) {
         return {
           provider: this.name,
           status: "error",
@@ -129,7 +115,19 @@ export class ChainalysisComplianceProvider implements ComplianceProvider {
         };
       }
 
-      const providerStatus = typeof payload.status === "string" ? payload.status : undefined;
+      const parsed = chainalysisRiskResponseSchema.safeParse(body);
+      if (!parsed.success) {
+        return {
+          provider: this.name,
+          status: "error",
+          riskScore: null,
+          message: `Chainalysis returned an unreadable screening (${describeSchemaFailure(parsed.error)}).`,
+          evaluatedAt,
+        };
+      }
+
+      const payload = parsed.data;
+      const providerStatus = payload.status;
 
       // A screening the provider itself calls unfinished is NOT a verdict.
       // Reporting it `ok` let an IN_PROGRESS response read as a pass; it is
@@ -148,37 +146,48 @@ export class ChainalysisComplianceProvider implements ComplianceProvider {
       const read = readRiskScore(payload);
       const riskLevel = readRiskLevel(payload);
       if (read === "ambiguous") {
-        return {
+        const ambiguous: ComplianceProviderResult = {
           provider: this.name,
           status: "error",
           riskScore: null,
-          ...(providerStatus !== undefined ? { providerStatus } : {}),
           message: "Chainalysis returned conflicting risk-score fields; refusing to guess.",
           evaluatedAt,
         };
+        if (providerStatus !== undefined) {
+          ambiguous.providerStatus = providerStatus;
+        }
+        return ambiguous;
       }
 
       // A completed screening with neither a score nor a level carries no
       // verdict at all — malformed, so fail closed rather than pass on it.
-      if (read.score === null && !riskLevel) {
-        return {
+      if (read.score === null && riskLevel === undefined) {
+        const verdictless: ComplianceProviderResult = {
           provider: this.name,
           status: "error",
           riskScore: null,
-          ...(providerStatus !== undefined ? { providerStatus } : {}),
           message: "Chainalysis response carried no risk score or risk level.",
           evaluatedAt,
         };
+        if (providerStatus !== undefined) {
+          verdictless.providerStatus = providerStatus;
+        }
+        return verdictless;
       }
 
-      return {
+      const passed: ComplianceProviderResult = {
         provider: this.name,
         status: "ok",
         riskScore: read.score,
-        ...(riskLevel ? { riskLevel } : {}),
-        ...(providerStatus !== undefined ? { providerStatus } : {}),
         evaluatedAt,
       };
+      if (riskLevel !== undefined) {
+        passed.riskLevel = riskLevel;
+      }
+      if (providerStatus !== undefined) {
+        passed.providerStatus = providerStatus;
+      }
+      return passed;
     } catch (error) {
       return {
         provider: this.name,

--- a/apps/sdp-api/src/services/compliance/providers/elliptic.test.ts
+++ b/apps/sdp-api/src/services/compliance/providers/elliptic.test.ts
@@ -59,6 +59,30 @@ describe("EllipticComplianceProvider", () => {
     expect(result.status).toBe("error");
   });
 
+  it("holds a readable score whose process_status says the analysis is unfinished", async () => {
+    // The score parses, so the old code answered `ok` — an in-progress
+    // analysis reading as a pass is the ambiguity this closes.
+    mockResponse({ risk_score: 1.2, risk_level: "low", process_status: "running" });
+    const result = await provider().screenAddress(INPUT);
+    expect(result).toMatchObject({
+      status: "pending",
+      riskScore: null,
+      providerStatus: "running",
+    });
+  });
+
+  it("holds a process_status it cannot recognize rather than passing on it", async () => {
+    mockResponse({ risk_score: 1.2, process_status: "queued_for_review" });
+    const result = await provider().screenAddress(INPUT);
+    expect(result.status).toBe("pending");
+  });
+
+  it("passes a completed process_status through as the verdict it is", async () => {
+    mockResponse({ risk_score: 1.2, process_status: "complete" });
+    const result = await provider().screenAddress(INPUT);
+    expect(result).toMatchObject({ status: "ok", riskScore: 1.2, providerStatus: "complete" });
+  });
+
   it("keeps the not-in-blockchain 404 as a passed check", async () => {
     mockResponse({ message: "NotInBlockchain" }, 404);
     const result = await provider().screenAddress(INPUT);

--- a/apps/sdp-api/src/services/compliance/providers/elliptic.test.ts
+++ b/apps/sdp-api/src/services/compliance/providers/elliptic.test.ts
@@ -83,6 +83,13 @@ describe("EllipticComplianceProvider", () => {
     expect(result).toMatchObject({ status: "ok", riskScore: 1.2, providerStatus: "complete" });
   });
 
+  it("fails closed on a wrong-typed risk_level instead of dropping it", async () => {
+    mockResponse({ risk_score: 2, risk_level: 5 });
+    const result = await provider().screenAddress(INPUT);
+    expect(result.status).toBe("error");
+    expect(result.message).toContain("risk_level");
+  });
+
   it("keeps the not-in-blockchain 404 as a passed check", async () => {
     mockResponse({ message: "NotInBlockchain" }, 404);
     const result = await provider().screenAddress(INPUT);

--- a/apps/sdp-api/src/services/compliance/providers/elliptic.test.ts
+++ b/apps/sdp-api/src/services/compliance/providers/elliptic.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EllipticComplianceProvider } from "./elliptic";
+
+const INPUT = { address: "addr1", network: "solana", intent: "unknown" as const };
+
+function provider() {
+  return new EllipticComplianceProvider({ apiToken: "token" });
+}
+
+function mockResponse(body: unknown, status = 200) {
+  vi.stubGlobal(
+    "fetch",
+    vi
+      .fn()
+      .mockResolvedValue(
+        new Response(typeof body === "string" ? body : JSON.stringify(body), { status })
+      )
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("EllipticComplianceProvider", () => {
+  it("reads only the canonical top-level risk_score", async () => {
+    // A nested per-rule risk_score must never become the wallet's verdict.
+    mockResponse({
+      risk_score: 3.5,
+      risk_level: "medium",
+      evaluation_detail: { source: [{ risk_score: 9.9 }] },
+    });
+    const result = await provider().screenAddress(INPUT);
+    expect(result).toMatchObject({ status: "ok", riskScore: 3.5, riskLevel: "medium" });
+  });
+
+  it("treats a null canonical score as a completed no-risk verdict", async () => {
+    mockResponse({ risk_score: null });
+    const result = await provider().screenAddress(INPUT);
+    expect(result).toMatchObject({ status: "ok", riskScore: null });
+  });
+
+  it("fails closed when the canonical field is absent, even if nested scores exist", async () => {
+    mockResponse({ evaluation_detail: { source: [{ risk_score: 9.9 }] } });
+    const result = await provider().screenAddress(INPUT);
+    expect(result.status).toBe("error");
+    expect(result.message).toContain("risk_score");
+  });
+
+  it("fails closed on an ambiguous non-numeric canonical value", async () => {
+    mockResponse({ risk_score: "high" });
+    const result = await provider().screenAddress(INPUT);
+    expect(result.status).toBe("error");
+  });
+
+  it("fails closed on a body that is not a JSON object", async () => {
+    mockResponse("<html>bad gateway</html>", 200);
+    const result = await provider().screenAddress(INPUT);
+    expect(result.status).toBe("error");
+  });
+
+  it("keeps the not-in-blockchain 404 as a passed check", async () => {
+    mockResponse({ message: "NotInBlockchain" }, 404);
+    const result = await provider().screenAddress(INPUT);
+    expect(result.status).toBe("ok");
+    expect(result.riskScore).toBeNull();
+  });
+
+  it("reports other HTTP failures as error", async () => {
+    mockResponse({ message: "unauthorized" }, 401);
+    const result = await provider().screenAddress(INPUT);
+    expect(result.status).toBe("error");
+    expect(result.message).toContain("401");
+  });
+});

--- a/apps/sdp-api/src/services/compliance/providers/elliptic.ts
+++ b/apps/sdp-api/src/services/compliance/providers/elliptic.ts
@@ -1,13 +1,13 @@
+import { z } from "zod";
 import type {
   ComplianceAddressScreeningInput,
   ComplianceProvider,
   ComplianceProviderResult,
 } from "../types";
+import { describeSchemaFailure, extractProviderErrorMessage } from "./provider-response";
 
 const DEFAULT_ELLIPTIC_API_BASE_URL = "https://aml-api.elliptic.co";
 const ELLIPTIC_SCREENING_PATH = "/v2/wallet/synchronous";
-
-type EllipticAddressScreeningResponse = Record<string, unknown>;
 
 export interface EllipticComplianceProviderConfig {
   apiToken?: string;
@@ -19,26 +19,6 @@ export interface EllipticComplianceProviderConfig {
 function normalizeEllipticApiBaseUrl(baseUrl: string | undefined): string {
   const value = (baseUrl ?? DEFAULT_ELLIPTIC_API_BASE_URL).trim();
   return value.endsWith("/") ? value.slice(0, -1) : value;
-}
-
-function extractErrorMessage(body: string): string {
-  if (!body) {
-    return "";
-  }
-
-  try {
-    const parsed = JSON.parse(body) as { error?: { message?: unknown }; message?: unknown };
-    if (typeof parsed.error?.message === "string") {
-      return parsed.error.message;
-    }
-    if (typeof parsed.message === "string") {
-      return parsed.message;
-    }
-  } catch {
-    // Fall back to raw body when response is not JSON.
-  }
-
-  return body;
 }
 
 function isNotInBlockchainResponse(responseStatus: number, body: string): boolean {
@@ -108,39 +88,24 @@ async function createSignature(input: {
  * rules triggered). The old deep search took the first `risk_score` found
  * ANYWHERE in the response, which could be a per-rule or per-exposure entry
  * rather than the wallet's own verdict; a nested contribution read as the
- * decision is exactly the ambiguity HOO-1012 closes. Anything but a number or
- * an explicit null at the top level is unreadable — the caller fails closed.
+ * decision is exactly the ambiguity HOO-1012 closes.
+ *
+ * The schema states that at the boundary: the canonical score is required, so
+ * a response without one fails to parse rather than being searched for a
+ * substitute, and the string fields must be strings. Nested objects are left
+ * untyped on purpose — nothing below the top level may inform the verdict.
  */
-function readCanonicalRiskScore(
-  payload: Record<string, unknown>
-): { score: number | null } | "unreadable" {
-  if (!("risk_score" in payload)) {
-    return "unreadable";
-  }
-  const value = payload.risk_score;
-  if (value === null) {
-    return { score: null };
-  }
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return { score: value };
-  }
-  return "unreadable";
-}
+const ellipticWalletResponseSchema = z.object({
+  risk_score: z.number().finite().nullable(),
+  risk_level: z.string().min(1).optional(),
+  process_status: z.string().min(1).optional(),
+});
 
 /**
  * Elliptic's own completion word for the synchronous wallet analysis. Compared
  * case-insensitively because the field is provider prose, not an SDP enum.
  */
 const ELLIPTIC_COMPLETED_PROCESS_STATUSES = new Set(["complete", "completed"]);
-
-/** Top level only, same reasoning as the score: never a nested rule's word. */
-function readCanonicalStringField(
-  payload: Record<string, unknown>,
-  field: string
-): string | undefined {
-  const value = payload[field];
-  return typeof value === "string" && value.length > 0 ? value : undefined;
-}
 
 export class EllipticComplianceProvider implements ComplianceProvider {
   readonly name = "elliptic" as const;
@@ -213,7 +178,7 @@ export class EllipticComplianceProvider implements ComplianceProvider {
           })();
 
       if (!response.ok) {
-        const body = extractErrorMessage(await response.text().catch(() => ""));
+        const body = extractProviderErrorMessage(await response.text().catch(() => ""));
         if (isNotInBlockchainResponse(response.status, body)) {
           return {
             provider: this.name,
@@ -235,33 +200,33 @@ export class EllipticComplianceProvider implements ComplianceProvider {
         };
       }
 
-      const result = (await response
-        .json()
-        .catch(() => null)) as EllipticAddressScreeningResponse | null;
-      if (result === null || typeof result !== "object" || Array.isArray(result)) {
+      const body = await response.json().catch(() => undefined);
+      if (body === undefined) {
         return {
           provider: this.name,
           status: "error",
           riskScore: null,
-          message: "Elliptic returned a response that is not a JSON object.",
+          message: "Elliptic returned a response that is not valid JSON.",
           evaluatedAt,
         };
       }
 
-      const read = readCanonicalRiskScore(result);
-      if (read === "unreadable") {
+      const parsed = ellipticWalletResponseSchema.safeParse(body);
+      if (!parsed.success) {
         return {
           provider: this.name,
           status: "error",
           riskScore: null,
-          message:
-            "Elliptic response carried no readable top-level risk_score; refusing to interpret nested fields as the verdict.",
+          message: `Elliptic returned no readable top-level risk_score; refusing to interpret nested fields as the verdict (${describeSchemaFailure(parsed.error)}).`,
           evaluatedAt,
         };
       }
 
-      const riskLevel = readCanonicalStringField(result, "risk_level");
-      const processStatus = readCanonicalStringField(result, "process_status");
+      const {
+        risk_score: riskScore,
+        risk_level: riskLevel,
+        process_status: processStatus,
+      } = parsed.data;
 
       // A screening Elliptic itself calls unfinished is NOT a verdict, exactly
       // as with Chainalysis: a readable score alongside a non-final
@@ -285,14 +250,19 @@ export class EllipticComplianceProvider implements ComplianceProvider {
 
       // A null canonical score is Elliptic's documented "no risk rules
       // triggered" — a completed verdict, not an absence of one.
-      return {
+      const screened: ComplianceProviderResult = {
         provider: this.name,
         status: "ok",
-        riskScore: read.score,
-        ...(riskLevel ? { riskLevel } : {}),
-        ...(processStatus ? { providerStatus: processStatus } : {}),
+        riskScore,
         evaluatedAt,
       };
+      if (riskLevel !== undefined) {
+        screened.riskLevel = riskLevel;
+      }
+      if (processStatus !== undefined) {
+        screened.providerStatus = processStatus;
+      }
+      return screened;
     } catch (error) {
       return {
         provider: this.name,

--- a/apps/sdp-api/src/services/compliance/providers/elliptic.ts
+++ b/apps/sdp-api/src/services/compliance/providers/elliptic.ts
@@ -127,6 +127,12 @@ function readCanonicalRiskScore(
   return "unreadable";
 }
 
+/**
+ * Elliptic's own completion word for the synchronous wallet analysis. Compared
+ * case-insensitively because the field is provider prose, not an SDP enum.
+ */
+const ELLIPTIC_COMPLETED_PROCESS_STATUSES = new Set(["complete", "completed"]);
+
 /** Top level only, same reasoning as the score: never a nested rule's word. */
 function readCanonicalStringField(
   payload: Record<string, unknown>,
@@ -256,6 +262,26 @@ export class EllipticComplianceProvider implements ComplianceProvider {
 
       const riskLevel = readCanonicalStringField(result, "risk_level");
       const processStatus = readCanonicalStringField(result, "process_status");
+
+      // A screening Elliptic itself calls unfinished is NOT a verdict, exactly
+      // as with Chainalysis: a readable score alongside a non-final
+      // process_status was still reporting `ok`, so an in-progress analysis
+      // read as a pass. The field is absent on most responses, and absence
+      // stays a completed verdict — only a stated non-final status holds
+      // (HOO-1012).
+      if (
+        processStatus !== undefined &&
+        !ELLIPTIC_COMPLETED_PROCESS_STATUSES.has(processStatus.toLowerCase())
+      ) {
+        return {
+          provider: this.name,
+          status: "pending",
+          riskScore: null,
+          providerStatus: processStatus,
+          message: `Elliptic screening is not complete (process_status: ${processStatus}).`,
+          evaluatedAt,
+        };
+      }
 
       // A null canonical score is Elliptic's documented "no risk rules
       // triggered" — a completed verdict, not an absence of one.

--- a/apps/sdp-api/src/services/compliance/providers/elliptic.ts
+++ b/apps/sdp-api/src/services/compliance/providers/elliptic.ts
@@ -102,58 +102,38 @@ async function createSignature(input: {
   return encodeBase64(new Uint8Array(signature));
 }
 
-function findNumericField(payload: unknown, field: string): number | null {
-  if (Array.isArray(payload)) {
-    for (const entry of payload) {
-      const nested = findNumericField(entry, field);
-      if (nested !== null) {
-        return nested;
-      }
-    }
-    return null;
+/**
+ * The canonical Elliptic verdict is the TOP-LEVEL `risk_score` of the
+ * synchronous wallet analysis — documented as nullable (null means no risk
+ * rules triggered). The old deep search took the first `risk_score` found
+ * ANYWHERE in the response, which could be a per-rule or per-exposure entry
+ * rather than the wallet's own verdict; a nested contribution read as the
+ * decision is exactly the ambiguity HOO-1012 closes. Anything but a number or
+ * an explicit null at the top level is unreadable — the caller fails closed.
+ */
+function readCanonicalRiskScore(
+  payload: Record<string, unknown>
+): { score: number | null } | "unreadable" {
+  if (!("risk_score" in payload)) {
+    return "unreadable";
   }
-  if (!payload || typeof payload !== "object") {
-    return null;
+  const value = payload.risk_score;
+  if (value === null) {
+    return { score: null };
   }
-
-  for (const [key, value] of Object.entries(payload)) {
-    if (key === field && typeof value === "number") {
-      return value;
-    }
-    const nested = findNumericField(value, field);
-    if (nested !== null) {
-      return nested;
-    }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return { score: value };
   }
-
-  return null;
+  return "unreadable";
 }
 
-function findStringField(payload: unknown, field: string): string | undefined {
-  if (Array.isArray(payload)) {
-    for (const entry of payload) {
-      const nested = findStringField(entry, field);
-      if (nested) {
-        return nested;
-      }
-    }
-    return undefined;
-  }
-  if (!payload || typeof payload !== "object") {
-    return undefined;
-  }
-
-  for (const [key, value] of Object.entries(payload)) {
-    if (key === field && typeof value === "string") {
-      return value;
-    }
-    const nested = findStringField(value, field);
-    if (nested) {
-      return nested;
-    }
-  }
-
-  return undefined;
+/** Top level only, same reasoning as the score: never a nested rule's word. */
+function readCanonicalStringField(
+  payload: Record<string, unknown>,
+  field: string
+): string | undefined {
+  const value = payload[field];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 export class EllipticComplianceProvider implements ComplianceProvider {
@@ -249,15 +229,42 @@ export class EllipticComplianceProvider implements ComplianceProvider {
         };
       }
 
-      const result = (await response.json().catch(() => ({}))) as EllipticAddressScreeningResponse;
-      const riskScore = findNumericField(result, "risk_score");
-      const riskLevel = findStringField(result, "risk_level");
+      const result = (await response
+        .json()
+        .catch(() => null)) as EllipticAddressScreeningResponse | null;
+      if (result === null || typeof result !== "object" || Array.isArray(result)) {
+        return {
+          provider: this.name,
+          status: "error",
+          riskScore: null,
+          message: "Elliptic returned a response that is not a JSON object.",
+          evaluatedAt,
+        };
+      }
 
+      const read = readCanonicalRiskScore(result);
+      if (read === "unreadable") {
+        return {
+          provider: this.name,
+          status: "error",
+          riskScore: null,
+          message:
+            "Elliptic response carried no readable top-level risk_score; refusing to interpret nested fields as the verdict.",
+          evaluatedAt,
+        };
+      }
+
+      const riskLevel = readCanonicalStringField(result, "risk_level");
+      const processStatus = readCanonicalStringField(result, "process_status");
+
+      // A null canonical score is Elliptic's documented "no risk rules
+      // triggered" — a completed verdict, not an absence of one.
       return {
         provider: this.name,
         status: "ok",
-        riskScore,
+        riskScore: read.score,
         ...(riskLevel ? { riskLevel } : {}),
+        ...(processStatus ? { providerStatus: processStatus } : {}),
         evaluatedAt,
       };
     } catch (error) {

--- a/apps/sdp-api/src/services/compliance/providers/provider-response.ts
+++ b/apps/sdp-api/src/services/compliance/providers/provider-response.ts
@@ -1,0 +1,37 @@
+import { prettifyError, z } from "zod";
+
+/**
+ * One-line rendering of why a provider response failed its schema, for the
+ * operator-facing `message` on a failed screening. `prettifyError` names the
+ * offending field, which is the part an on-call reader needs.
+ */
+export function describeSchemaFailure(error: z.ZodError): string {
+  return prettifyError(error).replace(/\s+/g, " ").trim();
+}
+
+const providerErrorBodySchema = z.object({
+  error: z.object({ message: z.string() }).optional(),
+  message: z.string().optional(),
+});
+
+/**
+ * The human-readable half of a provider's HTTP error body. Both compliance
+ * providers wrap their errors the same two ways; anything else travels as the
+ * raw body, which is all an operator can act on anyway.
+ */
+export function extractProviderErrorMessage(body: string): string {
+  if (!body) {
+    return "";
+  }
+
+  try {
+    const parsed = providerErrorBodySchema.safeParse(JSON.parse(body));
+    if (parsed.success) {
+      return parsed.data.error?.message ?? parsed.data.message ?? body;
+    }
+  } catch {
+    // Not JSON at all: the raw body is the message.
+  }
+
+  return body;
+}

--- a/apps/sdp-api/src/services/compliance/types.ts
+++ b/apps/sdp-api/src/services/compliance/types.ts
@@ -5,7 +5,18 @@ export type ComplianceScreeningIntent =
   | "wallet_address_addition"
   | "unknown";
 
-export type ComplianceScreeningStatus = "ok" | "unavailable" | "error";
+/**
+ * Normalized decision, deliberately narrower than any provider's own status
+ * space (HOO-1012):
+ *  - `ok`          — the provider COMPLETED the screening and returned an
+ *                    unambiguous verdict; only this value may read as a pass.
+ *  - `pending`     — the provider accepted the request but has not finished
+ *                    (e.g. Chainalysis non-COMPLETE); never a pass.
+ *  - `unavailable` — the provider is not configured for this deployment.
+ *  - `error`       — the call failed, or the response was malformed or
+ *                    ambiguous; fail closed rather than guess.
+ */
+export type ComplianceScreeningStatus = "ok" | "pending" | "unavailable" | "error";
 
 export interface ComplianceAddressScreeningInput {
   address: string;
@@ -18,6 +29,11 @@ export interface ComplianceProviderResult {
   status: ComplianceScreeningStatus;
   riskScore: number | null;
   riskLevel?: string;
+  /**
+   * The provider's own status word, verbatim, retained for audit. The
+   * normalized `status` is the decision; this is the evidence.
+   */
+  providerStatus?: string;
   message?: string;
   evaluatedAt: string;
 }

--- a/apps/sdp-web/src/lib/compliance.ts
+++ b/apps/sdp-web/src/lib/compliance.ts
@@ -1,16 +1,19 @@
-import type { ComplianceProviderId } from "@sdp/types";
+import { COMPLIANCE_PROVIDERS, type ComplianceProviderId } from "@sdp/types";
+import { z } from "zod";
 
 export type ComplianceIntent = "transfer_destination" | "wallet_address_addition" | "unknown";
 
-export type ComplianceProviderResult = {
-  provider: ComplianceProviderId;
-  status: "ok" | "pending" | "unavailable" | "error";
-  riskScore: number | null;
-  riskLevel?: string;
-  providerStatus?: string;
-  message?: string;
-  evaluatedAt: string;
-};
+const complianceProviderResultSchema = z.object({
+  provider: z.enum(COMPLIANCE_PROVIDERS),
+  status: z.enum(["ok", "pending", "unavailable", "error"]),
+  riskScore: z.number().nullable(),
+  riskLevel: z.string().optional(),
+  providerStatus: z.string().optional(),
+  message: z.string().optional(),
+  evaluatedAt: z.string().min(1),
+});
+
+export type ComplianceProviderResult = z.infer<typeof complianceProviderResultSchema>;
 
 export const COMPLIANCE_PROVIDER_LOGOS = {
   range: "/provider-logos/range-compliance.svg",
@@ -19,22 +22,27 @@ export const COMPLIANCE_PROVIDER_LOGOS = {
   chainalysis: "/provider-logos/chainalysis-compliance.svg",
 } as const satisfies Record<ComplianceProviderId, string>;
 
-export type AddressScreeningResult = {
-  checkedAt: string;
-  providers: ComplianceProviderResult[];
-};
-
 type AddressScreeningEnvelope = {
-  data?: {
-    screening?: {
-      checkedAt?: string;
-      providers?: ComplianceProviderResult[];
-    };
-  };
+  data?: unknown;
   error?: {
     message?: string;
   };
 };
+
+/**
+ * A screening the dashboard cannot read is not an empty screening. Defaulting
+ * a malformed or missing payload to `{ providers: [] }` turned a dropped
+ * response into a silent "nothing flagged", which is the one thing a
+ * compliance surface must never show (HOO-1012).
+ */
+const addressScreeningSchema = z.object({
+  screening: z.object({
+    checkedAt: z.string().min(1),
+    providers: z.array(complianceProviderResultSchema),
+  }),
+});
+
+export type AddressScreeningResult = z.infer<typeof addressScreeningSchema>["screening"];
 
 export class ComplianceNotEnabledError extends Error {}
 
@@ -71,8 +79,10 @@ export async function screenAddressCompliance(input: {
     throw new Error(message);
   }
 
-  return {
-    checkedAt: payload.data?.screening?.checkedAt ?? new Date().toISOString(),
-    providers: payload.data?.screening?.providers ?? [],
-  };
+  const parsed = addressScreeningSchema.safeParse(payload.data);
+  if (!parsed.success) {
+    throw new Error("Compliance response could not be read.");
+  }
+
+  return parsed.data.screening;
 }

--- a/apps/sdp-web/src/lib/compliance.ts
+++ b/apps/sdp-web/src/lib/compliance.ts
@@ -4,9 +4,10 @@ export type ComplianceIntent = "transfer_destination" | "wallet_address_addition
 
 export type ComplianceProviderResult = {
   provider: ComplianceProviderId;
-  status: "ok" | "unavailable" | "error";
+  status: "ok" | "pending" | "unavailable" | "error";
   riskScore: number | null;
   riskLevel?: string;
+  providerStatus?: string;
   message?: string;
   evaluatedAt: string;
 };

--- a/apps/sdp-web/src/lib/compliance.unit.test.ts
+++ b/apps/sdp-web/src/lib/compliance.unit.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ComplianceNotEnabledError, screenAddressCompliance } from "./compliance";
+
+const INPUT = { address: "addr1" };
+
+const SCREENING = {
+  checkedAt: "2026-09-08T00:00:00.000Z",
+  providers: [
+    {
+      provider: "elliptic",
+      status: "ok",
+      riskScore: 1.2,
+      riskLevel: "low",
+      evaluatedAt: "2026-09-08T00:00:00.000Z",
+    },
+  ],
+};
+
+function mockResponse(body: unknown, status = 200) {
+  vi.stubGlobal(
+    "fetch",
+    vi
+      .fn()
+      .mockResolvedValue(
+        new Response(typeof body === "string" ? body : JSON.stringify(body), { status })
+      )
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("screenAddressCompliance", () => {
+  it("returns the screening the API reported", async () => {
+    mockResponse({ data: { screening: SCREENING } });
+    await expect(screenAddressCompliance(INPUT)).resolves.toEqual(SCREENING);
+  });
+
+  it("throws on a body it cannot read rather than reporting an empty screening", async () => {
+    // The dangerous case: a 200 whose payload never arrived used to surface as
+    // "checked just now, nothing flagged".
+    mockResponse("<html>gateway</html>", 200);
+    await expect(screenAddressCompliance(INPUT)).rejects.toThrow();
+  });
+
+  it("throws when the screening is missing from an otherwise valid envelope", async () => {
+    mockResponse({ data: {} });
+    await expect(screenAddressCompliance(INPUT)).rejects.toThrow();
+  });
+
+  it("throws when a provider entry is malformed", async () => {
+    mockResponse({
+      data: { screening: { ...SCREENING, providers: [{ provider: "elliptic" }] } },
+    });
+    await expect(screenAddressCompliance(INPUT)).rejects.toThrow();
+  });
+
+  it("keeps the disabled-compliance signal distinct", async () => {
+    mockResponse({ error: { message: "Compliance is not enabled" } }, 403);
+    await expect(screenAddressCompliance(INPUT)).rejects.toBeInstanceOf(ComplianceNotEnabledError);
+  });
+});


### PR DESCRIPTION
Closes the two confirmed HOO-1012 DeepSec findings.

## Chainalysis
- A non-COMPLETE provider status normalizes to the new `pending` screening status — never a pass (previously an IN_PROGRESS screening returned `ok` with only a message). The dashboard already treats anything but `ok` as unresolved, so `pending` is fail-closed there without UI changes.
- A completed response with neither a risk score nor a risk level fails closed as malformed.
- Conflicting risk-score aliases (e.g. `riskScore` vs `risk_score` disagreeing) fail closed instead of picking one.
- A non-JSON body is an `error`, not an empty success.

## Elliptic
- The verdict is the canonical TOP-LEVEL `risk_score` only. The old depth-first search took the first `risk_score` found anywhere — a nested per-rule/per-exposure entry could read as the wallet's decision.
- Absent or non-numeric-non-null canonical value fails closed; `null` keeps its documented meaning (no risk rules triggered — a completed verdict).
- `risk_level` / `process_status` are read from the top level only; the NotInBlockchain 404 pass is unchanged.
- The route fixture that nested `risk_score` under an invented `analysis` envelope — asserting the deep search was correct — now uses the documented shape.

## Audit trail
- New optional `providerStatus` on the result (OpenAPI + dashboard types): the provider's own status word verbatim, so normalized decisions never erase the evidence.

## Tests
- New fixture suites for both providers: incomplete, malformed, ambiguous, error, and successful responses (13 cases).
- compliance service/routes 24/24, openapi 46/46.

Linear: HOO-1012