### PR TITLE
chore(ci): correct checkout sha annotations to v7.0.1

### DIFF
--- a/.github/workflows/sdp-api-ephemeral.yml
+++ b/.github/workflows/sdp-api-ephemeral.yml
@@ -50,7 +50,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/head', inputs.pr_number) }}
 
@@ -76,7 +76,7 @@ jobs:
           echo "IMAGE=${IMAGE}" >> "${GITHUB_ENV}"
 
       - name: Checkout trusted deploy scripts
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
           path: trusted
@@ -131,7 +131,7 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
 
@@ -158,7 +158,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3


### PR DESCRIPTION
Annotation-only: `3d3c42e5aac5ba805825da76410c181273ba90b1` is `v7.0.1` (`git ls-remote --tags actions/checkout` resolves it to `refs/tags/v7` and `refs/tags/v7.0.1`), but the ephemeral workflow annotated it `# v6`. Same pin, honest comment. Surfaced by review on #1575.

🤖 Generated with [Claude Code](https://claude.com/claude-code)