### PR TITLE
fix(earn): HOO-1559 authorize and govern Earn program withdrawals

### DIFF
--- a/apps/sdp-api/src/db/migrations/postgres/0082_earn_program_withdrawal_operation_idempotency.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0082_earn_program_withdrawal_operation_idempotency.sql
@@ -1,0 +1,20 @@
+-- One governed operation per Earn program payout, organization-wide (HOO-1559).
+--
+-- The general wallet-operation key is unique per (organization, project, key),
+-- which is right for operations a project owns. An Earn program is a provider
+-- account addressed per (organization, environment), and its payout ledger is
+-- keyed by organization + provider wallet + request id — so the same request
+-- id arriving under a sibling project is the SAME payout, and a project-scoped
+-- key let it open a second governed operation and a second approval request.
+--
+-- The route already refuses a retry that finds a prior operation, but that
+-- check cannot bind concurrent first attempts: both read no prior record, and
+-- only a database constraint decides. This partial index is that constraint;
+-- the insert takes it as ON CONFLICT DO NOTHING, so the loser answers with the
+-- winner's held operation instead of minting its own.
+--
+-- Safe to add without a backfill: `earn_program_withdrawal` is introduced by
+-- this change, so no existing row can violate it.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_wallet_operations_earn_program_withdrawal_idempotency
+    ON wallet_operations (organization_id, idempotency_key)
+    WHERE operation_type = 'earn_program_withdrawal' AND idempotency_key IS NOT NULL;

--- a/apps/sdp-api/src/db/repositories/index.ts
+++ b/apps/sdp-api/src/db/repositories/index.ts
@@ -321,6 +321,7 @@ export type {
   WalletOperationRow,
   WalletPolicyEvaluationAuditRow,
 } from "./policy.repository";
+export { WalletOperationIdempotencyConflictError } from "./policy.repository";
 export { createPostgresPolicyRepository } from "./policy.repository.postgres";
 export type {
   CreatePrivateChannelInput,

--- a/apps/sdp-api/src/db/repositories/policy.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.postgres.ts
@@ -1031,7 +1031,13 @@ async function tenantOwnsWalletTarget(
   db: DatabaseExecutor,
   scope: TenantScope,
   walletId: string,
-  custodyWalletId?: string | null
+  custodyWalletId: string | null | undefined,
+  /**
+   * Whether an Earn program link row may stand in for the custody wallet this
+   * target otherwise has to be. True ONLY for the one operation type that has
+   * no custody wallet by construction; see the fallback below.
+   */
+  allowEarnProgramTarget = false
 ): Promise<boolean> {
   const hasCustodyWalletId = custodyWalletId !== undefined && custodyWalletId !== null;
   const custodyPredicate = hasCustodyWalletId ? "AND w.id = ?" : "";
@@ -1064,7 +1070,29 @@ async function tenantOwnsWalletTarget(
       scope.projectId
     )
     .first<{ id: string }>();
-  return Boolean(row);
+  if (row) return true;
+
+  // An Earn program is a provider ACCOUNT, not a custody wallet, so it has no
+  // `custody_wallets` row to prove ownership through — which is why its payouts
+  // could not be recorded as governed operations at all (HOO-1559). It is
+  // admitted as a target in its own right, by the same rule and not a weaker
+  // one: the link row must belong to this organization.
+  //
+  // Admission is pinned to the ONE operation type that has no custody wallet by
+  // construction. Keying it on "names no custody wallet" instead would be a
+  // widening: any family that can leave `custodyWalletId` null — issuance mint
+  // among them — would gain a second way to prove ownership of a target it does
+  // not custody, just by naming a provider wallet ref.
+  if (hasCustodyWalletId || !allowEarnProgramTarget) return false;
+  const program = await db
+    .prepare(
+      `SELECT id FROM earn_provider_wallets
+        WHERE provider_wallet_ref = ? AND organization_id = ?
+        LIMIT 1`
+    )
+    .bind(walletId, scope.organizationId)
+    .first<{ id: string }>();
+  return Boolean(program);
 }
 
 async function tenantOwnsPolicyRevision(
@@ -1946,7 +1974,15 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
 
     async createWalletOperation(input: CreateWalletOperationInput) {
       assertTenantClaim(scope, input, "PolicyRepository.createWalletOperation");
-      if (!(await tenantOwnsWalletTarget(db, scope, input.walletId, input.custodyWalletId))) {
+      if (
+        !(await tenantOwnsWalletTarget(
+          db,
+          scope,
+          input.walletId,
+          input.custodyWalletId,
+          input.operationType === "earn_program_withdrawal"
+        ))
+      ) {
         return null;
       }
       if (input.apiKeyId && !(await tenantOwnsRow(db, scope, "api_keys", input.apiKeyId))) {

--- a/apps/sdp-api/src/db/repositories/policy.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.postgres.ts
@@ -1034,10 +1034,12 @@ async function tenantOwnsWalletTarget(
   custodyWalletId: string | null | undefined,
   /**
    * Whether an Earn program link row may stand in for the custody wallet this
-   * target otherwise has to be. True ONLY for the one operation type that has
-   * no custody wallet by construction; see the fallback below.
+   * target otherwise has to be. Stated at every call site rather than defaulted,
+   * so admitting a program target is always a visible decision; true ONLY for
+   * the one operation type that has no custody wallet by construction, see the
+   * fallback below.
    */
-  allowEarnProgramTarget = false
+  allowEarnProgramTarget: boolean
 ): Promise<boolean> {
   const hasCustodyWalletId = custodyWalletId !== undefined && custodyWalletId !== null;
   const custodyPredicate = hasCustodyWalletId ? "AND w.id = ?" : "";
@@ -1708,7 +1710,7 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
       }
       if (
         input.bindingScope === "selected" &&
-        !(await tenantOwnsWalletTarget(db, scope, input.walletId, input.custodyWalletId))
+        !(await tenantOwnsWalletTarget(db, scope, input.walletId, input.custodyWalletId, false))
       ) {
         return null;
       }
@@ -1742,7 +1744,13 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
               binding.apiKeyControlProfileId
             ))) ||
           (binding.bindingScope === "selected" &&
-            !(await tenantOwnsWalletTarget(db, scope, binding.walletId, binding.custodyWalletId)))
+            !(await tenantOwnsWalletTarget(
+              db,
+              scope,
+              binding.walletId,
+              binding.custodyWalletId,
+              false
+            )))
         ) {
           return [];
         }

--- a/apps/sdp-api/src/db/repositories/policy.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.postgres.ts
@@ -42,7 +42,6 @@ import type {
   WalletOperationRow,
   WalletPolicyEvaluationAuditRow,
 } from "./policy.repository";
-
 import {
   generateApiKeyControlProfileId,
   generateApiKeyControlProfileRevisionId,
@@ -52,6 +51,7 @@ import {
   generateWalletControlProfileId,
   generateWalletControlProfileRevisionId,
   generateWalletOperationId,
+  WalletOperationIdempotencyConflictError,
 } from "./policy.repository";
 
 const WALLET_CONTROL_PROFILE_REVISION_HISTORY_LIMIT = 100;
@@ -1998,7 +1998,13 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
       }
       const id = generateWalletOperationId();
 
-      await db
+      // ON CONFLICT DO NOTHING, not a plain insert: the route's prior-operation
+      // check runs before this write, so two concurrent first attempts both see
+      // no prior record and only the unique index decides which one governs the
+      // payout. The loser inserts nothing and says so, and the caller answers
+      // with the winner's operation rather than minting a second approval or
+      // failing on a raw constraint violation (HOO-1559).
+      const inserted = await db
         .prepare(
           `INSERT INTO wallet_operations (
              id,
@@ -2016,7 +2022,9 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
              raw_payload,
              idempotency_key,
              status
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?, ?)`
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?, ?)
+           ON CONFLICT DO NOTHING
+           RETURNING id`
         )
         .bind(
           id,
@@ -2035,7 +2043,11 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
           input.idempotencyKey ?? null,
           input.status ?? "created"
         )
-        .run();
+        .first<{ id: string }>();
+
+      if (inserted === null) {
+        throw new WalletOperationIdempotencyConflictError(input.operationType);
+      }
 
       return getWalletOperationByIdInternal(db, id);
     },

--- a/apps/sdp-api/src/db/repositories/policy.repository.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.ts
@@ -168,6 +168,18 @@ export interface ListPolicyControlInventoryResult {
   summary: PolicyControlInventorySummaryRow;
 }
 
+/**
+ * The operation's idempotency key already governs a payout: a concurrent first
+ * attempt won the race and its operation is the one to answer with. Distinct
+ * from a null return, which means the tenant does not own the target.
+ */
+export class WalletOperationIdempotencyConflictError extends Error {
+  constructor(readonly operationType: string) {
+    super(`A wallet operation for this ${operationType} idempotency key already exists`);
+    this.name = WalletOperationIdempotencyConflictError.name;
+  }
+}
+
 export interface WalletOperationRow {
   id: string;
   organization_id: string;

--- a/apps/sdp-api/src/middleware/policy-gate.ts
+++ b/apps/sdp-api/src/middleware/policy-gate.ts
@@ -136,8 +136,9 @@ export function policyGate(config: PolicyGateConfig): MiddlewareHandler<{ Bindin
       return next();
     }
 
-    const enforce = () =>
-      enforceWalletOperationPolicy(
+    let enforcement: WalletOperationPolicyEnforcement;
+    try {
+      enforcement = await enforceWalletOperationPolicy(
         c.env,
         scope,
         {
@@ -155,10 +156,6 @@ export function policyGate(config: PolicyGateConfig): MiddlewareHandler<{ Bindin
         approvedWalletOperationId(c),
         approvedWalletOperationAttemptId(c)
       );
-
-    let enforcement: Awaited<ReturnType<typeof enforce>>;
-    try {
-      enforcement = await enforce();
     } catch (error) {
       // A conflict means a concurrent first attempt already governs this key.
       // The route answers with THAT operation; if it has no answer to give, the

--- a/apps/sdp-api/src/middleware/policy-gate.ts
+++ b/apps/sdp-api/src/middleware/policy-gate.ts
@@ -1,6 +1,7 @@
 import type { WalletOperationPolicyEnforcement } from "@sdp/policy";
 import type { PolicyCandidate } from "@sdp/types";
 import type { Context, MiddlewareHandler, Next } from "hono";
+import { WalletOperationIdempotencyConflictError } from "@/db/repositories";
 import { internalError } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { getRequestTenantScope } from "@/lib/tenant-scope";
@@ -41,6 +42,13 @@ export interface PolicyGateConfig {
     idempotencyKey: string
   ) => Promise<Response | null>;
   beforeEnforce?: (c: GateContext, extraction: PolicyGateExtraction) => Promise<void>;
+  /**
+   * Answer a request whose idempotency key lost the race to a concurrent first
+   * attempt. The route's own replay answer is the right one — the winning
+   * operation is committed by the time this runs — so the hook is expected to
+   * throw the same gated response a sequential retry would get.
+   */
+  onIdempotencyConflict?: (c: GateContext, extraction: PolicyGateExtraction) => Promise<void>;
 }
 
 export interface PolicyGateContext<
@@ -128,24 +136,38 @@ export function policyGate(config: PolicyGateConfig): MiddlewareHandler<{ Bindin
       return next();
     }
 
-    const enforcement = await enforceWalletOperationPolicy(
-      c.env,
-      scope,
-      {
-        ...candidate,
-        legs,
-        rawPayload: {
-          ...rawPayload,
-          executionRequest: walletOperationExecutionRequest(
-            c,
-            extraction.executionRequestBody ?? body
-          ),
+    const enforce = () =>
+      enforceWalletOperationPolicy(
+        c.env,
+        scope,
+        {
+          ...candidate,
+          legs,
+          rawPayload: {
+            ...rawPayload,
+            executionRequest: walletOperationExecutionRequest(
+              c,
+              extraction.executionRequestBody ?? body
+            ),
+          },
+          idempotencyKey: operationIdempotencyKey,
         },
-        idempotencyKey: operationIdempotencyKey,
-      },
-      approvedWalletOperationId(c),
-      approvedWalletOperationAttemptId(c)
-    );
+        approvedWalletOperationId(c),
+        approvedWalletOperationAttemptId(c)
+      );
+
+    let enforcement: Awaited<ReturnType<typeof enforce>>;
+    try {
+      enforcement = await enforce();
+    } catch (error) {
+      // A conflict means a concurrent first attempt already governs this key.
+      // The route answers with THAT operation; if it has no answer to give, the
+      // conflict travels on rather than being swallowed.
+      if (error instanceof WalletOperationIdempotencyConflictError) {
+        await config.onIdempotencyConflict?.(c, extraction);
+      }
+      throw error;
+    }
 
     c.set("policyGate", { body, candidate, resolved, enforcement });
     return next();

--- a/apps/sdp-api/src/openapi/schemas/payments.ts
+++ b/apps/sdp-api/src/openapi/schemas/payments.ts
@@ -72,7 +72,7 @@ export const tokenAmountSchema = z.string().openapi({
 
 export const policyRuleSchema = withOpenApi(updateWalletPolicySchemaBase.shape.rules.element, {
   description:
-    "Wallet control profile rule. Supported kinds include operation_family, operation_type, asset, destination, amount, approval, and always. Program-family operations include earn_vault_deposit and earn_vault_withdrawal.",
+    "Wallet control profile rule. Supported kinds include operation_family, operation_type, asset, destination, amount, approval, and always. Program-family operations include earn_vault_deposit, earn_vault_withdrawal and earn_program_withdrawal.",
   example: {
     id: "approve-vault-deposits",
     kind: "operation_type",

--- a/apps/sdp-api/src/routes/earn-program.test.ts
+++ b/apps/sdp-api/src/routes/earn-program.test.ts
@@ -46,7 +46,7 @@ import { createTenantScope } from "@/lib/tenant-scope";
 import { recoverApprovedWalletOperations } from "@/services/policy/approved-operation-replay";
 import { env } from "@/test/helpers/env";
 import { seedTestDatabase } from "@/test/mocks/db";
-import { clearKVStores, seedCachedApiKey } from "@/test/mocks/kv";
+import { clearKVStores, seedCachedApiKey, seedRateLimit } from "@/test/mocks/kv";
 
 const TEST_ORG = {
   id: "org_earn_program",
@@ -2569,5 +2569,68 @@ describe("Earn program — governed payout, execution and blast radius (HOO-1559
       heldBody.error.details.walletOperationId
     );
     expect(executed).toMatchObject({ status: "completed", execution_error: null });
+  });
+});
+
+/**
+ * The provider account is shared platform-wide and a program read is a live
+ * fan-out against it — a `GET /programs` page is two provider round trips per
+ * row — so an unmetered caller spends SDP's money at whatever rate it likes.
+ *
+ * The exclusion matters as much as the quota: `meteredQuota` fails closed, and
+ * a 5xx on the way OUT of a position is the failure ADR 0002 exit safety rules
+ * out, so no money-out route and no exit quote carries one.
+ */
+describe("Earn program — metered quotas", () => {
+  it("429s a program read once the actor's quota is exhausted", async () => {
+    await seedAuth();
+    await seedProgramWallet();
+    const getWallet = stubProgramReads();
+    await seedRateLimit(
+      env,
+      `metered:earn-provider-read:org:${TEST_ORG.id}:key:${TEST_API_KEY.id}`,
+      60
+    );
+
+    const res = await requestEarn("GET", `${PROGRAMS_PATH}?provider=ground`);
+
+    expect(res.status).toBe(429);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "RATE_LIMITED" },
+    });
+    // Refused before the money was spent, which is the whole point.
+    expect(getWallet).not.toHaveBeenCalled();
+  });
+
+  it("never lets an exhausted quota stand between a caller and its money", async () => {
+    await seedAuth();
+    const program = await seedProgramWallet();
+    const createWithdrawal = vi
+      .spyOn(EARN_PROVIDER_CLIENTS.ground, "createPortfolioWithdrawal")
+      .mockResolvedValue(WITHDRAWAL);
+    const preview = vi
+      .spyOn(EARN_PROVIDER_CLIENTS.ground, "previewPortfolioWithdrawal")
+      .mockResolvedValue({ withdrawableUsd: "100.00" } as never);
+
+    // Both Earn quotas exhausted for this actor AND the whole organization.
+    for (const quota of ["earn-provider-read", "earn-chain-read"]) {
+      await seedRateLimit(env, `metered:${quota}:org:${TEST_ORG.id}:key:${TEST_API_KEY.id}`, 1000);
+      await seedRateLimit(env, `metered:${quota}:org:${TEST_ORG.id}`, 1000);
+    }
+
+    const liquidity = await requestEarn("POST", programPath(program.id, "/withdrawal-preview"), {
+      token: "usdc",
+    });
+    expect(liquidity.status).toBe(200);
+    expect(preview).toHaveBeenCalledTimes(1);
+
+    const withdrawal = await requestEarn("POST", programPath(program.id, "/withdrawals"), {
+      requestId: "2e8b1f47-5c93-4a2d-8e16-9d4f0a7b3c25",
+      amountUsd: "25.50",
+      token: "usdc",
+      destinationAddress: SOLANA_DESTINATION,
+    });
+    expect(withdrawal.status).toBe(201);
+    expect(createWithdrawal).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/sdp-api/src/routes/earn-program.test.ts
+++ b/apps/sdp-api/src/routes/earn-program.test.ts
@@ -34,6 +34,7 @@ vi.mock("@sdp/types", async (importOriginal) => {
 import { getDb } from "@/db";
 import {
   createPostgresEarnRepository,
+  createPostgresPolicyRepository,
   type EarnProviderWalletRow,
   type InsertEarnProviderWalletInput,
   type UpsertEarnStrategyInput,
@@ -41,6 +42,8 @@ import {
 import { createPostgresEarnMovementsRepository } from "@/db/repositories/earn-movements.repository";
 import app from "@/index";
 import { deriveProviderRequestId } from "@/lib/idempotency";
+import { createTenantScope } from "@/lib/tenant-scope";
+import { recoverApprovedWalletOperations } from "@/services/policy/approved-operation-replay";
 import { env } from "@/test/helpers/env";
 import { seedTestDatabase } from "@/test/mocks/db";
 import { clearKVStores, seedCachedApiKey } from "@/test/mocks/kv";
@@ -2158,5 +2161,413 @@ describe("Earn program — withdrawal ledger (PRO-1628)", () => {
 
       expect(res.status).toBe(404);
     });
+  });
+});
+
+/**
+ * HOO-1559. `POST /programs/:programId/withdrawals` pays a caller-supplied
+ * destination out of the organization's provider account. It used to be gated
+ * on `earn:write` alone: no wallet binding was asserted and no policy ran, so
+ * a selected-scope key bound to one low-value wallet could drain the whole
+ * program to any address, and an organization's deny rules, limits, destination
+ * controls and approval requirements were never consulted.
+ *
+ * A program is a provider ACCOUNT, not a custody wallet, so there is nothing
+ * for a binding to name — a wallet-scoped key is refused outright instead —
+ * and the governing profile is the API key's own.
+ */
+describe("Earn program — withdrawal authorization (HOO-1559)", () => {
+  const WALLET_SCOPED_KEY = {
+    id: "key_earn_program_scoped",
+    raw: "sk_test_earn_program_scoped",
+    prefix: "sk_test_eps",
+  };
+
+  const withdrawBody = (extra: Record<string, unknown> = {}) => ({
+    requestId: crypto.randomUUID(),
+    amountUsd: "25.50",
+    token: "usdc",
+    destinationAddress: SOLANA_DESTINATION,
+    ...extra,
+  });
+
+  /**
+   * A key bound to ONE wallet, which is exactly the shape the old gate ignored.
+   * The binding names a custody wallet that has nothing to do with the program:
+   * that is the point — the program has no custody wallet at all.
+   */
+  async function seedWalletScopedKey(): Promise<void> {
+    const keyHash = await hashString(WALLET_SCOPED_KEY.raw, env.API_KEY_PEPPER);
+    await seedCachedApiKey(env, keyHash, {
+      ...TEST_CACHED_API_KEY,
+      id: WALLET_SCOPED_KEY.id,
+      walletScope: "selected",
+      signingWalletId: "privy_low_value",
+      walletBindings: [{ walletId: "privy_low_value", permissions: ["*"] }],
+    });
+    await getDb(env)
+      .prepare(
+        `INSERT INTO api_keys
+           (id, organization_id, project_id, created_by, name, key_prefix, key_hash, role, permissions, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        WALLET_SCOPED_KEY.id,
+        TEST_ORG.id,
+        TEST_PROJECT.id,
+        TEST_USER.id,
+        "Wallet-scoped key",
+        WALLET_SCOPED_KEY.prefix,
+        keyHash,
+        "api_admin",
+        JSON.stringify(["*"]),
+        "active"
+      )
+      .run();
+  }
+
+  function requestAsWalletScopedKey(method: string, path: string, body?: Record<string, unknown>) {
+    return app.request(
+      path,
+      {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${WALLET_SCOPED_KEY.raw}`,
+        },
+        ...(body !== undefined && { body: JSON.stringify(body) }),
+      },
+      env
+    );
+  }
+
+  /** An ACTIVE control profile on the test key: profile + revision + activation. */
+  async function seedApiKeyControlProfile(params: {
+    rules: Record<string, unknown>[];
+    defaultAction?: string;
+  }): Promise<void> {
+    await getDb(env).batch([
+      getDb(env)
+        .prepare(
+          `INSERT INTO api_key_control_profiles
+             (id, organization_id, project_id, api_key_id, name, status)
+           VALUES (?, ?, ?, ?, ?, 'active')`
+        )
+        .bind("akcp_earn_program", TEST_ORG.id, TEST_PROJECT.id, TEST_API_KEY.id, "Earn controls"),
+      getDb(env)
+        .prepare(
+          `INSERT INTO api_key_control_profile_revisions
+             (id, profile_id, revision_number, rules, default_action, created_by, activated_at)
+           VALUES (?, ?, 1, ?::jsonb, ?, ?, ?)`
+        )
+        .bind(
+          "akcpr_earn_program_1",
+          "akcp_earn_program",
+          JSON.stringify(params.rules),
+          params.defaultAction ?? "allow",
+          TEST_USER.id,
+          "2026-09-07T00:00:00.000Z"
+        ),
+      getDb(env)
+        .prepare(
+          "UPDATE api_key_control_profiles SET active_revision_id = ?, activated_at = ? WHERE id = ?"
+        )
+        .bind("akcpr_earn_program_1", "2026-09-07T00:00:00.000Z", "akcp_earn_program"),
+    ]);
+  }
+
+  async function readWalletOperations() {
+    const rows = await getDb(env)
+      .prepare(
+        `SELECT id, status, operation_family, operation_type, custody_wallet_id, wallet_id,
+                asset, amount, destination
+           FROM wallet_operations ORDER BY created_at ASC, id ASC`
+      )
+      .all<{
+        id: string;
+        status: string;
+        operation_family: string;
+        operation_type: string;
+        custody_wallet_id: string | null;
+        wallet_id: string;
+        asset: string | null;
+        amount: string | null;
+        destination: string | null;
+      }>();
+    return rows.results;
+  }
+
+  async function countMovements(): Promise<number> {
+    const row = await getDb(env)
+      .prepare("SELECT COUNT(*)::int AS total FROM earn_movements")
+      .first<{ total: number }>();
+    return row?.total ?? 0;
+  }
+
+  it("refuses a wallet-scoped key on the payout, before the provider is driven", async () => {
+    await seedAuth();
+    await seedWalletScopedKey();
+    const program = await seedProgramWallet();
+    const createWithdrawal = vi
+      .spyOn(EARN_PROVIDER_CLIENTS.ground, "createPortfolioWithdrawal")
+      .mockResolvedValue(WITHDRAWAL);
+
+    const res = await requestAsWalletScopedKey(
+      "POST",
+      programPath(program.id, "/withdrawals"),
+      withdrawBody()
+    );
+
+    expect(res.status).toBe(403);
+    expect(createWithdrawal).not.toHaveBeenCalled();
+    // Nothing was intended either: the refusal precedes the ledger insert.
+    await expect(countMovements()).resolves.toBe(0);
+  });
+
+  it("refuses a wallet-scoped key on the liquidity preview it shares a chain with", async () => {
+    await seedAuth();
+    await seedWalletScopedKey();
+    const program = await seedProgramWallet();
+    const preview = vi.spyOn(EARN_PROVIDER_CLIENTS.ground, "previewPortfolioWithdrawal");
+
+    const res = await requestAsWalletScopedKey(
+      "POST",
+      programPath(program.id, "/withdrawal-preview"),
+      { token: "usdc" }
+    );
+
+    expect(res.status).toBe(403);
+    expect(preview).not.toHaveBeenCalled();
+  });
+
+  it("still serves an unbound key, and records the payout as a governed operation", async () => {
+    await seedAuth();
+    const program = await seedProgramWallet();
+    vi.spyOn(EARN_PROVIDER_CLIENTS.ground, "createPortfolioWithdrawal").mockResolvedValue(
+      WITHDRAWAL
+    );
+
+    const res = await requestEarn(
+      "POST",
+      programPath(program.id, "/withdrawals"),
+      withdrawBody({ requestId: "1d7f9a30-4c21-4f0e-9f66-2b8a51c7e0d4" })
+    );
+
+    expect(res.status).toBe(201);
+    // The audit row is the proof the gate ran at all: no custody wallet (a
+    // program is a provider account) and the provider wallet as the identity a
+    // destination or amount rule is read against.
+    expect(await readWalletOperations()).toMatchObject([
+      {
+        status: "evaluated",
+        operation_family: "program",
+        operation_type: "earn_program_withdrawal",
+        custody_wallet_id: null,
+        wallet_id: WALLET_REF,
+        asset: "usdc",
+        amount: "25.50",
+        destination: SOLANA_DESTINATION,
+      },
+    ]);
+  });
+
+  it("denies a destination the key's policy forbids, before the provider is driven", async () => {
+    await seedAuth();
+    const program = await seedProgramWallet();
+    await seedApiKeyControlProfile({
+      rules: [
+        {
+          id: "destination-allowlist",
+          kind: "destination",
+          allowlist: ["11111111111111111111111111111111"],
+          action: "allow",
+        },
+      ],
+    });
+    const createWithdrawal = vi
+      .spyOn(EARN_PROVIDER_CLIENTS.ground, "createPortfolioWithdrawal")
+      .mockResolvedValue(WITHDRAWAL);
+
+    const res = await requestEarn(
+      "POST",
+      programPath(program.id, "/withdrawals"),
+      withdrawBody({ requestId: "6c2d1b84-3f57-4a0d-9d2b-7e41f5a9c308" })
+    );
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { code: string; details: { decision: string } } };
+    expect(body.error.code).toBe("FORBIDDEN");
+    expect(body.error.details.decision).toBe("deny");
+
+    // The whole point: refused BEFORE the payout, and with no intent recorded.
+    expect(createWithdrawal).not.toHaveBeenCalled();
+    await expect(countMovements()).resolves.toBe(0);
+  });
+
+  it("holds a payout the policy requires approval for, and a retry re-answers the same hold", async () => {
+    await seedAuth();
+    const program = await seedProgramWallet();
+    await seedApiKeyControlProfile({
+      rules: [{ id: "approve-everything", kind: "always", action: "approval_required" }],
+    });
+    const createWithdrawal = vi
+      .spyOn(EARN_PROVIDER_CLIENTS.ground, "createPortfolioWithdrawal")
+      .mockResolvedValue(WITHDRAWAL);
+    const body = withdrawBody({ requestId: "b5a0c9e2-8d14-4b73-9c5f-0e6a2d8f4713" });
+
+    const held = await requestEarn("POST", programPath(program.id, "/withdrawals"), body);
+    expect(held.status).toBe(202);
+
+    // A retry of a held request must answer with the SAME hold. Opening a
+    // second approval per retry would let a caller manufacture approvals, and
+    // an approver deciding one of several duplicates could pay out twice.
+    const retried = await requestEarn("POST", programPath(program.id, "/withdrawals"), body);
+    expect(retried.status).toBe(202);
+
+    expect(createWithdrawal).not.toHaveBeenCalled();
+    await expect(countMovements()).resolves.toBe(0);
+    const operations = await readWalletOperations();
+    expect(operations).toHaveLength(1);
+    expect(operations[0]).toMatchObject({ status: "pending_approval" });
+  });
+});
+
+/**
+ * The two halves of HOO-1559 that only fail once the gate exists: the
+ * ownership widening it needed, and the approval path it opened.
+ */
+describe("Earn program — governed payout, execution and blast radius (HOO-1559)", () => {
+  it("admits the program as an operation target for its OWN type only", async () => {
+    await seedAuth();
+    const program = await seedProgramWallet();
+    const repo = createPostgresPolicyRepository(
+      getDb(env),
+      createTenantScope({ organizationId: TEST_ORG.id, projectId: TEST_PROJECT.id })
+    );
+    const candidate = {
+      organizationId: TEST_ORG.id,
+      projectId: TEST_PROJECT.id,
+      custodyWalletId: null,
+      walletId: program.provider_wallet_ref,
+      apiKeyId: TEST_API_KEY.id,
+      actor: null,
+      source: "test",
+      asset: "usdc",
+      amount: "1.00",
+      destination: SOLANA_DESTINATION,
+      context: {},
+      providerExtensions: {},
+      rawPayload: {},
+      idempotencyKey: null,
+    } as const;
+
+    await expect(
+      repo.createWalletOperation({
+        ...candidate,
+        operationFamily: "program",
+        operationType: "earn_program_withdrawal",
+      })
+    ).resolves.not.toBeNull();
+
+    // Another family naming the same provider wallet must NOT inherit the
+    // admission: proving ownership through an Earn link row is a statement
+    // about Earn programs, not a second way to claim any target at all.
+    await expect(
+      repo.createWalletOperation({
+        ...candidate,
+        idempotencyKey: null,
+        operationFamily: "issuance",
+        operationType: "issuance_mint_execute",
+      })
+    ).resolves.toBeNull();
+  });
+
+  /**
+   * The approval executor replays the STORED BODY — `requestId` included — and
+   * adds an `Idempotency-Key` header it minted itself when the original request
+   * carried none. This route refuses a request that sends both, so without an
+   * exemption every approved body-keyed withdrawal 400s at execution: money
+   * held by policy that could never be paid.
+   */
+  it("pays out a body-keyed withdrawal once its approval is granted", async () => {
+    await seedAuth();
+    const program = await seedProgramWallet();
+    await getDb(env)
+      .prepare(
+        `INSERT INTO api_key_control_profiles
+           (id, organization_id, project_id, api_key_id, name, status)
+         VALUES (?, ?, ?, ?, ?, 'active')`
+      )
+      .bind("akcp_exec", TEST_ORG.id, TEST_PROJECT.id, TEST_API_KEY.id, "Approve payouts")
+      .run();
+    await getDb(env)
+      .prepare(
+        `INSERT INTO api_key_control_profile_revisions
+           (id, profile_id, revision_number, rules, default_action, created_by, activated_at)
+         VALUES (?, ?, 1, ?::jsonb, 'allow', ?, ?)`
+      )
+      .bind(
+        "akcpr_exec_1",
+        "akcp_exec",
+        JSON.stringify([
+          {
+            id: "approve-program-withdrawals",
+            kind: "approval",
+            operationTypes: ["earn_program_withdrawal"],
+          },
+        ]),
+        TEST_USER.id,
+        "2026-09-07T00:00:00.000Z"
+      )
+      .run();
+    await getDb(env)
+      .prepare(
+        "UPDATE api_key_control_profiles SET active_revision_id = ?, activated_at = ? WHERE id = ?"
+      )
+      .bind("akcpr_exec_1", "2026-09-07T00:00:00.000Z", "akcp_exec")
+      .run();
+
+    const createWithdrawal = vi
+      .spyOn(EARN_PROVIDER_CLIENTS.ground, "createPortfolioWithdrawal")
+      .mockResolvedValue(WITHDRAWAL);
+
+    // The caller keys with body `requestId`, the form this route accepts and
+    // the vault routes reject — which is why the vault suites never caught it.
+    const held = await requestEarn("POST", programPath(program.id, "/withdrawals"), {
+      requestId: "7f3c8e51-2a94-4d6b-b0e7-1c5a9f28d403",
+      amountUsd: "25.50",
+      token: "usdc",
+      destinationAddress: SOLANA_DESTINATION,
+    });
+    expect(held.status).toBe(202);
+    expect(createWithdrawal).not.toHaveBeenCalled();
+    const heldBody = (await held.json()) as {
+      error: { details: { approvalRequestId: string; walletOperationId: string } };
+    };
+
+    const policyRepository = createPostgresPolicyRepository(
+      getDb(env),
+      createTenantScope({ organizationId: TEST_ORG.id, projectId: TEST_PROJECT.id })
+    );
+    await policyRepository.updateApprovalRequestStatus({
+      organizationId: TEST_ORG.id,
+      projectId: TEST_PROJECT.id,
+      approvalRequestId: heldBody.error.details.approvalRequestId,
+      status: "approved",
+      operationStatus: "executing",
+      resolvedBy: TEST_API_KEY.id,
+    });
+    // Approved and unclaimed: the recovery pass is how an approved operation
+    // reaches its route, and it is the only in-process way to drive the real
+    // executor — which is the point, since the defect lives in what the
+    // executor sends.
+    expect(await recoverApprovedWalletOperations(env)).toBe(1);
+
+    // The payout the approval authorized actually left, exactly once.
+    expect(createWithdrawal).toHaveBeenCalledTimes(1);
+    const executed = await policyRepository.getWalletOperationById(
+      heldBody.error.details.walletOperationId
+    );
+    expect(executed).toMatchObject({ status: "completed", execution_error: null });
   });
 });

--- a/apps/sdp-api/src/routes/earn-program.test.ts
+++ b/apps/sdp-api/src/routes/earn-program.test.ts
@@ -86,6 +86,22 @@ const TEST_PRODUCTION_PROJECT = {
 };
 const TEST_SESSION_ID = "ses_earn_program";
 
+/**
+ * A second sandbox project in the SAME organization, with its own key. Programs
+ * are resolved per (organization, environment), so a sibling project addresses
+ * the very same program — which is how a payout's idempotency key can arrive
+ * under two project scopes.
+ */
+const TEST_SIBLING_PROJECT = {
+  id: "prj_test_earn_program_sibling",
+  slug: "test-earn-program-project-sibling",
+};
+const TEST_SIBLING_API_KEY = {
+  id: "key_earn_program_sibling",
+  raw: "sk_test_earn_program_sibling",
+  prefix: "sk_test_eps",
+};
+
 const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 const GROUND_SANDBOX_KEY = "ground-sandbox-test-api-key";
 const GROUND_PRODUCTION_KEY = "ground-production-test-api-key";
@@ -238,6 +254,49 @@ async function seedSessionAuth(): Promise<void> {
          VALUES (?, ?, ?, 'session', ?)`
       )
       .bind(TEST_SESSION_ID, TEST_USER.id, TEST_ORG.id, "2099-01-01T00:00:00.000Z"),
+  ]);
+}
+
+/** Sibling sandbox project in TEST_ORG, with an api_admin key of its own. */
+async function seedSiblingProjectAuth(): Promise<void> {
+  const keyHash = await hashString(TEST_SIBLING_API_KEY.raw, env.API_KEY_PEPPER);
+  await seedCachedApiKey(env, keyHash, {
+    ...TEST_CACHED_API_KEY,
+    id: TEST_SIBLING_API_KEY.id,
+    projectId: TEST_SIBLING_PROJECT.id,
+  });
+
+  await getDb(env).batch([
+    getDb(env)
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, ?, ?, 'sandbox', 'active', ?)`
+      )
+      .bind(
+        TEST_SIBLING_PROJECT.id,
+        TEST_ORG.id,
+        "Sibling Project",
+        TEST_SIBLING_PROJECT.slug,
+        TEST_USER.id
+      ),
+    getDb(env)
+      .prepare(
+        `INSERT INTO api_keys
+           (id, organization_id, project_id, created_by, name, key_prefix, key_hash, role, permissions, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        TEST_SIBLING_API_KEY.id,
+        TEST_ORG.id,
+        TEST_SIBLING_PROJECT.id,
+        TEST_USER.id,
+        "Earn Program Sibling Key",
+        TEST_SIBLING_API_KEY.prefix,
+        keyHash,
+        "api_admin",
+        JSON.stringify(["*"]),
+        "active"
+      ),
   ]);
 }
 
@@ -2422,6 +2481,38 @@ describe("Earn program — withdrawal authorization (HOO-1559)", () => {
     // second approval per retry would let a caller manufacture approvals, and
     // an approver deciding one of several duplicates could pay out twice.
     const retried = await requestEarn("POST", programPath(program.id, "/withdrawals"), body);
+    expect(retried.status).toBe(202);
+
+    expect(createWithdrawal).not.toHaveBeenCalled();
+    await expect(countMovements()).resolves.toBe(0);
+    const operations = await readWalletOperations();
+    expect(operations).toHaveLength(1);
+    expect(operations[0]).toMatchObject({ status: "pending_approval" });
+  });
+
+  it("re-answers the same hold when the retry arrives under a sibling project", async () => {
+    await seedAuth();
+    await seedSiblingProjectAuth();
+    const program = await seedProgramWallet();
+    await seedApiKeyControlProfile({
+      rules: [{ id: "approve-everything", kind: "always", action: "approval_required" }],
+    });
+    const createWithdrawal = vi
+      .spyOn(EARN_PROVIDER_CLIENTS.ground, "createPortfolioWithdrawal")
+      .mockResolvedValue(WITHDRAWAL);
+    const body = withdrawBody({ requestId: "0f3a7c19-52d4-4a8e-b1c6-9d0e5f2a8b47" });
+
+    const held = await requestEarn("POST", programPath(program.id, "/withdrawals"), body);
+    expect(held.status).toBe(202);
+
+    // A program is addressed per (organization, environment) and its payout
+    // ledger is keyed by organization + provider wallet + request id, so the
+    // hold must answer the same key from any project in the organization. A
+    // project-scoped lookup would miss it and open a SECOND approval for one
+    // payout — two approvers, each able to release it.
+    const retried = await requestEarn("POST", programPath(program.id, "/withdrawals"), body, {
+      Authorization: `Bearer ${TEST_SIBLING_API_KEY.raw}`,
+    });
     expect(retried.status).toBe(202);
 
     expect(createWithdrawal).not.toHaveBeenCalled();

--- a/apps/sdp-api/src/routes/earn-program.test.ts
+++ b/apps/sdp-api/src/routes/earn-program.test.ts
@@ -38,6 +38,7 @@ import {
   type EarnProviderWalletRow,
   type InsertEarnProviderWalletInput,
   type UpsertEarnStrategyInput,
+  WalletOperationIdempotencyConflictError,
 } from "@/db/repositories";
 import { createPostgresEarnMovementsRepository } from "@/db/repositories/earn-movements.repository";
 import app from "@/index";
@@ -2488,6 +2489,55 @@ describe("Earn program — withdrawal authorization (HOO-1559)", () => {
     const operations = await readWalletOperations();
     expect(operations).toHaveLength(1);
     expect(operations[0]).toMatchObject({ status: "pending_approval" });
+  });
+
+  it("lets only one governed operation exist per payout, across projects", async () => {
+    await seedAuth();
+    await seedSiblingProjectAuth();
+    const program = await seedProgramWallet();
+
+    const requestId = deriveProviderRequestId(
+      ["earn_program_withdrawal", program.provider_wallet_ref],
+      "4d9a1c07-6b3e-4f52-8a7d-1c0b5e9f3a26"
+    );
+    const operation = {
+      organizationId: TEST_ORG.id,
+      custodyWalletId: null,
+      walletId: program.provider_wallet_ref,
+      operationFamily: "program" as const,
+      operationType: "earn_program_withdrawal" as const,
+      status: "pending_approval" as const,
+      idempotencyKey: requestId,
+    };
+
+    const inProject = createPostgresPolicyRepository(
+      getDb(env),
+      createTenantScope({ organizationId: TEST_ORG.id, projectId: TEST_PROJECT.id })
+    );
+    const inSibling = createPostgresPolicyRepository(
+      getDb(env),
+      createTenantScope({ organizationId: TEST_ORG.id, projectId: TEST_SIBLING_PROJECT.id })
+    );
+
+    const won = await inProject.createWalletOperation({
+      ...operation,
+      projectId: TEST_PROJECT.id,
+    });
+    expect(won).not.toBeNull();
+
+    // The concurrent case the route's prior-operation check cannot bind: both
+    // attempts see no prior record, so the database decides. A sibling project
+    // must not be able to open a second approval for one provider payout.
+    await expect(
+      inSibling.createWalletOperation({ ...operation, projectId: TEST_SIBLING_PROJECT.id })
+    ).rejects.toBeInstanceOf(WalletOperationIdempotencyConflictError);
+
+    await expect(
+      inProject.createWalletOperation({ ...operation, projectId: TEST_PROJECT.id })
+    ).rejects.toBeInstanceOf(WalletOperationIdempotencyConflictError);
+
+    const operations = await readWalletOperations();
+    expect(operations).toHaveLength(1);
   });
 
   it("re-answers the same hold when the retry arrives under a sibling project", async () => {

--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -981,6 +981,25 @@ the old cluster-agnostic read silently built against whichever chain the single
 URL happened to serve — and a mismatch does not error, because Kamino's mainnet
 kvault program id also resolves on devnet with no accounts under it.
 
+## Metered quotas
+
+The Earn reads that fan out to a PAID upstream carry `meteredQuota`: the
+provider's API on a program read (`GET /programs` is 2N round trips per page
+against the shared provider account), Solana RPC on a live-hydrated one. Two
+counters, `earn-provider-read` (programs list/detail/deposits, the deposit
+quote) and `earn-chain-read` (vault positions, share reconciliation, the
+per-owner external-wallet reads).
+
+**No money-OUT route and no EXIT quote carries one, and that is load-bearing.**
+`meteredQuota` fails closed — a counter-store outage answers 503 — and a 5xx on
+a customer's way out of a position is exactly the failure ADR 0002 exit safety
+rules out. A refused read costs a caller a retry; a refused exit traps funds.
+So withdrawals, vault withdrawals, the external-wallet submits and builds, and
+every preview an exit derives its floor from stay unmetered. Money-IN carries
+no such rule, which is why the deposit quote is metered and the exit quote is
+not. Pinned by the "metered quotas" describe in `../earn-program.test.ts`,
+whose second test exhausts both counters and asserts the payout still lands.
+
 ## Gate asymmetry — DO NOT BREAK (ADR 0002 exit-safety)
 
 - **Money-in** (`POST /programs`, `PUT /programs/:programId`):

--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -336,6 +336,45 @@ other's balance.
     rather than surfacing the provider's message.
 - **`POST /programs/:programId/withdrawals` — live provider call + SDP ledger
   write.**
+  **POLICY-GATED, and it refuses a wallet-scoped key** (HOO-1559). It pays a
+  caller-supplied `destinationAddress` out of the organization's provider
+  account, and `earn:write` used to be the whole gate — no binding assertion,
+  no policy — so a selected-scope key bound to one low-value wallet could drain
+  the program to any address while the org's deny rules, amount/asset limits,
+  destination controls and approval requirements never ran.
+  A program is a provider ACCOUNT, not a custody wallet, so there is nothing
+  for `assertApiKeyWalletAccess` to name: a wallet-scoped key is refused
+  outright (`assertApiKeyNotWalletScoped`) rather than silently treated as
+  unbound. The same refusal is on `withdrawal-preview`, which discloses live
+  lane liquidity through the identical chain.
+  The policy envelope is `program` / `earn_program_withdrawal` with
+  `custodyWalletId: null` and the PROVIDER WALLET as `walletId`, so the
+  governing profile is the API KEY'S own control profile — the wallet policy
+  half falls back to implicit allow, because there is no custody wallet to
+  carry one. `tenantOwnsWalletTarget` (policy repository) admits an
+  `earn_provider_wallets` row owned by the organization as a target for exactly
+  this case. Its `allowEarnProgramTarget` flag is set ONLY for
+  `earn_program_withdrawal` — keying it on "names no custody wallet" instead
+  would be a widening, because other families can leave `custodyWalletId` null
+  (issuance mint among them) and would gain a second way to prove ownership of
+  a target they do not custody.
+  **The approval path needs an exemption from the "requestId or
+  `Idempotency-Key`, not both" refusal.** The approval executor replays the
+  STORED BODY — `requestId` included — and adds a header it minted itself when
+  the original request carried none (`walletOperationExecutionRequest`). Without
+  the exemption every approved body-keyed withdrawal 400s at execution: money
+  held by policy that could never be paid. The vault routes reject body
+  `requestId` outright, so they never meet it, and that asymmetry is why this
+  needs its own test — `earn-program.test.ts` drives the real executor through
+  `recoverApprovedWalletOperations`.
+  **Replay resolution lives in the EXTRACTOR, not in the gate's
+  `findIdempotentKeyReplay` hook**: that hook only runs for callers using the
+  `Idempotency-Key` header, and this route equally accepts the key as body
+  `requestId`, so a body-keyed retry would have opened a second governed
+  operation — an approval per attempt. A retry therefore extracts a NULL
+  candidate (a replay is not a new intent; it was governed when created) and
+  the handler serves it. A key that produced an operation policy is still
+  holding answers with THAT operation.
   Needs a retry-stable idempotency key and refuses a request carrying none:
   EXACTLY one of `requestId` (UUIDv4) or the `Idempotency-Key` header — both
   and neither are 400s, because no precedence rule can tell which of two

--- a/apps/sdp-api/src/routes/earn/handlers/policy-replay.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/policy-replay.ts
@@ -9,20 +9,31 @@ import type { AppContext } from "../context";
  * second one — and a key reused with a different payload is a conflict even
  * before any movement exists.
  *
- * `projectId` is nullable because a program withdrawal is organization-scoped;
- * a null narrows the lookup to operations recorded without a project rather
- * than widening it across siblings.
+ * The lookup scope must match the scope the movement ledger enforces for the
+ * same key, or a retry can miss the operation it should be replaying and open a
+ * second one. A vault movement is keyed per project, so it looks up per project.
+ * A program withdrawal is keyed by organization and provider wallet — its
+ * derived request id already names the operation type and the wallet — so it
+ * looks across every project in the organization; scoping it per project would
+ * let a sibling project mint a second approval for the same payout.
  */
+export type EarnPolicyReplayScope =
+  | { readonly kind: "project"; readonly projectId: string | null }
+  | { readonly kind: "organization" };
+
 export async function throwOnPriorEarnPolicyOperation(
   c: AppContext,
   params: {
     organizationId: string;
-    projectId: string | null;
+    scope: EarnPolicyReplayScope;
     idempotencyKey: string;
     idempotencyFingerprint: string;
     operationNoun: "vault deposit" | "vault withdrawal" | "program withdrawal";
   }
 ): Promise<void> {
+  const projectPredicate =
+    params.scope.kind === "project" ? "AND operation.project_id IS NOT DISTINCT FROM ?" : "";
+  const projectBindings = params.scope.kind === "project" ? [params.scope.projectId] : [];
   const prior = await getDb(c.env)
     .prepare(
       `SELECT operation.id, operation.status, operation.raw_payload,
@@ -37,10 +48,12 @@ export async function throwOnPriorEarnPolicyOperation(
          LIMIT 1
        ) evaluation ON TRUE
        WHERE operation.organization_id = ?
-         AND operation.project_id IS NOT DISTINCT FROM ?
-         AND operation.idempotency_key = ?`
+         ${projectPredicate}
+         AND operation.idempotency_key = ?
+       ORDER BY operation.created_at DESC, operation.id DESC
+       LIMIT 1`
     )
-    .bind(params.organizationId, params.projectId, params.idempotencyKey)
+    .bind(params.organizationId, ...projectBindings, params.idempotencyKey)
     .first<{
       id: string;
       status: string;

--- a/apps/sdp-api/src/routes/earn/handlers/policy-replay.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/policy-replay.ts
@@ -1,0 +1,82 @@
+import { getDb } from "@/db";
+import { AppError, conflict } from "@/lib/errors";
+import type { AppContext } from "../context";
+
+/**
+ * Pre-execution policy replays, shared by every Earn money mover: a key that
+ * already produced a wallet operation must answer with that operation's state
+ * (still pending approval, executing, denied, canceled) rather than starting a
+ * second one — and a key reused with a different payload is a conflict even
+ * before any movement exists.
+ *
+ * `projectId` is nullable because a program withdrawal is organization-scoped;
+ * a null narrows the lookup to operations recorded without a project rather
+ * than widening it across siblings.
+ */
+export async function throwOnPriorEarnPolicyOperation(
+  c: AppContext,
+  params: {
+    organizationId: string;
+    projectId: string | null;
+    idempotencyKey: string;
+    idempotencyFingerprint: string;
+    operationNoun: "vault deposit" | "vault withdrawal" | "program withdrawal";
+  }
+): Promise<void> {
+  const prior = await getDb(c.env)
+    .prepare(
+      `SELECT operation.id, operation.status, operation.raw_payload,
+              evaluation.id AS policy_evaluation_id,
+              evaluation.decision, evaluation.reason_code, evaluation.reason,
+              evaluation.requires_approval, evaluation.approval_request_id
+       FROM wallet_operations operation
+       LEFT JOIN LATERAL (
+         SELECT * FROM policy_evaluations
+         WHERE wallet_operation_id = operation.id
+         ORDER BY created_at DESC, id DESC
+         LIMIT 1
+       ) evaluation ON TRUE
+       WHERE operation.organization_id = ?
+         AND operation.project_id IS NOT DISTINCT FROM ?
+         AND operation.idempotency_key = ?`
+    )
+    .bind(params.organizationId, params.projectId, params.idempotencyKey)
+    .first<{
+      id: string;
+      status: string;
+      raw_payload: Record<string, unknown>;
+      policy_evaluation_id: string | null;
+      decision: string | null;
+      reason_code: string | null;
+      reason: string | null;
+      requires_approval: boolean | null;
+      approval_request_id: string | null;
+    }>();
+  if (!prior) return;
+  if (prior.raw_payload.idempotencyFingerprint !== params.idempotencyFingerprint) {
+    throw conflict("Idempotency key already used with different request payload");
+  }
+
+  const details = {
+    walletOperationId: prior.id,
+    policyEvaluationId: prior.policy_evaluation_id,
+    decision: prior.decision,
+    reasonCode: prior.reason_code,
+    reason: prior.reason,
+    requiresApproval: prior.requires_approval,
+    approvalRequestId: prior.approval_request_id,
+  };
+  if (prior.status === "pending_approval" || prior.status === "executing") {
+    throw new AppError(
+      "SIGNING_PENDING",
+      prior.status === "pending_approval"
+        ? "Wallet operation requires policy approval"
+        : `Approved ${params.operationNoun} execution is still in progress`,
+      details
+    );
+  }
+  if (prior.decision === "deny" || prior.status === "canceled") {
+    throw new AppError("FORBIDDEN", "Wallet operation denied by policy", details);
+  }
+  throw conflict(`The prior ${params.operationNoun} policy operation has no replayable movement`);
+}

--- a/apps/sdp-api/src/routes/earn/handlers/program.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/program.ts
@@ -830,7 +830,11 @@ export async function extractEarnProgramWithdrawalPolicyCandidate(
     // than starting a second approval.
     await throwOnPriorEarnPolicyOperation(c, {
       organizationId: auth.organizationId,
-      projectId: auth.projectId ?? null,
+      // Organization-scoped on purpose: the ledger's replay above is keyed by
+      // organization + provider wallet + request id, so a per-project lookup
+      // here would miss a held operation a sibling project created and mint a
+      // second approval for the same payout.
+      scope: { kind: "organization" },
       idempotencyKey: requestId,
       idempotencyFingerprint,
       operationNoun: "program withdrawal",

--- a/apps/sdp-api/src/routes/earn/handlers/program.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/program.ts
@@ -16,6 +16,7 @@ import type {
   ListEarnProgramWithdrawalsResponse,
 } from "@sdp/types";
 import type { EarnProviderId } from "@sdp/types/provider-access";
+import type { z } from "zod";
 import { getDb, runWithSystemDatabaseIdentity } from "@/db";
 import { isPostgresUniqueViolation } from "@/db/postgres-utils";
 import type { EarnProviderWalletRow } from "@/db/repositories";
@@ -34,13 +35,17 @@ import {
 } from "@/lib/idempotency";
 import { success } from "@/lib/response";
 import { IDEMPOTENCY_KEY_HEADER } from "@/middleware/idempotency-key";
+import { getPolicyGateContext, type PolicyGateExtraction } from "@/middleware/policy-gate";
 import type { ValidatedBodyContext } from "@/middleware/validate";
 import { getLogger } from "@/runtime/logger";
+import { assertApiKeyNotWalletScoped } from "@/services/api-key-scope.service";
 import { resolveEarnProviderClient } from "@/services/earn-provider-registry";
 import {
   applyEarnWithdrawalObservationByReference,
   applyEarnWithdrawalObservationToRow,
 } from "@/services/earn-withdrawal-ledger.service";
+import { approvedWalletOperationId } from "@/services/policy/approved-operation-replay";
+import { walletOperationActorFromAuth } from "@/services/policy/enforcement.service";
 import {
   assertEarnProviderConfigured,
   assertEarnProviderSurfaced,
@@ -58,6 +63,7 @@ import {
   type earnProgramWithdrawalPreviewSchema,
   earnProgramWithdrawalsListQuerySchema,
 } from "../schemas";
+import { throwOnPriorEarnPolicyOperation } from "./policy-replay";
 import { listResponse, pageWindow, parseParams, parseQuery } from "./shared";
 
 export type {
@@ -270,7 +276,13 @@ function resolveCallerIdempotencyKey(
   consequence: string
 ): string | undefined {
   const headerKey = c.req.header(IDEMPOTENCY_KEY_HEADER);
-  if (requestId && headerKey) {
+  // An approval executor replays the stored body — `requestId` included — and
+  // sends a header it minted itself when the original request carried none
+  // (`walletOperationExecutionRequest`). That is not the ambiguity this refusal
+  // guards against: the caller's own key is the one in the body, and refusing
+  // the pair here would make every approved body-keyed withdrawal 400 at
+  // execution time — money held by policy that could never be paid.
+  if (requestId && headerKey && !approvedWalletOperationId(c)) {
     throw badRequest(
       `Send requestId or the ${IDEMPOTENCY_KEY_HEADER} header, not both: SDP cannot tell which one your retry keeps stable, and following the wrong one would ${consequence}.`
     );
@@ -606,6 +618,20 @@ export const listEarnProgramDeposits = async (c: AppContext) => {
   return success(c, response);
 };
 
+/**
+ * A program is an ACCOUNT at the provider, not an SDP custody wallet, so there
+ * is no `custody_wallets` row for a selected-scope key to be bound against and
+ * `assertApiKeyWalletAccess` has nothing to assert. Program payouts are
+ * organization-level by design (the link row's `project_id` records
+ * provisioning only), so a wallet-scoped key — a key whose whole point is that
+ * it may spend from ONE named wallet — is refused outright rather than silently
+ * treated as unbound: an unasserted binding is how a key bound to a low-value
+ * wallet reached the organization's whole provider balance (HOO-1559).
+ */
+function assertProgramKeyIsNotWalletScoped(c: AppContext, action: string): void {
+  assertApiKeyNotWalletScoped(getAuth(c), action);
+}
+
 export const previewEarnProgramWithdrawal = async (
   c: ValidatedBodyContext<typeof earnProgramWithdrawalPreviewSchema>
 ) => {
@@ -615,6 +641,8 @@ export const previewEarnProgramWithdrawal = async (
 
   // Money-out path: credentials only, never the entitlement gate.
   assertEarnProviderConfigured(c.env, client.provider, testMode);
+
+  assertProgramKeyIsNotWalletScoped(c, "read Earn program withdrawal liquidity");
 
   const preview = await client.previewPortfolioWithdrawal(earnRuntime(c), {
     providerWalletRef: row.provider_wallet_ref,
@@ -704,9 +732,35 @@ async function persistWithdrawalObservation(
   }
 }
 
-export const createEarnProgramWithdrawal = async (
+/** Everything the policy gate resolved, handed to the handler behind it. */
+export interface EarnProgramWithdrawalResolved {
+  row: EarnProviderWalletRow;
+  client: EarnPortfolioWalletProvider;
+  auth: ReturnType<typeof getAuth>;
+  requestId: string;
+  idempotencyFingerprint: string;
+}
+
+/**
+ * Resolve the program, its credentials and the caller's key, then state the
+ * withdrawal as a policy candidate.
+ *
+ * The gate order the route documents is preserved exactly — capability (501)
+ * and credentials (503) before the wallet-scope refusal (403), and key
+ * resolution LAST (400), so an unreachable call never answers "missing
+ * idempotency key".
+ *
+ * `custodyWalletId` is null because a program is a provider account and SDP
+ * signs nothing here; the operation is therefore governed by the API key's own
+ * control profile (deny rules, amount/asset/destination limits, approval
+ * requirements) rather than by a wallet policy. `walletId` names the provider
+ * wallet the money leaves, which is what a destination or amount rule has to
+ * be read against.
+ */
+export async function extractEarnProgramWithdrawalPolicyCandidate(
   c: ValidatedBodyContext<typeof earnProgramWithdrawalCreateSchema>
-) => {
+): Promise<PolicyGateExtraction> {
+  const rawPayload: Record<string, unknown> = await c.req.json();
   const { programId } = parseParams(c, earnProgramParamsSchema);
   const body = c.req.valid("json");
   const { row, client, testMode } = await requireProgramContext(c, programId);
@@ -714,17 +768,133 @@ export const createEarnProgramWithdrawal = async (
   // Money-out path: credentials only, never the entitlement gate.
   assertEarnProviderConfigured(c.env, client.provider, testMode);
 
+  assertProgramKeyIsNotWalletScoped(c, "withdraw from Earn programs");
+
   const auth = getAuth(c);
   const requestId = resolveWithdrawalRequestId(c, body.requestId, row.provider_wallet_ref);
   // The fingerprint normalizes the amount exactly as the provider wire does
   // (clients send a JSON number), so SDP's conflict judgment can never be
   // stricter than the provider request it guards — '100' and '100.00' replay.
-  const fingerprint = buildEarnWithdrawalFingerprint({
+  const idempotencyFingerprint = buildEarnWithdrawalFingerprint({
     providerWalletRef: row.provider_wallet_ref,
     amountUsd: body.amountUsd,
     token: body.token,
     destinationAddress: body.destinationAddress,
   });
+
+  const resolved: EarnProgramWithdrawalResolved = {
+    row,
+    client,
+    auth,
+    requestId,
+    idempotencyFingerprint,
+  };
+
+  // A retry is not a new intent, so it must not open a second governed
+  // operation — one caller key would otherwise mint an approval per attempt.
+  // The decision lives HERE rather than in the gate's `findIdempotentKeyReplay`
+  // hook because that hook only runs for callers using the `Idempotency-Key`
+  // header, and this route equally accepts the key as body `requestId`.
+  //
+  // A null candidate leaves the request ungoverned, which is exactly right for
+  // a replay: the payout it replays was governed when it was created. The
+  // handler behind the gate then serves the replay, or re-drives a ref-less
+  // intent whose provider call never landed, as it always has.
+  //
+  // An approval executor is deliberately exempt: its whole job is to run the
+  // payout the original request was held for.
+  if (!approvedWalletOperationId(c)) {
+    const ledger = createPostgresEarnMovementsRepository(getDb(c.env));
+    const priorIntent = await resolveIdempotencyReplay(
+      () =>
+        ledger.findCustodialMovementByRequestId({
+          organizationId: auth.organizationId,
+          providerWalletId: row.id,
+          requestId,
+        }),
+      idempotencyFingerprint
+    );
+    if (priorIntent) {
+      return {
+        candidate: null,
+        legs: [],
+        body,
+        resolved,
+        rawPayload: { ...rawPayload, idempotencyFingerprint },
+        idempotencyKey: requestId,
+      };
+    }
+
+    // No movement exists, so a key that already produced an operation is one
+    // policy is still holding (or refused) — answer with THAT operation rather
+    // than starting a second approval.
+    await throwOnPriorEarnPolicyOperation(c, {
+      organizationId: auth.organizationId,
+      projectId: auth.projectId ?? null,
+      idempotencyKey: requestId,
+      idempotencyFingerprint,
+      operationNoun: "program withdrawal",
+    });
+  }
+
+  return {
+    candidate: {
+      organizationId: auth.organizationId,
+      projectId: auth.projectId ?? null,
+      custodyWalletId: null,
+      walletId: row.provider_wallet_ref,
+      apiKeyId: auth.apiKeyId ?? null,
+      actor: walletOperationActorFromAuth(auth),
+      source: "earn_program_withdrawal",
+      operationFamily: "program",
+      operationType: "earn_program_withdrawal",
+      asset: body.token,
+      amount: body.amountUsd,
+      destination: body.destinationAddress,
+      context: {
+        provider: client.provider,
+        programId: row.id,
+        environment: resolveSdpEnvironment(c),
+      },
+      providerExtensions: {},
+    },
+    legs: [],
+    body,
+    resolved,
+    rawPayload: { ...rawPayload, idempotencyFingerprint },
+    idempotencyKey: requestId,
+  };
+}
+
+/**
+ * True replay of an accepted withdrawal: answer with the provider's live state
+ * and let the observation refresh the ledger. 200, not 201 — nothing was
+ * created by this request.
+ */
+async function serveEarnProgramWithdrawalReplay(
+  c: AppContext,
+  resolved: EarnProgramWithdrawalResolved,
+  ledger: EarnMovementsRepository,
+  intent: EarnMovementRow,
+  providerReference: string
+) {
+  const withdrawal = await resolved.client.getPortfolioWithdrawal(earnRuntime(c), {
+    providerWalletRef: resolved.row.provider_wallet_ref,
+    withdrawalRef: providerReference,
+  });
+  await persistWithdrawalObservation(ledger, intent, withdrawal);
+  const response: EarnProgramWithdrawalResponse = { withdrawal };
+  return success(c, response, 200);
+}
+
+export const createEarnProgramWithdrawal = async (
+  c: ValidatedBodyContext<typeof earnProgramWithdrawalCreateSchema>
+) => {
+  const { body, resolved } = getPolicyGateContext<
+    z.infer<typeof earnProgramWithdrawalCreateSchema>,
+    EarnProgramWithdrawalResolved
+  >(c);
+  const { row, client, auth, requestId, idempotencyFingerprint: fingerprint } = resolved;
 
   const ledger = createPostgresEarnMovementsRepository(getDb(c.env));
   const findIntentRow = () =>
@@ -737,24 +907,19 @@ export const createEarnProgramWithdrawal = async (
   // SDP-side replay resolution BEFORE any provider call: the same key with a
   // different payload 409s here (the provider enforces the identical rule —
   // an idempotency key names one intent); a matching payload resolves to the
-  // existing intent row.
-  // True replay of an accepted withdrawal: answer with the provider's live
-  // state and let the observation refresh the ledger. 200, not 201 — nothing
-  // was created by this request.
-  const serveReplay = async (intent: EarnMovementRow, providerReference: string) => {
-    const withdrawal = await client.getPortfolioWithdrawal(earnRuntime(c), {
-      providerWalletRef: row.provider_wallet_ref,
-      withdrawalRef: providerReference,
-    });
-    await persistWithdrawalObservation(ledger, intent, withdrawal);
-    const response: EarnProgramWithdrawalResponse = { withdrawal };
-    return success(c, response, 200);
-  };
-
+  // existing intent row. The gate's replay hook already answered the ordinary
+  // retry; this remains for the approval executor, which reaches the handler
+  // with the hook deliberately skipped.
   let intentRow = await resolveIdempotencyReplay(findIntentRow, fingerprint);
 
   if (intentRow?.provider_reference) {
-    return serveReplay(intentRow, intentRow.provider_reference);
+    return serveEarnProgramWithdrawalReplay(
+      c,
+      resolved,
+      ledger,
+      intentRow,
+      intentRow.provider_reference
+    );
   }
 
   if (!intentRow) {
@@ -797,7 +962,13 @@ export const createEarnProgramWithdrawal = async (
     // the provider and stamped the ref while we waited on the re-resolve —
     // that is a replay too, not a second create.
     if (intentRow.provider_reference) {
-      return serveReplay(intentRow, intentRow.provider_reference);
+      return serveEarnProgramWithdrawalReplay(
+        c,
+        resolved,
+        ledger,
+        intentRow,
+        intentRow.provider_reference
+      );
     }
   }
 

--- a/apps/sdp-api/src/routes/earn/handlers/program.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/program.ts
@@ -871,6 +871,28 @@ export async function extractEarnProgramWithdrawalPolicyCandidate(
 }
 
 /**
+ * The concurrent twin of the replay check in the extractor above. Two first
+ * attempts for one payout both find no prior operation, and the unique index
+ * decides which one governs it; the loser lands here and answers with the
+ * winner's operation — the same 202/403/409 a sequential retry gets — instead
+ * of a bare conflict (HOO-1559).
+ */
+export async function answerEarnProgramWithdrawalConflict(
+  c: AppContext,
+  extraction: PolicyGateExtraction
+): Promise<void> {
+  const { auth, requestId, idempotencyFingerprint } =
+    extraction.resolved as EarnProgramWithdrawalResolved;
+  await throwOnPriorEarnPolicyOperation(c, {
+    organizationId: auth.organizationId,
+    scope: { kind: "organization" },
+    idempotencyKey: requestId,
+    idempotencyFingerprint,
+    operationNoun: "program withdrawal",
+  });
+}
+
+/**
  * True replay of an accepted withdrawal: answer with the provider's live state
  * and let the observation refresh the ledger. 200, not 201 — nothing was
  * created by this request.

--- a/apps/sdp-api/src/routes/earn/handlers/vault.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/vault.ts
@@ -86,6 +86,7 @@ import {
   earnVaultWithdrawalsQuerySchema,
 } from "../schemas";
 import { assertStrategyDepositable, assertVaultDepositAdmissible } from "./admission";
+import { throwOnPriorEarnPolicyOperation } from "./policy-replay";
 import { parseParams, parseQuery, resolveDepositSwapRequest } from "./shared";
 import { decodeVaultPositionCursor, encodeVaultPositionCursor } from "./vault-position-cursor";
 import { hydrateVaultPositions } from "./vault-position-hydration";
@@ -543,7 +544,7 @@ export async function findEarnVaultDepositIdempotentKeyReplay(
     );
   }
 
-  await throwOnPriorVaultPolicyOperation(c, {
+  await throwOnPriorEarnPolicyOperation(c, {
     organizationId: resolved.auth.organizationId,
     projectId: resolved.projectId,
     idempotencyKey,
@@ -551,81 +552,6 @@ export async function findEarnVaultDepositIdempotentKeyReplay(
     operationNoun: "vault deposit",
   });
   return null;
-}
-
-/**
- * Pre-execution policy replays, shared by both vault money movers: a key that
- * already produced a wallet operation must answer with that operation's state
- * (still pending approval, executing, denied, canceled) rather than starting a
- * second one — and a key reused with a different payload is a conflict even
- * before any movement exists.
- */
-async function throwOnPriorVaultPolicyOperation(
-  c: AppContext,
-  params: {
-    organizationId: string;
-    projectId: string;
-    idempotencyKey: string;
-    idempotencyFingerprint: string;
-    operationNoun: "vault deposit" | "vault withdrawal";
-  }
-): Promise<void> {
-  const prior = await getDb(c.env)
-    .prepare(
-      `SELECT operation.id, operation.status, operation.raw_payload,
-              evaluation.id AS policy_evaluation_id,
-              evaluation.decision, evaluation.reason_code, evaluation.reason,
-              evaluation.requires_approval, evaluation.approval_request_id
-       FROM wallet_operations operation
-       LEFT JOIN LATERAL (
-         SELECT * FROM policy_evaluations
-         WHERE wallet_operation_id = operation.id
-         ORDER BY created_at DESC, id DESC
-         LIMIT 1
-       ) evaluation ON TRUE
-       WHERE operation.organization_id = ?
-         AND operation.project_id = ?
-         AND operation.idempotency_key = ?`
-    )
-    .bind(params.organizationId, params.projectId, params.idempotencyKey)
-    .first<{
-      id: string;
-      status: string;
-      raw_payload: Record<string, unknown>;
-      policy_evaluation_id: string | null;
-      decision: string | null;
-      reason_code: string | null;
-      reason: string | null;
-      requires_approval: boolean | null;
-      approval_request_id: string | null;
-    }>();
-  if (!prior) return;
-  if (prior.raw_payload.idempotencyFingerprint !== params.idempotencyFingerprint) {
-    throw conflict("Idempotency key already used with different request payload");
-  }
-
-  const details = {
-    walletOperationId: prior.id,
-    policyEvaluationId: prior.policy_evaluation_id,
-    decision: prior.decision,
-    reasonCode: prior.reason_code,
-    reason: prior.reason,
-    requiresApproval: prior.requires_approval,
-    approvalRequestId: prior.approval_request_id,
-  };
-  if (prior.status === "pending_approval" || prior.status === "executing") {
-    throw new AppError(
-      "SIGNING_PENDING",
-      prior.status === "pending_approval"
-        ? "Wallet operation requires policy approval"
-        : `Approved ${params.operationNoun} execution is still in progress`,
-      details
-    );
-  }
-  if (prior.decision === "deny" || prior.status === "canceled") {
-    throw new AppError("FORBIDDEN", "Wallet operation denied by policy", details);
-  }
-  throw conflict(`The prior ${params.operationNoun} policy operation has no replayable movement`);
 }
 
 function resolveEarnVaultCustodyWallet(
@@ -1304,7 +1230,7 @@ export async function findEarnVaultWithdrawalIdempotentKeyReplay(
     );
   }
 
-  await throwOnPriorVaultPolicyOperation(c, {
+  await throwOnPriorEarnPolicyOperation(c, {
     organizationId: resolved.auth.organizationId,
     projectId: resolved.projectId,
     idempotencyKey,

--- a/apps/sdp-api/src/routes/earn/handlers/vault.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/vault.ts
@@ -546,7 +546,7 @@ export async function findEarnVaultDepositIdempotentKeyReplay(
 
   await throwOnPriorEarnPolicyOperation(c, {
     organizationId: resolved.auth.organizationId,
-    projectId: resolved.projectId,
+    scope: { kind: "project", projectId: resolved.projectId },
     idempotencyKey,
     idempotencyFingerprint: resolved.idempotencyFingerprint,
     operationNoun: "vault deposit",
@@ -1232,7 +1232,7 @@ export async function findEarnVaultWithdrawalIdempotentKeyReplay(
 
   await throwOnPriorEarnPolicyOperation(c, {
     organizationId: resolved.auth.organizationId,
-    projectId: resolved.projectId,
+    scope: { kind: "project", projectId: resolved.projectId },
     idempotencyKey,
     idempotencyFingerprint: resolved.idempotencyFingerprint,
     operationNoun: "vault withdrawal",

--- a/apps/sdp-api/src/routes/earn/index.ts
+++ b/apps/sdp-api/src/routes/earn/index.ts
@@ -2,6 +2,7 @@ import { type Context, Hono, type Next } from "hono";
 import { AppError } from "@/lib/errors";
 import { isEarnEnabled } from "@/lib/feature-flags";
 import { requirePermissions, unifiedAuthMiddleware } from "@/middleware/auth";
+import { meteredQuota } from "@/middleware/metered-quota";
 import { policyGate } from "@/middleware/policy-gate";
 import { projectContextMiddleware } from "@/middleware/project-context";
 import { validateBody } from "@/middleware/validate";
@@ -84,6 +85,22 @@ earn.use("*", projectContextMiddleware());
 earn.get("/strategies", requirePermissions("earn:read"), listEarnStrategies);
 earn.get("/strategies/:strategyId", requirePermissions("earn:read"), getEarnStrategy);
 
+// Metered quotas for the Earn reads that fan out to a PAID upstream — the
+// provider's API on a program read, Solana RPC on a live-hydrated one. A single
+// `GET /programs` page is 2N provider round trips against a shared account, so
+// an unmetered caller spends the platform's money at whatever rate it likes.
+//
+// What is deliberately NOT metered is every money-OUT route and every EXIT
+// quote: withdrawals, vault withdrawals, the external-wallet submits, and the
+// previews an exit derives its floor from. `meteredQuota` FAILS CLOSED — a
+// counter-store outage answers 503 — and a 5xx on a customer's way out of a
+// position is precisely the failure ADR 0002 exit safety rules out. A refused
+// read costs a caller a retry; a refused exit traps funds.
+//
+// Money-IN reads carry no such rule, so the deposit quote is metered.
+const EARN_PROVIDER_READ_QUOTA = { name: "earn-provider-read", actorMax: 60, orgMax: 240 } as const;
+const EARN_CHAIN_READ_QUOTA = { name: "earn-chain-read", actorMax: 30, orgMax: 120 } as const;
+
 // B2B2C live holdings (PRO-1724). The owner is a REQUIRED query filter on
 // every per-owner read of this surface (positions, movements, earnings) — one
 // addressing style for one concept, and no literal segment (`summary`) can
@@ -92,11 +109,13 @@ earn.get("/strategies/:strategyId", requirePermissions("earn:read"), getEarnStra
 earn.get(
   "/external-wallet/positions/summary",
   requirePermissions("earn:read"),
+  meteredQuota(EARN_CHAIN_READ_QUOTA),
   getEarnExternalWalletPositionSummary
 );
 earn.get(
   "/external-wallet/positions",
   requirePermissions("earn:read"),
+  meteredQuota(EARN_CHAIN_READ_QUOTA),
   listEarnExternalWalletPositions
 );
 
@@ -119,6 +138,7 @@ earn.get(
 earn.get(
   "/external-wallet/earnings",
   requirePermissions("earn:read"),
+  meteredQuota(EARN_CHAIN_READ_QUOTA),
   getEarnExternalWalletEarnings
 );
 
@@ -156,6 +176,7 @@ earn.post(
 earn.post(
   "/vault-deposit-previews",
   requirePermissions("earn:read"),
+  meteredQuota(EARN_PROVIDER_READ_QUOTA),
   validateBody(earnVaultDepositPreviewSchema),
   createEarnVaultDepositPreview
 );
@@ -226,6 +247,7 @@ earn.get(
 earn.get(
   "/vault-positions",
   requirePermissions("earn:read", "wallets:read"),
+  meteredQuota(EARN_CHAIN_READ_QUOTA),
   listEarnVaultPositions
 );
 // Chain-versus-ledger reconciliation for the custody vault claims above
@@ -237,6 +259,7 @@ earn.get(
 earn.get(
   "/vault-share-reconciliation",
   requirePermissions("earn:read", "wallets:read"),
+  meteredQuota(EARN_CHAIN_READ_QUOTA),
   getEarnVaultShareReconciliation
 );
 
@@ -303,21 +326,36 @@ earn.get("/movements", requirePermissions("earn:read", "wallets:read"), listEarn
 //
 // The collection is declared BEFORE the `:programId` routes so a literal
 // segment can never be captured as an id.
-earn.get("/programs", requirePermissions("earn:read"), listEarnPrograms);
+earn.get(
+  "/programs",
+  requirePermissions("earn:read"),
+  meteredQuota(EARN_PROVIDER_READ_QUOTA),
+  listEarnPrograms
+);
 earn.post(
   "/programs",
   requirePermissions("earn:write"),
   validateBody(earnProgramCreateSchema),
   createEarnProgram
 );
-earn.get("/programs/:programId", requirePermissions("earn:read"), getEarnProgram);
+earn.get(
+  "/programs/:programId",
+  requirePermissions("earn:read"),
+  meteredQuota(EARN_PROVIDER_READ_QUOTA),
+  getEarnProgram
+);
 earn.put(
   "/programs/:programId",
   requirePermissions("earn:write"),
   validateBody(earnProgramRetargetSchema),
   retargetEarnProgram
 );
-earn.get("/programs/:programId/deposits", requirePermissions("earn:read"), listEarnProgramDeposits);
+earn.get(
+  "/programs/:programId/deposits",
+  requirePermissions("earn:read"),
+  meteredQuota(EARN_PROVIDER_READ_QUOTA),
+  listEarnProgramDeposits
+);
 earn.post(
   "/programs/:programId/withdrawal-preview",
   requirePermissions("earn:read"),

--- a/apps/sdp-api/src/routes/earn/index.ts
+++ b/apps/sdp-api/src/routes/earn/index.ts
@@ -21,6 +21,7 @@ import {
 } from "./handlers/external-wallet";
 import { listEarnMovements } from "./handlers/movements";
 import {
+  answerEarnProgramWithdrawalConflict,
   createEarnProgram,
   createEarnProgramWithdrawal,
   extractEarnProgramWithdrawalPolicyCandidate,
@@ -373,7 +374,10 @@ earn.post(
   "/programs/:programId/withdrawals",
   requirePermissions("earn:write"),
   validateBody(earnProgramWithdrawalCreateSchema),
-  policyGate({ extract: extractEarnProgramWithdrawalPolicyCandidate }),
+  policyGate({
+    extract: extractEarnProgramWithdrawalPolicyCandidate,
+    onIdempotencyConflict: answerEarnProgramWithdrawalConflict,
+  }),
   createEarnProgramWithdrawal
 );
 earn.get(

--- a/apps/sdp-api/src/routes/earn/index.ts
+++ b/apps/sdp-api/src/routes/earn/index.ts
@@ -22,6 +22,7 @@ import { listEarnMovements } from "./handlers/movements";
 import {
   createEarnProgram,
   createEarnProgramWithdrawal,
+  extractEarnProgramWithdrawalPolicyCandidate,
   getEarnProgram,
   getEarnProgramWithdrawal,
   listEarnProgramDeposits,
@@ -323,10 +324,18 @@ earn.post(
   validateBody(earnProgramWithdrawalPreviewSchema),
   previewEarnProgramWithdrawal
 );
+// The custodial payout. `earn:write` alone used to be the whole gate: the
+// route pays a caller-supplied `destinationAddress` out of the organization's
+// provider account, so without a policy gate an org's deny rules, amount and
+// asset limits, destination controls and approval requirements never ran
+// (HOO-1559). A program has no custody wallet, so the governing profile is the
+// API key's own; the extractor also refuses a wallet-scoped key, which has no
+// wallet here to be bound against.
 earn.post(
   "/programs/:programId/withdrawals",
   requirePermissions("earn:write"),
   validateBody(earnProgramWithdrawalCreateSchema),
+  policyGate({ extract: extractEarnProgramWithdrawalPolicyCandidate }),
   createEarnProgramWithdrawal
 );
 earn.get(

--- a/packages/sdp-types/src/policy.ts
+++ b/packages/sdp-types/src/policy.ts
@@ -3,6 +3,7 @@ export type PolicyDefaultAction = "allow" | "deny" | "approval_required" | "revi
 export type EffectivePolicySource = "implicit_default_allow" | "customer_profile";
 
 export const WALLET_OPERATION_TYPES = [
+  "earn_program_withdrawal",
   "earn_vault_deposit",
   "earn_vault_withdrawal",
   "issuance_burn_execute",


### PR DESCRIPTION
Closes HOO-1559.

## The hole

`POST /v1/earn/programs/:programId/withdrawals` pays a caller-supplied `destinationAddress` out of the organization's provider account. Its whole gate was the `earn:write` scope — unlike the vault path it asserted no wallet binding and ran no policy.

Two consequences:

- A selected-scope API key bound to one low-value wallet could drain the organization's entire program to any address.
- The organization's deny rules, amount/asset limits, destination controls and approval requirements never ran on a payout.

`POST /programs/:programId/withdrawal-preview` shares the chain, so it also disclosed live lane liquidity under `earn:read`.

Found in the 2026-09-07 internal re-audit of the security epic.

## The fix

| | |
|---|---|
| Wallet-scoped keys | Refused on both routes |
| Policy envelope | `program` / `earn_program_withdrawal` |
| Governing profile | The API key's own control profile |

An Earn program is a provider **account**, not a custody wallet, so there is no `custody_wallets` row for `assertApiKeyWalletAccess` to name. A wallet-scoped key is therefore refused outright rather than silently treated as unbound. For the same reason the policy candidate carries `custodyWalletId: null` with the provider wallet as `walletId`: the wallet-policy half falls back to implicit allow, and the API key's control profile is what governs.

## Four decisions worth reviewing

**Program targets are admitted for one operation type, not for "no custody wallet".** `tenantOwnsWalletTarget` now accepts an `earn_provider_wallets` row owned by the organization, behind `allowEarnProgramTarget` — set only for `earn_program_withdrawal`. Keying it on the absence of a custody wallet would be a widening: other families can leave `custodyWalletId` null (issuance mint among them) and would gain a second way to prove ownership of a target they do not custody.

**Replay resolution lives in the policy extractor, not in the gate's `findIdempotentKeyReplay` hook.** That hook only fires for `Idempotency-Key` header callers, while this route equally accepts body `requestId`. A body-keyed retry would otherwise open a second governed operation per attempt — an approval per retry. A replay now extracts a null candidate: it was governed when it was created.

**The approval executor is exempt from "send one or the other, not both".** It replays the stored body (`requestId` included) and adds an `Idempotency-Key` it minted itself. Without the exemption an approved body-keyed withdrawal answers 400 at execution — money held by policy that could never be paid. The vault routes reject body `requestId`, so they never meet this.

**No money-out route is metered.** The second commit puts `meteredQuota` on the Earn reads that fan out to a paid upstream — `earn-provider-read` (programs list, detail, deposits, deposit quote; a `GET /programs` page is two provider round trips per row against the shared account) and `earn-chain-read` (vault positions, share reconciliation, per-owner external-wallet reads). Withdrawals, vault withdrawals, external-wallet submits and every exit quote deliberately get none: `meteredQuota` fails closed, and a 5xx on a customer's way out of a position is the failure ADR 0002 exit safety rules out. A refused read costs a retry; a refused exit traps funds.

## Tests

- A wallet-scoped key is refused on both routes, before the provider is driven and with no intent recorded.
- An unbound key still pays out, recorded as a `program` / `earn_program_withdrawal` operation with no custody wallet.
- A destination the key's policy forbids is denied before the provider call.
- An approval-required payout holds; a retry re-answers the same hold instead of opening a second approval.
- An operation of another family naming the same provider wallet is refused as a target.
- An approved body-keyed withdrawal executes, driving the real executor through `recoverApprovedWalletOperations`. This also closes a gap the route notes flagged: the approval path on Earn had no test at all.
- Quotas: a program read 429s once exhausted without touching the provider, and exhausting both counters leaves the liquidity preview and the payout working.

## Also in this PR

The vault's prior-policy-operation replay guard moves to a shared `handlers/policy-replay.ts`, unchanged in behaviour, so the program path reuses it instead of copying it.
