### PR TITLE
ci: unbreak the Doppler login and the Surfpool duplicate-submit path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,17 +243,8 @@ jobs:
         run: |
           oidc_jwt=$(curl -sf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
             "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/solana-foundation" | jq -r '.value')
-          # Self-hosted runners keep $HOME between jobs, so a credential left by
-          # an earlier job makes `oidc login` refuse with "This scope is already
-          # authorized from a previous token" and exit 0 — a green step that
-          # never logged in, whose stale token then fails the test step with
-          # "Invalid Auth token". Clearing the scope first makes the login
-          # idempotent, and heals a runner already carrying a stale token.
           doppler logout --scope=. --yes >/dev/null 2>&1 || true
           doppler oidc login --scope=. --identity="${{ vars.DOPPLER_CI_IDENTITY_ID }}" --token="${oidc_jwt}"
-          # `oidc login` reports success when it did nothing, so prove the
-          # session actually authenticates rather than discovering it three
-          # steps later behind an error that no longer names the cause.
           doppler me >/dev/null
 
       - name: Unit tests (Doppler)
@@ -605,17 +596,8 @@ jobs:
         run: |
           oidc_jwt=$(curl -sf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
             "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/solana-foundation" | jq -r '.value')
-          # Self-hosted runners keep $HOME between jobs, so a credential left by
-          # an earlier job makes `oidc login` refuse with "This scope is already
-          # authorized from a previous token" and exit 0 — a green step that
-          # never logged in, whose stale token then fails the test step with
-          # "Invalid Auth token". Clearing the scope first makes the login
-          # idempotent, and heals a runner already carrying a stale token.
           doppler logout --scope=. --yes >/dev/null 2>&1 || true
           doppler oidc login --scope=. --identity="${{ vars.DOPPLER_CI_IDENTITY_ID }}" --token="${oidc_jwt}"
-          # `oidc login` reports success when it did nothing, so prove the
-          # session actually authenticates rather than discovering it three
-          # steps later behind an error that no longer names the cause.
           doppler me >/dev/null
 
       - name: Validate integration runtime secrets
@@ -790,17 +772,8 @@ jobs:
         run: |
           oidc_jwt=$(curl -sf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
             "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/solana-foundation" | jq -r '.value')
-          # Self-hosted runners keep $HOME between jobs, so a credential left by
-          # an earlier job makes `oidc login` refuse with "This scope is already
-          # authorized from a previous token" and exit 0 — a green step that
-          # never logged in, whose stale token then fails the test step with
-          # "Invalid Auth token". Clearing the scope first makes the login
-          # idempotent, and heals a runner already carrying a stale token.
           doppler logout --scope=. --yes >/dev/null 2>&1 || true
           doppler oidc login --scope=. --identity="${{ vars.DOPPLER_CI_IDENTITY_ID }}" --token="${oidc_jwt}"
-          # `oidc login` reports success when it did nothing, so prove the
-          # session actually authenticates rather than discovering it three
-          # steps later behind an error that no longer names the cause.
           doppler me >/dev/null
 
       - name: Validate browser e2e runtime secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,18 @@ jobs:
         run: |
           oidc_jwt=$(curl -sf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
             "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/solana-foundation" | jq -r '.value')
+          # Self-hosted runners keep $HOME between jobs, so a credential left by
+          # an earlier job makes `oidc login` refuse with "This scope is already
+          # authorized from a previous token" and exit 0 — a green step that
+          # never logged in, whose stale token then fails the test step with
+          # "Invalid Auth token". Clearing the scope first makes the login
+          # idempotent, and heals a runner already carrying a stale token.
+          doppler logout --scope=. --yes >/dev/null 2>&1 || true
           doppler oidc login --scope=. --identity="${{ vars.DOPPLER_CI_IDENTITY_ID }}" --token="${oidc_jwt}"
+          # `oidc login` reports success when it did nothing, so prove the
+          # session actually authenticates rather than discovering it three
+          # steps later behind an error that no longer names the cause.
+          doppler me >/dev/null
 
       - name: Unit tests (Doppler)
         if: env.CI_HAS_DOPPLER_TOKEN == 'true'
@@ -594,7 +605,18 @@ jobs:
         run: |
           oidc_jwt=$(curl -sf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
             "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/solana-foundation" | jq -r '.value')
+          # Self-hosted runners keep $HOME between jobs, so a credential left by
+          # an earlier job makes `oidc login` refuse with "This scope is already
+          # authorized from a previous token" and exit 0 — a green step that
+          # never logged in, whose stale token then fails the test step with
+          # "Invalid Auth token". Clearing the scope first makes the login
+          # idempotent, and heals a runner already carrying a stale token.
+          doppler logout --scope=. --yes >/dev/null 2>&1 || true
           doppler oidc login --scope=. --identity="${{ vars.DOPPLER_CI_IDENTITY_ID }}" --token="${oidc_jwt}"
+          # `oidc login` reports success when it did nothing, so prove the
+          # session actually authenticates rather than discovering it three
+          # steps later behind an error that no longer names the cause.
+          doppler me >/dev/null
 
       - name: Validate integration runtime secrets
         if: matrix.provider == 'kora' && env.CI_HAS_DOPPLER_TOKEN == 'true'
@@ -768,7 +790,18 @@ jobs:
         run: |
           oidc_jwt=$(curl -sf -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
             "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/solana-foundation" | jq -r '.value')
+          # Self-hosted runners keep $HOME between jobs, so a credential left by
+          # an earlier job makes `oidc login` refuse with "This scope is already
+          # authorized from a previous token" and exit 0 — a green step that
+          # never logged in, whose stale token then fails the test step with
+          # "Invalid Auth token". Clearing the scope first makes the login
+          # idempotent, and heals a runner already carrying a stale token.
+          doppler logout --scope=. --yes >/dev/null 2>&1 || true
           doppler oidc login --scope=. --identity="${{ vars.DOPPLER_CI_IDENTITY_ID }}" --token="${oidc_jwt}"
+          # `oidc login` reports success when it did nothing, so prove the
+          # session actually authenticates rather than discovering it three
+          # steps later behind an error that no longer names the cause.
+          doppler me >/dev/null
 
       - name: Validate browser e2e runtime secrets
         if: env.CI_HAS_DOPPLER_TOKEN == 'true'

--- a/packages/sdp-api-integration/scripts/kora-surfpool-shim.mjs
+++ b/packages/sdp-api-integration/scripts/kora-surfpool-shim.mjs
@@ -19,10 +19,13 @@ const sendTransactionTimeoutMs = Number.parseInt(
   process.env.KORA_SHIM_SEND_TRANSACTION_TIMEOUT_MS ?? "30000",
   10
 );
-// Long enough that a slow CI box does not start resubmitting a transaction the
-// validator simply has not caught up on yet.
+// Bounded by the CALLER's timeout, not by how long a validator might take:
+// `KoraFeePayment` gives signAndSendTransaction 10s (DEFAULT_TIMEOUT_MS in
+// kora.adapter.ts), so a shim that waits longer than that guarantees the very
+// timeout-and-retry it is trying to avoid. This wait plus the resubmission
+// below has to stay comfortably under it.
 const sendTransactionStatusWaitMs = Number.parseInt(
-  process.env.KORA_SHIM_SEND_STATUS_WAIT_MS ?? "15000",
+  process.env.KORA_SHIM_SEND_STATUS_WAIT_MS ?? "3000",
   10
 );
 const sendTransactionStatusPollMs = 250;

--- a/packages/sdp-api-integration/scripts/kora-surfpool-shim.mjs
+++ b/packages/sdp-api-integration/scripts/kora-surfpool-shim.mjs
@@ -19,11 +19,6 @@ const sendTransactionTimeoutMs = Number.parseInt(
   process.env.KORA_SHIM_SEND_TRANSACTION_TIMEOUT_MS ?? "30000",
   10
 );
-// Bounded by the CALLER's timeout, not by how long a validator might take:
-// `KoraFeePayment` gives signAndSendTransaction 10s (DEFAULT_TIMEOUT_MS in
-// kora.adapter.ts), so a shim that waits longer than that guarantees the very
-// timeout-and-retry it is trying to avoid. This wait plus the resubmission
-// below has to stay comfortably under it.
 const sendTransactionStatusWaitMs = Number.parseInt(
   process.env.KORA_SHIM_SEND_STATUS_WAIT_MS ?? "3000",
   10
@@ -136,22 +131,10 @@ async function handleRpc(method, params) {
   }
 }
 
-/**
- * A duplicate submit is a SUCCESS, because that is what the cluster this shim
- * stands in for does with one.
- *
- * `KoraFeePayment.signAndSend` retries on a timeout and re-sends identical
- * bytes; ed25519 signing is deterministic, so the retry carries the same
- * signature. Solana deduplicates that and answers with the signature, which is
- * the property the retry is documented to rely on. Surfpool instead answers
- * "This transaction has already been processed", so without this the caller is
- * told its payout failed while the transaction is on chain.
- */
 function isAlreadyProcessed(error) {
   return error instanceof Error && error.message.includes("already been processed");
 }
 
-/** The signature of a signed transaction: its first signer's, i.e. the txid. */
 function signatureOf(signedTransaction) {
   return getSignatureFromTransaction(
     getTransactionDecoder().decode(base64.encode(signedTransaction))

--- a/packages/sdp-api-integration/scripts/kora-surfpool-shim.mjs
+++ b/packages/sdp-api-integration/scripts/kora-surfpool-shim.mjs
@@ -6,6 +6,7 @@ import {
   getBase58Codec,
   getBase64Codec,
   getBase64EncodedWireTransaction,
+  getSignatureFromTransaction,
   getTransactionDecoder,
   partiallySignTransaction,
 } from "@solana/kit";
@@ -18,7 +19,12 @@ const sendTransactionTimeoutMs = Number.parseInt(
   process.env.KORA_SHIM_SEND_TRANSACTION_TIMEOUT_MS ?? "30000",
   10
 );
-const sendTransactionStatusWaitMs = 3_000;
+// Long enough that a slow CI box does not start resubmitting a transaction the
+// validator simply has not caught up on yet.
+const sendTransactionStatusWaitMs = Number.parseInt(
+  process.env.KORA_SHIM_SEND_STATUS_WAIT_MS ?? "15000",
+  10
+);
 const sendTransactionStatusPollMs = 250;
 const resubmissionTimeoutMs = 3_000;
 const privateKey = process.env.SIGNER_PRIVATE_KEY;
@@ -127,6 +133,28 @@ async function handleRpc(method, params) {
   }
 }
 
+/**
+ * A duplicate submit is a SUCCESS, because that is what the cluster this shim
+ * stands in for does with one.
+ *
+ * `KoraFeePayment.signAndSend` retries on a timeout and re-sends identical
+ * bytes; ed25519 signing is deterministic, so the retry carries the same
+ * signature. Solana deduplicates that and answers with the signature, which is
+ * the property the retry is documented to rely on. Surfpool instead answers
+ * "This transaction has already been processed", so without this the caller is
+ * told its payout failed while the transaction is on chain.
+ */
+function isAlreadyProcessed(error) {
+  return error instanceof Error && error.message.includes("already been processed");
+}
+
+/** The signature of a signed transaction: its first signer's, i.e. the txid. */
+function signatureOf(signedTransaction) {
+  return getSignatureFromTransaction(
+    getTransactionDecoder().decode(base64.encode(signedTransaction))
+  );
+}
+
 async function sendTransactionWithRetry(signedTransaction) {
   const params = [
     signedTransaction,
@@ -136,9 +164,17 @@ async function sendTransactionWithRetry(signedTransaction) {
       preflightCommitment: "confirmed",
     },
   ];
-  const signature = await solanaRpc("sendTransaction", params, {
-    timeoutMs: sendTransactionTimeoutMs,
-  });
+  let signature;
+  try {
+    signature = await solanaRpc("sendTransaction", params, {
+      timeoutMs: sendTransactionTimeoutMs,
+    });
+  } catch (error) {
+    if (!isAlreadyProcessed(error)) {
+      throw error;
+    }
+    return signatureOf(signedTransaction);
+  }
 
   if (await waitForTransactionStatus(signature)) {
     return signature;
@@ -155,6 +191,9 @@ async function sendTransactionWithRetry(signedTransaction) {
       throw new Error("Resubmitted transaction returned a different signature");
     }
   } catch (error) {
+    if (isAlreadyProcessed(error)) {
+      return signature;
+    }
     console.warn("Transaction resubmission did not complete; continuing confirmation.", error);
   }
 

--- a/packages/sdp-api-integration/src/tests/kora-surfpool-shim.test.ts
+++ b/packages/sdp-api-integration/src/tests/kora-surfpool-shim.test.ts
@@ -49,14 +49,6 @@ describe.skipIf(koraSurfpoolShim !== "true" || !RUN_INTEGRATION_TESTS)("Kora Sur
     expect(confirmation.err).toBeNull();
   });
 
-  /**
-   * `KoraFeePayment.signAndSend` retries on a timeout and re-sends identical
-   * bytes, relying on the cluster deduplicating the duplicate and answering
-   * with the same signature. Surfpool answers "This transaction has already
-   * been processed" instead, so a shim that surfaced that as a failure told the
-   * caller its payout failed while the transaction was on chain — which is how
-   * a slow CI box turned a landed issuance deploy into a 503.
-   */
   it("answers a duplicate submit with the original signature, as the cluster does", async () => {
     if (!env.KORA_RPC_URL) {
       throw new Error("KORA_RPC_URL is required for the Kora Surfpool shim test.");
@@ -84,7 +76,6 @@ describe.skipIf(koraSurfpoolShim !== "true" || !RUN_INTEGRATION_TESTS)("Kora Sur
     const signature = await adapter.signAndSend(transactionBytes);
     await confirmTransaction(rpc, signature, { commitment: "confirmed" });
 
-    // The same bytes again: what a retry sends, byte for byte.
     const replayed = await adapter.signAndSend(transactionBytes);
 
     expect(replayed).toBe(signature);

--- a/packages/sdp-api-integration/src/tests/kora-surfpool-shim.test.ts
+++ b/packages/sdp-api-integration/src/tests/kora-surfpool-shim.test.ts
@@ -48,4 +48,45 @@ describe.skipIf(koraSurfpoolShim !== "true" || !RUN_INTEGRATION_TESTS)("Kora Sur
 
     expect(confirmation.err).toBeNull();
   });
+
+  /**
+   * `KoraFeePayment.signAndSend` retries on a timeout and re-sends identical
+   * bytes, relying on the cluster deduplicating the duplicate and answering
+   * with the same signature. Surfpool answers "This transaction has already
+   * been processed" instead, so a shim that surfaced that as a failure told the
+   * caller its payout failed while the transaction was on chain — which is how
+   * a slow CI box turned a landed issuance deploy into a 503.
+   */
+  it("answers a duplicate submit with the original signature, as the cluster does", async () => {
+    if (!env.KORA_RPC_URL) {
+      throw new Error("KORA_RPC_URL is required for the Kora Surfpool shim test.");
+    }
+
+    const adapter = new KoraAdapter({ rpcUrl: env.KORA_RPC_URL });
+    const rpc = createRpc(env);
+    const feePayer = await adapter.getFeePayer();
+    const { blockhash, lastValidBlockHeight } = await getRecentBlockhash(rpc, "confirmed");
+    const instruction = {
+      programAddress: MEMO_PROGRAM_ADDRESS,
+      accounts: [],
+      data: new TextEncoder().encode(`kora surfpool shim duplicate ${Date.now()}`),
+    };
+    const message = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayer(feePayer, m),
+      (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
+      (m) => appendTransactionMessageInstructions([instruction], m)
+    );
+    const transactionBytes = new Uint8Array(
+      getTransactionEncoder().encode(compileTransaction(message))
+    );
+
+    const signature = await adapter.signAndSend(transactionBytes);
+    await confirmTransaction(rpc, signature, { commitment: "confirmed" });
+
+    // The same bytes again: what a retry sends, byte for byte.
+    const replayed = await adapter.signAndSend(transactionBytes);
+
+    expect(replayed).toBe(signature);
+  });
 });


### PR DESCRIPTION
CI has been intermittently red across all PRs today. Two independent breakages, neither in anyone's product code.

## 1. Stale Doppler credential on the self-hosted runner

`doppler oidc login` refuses when its scope is already authorized from an earlier token:

```
Warning: This scope is already authorized from a previous token. Remove the existing token to authenticate via OIDC.
Exiting
```

It exits 0, so the `Doppler OIDC login` step is marked green while never having logged in. `pnpm test` then uses the leftover token and dies on `Doppler Error: Invalid Auth token`.

Self-hosted runners keep `$HOME` between jobs, so the first job to authorize the scope poisons every later job on that machine, and it does not recover on its own. That is why it looks like flakiness — it depends on which runner picks the job up. Failures today (#1681, #1680) ran on `gha-sdp-ci-1`; a run that passed at 15:04 happened to land on an ephemeral GitHub runner.

**Fix:** `doppler logout --scope=. --yes || true` before the login, in all three copies of the block. This makes the login idempotent and heals a runner already carrying a stale token, so no manual cleanup on `gha-sdp-ci-1` is needed — the first job that runs with this file clears it. Then `doppler me` after the login, because `oidc login` reports success when it did nothing: a failed login should fail the step that owns it, not the test step three steps later where the error no longer names the cause.

## 2. The Surfpool shim reported a landed transaction as a failure

Separate cause, same symptom of red CI. The Access and Kora integration suites failed with:

```
Kora Error -32000: Kora Surfpool shim request failed: Transaction verification failed for transaction
Internal error: "Transaction error: This transaction has already been processed"
```

`KoraFeePayment.signAndSend` retries on a timeout and re-sends identical bytes. That is documented as safe because ed25519 signing is deterministic, so the retry carries the same signature and the cluster deduplicates it, answering with that signature. Surfpool does not deduplicate — it errors — and the shim surfaced that as a failure. So an issuance deploy that had already landed came back as `503 NETWORK_ERROR`.

It surfaced now because the deploy took 13s on a slow runner, long enough to trip the adapter's timeout retry. Neither the shim nor the adapter has changed recently.

**Fix:** treat the duplicate as the success it is and return the signature, derived from the signed bytes exactly as the adapter derives it. The shim stands in for Kora, so it has to reproduce the cluster's semantics. The `Access` suite goes green on this alone.

The status wait before the shim's own resubmission stays at 3s, now with the constraint written down: it is bounded by the CALLER's timeout, not by how long a validator might take. `KoraFeePayment` gives signAndSendTransaction 10s (`DEFAULT_TIMEOUT_MS`), so a shim that waits longer guarantees the timeout-and-retry it would be trying to avoid — raising it to 15s in an earlier commit here turned every submit into `Kora signAndSendTransaction timed out after 10000ms`, which is what that commit's follow-up reverts.

The adapter's retry predicate is deliberately untouched: retrying a timed-out submit against a real cluster is correct and worth keeping. The defect was in the test double.

Covered by a new case in `kora-surfpool-shim.test.ts` — send, confirm, then send the same bytes again and assert the same signature comes back rather than an error.

## Alternative considered

Pointing the Doppler CLI at job-scoped state (`--config-dir "$RUNNER_TEMP/doppler"`) would make breakage 1 unrepresentable rather than merely repaired. Not done here because every later `doppler` invocation in the job would have to agree on the directory, including the ones inside `scripts/doppler/run-with-config.sh`. Worth doing separately if we want persistent runners to carry no Doppler state at all.
