### PR TITLE
feat(smoke): fail the gate loudly when STAGE_SMOKE_READY is unset

### DIFF
--- a/.github/workflows/sdp-stage-smoke.yml
+++ b/.github/workflows/sdp-stage-smoke.yml
@@ -59,6 +59,13 @@ jobs:
             "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/solana-foundation" | jq -r '.value')
           doppler oidc login --scope=. --identity="${{ vars.DOPPLER_CI_IDENTITY_ID }}" --token="${oidc_jwt}"
 
+      - name: Require the full smoke to be armed
+        run: |
+          if [ "${{ vars.STAGE_SMOKE_READY }}" != "true" ]; then
+            echo "::error::STAGE_SMOKE_READY is not set - a skipped stage smoke must not vouch for prod (PRO-1856)"
+            exit 1
+          fi
+
       - name: Probe API readiness
         id: health
         run: |
@@ -71,7 +78,6 @@ jobs:
         run: pnpm --filter sdp-web exec playwright install --with-deps chromium
 
       - name: Build web app against the target API
-        if: vars.STAGE_SMOKE_READY == 'true'
         env:
           DOPPLER_CONFIG: dev_ci
           SDP_API_BASE_URL: ${{ env.PLAYWRIGHT_API_URL }}
@@ -80,7 +86,6 @@ jobs:
         run: scripts/doppler/run-with-config.sh node scripts/run-with-healthy-solana-rpc.mjs pnpm --filter sdp-web build
 
       - name: Run GCP read-only smoke
-        if: vars.STAGE_SMOKE_READY == 'true'
         id: smoke
         env:
           DOPPLER_CONFIG: dev_ci
@@ -94,7 +99,7 @@ jobs:
         env:
           DOPPLER_PROJECT: solana-developer-platform
           DOPPLER_CONFIG: dev_ci
-          SMOKE_OUTCOME: ${{ steps.smoke.outcome == 'skipped' && steps.health.outcome || steps.smoke.outcome }}
+          SMOKE_OUTCOME: ${{ steps.smoke.outcome }}
           RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: doppler run --scope=. --project "$DOPPLER_PROJECT" --config "$DOPPLER_CONFIG" --preserve-env=SMOKE_OUTCOME,SMOKE_TARGET,RUN_ID,RUN_URL -- ./scripts/report-smoke-to-loki.sh


### PR DESCRIPTION
Second half of PRO-1856 (Andrey's #1648 review ask): a skipped smoke must never count as a passed prod gate.

- New first-class gate step: if `STAGE_SMOKE_READY` isn't `true`, the smoke job **fails** with an explicit error instead of skipping the suite and passing on the readiness probe alone — which is exactly how 0.71 and 0.72 slipped through on a curl.
- With the job now hard-gated, the per-step `if:` conditions and the `SMOKE_OUTCOME` health-probe fallback were dead code — removed.

**Merge order (deliberate):** do NOT merge until `STAGE_SMOKE_READY=true` is set, or every merge to main and every prod deploy fails by design. The flip depends on #1676 (ticket-flow auth, approved-pending-review) + the canary project id in `stg_ci` + one proving run — tracked on PRO-1856.

**Verification**
- `actionlint` — clean
- with var unset: job fails at the first step with the PRO-1856 error; with var set: identical behavior to today's happy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)