### PR TITLE
fix(custody): enforce provider entitlement at runtime

### DIFF
--- a/apps/sdp-api/src/routes/custody-connection-wallets.test.ts
+++ b/apps/sdp-api/src/routes/custody-connection-wallets.test.ts
@@ -240,6 +240,18 @@ describe("Connection-owned wallet control plane", () => {
     ).toEqual({ default_custody_wallet_id: body.data.wallet.id });
   });
 
+  it("rejects Connection wallet creation before Provider access when entitlement is revoked", async () => {
+    await setPrivyEntitlement(false);
+    const before = await walletCount();
+
+    const response = await request("", "POST", { connectionId: CONNECTION_ID });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({ error: { code: "FORBIDDEN" } });
+    expect(provisionPrivyWalletMock).not.toHaveBeenCalled();
+    expect(await walletCount()).toBe(before);
+  });
+
   it("fails exact create before Provider access on assertion or runtime errors", async () => {
     const missing = await request("", "POST", { connectionId: "cconn_missing" });
     expect(missing.status).toBe(404);
@@ -362,6 +374,23 @@ describe("Connection-owned wallet control plane", () => {
       walletId: DEFAULT_WALLET_ID,
     });
     expect(disabled.status).toBe(403);
+  });
+
+  it("keeps the Connection default wallet unchanged when entitlement is revoked", async () => {
+    await setPrivyEntitlement(false);
+
+    const response = await request("/default-wallet", "POST", {
+      walletId: SECOND_WALLET_ID,
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({ error: { code: "FORBIDDEN" } });
+    expect(
+      await getDb(env)
+        .prepare("SELECT default_custody_wallet_id FROM custody_connections WHERE id = ?")
+        .bind(CONNECTION_ID)
+        .first()
+    ).toEqual({ default_custody_wallet_id: DEFAULT_WALLET_RECORD_ID });
   });
 
   it("rejects default changes while the owning Connection is unusable", async () => {
@@ -557,4 +586,11 @@ async function walletCount(): Promise<number> {
         .first<{ count: number }>()
     )?.count ?? 0
   );
+}
+
+async function setPrivyEntitlement(entitled: boolean): Promise<void> {
+  await getDb(env)
+    .prepare("UPDATE organizations SET settings = ? WHERE id = ?")
+    .bind(JSON.stringify({ providerOverrides: { custody: { privy: entitled } } }), ORGANIZATION_ID)
+    .run();
 }

--- a/apps/sdp-api/src/routes/custody-multi-provider.test.ts
+++ b/apps/sdp-api/src/routes/custody-multi-provider.test.ts
@@ -495,6 +495,44 @@ describe("Custody multi-provider routes", () => {
     expect(await res.json()).toMatchObject({ error: { code: "FORBIDDEN" } });
   });
 
+  it("rejects an exact Connection switch without changing the target when entitlement is revoked", async () => {
+    env.PRIVY_BYOK_ENABLED = "true";
+    const connection = await seedActivePrivyConnection("unentitled");
+    await getDb(env)
+      .prepare("UPDATE organizations SET settings = ? WHERE id = ?")
+      .bind(JSON.stringify({ providerOverrides: { custody: { privy: false } } }), TEST_ORG.id)
+      .run();
+
+    const res = await app.request(
+      "/v1/wallets/switch",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({ connectionId: connection.connectionId }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ error: { code: "FORBIDDEN" } });
+    expect(
+      await getDb(env)
+        .prepare(
+          `SELECT default_custody_config_id, default_custody_connection_id
+           FROM custody_scope_defaults
+           WHERE organization_id = ? AND project_id = ?`
+        )
+        .bind(TEST_ORG.id, TEST_PROJECT.id)
+        .first()
+    ).toEqual({
+      default_custody_config_id: PRIVY_CONFIG_ID,
+      default_custody_connection_id: null,
+    });
+  });
+
   it.each([null, "", 42])("rejects a malformed Connection selector: %s", async (connectionId) => {
     const res = await app.request(
       "/v1/wallets/switch",
@@ -656,6 +694,18 @@ describe("Custody multi-provider routes", () => {
     });
 
     env.PRIVY_BYOK_ENABLED = "false";
+    await expect(readWallet()).resolves.toMatchObject({
+      custodyConnectionId: connection.connectionId,
+      isDefaultProvider: false,
+      isRuntimeExecutionAllowed: false,
+      provider: "privy",
+    });
+
+    env.PRIVY_BYOK_ENABLED = "true";
+    await getDb(env)
+      .prepare("UPDATE organizations SET settings = ? WHERE id = ?")
+      .bind(JSON.stringify({ providerOverrides: { custody: { privy: false } } }), TEST_ORG.id)
+      .run();
     await expect(readWallet()).resolves.toMatchObject({
       custodyConnectionId: connection.connectionId,
       isDefaultProvider: false,

--- a/apps/sdp-api/src/routes/custody/handlers/wallets.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/wallets.ts
@@ -30,7 +30,10 @@ import {
   attachUsdValuesToBalanceMap,
   attachUsdValuesToBalances,
 } from "@/services/helius-das.service";
-import { assertProviderAvailable } from "@/services/provider-availability.service";
+import {
+  assertCustodyProviderEntitled,
+  assertProviderAvailable,
+} from "@/services/provider-availability.service";
 import { type AppContext, parseBooleanQueryParam, resolveActor } from "../context";
 import type {
   CustodyWalletAggregateResponse,
@@ -537,6 +540,7 @@ export const setDefaultWallet = async (c: ValidatedBodyContext<typeof setDefault
     if (!isCustodyConnectionRuntimeEnabled(c.env, wallet.provider)) {
       throw new AppError("FORBIDDEN", "Custody Connection runtime is disabled");
     }
+    await assertCustodyProviderEntitled(c.env, getDb(c.env), actor.organizationId, wallet.provider);
     if (!wallet.isRuntimeExecutionAllowed) {
       throw new AppError("CONFLICT", "Custody Connection is unavailable");
     }

--- a/apps/sdp-api/src/routes/internal-custody/index.ts
+++ b/apps/sdp-api/src/routes/internal-custody/index.ts
@@ -11,6 +11,10 @@ import { idempotencyKeyMiddleware } from "@/middleware/idempotency-key";
 import { projectContextMiddleware } from "@/middleware/project-context";
 import { getCustodySetupStatus } from "@/services/custody-setup-status.service";
 import { isCustodyConnectionRuntimeAvailable } from "@/services/domain/signing/custody-runtime-target";
+import {
+  getProviderAvailability,
+  isCustodyProviderEntitled,
+} from "@/services/provider-availability.service";
 import { getProviderCredentialInstallation } from "@/services/provider-credential-installation.service";
 import { getProviderSetupDefinition } from "@/services/provider-setup-registry";
 import {
@@ -45,11 +49,10 @@ internalCustody.get("/connections", async (c) => {
     : 0;
 
   const store = new ProviderCredentialStore(getDb(c.env));
-  const { connections, total } = await store.listProjectConnectionsPage(
-    auth.organizationId,
-    projectId,
-    { limit, offset }
-  );
+  const [{ connections, total }, availability] = await Promise.all([
+    store.listProjectConnectionsPage(auth.organizationId, projectId, { limit, offset }),
+    getProviderAvailability(c.env, getDb(c.env), auth.organizationId),
+  ]);
 
   return success(c, {
     connections: connections.map((row) => ({
@@ -58,7 +61,9 @@ internalCustody.get("/connections", async (c) => {
       label: row.credential_label,
       status: row.connection_status,
       isDefault: isCustodyConnectionRuntimeEnabled(c.env, row.provider) && row.is_selected,
-      isRuntimeExecutionAllowed: isCustodyConnectionRuntimeAvailable(c.env, row.provider, row),
+      isRuntimeExecutionAllowed:
+        isCustodyConnectionRuntimeAvailable(c.env, row.provider, row) &&
+        isCustodyProviderEntitled(availability, row.provider),
       defaultCustodyWalletId: row.default_custody_wallet_id,
       createdAt: row.created_at,
       activatedAt: row.activated_at,

--- a/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
+++ b/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
@@ -184,8 +184,17 @@ async function seedAuthAndWallet(): Promise<void> {
   await seedCachedApiKey(env, keyHash, TEST_CACHED_API_KEY);
   await getDb(env).batch([
     getDb(env)
-      .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
-      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, "enterprise", "active"),
+      .prepare(
+        "INSERT INTO organizations (id, name, slug, tier, status, settings) VALUES (?, ?, ?, ?, ?, ?)"
+      )
+      .bind(
+        TEST_ORG.id,
+        TEST_ORG.name,
+        TEST_ORG.slug,
+        "enterprise",
+        "active",
+        JSON.stringify({ providerOverrides: { custody: { local: true } } })
+      ),
     getDb(env)
       .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, ?, ?)")
       .bind(TEST_USER.id, TEST_USER.email, 1, "active"),

--- a/apps/sdp-api/src/services/domain/signing/custody-runtime-target.test.ts
+++ b/apps/sdp-api/src/services/domain/signing/custody-runtime-target.test.ts
@@ -9,7 +9,10 @@ import type { SigningConfigRecord } from "@/services/adapters";
 import * as credentialSecretStore from "@/services/credential-secret-store";
 import { RuntimeEnvCredentialSecretStore } from "@/services/credential-secret-store";
 import { getPrivyProviderAccountFingerprint } from "@/services/custody/privy-credential";
-import { CustodyRuntimeTargets } from "@/services/domain/signing/custody-runtime-target";
+import {
+  CustodyRuntimeTargets,
+  selectCustodyConnectionTarget,
+} from "@/services/domain/signing/custody-runtime-target";
 import { createSigningService } from "@/services/domain/signing.service";
 import { CustodyConfigStore } from "@/services/stores/custody-config.store";
 import { env } from "@/test/helpers/env";
@@ -193,6 +196,27 @@ describe("CustodyRuntimeTargets", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it.each(["config", "connection"] as const)(
+    "rejects exact %s admission when the custody provider entitlement is revoked",
+    async (owner) => {
+      const wallet =
+        owner === "config" ? await seedConfig({ provider: "privy" }) : await seedConnection();
+      await setPrivyEntitlement(false);
+      const read = mockStoredCredentialRead();
+      const targets = new CustodyRuntimeTargets(getDb(env), env, new Map());
+
+      await expect(
+        targets.admitRuntimeExecution({
+          organizationId: ORGANIZATION_ID,
+          projectId: PROJECT_ID,
+          custodyWalletId: `cwlt_${wallet.id}`,
+        })
+      ).rejects.toMatchObject({ code: "FORBIDDEN", statusCode: 403 });
+      expect(read).not.toHaveBeenCalled();
+      expect(fetch).not.toHaveBeenCalled();
+    }
+  );
+
   it("pauses exact Connection admission before reading credentials when runtime is off", async () => {
     const connection = await seedConnection();
     env.PRIVY_BYOK_ENABLED = "false";
@@ -350,6 +374,70 @@ describe("CustodyRuntimeTargets", () => {
     });
     expect(read).not.toHaveBeenCalled();
     expect(getConfigAdapter).not.toHaveBeenCalled();
+  });
+
+  it("rechecks Connection entitlement before cached generic and exact signer resolution", async () => {
+    const config = await seedConfig({ provider: "privy" });
+    const connection = await seedConnection();
+    await setProjectDefault(config.id, connection.id);
+    const read = mockStoredCredentialRead();
+    const getConfigAdapter = createConfigAdapterFactory();
+    const targets = new CustodyRuntimeTargets(getDb(env), env, new Map());
+
+    await targets.admitRuntimeExecution({
+      organizationId: ORGANIZATION_ID,
+      projectId: PROJECT_ID,
+      custodyWalletId: `cwlt_${connection.id}`,
+    });
+    await expect(
+      targets.getTransactionSigner(ORGANIZATION_ID, PROJECT_ID, undefined, getConfigAdapter)
+    ).resolves.toMatchObject({ address: CONNECTION_PUBLIC_KEY });
+    expect(read).toHaveBeenCalledOnce();
+
+    await setPrivyEntitlement(false);
+
+    await expect(
+      targets.getTransactionSigner(ORGANIZATION_ID, PROJECT_ID, undefined, getConfigAdapter)
+    ).rejects.toMatchObject({ code: "FORBIDDEN", statusCode: 403 });
+    await expect(
+      targets.getTransactionSignerForWalletRecord(
+        ORGANIZATION_ID,
+        PROJECT_ID,
+        `cwlt_${connection.id}`,
+        getConfigAdapter
+      )
+    ).rejects.toMatchObject({ code: "FORBIDDEN", statusCode: 403 });
+    expect(read).toHaveBeenCalledOnce();
+    expect(getConfigAdapter).not.toHaveBeenCalled();
+    expect(await getProjectDefault()).toEqual({
+      default_custody_config_id: config.id,
+      default_custody_connection_id: connection.id,
+    });
+  });
+
+  it("rechecks Config entitlement before generic and exact signer resolution", async () => {
+    const config = await seedConfig({ provider: "privy" });
+    await setProjectDefault(config.id, null);
+    const getConfigAdapter = createConfigAdapterFactory();
+    const targets = new CustodyRuntimeTargets(getDb(env), env, new Map());
+
+    await expect(
+      targets.getTransactionSigner(ORGANIZATION_ID, PROJECT_ID, undefined, getConfigAdapter)
+    ).resolves.toMatchObject({ address: CONFIG_PUBLIC_KEY });
+    await setPrivyEntitlement(false);
+
+    await expect(
+      targets.getTransactionSigner(ORGANIZATION_ID, PROJECT_ID, undefined, getConfigAdapter)
+    ).rejects.toMatchObject({ code: "FORBIDDEN", statusCode: 403 });
+    await expect(
+      targets.getTransactionSignerForWalletRecord(
+        ORGANIZATION_ID,
+        PROJECT_ID,
+        `cwlt_${config.id}`,
+        getConfigAdapter
+      )
+    ).rejects.toMatchObject({ code: "FORBIDDEN", statusCode: 403 });
+    expect(getConfigAdapter).toHaveBeenCalledOnce();
   });
 
   it("signs with an exact non-default wallet under a non-selected Connection", async () => {
@@ -580,6 +668,25 @@ describe("CustodyRuntimeTargets", () => {
     ).resolves.toBeNull();
   });
 
+  it("does not select a retained Connection after its provider entitlement is revoked", async () => {
+    const config = await seedConfig({ provider: "privy" });
+    const connection = await seedConnection();
+    await setProjectDefault(config.id, null);
+    await setPrivyEntitlement(false);
+
+    await expect(
+      selectCustodyConnectionTarget(getDb(env), env, {
+        organizationId: ORGANIZATION_ID,
+        projectId: PROJECT_ID,
+        connectionId: connection.id,
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN", statusCode: 403 });
+    expect(await getProjectDefault()).toEqual({
+      default_custody_config_id: config.id,
+      default_custody_connection_id: null,
+    });
+  });
+
   it("keeps an effective same-provider Config ahead of an unselected Connection", async () => {
     const config = await seedConfig({ provider: "privy" });
     await seedConnection();
@@ -738,6 +845,41 @@ describe("CustodyRuntimeTargets", () => {
     await expect(
       targets.getTransactionSigner(ORGANIZATION_ID, PROJECT_ID, config.walletId, getConfigAdapter)
     ).resolves.toMatchObject({ address: CONFIG_PUBLIC_KEY });
+  });
+
+  it("projects revoked entitlement without changing retained Config or Connection selection", async () => {
+    const config = await seedConfig({ provider: "privy" });
+    const connection = await seedConnection();
+    await setProjectDefault(config.id, connection.id);
+    await setPrivyEntitlement(false);
+    const targets = new CustodyRuntimeTargets(getDb(env), env, new Map());
+
+    await expect(
+      targets.listWallets({
+        organizationId: ORGANIZATION_ID,
+        projectId: PROJECT_ID,
+        includeAllProviders: true,
+      })
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          custodyConfigId: config.id,
+          isRuntimeExecutionAllowed: false,
+        }),
+        expect.objectContaining({
+          custodyConnectionId: connection.id,
+          isDefaultProvider: true,
+          isRuntimeExecutionAllowed: false,
+        }),
+      ])
+    );
+    await expect(
+      targets.resolve({
+        kind: "effective",
+        organizationId: ORGANIZATION_ID,
+        projectId: PROJECT_ID,
+      })
+    ).resolves.toMatchObject({ kind: "connection", connectionId: connection.id });
   });
 
   it.each([null, "root", "mint_authority", "freeze_authority", "fee_payer", "transfer"] as const)(
@@ -1178,6 +1320,13 @@ async function setOrganizationDefault(configId: string): Promise<void> {
        ) VALUES ('csd_runtime_targets_org', ?, NULL, ?)`
     )
     .bind(ORGANIZATION_ID, configId)
+    .run();
+}
+
+async function setPrivyEntitlement(entitled: boolean): Promise<void> {
+  await getDb(env)
+    .prepare("UPDATE organizations SET settings = ? WHERE id = ?")
+    .bind(JSON.stringify({ providerOverrides: { custody: { privy: entitled } } }), ORGANIZATION_ID)
     .run();
 }
 

--- a/apps/sdp-api/src/services/domain/signing/custody-runtime-target.ts
+++ b/apps/sdp-api/src/services/domain/signing/custody-runtime-target.ts
@@ -5,6 +5,7 @@ import type {
   CustodyConnectionLifecycle,
   CustodyWalletPurpose,
   CustodyWalletStatus,
+  OrganizationProviderAvailabilityResponse,
   ProviderCredentialStatus,
 } from "@sdp/types";
 import type { Address, TransactionSigner } from "@solana/kit";
@@ -33,7 +34,11 @@ import {
 import { provisionPrivyWallet } from "@/services/custody/provisioning";
 import { assertCustodyProviderCanCreateWallet } from "@/services/custody-provider-lifecycle.service";
 import { createPrivyAdapterFromCredential } from "@/services/domain/signing/provider-adapter-factory";
-import { getProviderAvailability } from "@/services/provider-availability.service";
+import {
+  assertCustodyProviderEntitled,
+  getProviderAvailability,
+  isCustodyProviderEntitled,
+} from "@/services/provider-availability.service";
 import type { Env } from "@/types/env";
 
 type ConfigAdapterResolver = (
@@ -328,6 +333,7 @@ export class CustodyRuntimeTargets {
       throw notFound("Custody wallet");
     }
     this.assertRuntimeExecutionAllowed(target, params.custodyWalletId);
+    await assertCustodyProviderEntitled(this.env, this.db, params.organizationId, target.provider);
   }
 
   async listWallets(params: {
@@ -337,15 +343,18 @@ export class CustodyRuntimeTargets {
     includeAllProviders: boolean;
   }): Promise<CustodyRuntimeWalletProjection[]> {
     const effective = await this.resolveEffective(params.organizationId, params.projectId);
-    const [configRows, connectionRows] = await Promise.all([
+    const [configRows, connectionRows, availability] = await Promise.all([
       this.findOperationalConfigWallets(params.organizationId, params.projectId),
       params.projectId
         ? this.findOperationalConnectionWallets(params.organizationId, params.projectId)
         : Promise.resolve([]),
+      getProviderAvailability(this.env, this.db, params.organizationId),
     ]);
     const wallets = [
-      ...configRows.map((row) => this.mapOperationalConfigWallet(row, effective)),
-      ...connectionRows.map((row) => this.mapOperationalConnectionWallet(row, effective)),
+      ...configRows.map((row) => this.mapOperationalConfigWallet(row, effective, availability)),
+      ...connectionRows.map((row) =>
+        this.mapOperationalConnectionWallet(row, effective, availability)
+      ),
     ].filter((wallet) => !params.provider || wallet.provider === params.provider);
 
     if (params.includeAllProviders) {
@@ -484,13 +493,11 @@ export class CustodyRuntimeTargets {
       throw conflict("Custody Connection is unavailable");
     }
 
+    await assertCustodyProviderEntitled(this.env, this.db, params.organizationId, target.provider);
+
     const credential = await this.loadConnectionCredential(target);
     if (!credential || !isUsableCredentialConnection(credential)) {
       throw conflict("Custody Connection is unavailable");
-    }
-    const availability = await getProviderAvailability(this.env, this.db, params.organizationId);
-    if (availability.providers.custody[target.provider]?.entitled !== true) {
-      throw forbidden(`${target.provider} is unavailable for this organization`);
     }
     if (target.provider !== "privy") {
       throw internalError("Custody Connection provider is unsupported");
@@ -549,6 +556,7 @@ export class CustodyRuntimeTargets {
     }
 
     if (target.kind === "config") {
+      await assertCustodyProviderEntitled(this.env, this.db, organizationId, target.provider);
       const adapter = await getConfigAdapter(organizationId, target.config);
       return getTransactionSigner(adapter, target.wallet);
     }
@@ -563,6 +571,7 @@ export class CustodyRuntimeTargets {
       throw conflict("Custody Connection is unavailable");
     }
 
+    await assertCustodyProviderEntitled(this.env, this.db, organizationId, target.provider);
     const adapter = await this.getConnectionAdapter(target);
     return getTransactionSigner(adapter, target.wallet);
   }
@@ -589,6 +598,7 @@ export class CustodyRuntimeTargets {
       throw new SigningError("Custody wallet not found", "WALLET_NOT_FOUND");
     }
     this.assertRuntimeExecutionAllowed(target, custodyWalletId);
+    await assertCustodyProviderEntitled(this.env, this.db, organizationId, target.provider);
 
     if (target.kind === "config") {
       const adapter = await getConfigAdapter(organizationId, target.config);
@@ -1268,15 +1278,17 @@ export class CustodyRuntimeTargets {
 
   private mapOperationalConfigWallet(
     row: OperationalConfigWalletRow,
-    effective: CustodyRuntimeTarget | null
+    effective: CustodyRuntimeTarget | null,
+    availability: OrganizationProviderAvailabilityResponse
   ): CustodyRuntimeWalletProjection {
+    const provider = this.parseProvider(row.provider);
     return {
       id: row.wallet_record_id,
       custodyConfigId: row.custody_config_id,
-      provider: this.parseProvider(row.provider),
+      provider,
       isDefaultProvider:
         effective?.kind === "config" && effective.config.id === row.custody_config_id,
-      isRuntimeExecutionAllowed: true,
+      isRuntimeExecutionAllowed: isCustodyProviderEntitled(availability, provider),
       walletId: row.wallet_id,
       publicKey: row.wallet_public_key,
       label: row.wallet_label,
@@ -1288,15 +1300,18 @@ export class CustodyRuntimeTargets {
 
   private mapOperationalConnectionWallet(
     row: OperationalConnectionWalletRow,
-    effective: CustodyRuntimeTarget | null
+    effective: CustodyRuntimeTarget | null,
+    availability: OrganizationProviderAvailabilityResponse
   ): CustodyRuntimeWalletProjection {
+    const provider = this.parseProvider(row.provider);
     return {
       id: row.wallet_record_id,
       custodyConnectionId: row.connection_id,
-      provider: this.parseProvider(row.provider),
+      provider,
       isDefaultProvider:
         effective?.kind === "connection" && effective.connectionId === row.connection_id,
-      isRuntimeExecutionAllowed: this.isConnectionRuntimeAvailable(row),
+      isRuntimeExecutionAllowed:
+        this.isConnectionRuntimeAvailable(row) && isCustodyProviderEntitled(availability, provider),
       walletId: row.wallet_id,
       publicKey: row.wallet_public_key,
       label: row.wallet_label,
@@ -1548,6 +1563,7 @@ export async function selectCustodyConnectionTarget(
     if (!isCustodyConnectionRuntimeEnabled(env, provider)) {
       throw forbidden("Custody Connection runtime is disabled");
     }
+    await assertCustodyProviderEntitled(env, tx, params.organizationId, provider);
 
     const wallet = connection.default_custody_wallet_id
       ? await tx.queryOne<{ wallet_id: string; public_key: string; status: string }>(

--- a/apps/sdp-api/src/services/provider-availability.service.test.ts
+++ b/apps/sdp-api/src/services/provider-availability.service.test.ts
@@ -1,7 +1,9 @@
 import { resolveOrganizationProviderEntitlements } from "@sdp/types";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
+import { getLogger } from "@/runtime/logger";
 import {
+  assertCustodyProviderEntitled,
   assertEarnProviderConfigured,
   assertProviderAvailable,
   getProviderAvailability,
@@ -143,10 +145,43 @@ describe("provider-availability.service", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     writeProviderEnv(originalProviderEnv);
     env.SDP_DEPLOYMENT_MODE = originalDeploymentMode;
     env.PRIVY_BYOK_ENABLED = originalPrivyByokEnabled;
     env.SELF_HOSTED_STORED_CONNECTION_SETUP_ENABLED = originalSelfHostedStoredSetupEnabled;
+  });
+
+  it("logs an attributable custody entitlement denial without changing its 403 response", async () => {
+    const logger = getLogger();
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => logger);
+    await expect(
+      assertCustodyProviderEntitled(env, getDb(env), TEST_ORG_ID, "privy")
+    ).resolves.toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+
+    await getDb(env).execute("UPDATE organizations SET settings = ? WHERE id = ?", [
+      JSON.stringify({ providerOverrides: { custody: { privy: false } } }),
+      TEST_ORG_ID,
+    ]);
+    await expect(
+      assertCustodyProviderEntitled(env, getDb(env), TEST_ORG_ID, "privy")
+    ).rejects.toMatchObject({ code: "FORBIDDEN", statusCode: 403 });
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      {
+        event: "sdp_api_custody_entitlement_denied",
+        organization_id: TEST_ORG_ID,
+        provider: "privy",
+        reason: "provider_not_entitled",
+      },
+      "sdp_api_custody_entitlement_denied"
+    );
+    warn.mockImplementation(() => {
+      throw new Error("logger unavailable");
+    });
+    await expect(
+      assertCustodyProviderEntitled(env, getDb(env), TEST_ORG_ID, "privy")
+    ).rejects.toMatchObject({ code: "FORBIDDEN", statusCode: 403 });
   });
 
   it("resolves general defaults independently of the legacy tier value", () => {

--- a/apps/sdp-api/src/services/provider-availability.service.ts
+++ b/apps/sdp-api/src/services/provider-availability.service.ts
@@ -22,10 +22,12 @@ import {
   resolveOrganizationProviderEntitlements,
   type SdpEnvironment,
 } from "@sdp/types";
+import type { DatabaseExecutor } from "@/db";
 import { parsePostgresJson } from "@/db/postgres-utils";
 import { AppError } from "@/lib/errors";
 import { isCustodyConnectionRuntimeEnabled } from "@/lib/feature-flags";
 import { isSelfHostedDeployment } from "@/lib/runtime-env";
+import { logEvent } from "@/runtime/money-path-events";
 import type { Env } from "@/types/env";
 
 type OrganizationProviderRow = {
@@ -484,7 +486,7 @@ export function parseClerkOrganizationTierMetadata(organization: ClerkOrganizati
 }
 
 export async function getOrganizationTierState(
-  db: DatabaseClient,
+  db: DatabaseExecutor,
   organizationId: string
 ): Promise<{ tier: OrganizationTier; settings: OrganizationSettings | null }> {
   const row = await db
@@ -577,7 +579,7 @@ function getProviderLabel(family: OrganizationProviderFamily, providerId: string
 
 export async function getProviderAvailability(
   env: Env,
-  db: DatabaseClient,
+  db: DatabaseExecutor,
   organizationId: string
 ): Promise<OrganizationProviderAvailabilityResponse> {
   const organization = await getOrganizationTierState(db, organizationId);
@@ -609,6 +611,46 @@ export async function getProviderAvailability(
       earn: buildAvailabilityEntries(entitled.earn, configured.earn),
     },
   };
+}
+
+export function isCustodyProviderEntitled(
+  availability: OrganizationProviderAvailabilityResponse,
+  provider: CustodyProvider
+): boolean {
+  return availability.providers.custody[provider]?.entitled === true;
+}
+
+/**
+ * Runtime admission for persisted custody owners depends on organization
+ * entitlement, not on legacy environment credentials. Stored Connection
+ * credentials remain usable when the matching runtime-env credential is absent.
+ */
+export async function assertCustodyProviderEntitled(
+  env: Env,
+  db: DatabaseExecutor,
+  organizationId: string,
+  provider: CustodyProvider
+): Promise<void> {
+  const availability = await getProviderAvailability(env, db, organizationId);
+  const entry = availability.providers.custody[provider];
+  if (!isCustodyProviderEntitled(availability, provider)) {
+    logEvent("warn", {
+      event: "sdp_api_custody_entitlement_denied",
+      organization_id: organizationId,
+      provider,
+      reason: "provider_not_entitled",
+    });
+    throw new AppError(
+      "FORBIDDEN",
+      getAvailabilityMessage(
+        env,
+        availability.tier,
+        "custody",
+        provider,
+        entry ?? { entitled: false, configured: false, enabled: false }
+      )
+    );
+  }
 }
 
 export async function isPersistedCustodyCompletionEnabled(

--- a/apps/sdp-api/src/test/helpers/payments-routes.ts
+++ b/apps/sdp-api/src/test/helpers/payments-routes.ts
@@ -236,8 +236,17 @@ async function seedAuthAndWallet(): Promise<void> {
 
   await getDb(env).batch([
     getDb(env)
-      .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
-      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, "enterprise", "active"),
+      .prepare(
+        "INSERT INTO organizations (id, name, slug, tier, status, settings) VALUES (?, ?, ?, ?, ?, ?)"
+      )
+      .bind(
+        TEST_ORG.id,
+        TEST_ORG.name,
+        TEST_ORG.slug,
+        "enterprise",
+        "active",
+        JSON.stringify({ providerOverrides: { custody: { local: true } } })
+      ),
     getDb(env)
       .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, ?, ?)")
       .bind(TEST_USER.id, TEST_USER.email, 1, "active"),


### PR DESCRIPTION
**What changed**

- Enforce organization provider entitlement when resolving Config and Connection signers, including cached Connection adapters.
- Check entitlement before Connection wallet creation, target selection, and default-wallet changes.
- Reflect entitlement in wallet and Connection runtime-availability projections.
- Emit `sdp_api_custody_entitlement_denied` warnings with the organization and provider.

**Why**

Persisted custody configuration and cached adapters must not bypass a revoked provider entitlement. Runtime admission should use the organization's current entitlement while preserving existing wallet ownership and selection.

**Impact**

This changes access to existing custody operations, including payment and workflow paths that use custody signing. Operations requiring a provider entitlement return `403` when that entitlement is absent.

The change also applies to Config-backed wallets. Disabling the BYOK feature does not isolate its entire impact.

No database migration is added.

**Pre/post release actions**

1. Before rollout, review effective custody entitlements and overrides for organizations with existing wallets.
2. After rollout, monitor `sdp_api_custody_entitlement_denied` and verify that entitled organizations can still sign and create Connection wallets.

**Result Validation**

- `pnpm --filter @sdp/api typecheck` and `pnpm --filter @sdp/api build` — passed.
- 153 targeted tests — passed, covering revoked entitlement, cached signers, runtime projections, and unchanged defaults after rejection.
- `pnpm --filter @sdp/api test` — 4,515 passed, 14 skipped.
- Scoped Biome, module-boundary, and diff checks — passed.
- Live API and provider smoke tests — not run.

**Does it affect current flows & behavior and how**

**Before:** Config signing and some Connection runtime paths could proceed without checking the organization's current provider entitlement.

**After:**

1. Resolve the persisted custody target.
2. Check runtime eligibility and current organization entitlement.
3. Access credentials or the provider only after admission succeeds.

An entitlement rejection does not delete wallets, change the selected target/default, or fall back to another provider.

For persisted Connections, entitlement is checked independently of whether matching legacy credentials exist in the deployment environment.

**Notes**

Part 1 of 4. This PR contains runtime admission changes only; secret persistence, rotation, rollback, and deactivation are separate parts of the stack.