### PR TITLE
fix(custody): persist credential creation and reconcile shared GCP secrets

### DIFF
--- a/apps/sdp-api/src/cron/provider-credential-secret-cleanup.test.ts
+++ b/apps/sdp-api/src/cron/provider-credential-secret-cleanup.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BackgroundRunner } from "@/runtime/background";
+import type { Observability } from "@/runtime/observability";
+import { cleanupRetiredProviderCredentialSecrets } from "@/services/jobs/cleanup-provider-credential-secrets";
+import type { Env } from "@/types/env";
+import {
+  PROVIDER_CREDENTIAL_SECRET_CLEANUP_CRON,
+  PROVIDER_CREDENTIAL_SECRET_CLEANUP_MONITOR,
+  runProviderCredentialSecretCleanup,
+} from "./provider-credential-secret-cleanup";
+
+vi.mock("@/services/jobs/cleanup-provider-credential-secrets", () => ({
+  cleanupRetiredProviderCredentialSecrets: vi.fn(async () => ({
+    cleaned: 0,
+    skipped: 0,
+    failed: 0,
+  })),
+}));
+
+describe("runProviderCredentialSecretCleanup", () => {
+  it("runs the cleanup through its five-minute monitor and background tracker", async () => {
+    const env = {} as Env;
+    const bg = { run: vi.fn(), awaitAll: vi.fn(), draining: false } satisfies BackgroundRunner;
+    const observability = {
+      captureException: vi.fn(),
+      withScope: vi.fn(),
+      withMonitor: vi.fn((_slug, work) => work()),
+    } satisfies Observability;
+
+    runProviderCredentialSecretCleanup({ env, bg, observability });
+
+    expect(observability.withMonitor).toHaveBeenCalledExactlyOnceWith(
+      PROVIDER_CREDENTIAL_SECRET_CLEANUP_MONITOR,
+      expect.any(Function),
+      { schedule: { type: "crontab", value: PROVIDER_CREDENTIAL_SECRET_CLEANUP_CRON } }
+    );
+    expect(cleanupRetiredProviderCredentialSecrets).toHaveBeenCalledExactlyOnceWith(env);
+    expect(bg.run).toHaveBeenCalledOnce();
+    await vi.mocked(bg.run).mock.calls[0][0];
+  });
+});

--- a/apps/sdp-api/src/cron/provider-credential-secret-cleanup.ts
+++ b/apps/sdp-api/src/cron/provider-credential-secret-cleanup.ts
@@ -1,0 +1,27 @@
+import type { BackgroundRunner } from "@/runtime/background";
+import type { Observability } from "@/runtime/observability";
+import { cleanupRetiredProviderCredentialSecrets } from "@/services/jobs/cleanup-provider-credential-secrets";
+import type { Env } from "@/types/env";
+
+export const PROVIDER_CREDENTIAL_SECRET_CLEANUP_MONITOR =
+  "sdp-api-cleanup-provider-credential-secrets";
+export const PROVIDER_CREDENTIAL_SECRET_CLEANUP_CRON = "*/5 * * * *";
+
+export interface ProviderCredentialSecretCleanupDeps {
+  env: Env;
+  bg: BackgroundRunner;
+  observability?: Observability;
+}
+
+export function runProviderCredentialSecretCleanup(
+  deps: ProviderCredentialSecretCleanupDeps
+): void {
+  const work = () => cleanupRetiredProviderCredentialSecrets(deps.env);
+  const promise = deps.observability
+    ? deps.observability.withMonitor(PROVIDER_CREDENTIAL_SECRET_CLEANUP_MONITOR, work, {
+        schedule: { type: "crontab", value: PROVIDER_CREDENTIAL_SECRET_CLEANUP_CRON },
+      })
+    : Promise.resolve().then(work);
+
+  deps.bg.run(promise);
+}

--- a/apps/sdp-api/src/cron/runner.node.test.ts
+++ b/apps/sdp-api/src/cron/runner.node.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { currentDatabaseIdentity } from "@/db/identity";
 import type { BackgroundRunner } from "@/runtime/background";
 import { logEvent } from "@/runtime/money-path-events";
 import type { Observability } from "@/runtime/observability";
@@ -7,7 +8,7 @@ import {
   APPROVED_WALLET_OPERATIONS_CRON,
   runApprovedWalletOperationRecovery,
 } from "./approved-wallet-operations";
-import { DVP_TRADES_CRON } from "./dvp-trades";
+import { DVP_TRADES_CRON, runDvpTradeReconciliation } from "./dvp-trades";
 import { EARN_CATALOGUE_SYNC_CRON } from "./earn-catalogue-sync";
 import { EARN_METRICS_REFRESH_CRON, EARN_METRICS_REFRESH_MONITOR } from "./earn-metrics-refresh";
 import { EARN_SPLIT_SWAPS_CRON } from "./earn-split-swaps";
@@ -25,6 +26,10 @@ import {
   PENDING_WITHDRAWALS_CRON,
   runPendingWithdrawalsReconciliation,
 } from "./pending-withdrawals";
+import {
+  PROVIDER_CREDENTIAL_SECRET_CLEANUP_CRON,
+  runProviderCredentialSecretCleanup,
+} from "./provider-credential-secret-cleanup";
 import {
   RECURRING_PAYMENTS_COLLECTION_CRON,
   runRecurringPaymentsCollection,
@@ -146,6 +151,11 @@ vi.mock("./workflow-secret-retirements", () => ({
   runWorkflowSecretRetirements: vi.fn(),
 }));
 
+vi.mock("./provider-credential-secret-cleanup", () => ({
+  PROVIDER_CREDENTIAL_SECRET_CLEANUP_CRON: "*/5 * * * *",
+  runProviderCredentialSecretCleanup: vi.fn(),
+}));
+
 function makeBg(): BackgroundRunner {
   return { run: vi.fn(), awaitAll: vi.fn(async () => {}), draining: false };
 }
@@ -165,6 +175,7 @@ describe("startCron", () => {
     scheduleMock.mockReturnValue(fakeTask);
     vi.mocked(runApprovedWalletOperationRecovery).mockReset();
     vi.mocked(runEarnVaultMovementsReconciliation).mockReset();
+    vi.mocked(runDvpTradeReconciliation).mockReset();
     vi.mocked(runPendingDepositsReconciliation).mockReset();
     vi.mocked(runPendingTransfersReconciliation).mockReset();
     vi.mocked(runPendingWithdrawalsReconciliation).mockReset();
@@ -173,6 +184,7 @@ describe("startCron", () => {
     vi.mocked(runRingsIndexingPoll).mockReset();
     vi.mocked(runWorkflowExecutions).mockReset();
     vi.mocked(runWorkflowSecretRetirements).mockReset();
+    vi.mocked(runProviderCredentialSecretCleanup).mockReset();
   });
 
   // Asset profiles is on unless a self-hosted operator opts out, so the workflow
@@ -181,14 +193,14 @@ describe("startCron", () => {
   // "* * * * *"), so identity is asserted by firing the tick and seeing which
   // reconciler runs.
   //
-  // The secret-retirement sweep is registered last and behind no flag at all, so it is
+  // The secret-retirement sweep is registered behind no flag at all, so it is
   // in every count below too — including the ones where asset profiles is off.
   //
   // Feature-gated ticks whose flag is off are still scheduled as sdp_cron_run
-  // proof-of-life no-ops, so every configuration schedules all 13 tasks. What a
+  // proof-of-life no-ops, so every configuration schedules all 15 tasks. What a
   // flag changes is whether the tick does real work, asserted by firing it.
   const SELF_HOSTED_NO_PROFILES = { SDP_DEPLOYMENT_MODE: "self_hosted" } as Env;
-  const ALL_TASKS = 14;
+  const ALL_TASKS = 15;
 
   it("returns null and does not schedule when DISABLE_CRON=true", () => {
     const result = startCron({ env: { DISABLE_CRON: "true" } as Env, bg: makeBg() });
@@ -216,9 +228,10 @@ describe("startCron", () => {
     expect(scheduleMock.mock.calls[8][0]).toBe(EARN_CATALOGUE_SYNC_CRON);
     expect(scheduleMock.mock.calls[9][0]).toBe(EARN_METRICS_REFRESH_CRON);
     expect(scheduleMock.mock.calls[10][0]).toBe(WORKFLOW_SECRET_RETIREMENTS_CRON);
-    expect(scheduleMock.mock.calls[11][0]).toBe(EARN_VAULT_MOVEMENTS_CRON);
-    expect(scheduleMock.mock.calls[12][0]).toBe(DVP_TRADES_CRON);
-    expect(scheduleMock.mock.calls[13][0]).toBe(EARN_SPLIT_SWAPS_CRON);
+    expect(scheduleMock.mock.calls[11][0]).toBe(PROVIDER_CREDENTIAL_SECRET_CLEANUP_CRON);
+    expect(scheduleMock.mock.calls[12][0]).toBe(EARN_VAULT_MOVEMENTS_CRON);
+    expect(scheduleMock.mock.calls[13][0]).toBe(DVP_TRADES_CRON);
+    expect(scheduleMock.mock.calls[14][0]).toBe(EARN_SPLIT_SWAPS_CRON);
   });
 
   it("always schedules revoked API key cache reconciliation", () => {
@@ -331,6 +344,26 @@ describe("startCron", () => {
     }
     expect(runWorkflowExecutions).not.toHaveBeenCalled();
     expect(runWorkflowSecretRetirements).toHaveBeenCalledWith({
+      env: SELF_HOSTED_NO_PROFILES,
+      bg,
+      observability: expect.anything(),
+    });
+  });
+
+  it("cleans retained Provider Credential secrets behind no feature flag", () => {
+    const bg = makeBg();
+    const observability = makeObservability();
+    vi.mocked(runProviderCredentialSecretCleanup).mockImplementationOnce(() => {
+      expect(currentDatabaseIdentity()).toEqual({
+        kind: "system",
+        component: "cron:provider-credential-secret-cleanup",
+      });
+    });
+    startCron({ env: SELF_HOSTED_NO_PROFILES, bg, observability });
+
+    (scheduleMock.mock.calls[11][1] as () => void)();
+
+    expect(runProviderCredentialSecretCleanup).toHaveBeenCalledExactlyOnceWith({
       env: SELF_HOSTED_NO_PROFILES,
       bg,
       observability: expect.anything(),
@@ -490,9 +523,26 @@ describe("startCron", () => {
     // Indexed rather than `.at(-1)`: this asserts the vault-movement task
     // specifically, and taking whatever happens to be registered last silently
     // retargets the assertion the moment another task is appended.
-    const tick = scheduleMock.mock.calls[11][1] as () => void;
+    const tick = scheduleMock.mock.calls[12][1] as () => void;
     tick();
     expect(runEarnVaultMovementsReconciliation).toHaveBeenCalledWith({
+      env,
+      bg,
+      observability: expect.anything(),
+    });
+  });
+
+  it("keeps DvP reconciliation registered under the system identity", () => {
+    const bg = makeBg();
+    const env = SELF_HOSTED_NO_PROFILES;
+    vi.mocked(runDvpTradeReconciliation).mockImplementationOnce(() => {
+      expect(currentDatabaseIdentity()).toEqual({ kind: "system", component: "cron:dvp-trades" });
+    });
+    startCron({ env, bg });
+
+    (scheduleMock.mock.calls[13][1] as () => void)();
+
+    expect(runDvpTradeReconciliation).toHaveBeenCalledExactlyOnceWith({
       env,
       bg,
       observability: expect.anything(),

--- a/apps/sdp-api/src/cron/runner.ts
+++ b/apps/sdp-api/src/cron/runner.ts
@@ -51,6 +51,10 @@ import {
   runPendingWithdrawalsReconciliation,
 } from "./pending-withdrawals";
 import {
+  PROVIDER_CREDENTIAL_SECRET_CLEANUP_CRON,
+  runProviderCredentialSecretCleanup,
+} from "./provider-credential-secret-cleanup";
+import {
   RECURRING_PAYMENTS_COLLECTION_CRON,
   runRecurringPaymentsCollection,
 } from "./recurring-payments";
@@ -276,6 +280,14 @@ export function startCron(deps: CronDeps): CronHandle | null {
       WORKFLOW_SECRET_RETIREMENTS_CRON,
       "cron:workflow-secret-retirements",
       runWorkflowSecretRetirements
+    )
+  );
+
+  tasks.push(
+    scheduleSystemTask(
+      PROVIDER_CREDENTIAL_SECRET_CLEANUP_CRON,
+      "cron:provider-credential-secret-cleanup",
+      runProviderCredentialSecretCleanup
     )
   );
 

--- a/apps/sdp-api/src/db/migrations/0080_provider_credential_secret_retention.migration.test.ts
+++ b/apps/sdp-api/src/db/migrations/0080_provider_credential_secret_retention.migration.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+
+const ORGANIZATION_ID = "org_credential_secret_retention";
+const USER_ID = "usr_credential_secret_retention";
+
+async function insertCredential(params: {
+  id: string;
+  status: "pending" | "active" | "failed_validation" | "retired" | "deactivated";
+  backend?: "encrypted_db" | "gcp_secret_manager" | "runtime_env";
+  ciphertext?: string | null;
+  retentionExpiresAt?: string | null;
+  rotatedFromId?: string | null;
+}): Promise<void> {
+  const backend = params.backend ?? "encrypted_db";
+  const runtime = backend === "runtime_env";
+  const gcp = backend === "gcp_secret_manager";
+  await getDb(env)
+    .prepare(
+      `INSERT INTO provider_credentials (
+         id, organization_id, provider, label, scope, source, storage_backend,
+         secret_ref, secret_version_ref, encrypted_secret_payload, status, deactivated_at,
+         secret_retention_expires_at, rotated_from_provider_credential_id, created_by
+       ) VALUES (?, ?, 'privy', 'Privy', 'organization', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .bind(
+      params.id,
+      ORGANIZATION_ID,
+      runtime ? "runtime" : "stored",
+      backend,
+      gcp ? `projects/p/secrets/${params.id}` : null,
+      gcp ? `projects/p/secrets/${params.id}/versions/7` : null,
+      backend === "encrypted_db" ? (params.ciphertext ?? null) : null,
+      params.status,
+      params.status === "deactivated" ? "2026-09-04T10:00:00.000Z" : null,
+      params.retentionExpiresAt ?? null,
+      params.rotatedFromId ?? null,
+      USER_ID
+    )
+    .run();
+}
+
+describe("0080 provider Credential secret retention", () => {
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    await getDb(env)
+      .prepare(
+        `INSERT INTO organizations (id, name, slug, tier, status)
+         VALUES (?, 'Credential retention', 'credential-retention', 'enterprise', 'active')`
+      )
+      .bind(ORGANIZATION_ID)
+      .run();
+    await getDb(env)
+      .prepare(
+        `INSERT INTO users (id, email, email_verified, status)
+         VALUES (?, 'credential-retention@example.test', 1, 'active')`
+      )
+      .bind(USER_ID)
+      .run();
+  });
+
+  it("requires ciphertext while a retired encrypted-db Credential is rollback-retained", async () => {
+    await expect(
+      insertCredential({
+        id: "pcred_retained_without_secret",
+        status: "retired",
+        retentionExpiresAt: "2026-09-05T10:00:00.000Z",
+      })
+    ).rejects.toThrow(/provider_credentials_secret_location_check/);
+
+    await expect(
+      insertCredential({
+        id: "pcred_retained_with_secret",
+        status: "retired",
+        ciphertext: "v2.ciphertext",
+        retentionExpiresAt: "2026-09-05T10:00:00.000Z",
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("allows cleanup to atomically clear the ciphertext and retention marker", async () => {
+    await insertCredential({
+      id: "pcred_cleanup",
+      status: "retired",
+      ciphertext: "v2.ciphertext",
+      retentionExpiresAt: "2026-09-05T10:00:00.000Z",
+    });
+
+    await expect(
+      getDb(env)
+        .prepare(
+          `UPDATE provider_credentials
+           SET encrypted_secret_payload = NULL,
+               secret_retention_expires_at = NULL
+           WHERE id = ?`
+        )
+        .bind("pcred_cleanup")
+        .run()
+    ).resolves.toBe(1);
+  });
+
+  it("keeps pre-existing retired metadata without a retention marker valid", async () => {
+    await expect(
+      insertCredential({ id: "pcred_rpc_history", status: "retired" })
+    ).resolves.toBeUndefined();
+  });
+
+  it("permits a retention marker only on a stored retired Credential", async () => {
+    await expect(
+      insertCredential({
+        id: "pcred_active_marker",
+        status: "active",
+        ciphertext: "v2.ciphertext",
+        retentionExpiresAt: "2026-09-05T10:00:00.000Z",
+      })
+    ).rejects.toThrow(/provider_credentials_secret_retention_check/);
+
+    await expect(
+      insertCredential({
+        id: "pcred_runtime_marker",
+        status: "retired",
+        backend: "runtime_env",
+        retentionExpiresAt: "2026-09-05T10:00:00.000Z",
+      })
+    ).rejects.toThrow(/provider_credentials_secret_retention_check/);
+  });
+
+  it.each(["failed_validation", "deactivated"] as const)(
+    "permits an immediate cleanup marker only for a GCP rotation candidate that ends %s",
+    async (status) => {
+      const predecessorId = `pcred_${status}_predecessor`;
+      await insertCredential({
+        id: predecessorId,
+        status: "active",
+        ciphertext: "v2.predecessor",
+      });
+
+      await expect(
+        insertCredential({
+          id: `pcred_gcp_${status}`,
+          status,
+          backend: "gcp_secret_manager",
+          retentionExpiresAt: "2026-09-04T10:00:00.000Z",
+          rotatedFromId: predecessorId,
+        })
+      ).resolves.toBeUndefined();
+
+      await expect(
+        insertCredential({
+          id: `pcred_encrypted_${status}`,
+          status,
+          retentionExpiresAt: "2026-09-04T10:00:00.000Z",
+          rotatedFromId: predecessorId,
+        })
+      ).rejects.toThrow(/provider_credentials_secret_retention_check/);
+
+      await expect(
+        insertCredential({
+          id: `pcred_unrotated_gcp_${status}`,
+          status,
+          backend: "gcp_secret_manager",
+          retentionExpiresAt: "2026-09-04T10:00:00.000Z",
+        })
+      ).rejects.toThrow(/provider_credentials_secret_retention_check/);
+    }
+  );
+});

--- a/apps/sdp-api/src/db/migrations/0082_provider_credential_creation.migration.test.ts
+++ b/apps/sdp-api/src/db/migrations/0082_provider_credential_creation.migration.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+
+describe("0082 Provider Credential creation", () => {
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    await getDb(env).execute(
+      `INSERT INTO organizations (id, name, slug, tier, status)
+       VALUES ('org_creation', 'Creation', 'creation', 'enterprise', 'active')`
+    );
+  });
+
+  it("reserves a GCP location before a version exists, then retains abandoned root cleanup", async () => {
+    await getDb(env).execute(
+      `INSERT INTO provider_credentials (
+         id, organization_id, provider, label, scope, source, storage_backend,
+         secret_ref, status
+       ) VALUES (
+         'pcred_creation', 'org_creation', 'privy', 'Privy', 'organization', 'stored',
+         'gcp_secret_manager', 'projects/p/secrets/sdp-provider-credentials-pcred_creation',
+         'creating'
+       )`
+    );
+    await expect(
+      getDb(env).execute(
+        `UPDATE provider_credentials
+         SET status = 'deactivated', deactivated_at = sdp_iso_now(),
+             last_failure_code = 'secret_creation_abandoned',
+             secret_retention_expires_at = sdp_iso_now()
+         WHERE id = 'pcred_creation'`
+      )
+    ).resolves.toBe(1);
+  });
+
+  it("does not permit cleanup markers on unrelated deactivated GCP roots", async () => {
+    await expect(
+      getDb(env).execute(
+        `INSERT INTO provider_credentials (
+           id, organization_id, provider, label, scope, source, storage_backend,
+           secret_ref, status, deactivated_at, secret_retention_expires_at
+         ) VALUES (
+           'pcred_unrelated', 'org_creation', 'privy', 'Privy', 'organization', 'stored',
+           'gcp_secret_manager', 'projects/p/secrets/unrelated',
+           'deactivated', sdp_iso_now(), sdp_iso_now()
+         )`
+      )
+    ).rejects.toThrow(/provider_credentials_secret_retention_check/);
+  });
+
+  it.each([
+    "storage_backend = 'encrypted_db', secret_ref = NULL, encrypted_secret_payload = 'v2.payload'",
+    "source = 'runtime', storage_backend = 'runtime_env', secret_ref = NULL",
+    "secret_version_ref = 'projects/p/secrets/creation/versions/7'",
+  ])("restricts creating to a stored GCP location without a version: %s", async (change) => {
+    await getDb(env).execute(
+      `INSERT INTO provider_credentials (
+         id, organization_id, provider, label, scope, source, storage_backend,
+         secret_ref, status
+       ) VALUES ('pcred_creating_constraint', 'org_creation', 'privy', 'Privy',
+         'organization', 'stored', 'gcp_secret_manager', 'projects/p/secrets/creation', 'creating')`
+    );
+    await expect(
+      getDb(env).execute(
+        `UPDATE provider_credentials SET ${change} WHERE id = 'pcred_creating_constraint'`
+      )
+    ).rejects.toThrow(/provider_credentials_creating_location_check/);
+  });
+});

--- a/apps/sdp-api/src/db/migrations/0084_provider_credential_container_scans.migration.test.ts
+++ b/apps/sdp-api/src/db/migrations/0084_provider_credential_container_scans.migration.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+
+describe("0084 Provider Credential container scans", () => {
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    await getDb(env).execute(
+      `INSERT INTO organizations (id, name, slug, tier, status)
+       VALUES ('org_scans', 'Scans', 'scans', 'enterprise', 'active')`
+    );
+    await getDb(env).execute(
+      `INSERT INTO provider_credentials (
+         id, organization_id, provider, label, scope, source, storage_backend,
+         secret_ref, secret_version_ref, status, secret_next_scan_at
+       ) VALUES ('pcred_scan_owner', 'org_scans', 'privy', 'Privy', 'organization', 'stored',
+         'gcp_secret_manager', 'projects/p/secrets/shared', 'projects/p/secrets/shared/versions/1',
+         'pending', clock_timestamp())`
+    );
+  });
+
+  it("permits shared versions but only one schedule owner per container", async () => {
+    await getDb(env).execute(
+      `INSERT INTO provider_credentials (
+         id, organization_id, provider, label, scope, source, storage_backend,
+         secret_ref, secret_version_ref, status
+       ) VALUES ('pcred_scan_child', 'org_scans', 'privy', 'Privy', 'organization', 'stored',
+         'gcp_secret_manager', 'projects/p/secrets/shared', 'projects/p/secrets/shared/versions/2', 'pending')`
+    );
+    await expect(
+      getDb(env).execute(
+        "UPDATE provider_credentials SET secret_next_scan_at = clock_timestamp() WHERE id = 'pcred_scan_child'"
+      )
+    ).rejects.toThrow(/idx_provider_credentials_gcp_scan_owner/);
+  });
+
+  it.each(["retired", "deactivated"])(
+    "retains scheduling after the owner becomes %s",
+    async (status) => {
+      await getDb(env).execute(
+        "UPDATE provider_credentials SET status = ?, deactivated_at = CASE WHEN ? = 'deactivated' THEN sdp_iso_now() ELSE NULL END WHERE id = 'pcred_scan_owner'",
+        [status, status]
+      );
+      expect(
+        await getDb(env).queryOne(
+          "SELECT secret_next_scan_at IS NOT NULL AS scheduled FROM provider_credentials WHERE id = 'pcred_scan_owner'"
+        )
+      ).toEqual({ scheduled: true });
+    }
+  );
+
+  it.each([
+    "provider = 'other'",
+    "storage_backend = 'encrypted_db', secret_ref = NULL, secret_version_ref = NULL, encrypted_secret_payload = 'v2.payload'",
+    "source = 'runtime', storage_backend = 'runtime_env', secret_ref = NULL, secret_version_ref = NULL",
+  ])("rejects a scan owner outside stored Privy GCP credentials: %s", async (change) => {
+    await expect(
+      getDb(env).execute(`UPDATE provider_credentials SET ${change} WHERE id = 'pcred_scan_owner'`)
+    ).rejects.toThrow(/provider_credentials_scan_owner_check/);
+  });
+});

--- a/apps/sdp-api/src/db/migrations/postgres/0080_provider_credential_secret_retention.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0080_provider_credential_secret_retention.sql
@@ -1,0 +1,57 @@
+-- Retain one retired stored Credential for rollback and durably mark terminal
+-- GCP rotation-candidate versions for the shared secret-cleanup batch.
+
+ALTER TABLE provider_credentials
+    ADD COLUMN secret_retention_expires_at TEXT;
+
+ALTER TABLE provider_credentials
+    ADD CONSTRAINT provider_credentials_secret_retention_check
+        CHECK (
+            secret_retention_expires_at IS NULL
+            OR (
+                source = 'stored'
+                AND (
+                    status = 'retired'
+                    OR (
+                        storage_backend = 'gcp_secret_manager'
+                        AND status IN ('failed_validation', 'deactivated')
+                        AND rotated_from_provider_credential_id IS NOT NULL
+                    )
+                )
+            )
+        );
+
+ALTER TABLE provider_credentials
+    DROP CONSTRAINT provider_credentials_secret_location_check;
+
+ALTER TABLE provider_credentials
+    ADD CONSTRAINT provider_credentials_secret_location_check
+        CHECK (
+            (
+                source = 'runtime'
+                AND storage_backend = 'runtime_env'
+                AND secret_ref IS NULL
+                AND secret_version_ref IS NULL
+                AND encrypted_secret_payload IS NULL
+            )
+            OR (
+                source = 'stored'
+                AND storage_backend = 'gcp_secret_manager'
+                AND secret_ref IS NOT NULL
+                AND encrypted_secret_payload IS NULL
+            )
+            OR (
+                source = 'stored'
+                AND storage_backend = 'encrypted_db'
+                AND secret_ref IS NULL
+                AND (
+                    encrypted_secret_payload IS NOT NULL
+                    OR status IN ('failed_validation', 'deactivated')
+                    OR (status = 'retired' AND secret_retention_expires_at IS NULL)
+                )
+            )
+        );
+
+CREATE INDEX idx_provider_credentials_secret_retention_due
+    ON provider_credentials(secret_retention_expires_at, id)
+    WHERE secret_retention_expires_at IS NOT NULL;

--- a/apps/sdp-api/src/db/migrations/postgres/0082_provider_credential_creation.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0082_provider_credential_creation.sql
@@ -1,0 +1,48 @@
+-- Persist custody GCP creation before the external write. The Credential row
+-- is also the recovery record when a write or its SQL finalization is unknown.
+ALTER TABLE provider_credentials
+    DROP CONSTRAINT provider_credentials_status_check;
+
+ALTER TABLE provider_credentials
+    ADD CONSTRAINT provider_credentials_status_check
+        CHECK (status IN ('creating', 'pending', 'active', 'failed_validation', 'retired', 'deactivated')),
+    ADD CONSTRAINT provider_credentials_creating_location_check
+        CHECK (
+            status <> 'creating'
+            OR (
+                provider = 'privy'
+                AND source = 'stored'
+                AND storage_backend = 'gcp_secret_manager'
+                AND secret_ref IS NOT NULL
+                AND secret_version_ref IS NULL
+                AND encrypted_secret_payload IS NULL
+            )
+        );
+
+ALTER TABLE provider_credentials
+    DROP CONSTRAINT provider_credentials_secret_retention_check;
+
+ALTER TABLE provider_credentials
+    ADD CONSTRAINT provider_credentials_secret_retention_check
+        CHECK (
+            secret_retention_expires_at IS NULL
+            OR (
+                source = 'stored'
+                AND (
+                    status = 'retired'
+                    OR (
+                        storage_backend = 'gcp_secret_manager'
+                        AND status IN ('failed_validation', 'deactivated')
+                        AND (
+                            rotated_from_provider_credential_id IS NOT NULL
+                            OR (status = 'deactivated'
+                                AND last_failure_code IS NOT DISTINCT FROM 'secret_creation_abandoned')
+                        )
+                    )
+                )
+            )
+        );
+
+CREATE INDEX idx_provider_credentials_stale_creation
+    ON provider_credentials(created_at, id)
+    WHERE status = 'creating';

--- a/apps/sdp-api/src/db/migrations/postgres/0083_provider_credential_cleanup_retries.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0083_provider_credential_cleanup_retries.sql
@@ -1,0 +1,48 @@
+-- Cleanup scheduling is independent of rollback retention and Credential lifecycle.
+-- Retain the exact parent and outcome when the accepted absence policy closes a row.
+ALTER TABLE provider_credentials
+    ADD COLUMN secret_cleanup_attempt_count INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN secret_cleanup_next_attempt_at TEXT,
+    ADD COLUMN secret_cleanup_absent_since TEXT,
+    ADD COLUMN secret_cleanup_outcome TEXT,
+    -- Two distinct identities suffice to retain evidence of an inventory conflict.
+    ADD COLUMN secret_cleanup_observed_version_refs TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    ADD CONSTRAINT provider_credentials_cleanup_observed_versions_check
+        CHECK (cardinality(secret_cleanup_observed_version_refs) <= 2
+               AND array_position(secret_cleanup_observed_version_refs, NULL) IS NULL),
+    ADD CONSTRAINT provider_credentials_cleanup_attempt_count_check
+        CHECK (secret_cleanup_attempt_count >= 0),
+    ADD CONSTRAINT provider_credentials_cleanup_schedule_check
+        CHECK (
+            secret_cleanup_next_attempt_at IS NULL
+            OR (source = 'stored' AND storage_backend = 'gcp_secret_manager'
+                AND secret_retention_expires_at IS NOT NULL
+                AND secret_cleanup_attempt_count > 0)
+        ),
+    ADD CONSTRAINT provider_credentials_cleanup_absence_check
+        CHECK (
+            secret_cleanup_absent_since IS NULL
+            OR (source = 'stored' AND storage_backend = 'gcp_secret_manager'
+                AND status = 'deactivated'
+                AND last_failure_code IS NOT DISTINCT FROM 'secret_creation_abandoned'
+                AND secret_version_ref IS NULL
+                AND cardinality(secret_cleanup_observed_version_refs) = 0)
+        ),
+    ADD CONSTRAINT provider_credentials_cleanup_outcome_check
+        CHECK (
+            secret_cleanup_outcome IS NULL
+            OR (source = 'stored' AND storage_backend = 'gcp_secret_manager'
+                AND status IN ('retired', 'failed_validation', 'deactivated')
+                AND secret_retention_expires_at IS NULL
+                AND secret_cleanup_next_attempt_at IS NULL
+                AND (
+                    (secret_cleanup_outcome = 'confirmed_destroyed' AND secret_version_ref IS NOT NULL
+                        AND cardinality(secret_cleanup_observed_version_refs) <= 1)
+                    OR (secret_cleanup_outcome = 'assumed_absent'
+                        AND secret_cleanup_absent_since IS NOT NULL)
+                ))
+        );
+
+CREATE INDEX idx_provider_credentials_cleanup_retry_due
+    ON provider_credentials(secret_cleanup_next_attempt_at, id)
+    WHERE secret_retention_expires_at IS NOT NULL;

--- a/apps/sdp-api/src/db/migrations/postgres/0084_provider_credential_container_scans.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0084_provider_credential_container_scans.sql
@@ -1,0 +1,26 @@
+-- One retained Credential owns the periodic scan for one shared GCP container.
+-- Existing per-version cleanup evidence remains historical; new scans use only
+-- this timestamp and the normal Credential/reference/rollback guards.
+ALTER TABLE provider_credentials
+    ADD COLUMN secret_next_scan_at TIMESTAMPTZ,
+    ADD CONSTRAINT provider_credentials_scan_owner_check CHECK (
+        secret_next_scan_at IS NULL
+        OR (provider = 'privy' AND source = 'stored'
+            AND storage_backend = 'gcp_secret_manager' AND secret_ref IS NOT NULL)
+    );
+
+WITH owners AS (
+    SELECT id, row_number() OVER (
+        PARTITION BY secret_ref ORDER BY created_at, id
+    ) AS ordinal
+    FROM provider_credentials
+    WHERE provider = 'privy' AND source = 'stored'
+      AND storage_backend = 'gcp_secret_manager' AND secret_ref IS NOT NULL
+)
+UPDATE provider_credentials pc SET secret_next_scan_at = clock_timestamp()
+FROM owners WHERE owners.id = pc.id AND owners.ordinal = 1;
+
+CREATE UNIQUE INDEX idx_provider_credentials_gcp_scan_owner
+    ON provider_credentials(secret_ref) WHERE secret_next_scan_at IS NOT NULL;
+CREATE INDEX idx_provider_credentials_gcp_scan_due
+    ON provider_credentials(secret_next_scan_at, id) WHERE secret_next_scan_at IS NOT NULL;

--- a/apps/sdp-api/src/job.node.test.ts
+++ b/apps/sdp-api/src/job.node.test.ts
@@ -1,13 +1,18 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as solanaRpc from "@sdp/rpc/solana";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runEarnCatalogueSyncIfDue } from "@/cron/earn-catalogue-sync";
 import { runEarnMetricsRefreshTick } from "@/cron/earn-metrics-refresh";
 import { closeDatabasePools } from "@/db/client";
+import { currentDatabaseIdentity } from "@/db/identity";
 import { getProcessEnv } from "@/lib/runtime-env";
 import { closeAllRedisClients } from "@/runtime/kv-redis";
 import { logEvent } from "@/runtime/money-path-events";
+import { cleanupRetiredProviderCredentialSecrets } from "@/services/jobs/cleanup-provider-credential-secrets";
 import { collectDueRecurringPayments } from "@/services/jobs/collect-recurring-payments";
 import { detectOrphanedEarnSplitSwaps } from "@/services/jobs/detect-orphaned-earn-split-swaps";
+import { waitForEgress } from "@/services/jobs/egress-warmup";
 import { pollRingsIndexing } from "@/services/jobs/poll-rings-indexing";
+import { reconcileDvpTrades } from "@/services/jobs/reconcile-dvp-trades";
 import { reconcileEarnVaultMovements } from "@/services/jobs/reconcile-earn-vault-movements";
 import { reconcileRevokedApiKeyCache } from "@/services/jobs/reconcile-revoked-api-key-cache";
 import { reconcileSponsorshipBudgets } from "@/services/jobs/reconcile-sponsorship-budgets";
@@ -24,6 +29,9 @@ import {
   getManagedReconciliationCron,
   runCronJob,
 } from "./job";
+
+vi.mock("@sdp/rpc/solana", () => ({ createRpc: vi.fn() }));
+vi.mock("@/services/jobs/egress-warmup", () => ({ waitForEgress: vi.fn() }));
 
 vi.mock("@/cron/earn-catalogue-sync", () => ({
   EARN_CATALOGUE_SYNC_MONITOR: "sdp-api-sync-earn-catalogue",
@@ -58,6 +66,10 @@ vi.mock("@/cron/earn-vault-movements", () => ({
 // of this test's module graph (same reason runner.node.test.ts mocks it).
 vi.mock("@/cron/pending-transfers", () => ({
   PENDING_TRANSFERS_MONITOR: "sdp-api-track-pending-transfers",
+}));
+
+vi.mock("@/cron/provider-credential-secret-cleanup", () => ({
+  PROVIDER_CREDENTIAL_SECRET_CLEANUP_MONITOR: "sdp-api-cleanup-provider-credential-secrets",
 }));
 
 vi.mock("@/cron/pending-deposits", () => ({
@@ -106,6 +118,14 @@ vi.mock("@/runtime/money-path-events", async (importOriginal) => ({
 
 vi.mock("@/services/jobs/retire-workflow-secrets", () => ({
   retireOrphanedActionSecrets: vi.fn(async () => ({ retired: 0, failed: 0 })),
+}));
+
+vi.mock("@/services/jobs/cleanup-provider-credential-secrets", () => ({
+  cleanupRetiredProviderCredentialSecrets: vi.fn(async () => ({
+    cleaned: 0,
+    skipped: 0,
+    failed: 0,
+  })),
 }));
 
 vi.mock("@/services/jobs/run-workflow-executions", () => ({
@@ -168,8 +188,25 @@ function makeEnv(overrides: Partial<Record<keyof Env, string>> = {}): Env {
   } as Env;
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("runCronJob", () => {
   beforeEach(() => {
+    vi.spyOn(process, "uptime").mockReturnValue(0);
+    vi.mocked(solanaRpc.createRpc)
+      .mockReset()
+      .mockImplementation(() => {
+        throw new Error("No RPC endpoint");
+      });
+    vi.mocked(waitForEgress).mockReset();
     vi.mocked(getProcessEnv).mockReset().mockReturnValue(makeEnv());
     vi.mocked(trackPendingTransfers)
       .mockReset()
@@ -191,15 +228,60 @@ describe("runCronJob", () => {
     vi.mocked(trackPendingWithdrawals).mockReset().mockResolvedValue(undefined);
     vi.mocked(reconcileEarnVaultMovements).mockReset().mockResolvedValue(undefined);
     vi.mocked(detectOrphanedEarnSplitSwaps).mockReset().mockResolvedValue(undefined);
+    vi.mocked(reconcileDvpTrades).mockReset().mockResolvedValue(undefined);
     vi.mocked(runEarnCatalogueSyncIfDue).mockReset().mockResolvedValue("synced");
     vi.mocked(runEarnMetricsRefreshTick).mockReset().mockResolvedValue(undefined);
     vi.mocked(runDueWorkflowExecutions)
       .mockReset()
       .mockResolvedValue(undefined as never);
     vi.mocked(retireOrphanedActionSecrets).mockReset().mockResolvedValue({ retired: 0, failed: 0 });
+    vi.mocked(cleanupRetiredProviderCredentialSecrets).mockReset().mockResolvedValue({
+      cleaned: 0,
+      skipped: 0,
+      failed: 0,
+    });
     vi.mocked(closeDatabasePools).mockClear();
     vi.mocked(closeAllRedisClients).mockClear();
     vi.mocked(logEvent).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("gives cleanup only the managed budget left after process startup and egress warmup", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance"] });
+    await vi.advanceTimersByTimeAsync(10_000);
+    vi.mocked(process.uptime).mockReturnValue(20);
+    vi.mocked(solanaRpc.createRpc).mockReturnValue({} as ReturnType<typeof solanaRpc.createRpc>);
+    vi.mocked(waitForEgress).mockImplementationOnce(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+      return { ready: true, elapsedMs: 30_000, attempts: 6 };
+    });
+    await runCronJob();
+    expect(cleanupRetiredProviderCredentialSecrets).toHaveBeenCalledExactlyOnceWith(
+      expect.any(Object),
+      { deadlineMs: 90_000 }
+    );
+    expect(performance.now()).toBe(40_000);
+    expect(waitForEgress).toHaveBeenCalledWith(
+      expect.objectContaining({ deadlineMs: 120_000, intervalMs: 5_000 })
+    );
+  });
+
+  it("passes an exhausted cleanup budget without skipping money ticks or renewing the allowance", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance"] });
+    vi.mocked(process.uptime).mockReturnValue(110);
+    await runCronJob();
+    expect(cleanupRetiredProviderCredentialSecrets).toHaveBeenCalledExactlyOnceWith(
+      expect.any(Object),
+      { deadlineMs: -10_000 }
+    );
+    expect(trackPendingTransfers).toHaveBeenCalledOnce();
+    expect(collectDueRecurringPayments).toHaveBeenCalledOnce();
+    expect(runDueWorkflowExecutions).toHaveBeenCalledOnce();
+    expect(closeDatabasePools).toHaveBeenCalledOnce();
   });
 
   it("refuses to run when a managed deployment has no custody KMS key", async () => {
@@ -291,6 +373,13 @@ describe("runCronJob", () => {
   it("runs the ungated ticks — recurring collection included — when every flag is off", async () => {
     const env = makeEnv();
     vi.mocked(getProcessEnv).mockReturnValue(env);
+    vi.mocked(cleanupRetiredProviderCredentialSecrets).mockImplementationOnce(async () => {
+      expect(currentDatabaseIdentity()).toEqual({
+        kind: "system",
+        component: "job:sdp-api-cleanup-provider-credential-secrets",
+      });
+      return { cleaned: 0, skipped: 0, failed: 0 };
+    });
 
     await runCronJob();
 
@@ -302,6 +391,9 @@ describe("runCronJob", () => {
     expect(trackPendingTransfers).toHaveBeenCalledTimes(1);
     expect(recoverApprovedWalletOperations).toHaveBeenCalledTimes(1);
     expect(reconcileSponsorshipBudgets).toHaveBeenCalledTimes(1);
+    expect(cleanupRetiredProviderCredentialSecrets).toHaveBeenCalledExactlyOnceWith(env, {
+      deadlineMs: expect.any(Number),
+    });
     // Recurring payments are an always-on product surface: the collection tick
     // is deliberately behind no flag.
     expect(collectDueRecurringPayments).toHaveBeenCalledExactlyOnceWith(env);
@@ -324,6 +416,93 @@ describe("runCronJob", () => {
     expect(trackPendingWithdrawals).not.toHaveBeenCalled();
     expect(closeDatabasePools).toHaveBeenCalledTimes(1);
     expect(closeAllRedisClients).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs cleanup beside pending transfers and waits for both before reporting failure", async () => {
+    const transfers = deferred<void>();
+    vi.mocked(trackPendingTransfers).mockReturnValue(transfers.promise as never);
+    vi.mocked(cleanupRetiredProviderCredentialSecrets).mockRejectedValue(
+      new Error("credential cleanup down")
+    );
+
+    const running = runCronJob();
+    let settled = false;
+    void running.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      }
+    );
+    await vi.waitFor(() => {
+      expect(cleanupRetiredProviderCredentialSecrets).toHaveBeenCalledTimes(1);
+      expect(trackPendingTransfers).toHaveBeenCalledTimes(1);
+    });
+    expect(settled).toBe(false);
+
+    transfers.resolve(undefined);
+    await expect(running).rejects.toThrow("credential cleanup down");
+    expect(collectDueRecurringPayments).toHaveBeenCalledTimes(1);
+    expect(closeDatabasePools).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs every reconciler while credential cleanup is pending and reports its failure last", async () => {
+    vi.mocked(getProcessEnv).mockReturnValue(
+      makeEnv({ PRIVATE_CHANNELS_ENABLED: "true", MARKETS_ENABLED: "true", EARN_ENABLED: "true" })
+    );
+    const cleanup = deferred<{ cleaned: number; skipped: number; failed: number }>();
+    vi.mocked(cleanupRetiredProviderCredentialSecrets).mockReturnValue(cleanup.promise);
+
+    const completion = expect(runCronJob()).rejects.toThrow("credential cleanup down");
+    try {
+      await vi.waitFor(() => {
+        expect(collectDueRecurringPayments).toHaveBeenCalledTimes(1);
+        expect(trackPendingDeposits).toHaveBeenCalledTimes(1);
+        expect(trackPendingWithdrawals).toHaveBeenCalledTimes(1);
+        expect(pollRingsIndexing).toHaveBeenCalledTimes(1);
+        expect(reconcileEarnVaultMovements).toHaveBeenCalledTimes(1);
+        expect(reconcileDvpTrades).toHaveBeenCalledTimes(1);
+        expect(detectOrphanedEarnSplitSwaps).toHaveBeenCalledTimes(1);
+        expect(runDueWorkflowExecutions).toHaveBeenCalledTimes(1);
+        expect(retireOrphanedActionSecrets).toHaveBeenCalledTimes(1);
+        expect(runEarnMetricsRefreshTick).toHaveBeenCalledTimes(1);
+        expect(runEarnCatalogueSyncIfDue).toHaveBeenCalledTimes(1);
+      });
+      expect(closeDatabasePools).not.toHaveBeenCalled();
+      expect(closeAllRedisClients).not.toHaveBeenCalled();
+    } finally {
+      cleanup.reject(new Error("credential cleanup down"));
+      await completion;
+    }
+
+    expect(closeDatabasePools).toHaveBeenCalledTimes(1);
+    expect(closeAllRedisClients).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for in-flight cleanup when pending transfers fail", async () => {
+    const cleanup = deferred<{ cleaned: number; skipped: number; failed: number }>();
+    vi.mocked(cleanupRetiredProviderCredentialSecrets).mockReturnValue(cleanup.promise);
+    vi.mocked(trackPendingTransfers).mockRejectedValue(new Error("transfers down"));
+
+    const running = runCronJob();
+    let settled = false;
+    void running.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      }
+    );
+    await vi.waitFor(() => {
+      expect(cleanupRetiredProviderCredentialSecrets).toHaveBeenCalledTimes(1);
+      expect(trackPendingTransfers).toHaveBeenCalledTimes(1);
+    });
+    expect(settled).toBe(false);
+
+    cleanup.resolve({ cleaned: 0, skipped: 0, failed: 0 });
+    await expect(running).rejects.toThrow("transfers down");
   });
 
   it("fails the job on a recurring-collection error but still releases pools", async () => {
@@ -409,6 +588,7 @@ describe("runCronJob", () => {
       .mocked(logEvent)
       .mock.calls.filter(([, payload]) => payload.event === "sdp_cron_run");
     expect(runs.map(([, payload]) => payload.monitor).sort()).toEqual([
+      "sdp-api-managed-cleanup-provider-credential-secrets",
       "sdp-api-managed-collect-recurring-payments",
       "sdp-api-managed-detect-orphaned-earn-split-swaps",
       "sdp-api-managed-poll-rings-indexing",
@@ -490,6 +670,28 @@ describe("runCronJob", () => {
 
     expect(trackPendingTransfers).toHaveBeenCalledTimes(1);
     expect(closeDatabasePools).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps DvP failures non-fatal and runs later ticks alongside credential cleanup", async () => {
+    const observeIdentity = vi.fn();
+    vi.mocked(reconcileDvpTrades).mockImplementationOnce(async () => {
+      observeIdentity(currentDatabaseIdentity());
+      throw new Error("DvP RPC unavailable");
+    });
+
+    await expect(runCronJob()).resolves.toBeUndefined();
+
+    expect(observeIdentity).toHaveBeenCalledExactlyOnceWith({
+      kind: "system",
+      component: "job:sdp-api-reconcile-dvp-trades",
+    });
+    expect(reconcileDvpTrades).toHaveBeenCalledOnce();
+    expect(runDueWorkflowExecutions).toHaveBeenCalledOnce();
+    expect(cleanupRetiredProviderCredentialSecrets).toHaveBeenCalledOnce();
+    expect(logEvent).toHaveBeenCalledWith(
+      "error",
+      expect.objectContaining({ monitor: "sdp-api-managed-reconcile-dvp-trades", status: "error" })
+    );
   });
 
   it("requires both flags — the parent flag alone never runs the earn tick", async () => {
@@ -586,12 +788,14 @@ describe("runCronJob", () => {
     vi.mocked(getProcessEnv).mockReturnValue(makeEnv({ PRIVATE_CHANNELS_ENABLED: "true" }));
     vi.mocked(reconcileSponsorshipBudgets).mockRejectedValue(new Error("sponsorship down"));
     vi.mocked(trackPendingDeposits).mockRejectedValue(new Error("deposits down"));
+    vi.mocked(detectOrphanedEarnSplitSwaps).mockRejectedValue(new Error("split swaps down"));
 
     await expect(runCronJob()).rejects.toMatchObject({
       message: "reconciliation job had multiple tick failures",
       errors: [
         expect.objectContaining({ message: "sponsorship down" }),
         expect.objectContaining({ message: "deposits down" }),
+        expect.objectContaining({ message: "split swaps down" }),
       ],
     });
 

--- a/apps/sdp-api/src/job.ts
+++ b/apps/sdp-api/src/job.ts
@@ -13,6 +13,7 @@ import { EARN_VAULT_MOVEMENTS_MONITOR } from "@/cron/earn-vault-movements";
 import { PENDING_DEPOSITS_MONITOR } from "@/cron/pending-deposits";
 import { PENDING_TRANSFERS_MONITOR } from "@/cron/pending-transfers";
 import { PENDING_WITHDRAWALS_MONITOR } from "@/cron/pending-withdrawals";
+import { PROVIDER_CREDENTIAL_SECRET_CLEANUP_MONITOR } from "@/cron/provider-credential-secret-cleanup";
 import { RECURRING_PAYMENTS_COLLECTION_MONITOR } from "@/cron/recurring-payments";
 import { RINGS_INDEXING_MONITOR } from "@/cron/rings-indexing";
 import { runWithCronRunEvent } from "@/cron/run-event";
@@ -30,6 +31,7 @@ import { closeAllRedisClients } from "@/runtime/kv-redis";
 import { getLogger } from "@/runtime/logger";
 import { assertSigningProviderAllowed } from "@/services/adapters/signing";
 import { assertCustodyEncryptionScheme } from "@/services/custody-cipher/cipher-router";
+import { cleanupRetiredProviderCredentialSecrets } from "@/services/jobs/cleanup-provider-credential-secrets";
 import { collectDueRecurringPayments } from "@/services/jobs/collect-recurring-payments";
 import { detectOrphanedEarnSplitSwaps } from "@/services/jobs/detect-orphaned-earn-split-swaps";
 import { waitForEgress } from "@/services/jobs/egress-warmup";
@@ -47,6 +49,7 @@ import { recoverApprovedWalletOperations } from "@/services/policy/approved-oper
 import type { Env } from "@/types/env";
 
 const MAX_MANAGED_SCHEDULER_GAP_MINUTES = 5;
+const CLEANUP_SHUTDOWN_RESERVE_MS = 20_000;
 
 /**
  * One-shot reconciliation entrypoint for the managed Cloud Run Job — the only
@@ -63,16 +66,20 @@ const MAX_MANAGED_SCHEDULER_GAP_MINUTES = 5;
  * once everything has run (as an AggregateError when more than one failed, and
  * logged with full causes at the process exit below), failing the job loudly;
  * non-fatal ticks' failures are swallowed after their log. The next execution
- * retries everything. Workflow secret retirements and Earn metrics refresh are
- * intentionally the only ticks whose failures do not enter the final failure
- * collection.
+ * retries everything. DvP reconciliation, workflow secret retirements and Earn
+ * metrics refresh are the ticks whose failures do not enter the final failure
+ * collection. Provider Credential cleanup reports failures after its bounded
+ * batch; unfinished rows remain durable for the next run.
  *
- * The sequence:
+ * Provider Credential secret cleanup runs alongside the entire sequence below.
+ * Its latency must not delay later money ticks. Both tasks settle before fatal
+ * failures are reported and database/Redis pools are closed.
+ *
+ * The reconciliation sequence:
  *
  * 1. **Pending transfers** + approved-wallet-operation replay + sponsorship
- *    budget reconciliation — one monitored tick (the replay rides the
- *    transfers monitor, matching the in-process runner); the legs run settled
- *    so one failing never hides the other. Fatal.
+ *    budget reconciliation. The transfer legs settle before their tick reports
+ *    failure. Fatal.
  * 2. **Recurring-payment collection** — ungated, like the recurring routes: an
  *    always-on product surface. A money path, so it fails the job loudly. The
  *    deployment-provided Managed Reconciliation Cadence is its effective
@@ -89,17 +96,19 @@ const MAX_MANAGED_SCHEDULER_GAP_MINUTES = 5;
  * 5. **Earn vault-movement reconciliation** — deliberately outside the Earn
  *    gate: signed vault intents are an outbox, not feature state, so disabling
  *    new deposits cannot strand old ones. Fatal.
- * 6. **Workflow executions** (gated on asset profiles) — this job is the
+ * 6. **DvP trade reconciliation** — ungated here; failures are logged and
+ *    non-fatal, so later reconcilers still run.
+ * 7. **Workflow executions** (gated on asset profiles) — this job is the
  *    workflow engine's only tick on managed deployments; without it, enqueued
  *    executions would sit `pending` forever. Fatal.
- * 7. **Workflow secret retirements** — behind no flag, because the queue holds
+ * 8. **Workflow secret retirements** — behind no flag, because the queue holds
  *    credentials that are ALREADY orphaned, so cleanup must outlive the
  *    feature that filled it — and managed Cloud Run is where GCP Secret
  *    Manager is the default backend, so it is precisely where retirements are
  *    queued. Non-fatal: a queued row is never abandoned, the next run picks it
  *    up, and a failing sweep must not sink the reconciliation this job exists
  *    for.
- * 8. **Earn metrics refresh, then catalogue sync** (both gated on the two Earn
+ * 9. **Earn metrics refresh, then catalogue sync** (both gated on the two Earn
  *    flags). Refresh first — unslotted, this job's schedule IS its cadence —
  *    so a slow catalogue pass cannot eat the tick and leave rates stale;
  *    non-fatal because rates going one tick stale must not stop the sync.
@@ -119,7 +128,11 @@ export async function runCronJob(): Promise<void> {
   }
   assertCustodyEncryptionScheme(env);
   getManagedReconciliationCron(env);
-  getManagedReconciliationMaxRuntimeMinutes(env);
+  const timeoutSeconds = getManagedReconciliationTimeoutSeconds(env);
+  // Account for module startup and keep this same cutoff through warmup. The
+  // reserve covers settlement/shutdown; other reconcilers keep their own policy.
+  const cleanupDeadlineMs =
+    performance.now() + (timeoutSeconds - process.uptime()) * 1_000 - CLEANUP_SHUTDOWN_RESERVE_MS;
   assertSigningProviderAllowed(env);
 
   let probeRpc: ReturnType<typeof solanaRpc.createRpc> | null = null;
@@ -176,63 +189,71 @@ export async function runCronJob(): Promise<void> {
       }
     };
 
-    await collect(
-      monitored(PENDING_TRANSFERS_MONITOR, async () => {
-        const outcomes = await Promise.allSettled([
-          (async () => {
-            // Security sweep first so payment reconciliation failures cannot
-            // starve it: repairs revoked API keys whose cache write failed
-            // post-commit.
-            await reconcileRevokedApiKeyCache(env);
-            await trackPendingTransfers(env);
-            await recoverApprovedWalletOperations(env);
-          })(),
-          reconcileSponsorshipBudgets(env),
-        ]);
-        throwCollected(rejectionReasons(outcomes), "pending-transfers tick had multiple failures");
-      })
-    );
-    await collect(
-      monitored(RECURRING_PAYMENTS_COLLECTION_MONITOR, () => collectDueRecurringPayments(env))
-    );
-    if (privateChannelsEnabled) {
-      const outcomes = await Promise.allSettled([
-        monitored(PENDING_DEPOSITS_MONITOR, () => trackPendingDeposits(env)),
-        monitored(PENDING_WITHDRAWALS_MONITOR, () => trackPendingWithdrawals(env)),
-      ]);
-      failures.push(...rejectionReasons(outcomes));
-    } else {
-      await monitored(PENDING_DEPOSITS_MONITOR, async () => undefined);
-      await monitored(PENDING_WITHDRAWALS_MONITOR, async () => undefined);
-    }
-    await collect(monitored(RINGS_INDEXING_MONITOR, () => pollRingsIndexing(env)));
-    await collect(monitored(EARN_VAULT_MOVEMENTS_MONITOR, () => reconcileEarnVaultMovements(env)));
-    // Non-fatal: a DvP sweep that cannot reach the RPC must not fail the whole
-    // tick and starve the money-moving reconcilers that run after it.
-    await monitored(DVP_TRADES_MONITOR, () => reconcileDvpTrades(env)).catch(() => undefined);
-    // Orphaned split-swap detection (PRO-1864): advisory work that never touches
-    // a movement. Placed AFTER the vault-movement sweep on purpose, so the exit
-    // reconciler never waits on it (ADR 0002), and collected like that sweep
-    // rather than swallowed: a failed detection tick is a real failure of the
-    // job, and `collect` already guarantees every later tick still runs.
-    await collect(monitored(EARN_SPLIT_SWAPS_MONITOR, () => detectOrphanedEarnSplitSwaps(env)));
-    if (assetProfilesEnabled) {
-      await collect(monitored(WORKFLOW_EXECUTIONS_MONITOR, () => runDueWorkflowExecutions(env)));
-    } else {
-      await monitored(WORKFLOW_EXECUTIONS_MONITOR, async () => undefined);
-    }
-    await monitored(WORKFLOW_SECRET_RETIREMENTS_MONITOR, () =>
-      retireOrphanedActionSecrets(env)
-    ).catch(() => undefined);
-    if (earnEnabled) {
-      await monitored(EARN_METRICS_REFRESH_MONITOR, () =>
-        runEarnMetricsRefreshTick(env, undefined)
-      ).catch(() => undefined);
-      await collect(catalogueSync());
-    } else {
-      await monitored(EARN_METRICS_REFRESH_MONITOR, async () => undefined);
-      await collect(catalogueSync({ workEnabled: false }));
-    }
+    const jobOutcomes = await Promise.allSettled([
+      (async () => {
+        await collect(
+          monitored(PENDING_TRANSFERS_MONITOR, async () => {
+            const outcomes = await Promise.allSettled([
+              (async () => {
+                // Keep revocation recovery ahead of payment reconciliation.
+                await reconcileRevokedApiKeyCache(env);
+                await trackPendingTransfers(env);
+                await recoverApprovedWalletOperations(env);
+              })(),
+              reconcileSponsorshipBudgets(env),
+            ]);
+            throwCollected(
+              rejectionReasons(outcomes),
+              "pending-transfers tick had multiple failures"
+            );
+          })
+        );
+        await collect(
+          monitored(RECURRING_PAYMENTS_COLLECTION_MONITOR, () => collectDueRecurringPayments(env))
+        );
+        if (privateChannelsEnabled) {
+          const outcomes = await Promise.allSettled([
+            monitored(PENDING_DEPOSITS_MONITOR, () => trackPendingDeposits(env)),
+            monitored(PENDING_WITHDRAWALS_MONITOR, () => trackPendingWithdrawals(env)),
+          ]);
+          failures.push(...rejectionReasons(outcomes));
+        } else {
+          await monitored(PENDING_DEPOSITS_MONITOR, async () => undefined);
+          await monitored(PENDING_WITHDRAWALS_MONITOR, async () => undefined);
+        }
+        await collect(monitored(RINGS_INDEXING_MONITOR, () => pollRingsIndexing(env)));
+        await collect(
+          monitored(EARN_VAULT_MOVEMENTS_MONITOR, () => reconcileEarnVaultMovements(env))
+        );
+        // Preserve DvP's non-fatal sweep and its position before workflow execution.
+        await monitored(DVP_TRADES_MONITOR, () => reconcileDvpTrades(env)).catch(() => undefined);
+        // Keep advisory detection after vault reconciliation and collect its failures.
+        await collect(monitored(EARN_SPLIT_SWAPS_MONITOR, () => detectOrphanedEarnSplitSwaps(env)));
+        if (assetProfilesEnabled) {
+          await collect(
+            monitored(WORKFLOW_EXECUTIONS_MONITOR, () => runDueWorkflowExecutions(env))
+          );
+        } else {
+          await monitored(WORKFLOW_EXECUTIONS_MONITOR, async () => undefined);
+        }
+        await monitored(WORKFLOW_SECRET_RETIREMENTS_MONITOR, () =>
+          retireOrphanedActionSecrets(env)
+        ).catch(() => undefined);
+        if (earnEnabled) {
+          await monitored(EARN_METRICS_REFRESH_MONITOR, () =>
+            runEarnMetricsRefreshTick(env, undefined)
+          ).catch(() => undefined);
+          await collect(catalogueSync());
+        } else {
+          await monitored(EARN_METRICS_REFRESH_MONITOR, async () => undefined);
+          await collect(catalogueSync({ workEnabled: false }));
+        }
+      })(),
+      monitored(PROVIDER_CREDENTIAL_SECRET_CLEANUP_MONITOR, () =>
+        cleanupRetiredProviderCredentialSecrets(env, { deadlineMs: cleanupDeadlineMs })
+      ),
+    ]);
+    failures.push(...rejectionReasons(jobOutcomes));
     throwCollected(failures, "reconciliation job had multiple tick failures");
   } finally {
     await Promise.allSettled([closeAllRedisClients(), closeDatabasePools()]);
@@ -305,7 +326,7 @@ function getMaximumMinuteGap(minutes: readonly number[]): number {
   );
 }
 
-function getManagedReconciliationMaxRuntimeMinutes(
+function getManagedReconciliationTimeoutSeconds(
   env: Pick<Env, "SDP_MANAGED_RECONCILIATION_TIMEOUT_SECONDS">
 ): number {
   const seconds = Number(env.SDP_MANAGED_RECONCILIATION_TIMEOUT_SECONDS?.trim());
@@ -314,7 +335,7 @@ function getManagedReconciliationMaxRuntimeMinutes(
       "SDP_MANAGED_RECONCILIATION_TIMEOUT_SECONDS must be a positive number for the reconciliation job"
     );
   }
-  return Math.ceil(seconds / 60);
+  return seconds;
 }
 
 /**

--- a/apps/sdp-api/src/routes/internal-custody/provider-credential-check.test.ts
+++ b/apps/sdp-api/src/routes/internal-custody/provider-credential-check.test.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { getDb } from "@/db";
+import { type DatabaseExecutor, getDb } from "@/db";
 import type { ClerkJwtPayload } from "@/lib/clerk-token";
 import { AppError, internalError } from "@/lib/errors";
 import { kvStoreMiddleware } from "@/middleware/kv-store";
@@ -261,6 +261,21 @@ async function useRuntimeCredential(): Promise<void> {
     )
     .bind(CREDENTIAL_ID)
     .run();
+}
+
+async function seedCreatingCredential(
+  db: DatabaseExecutor = getDb(env),
+  predecessorId: string | null = null
+): Promise<void> {
+  await db.execute(
+    `INSERT INTO provider_credentials (
+       id, organization_id, project_id, provider, label, scope, source,
+       storage_backend, secret_ref, status, rotated_from_provider_credential_id, credential_version, created_by
+     ) VALUES ('pcred_creating_submission', ?, ?, 'privy', 'Creating', 'project',
+       'stored', 'gcp_secret_manager', 'projects/p/secrets/sdp-provider-credentials-creating',
+       'creating', ?, ?, ?)`,
+    [ORGANIZATION_ID, PROJECT_ID, predecessorId, predecessorId ? 2 : 1, USER_ID]
+  );
 }
 
 async function seedActiveFingerprintConnection(
@@ -935,6 +950,119 @@ describe("exact Custody Connection installation routes", () => {
     });
     expect(providerFetch).not.toHaveBeenCalled();
     expect(secretFactory).not.toHaveBeenCalled();
+  });
+
+  it("blocks a failed runtime retry while a stored GCP submission is still creating", async () => {
+    await useRuntimeCredential();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(privyJson({ error: "invalid" }, 401)));
+    const { app, token } = buildApp();
+    expect((await installationRequest(app, token, "complete")).status).toBe(200);
+    env.SELF_HOSTED_STORED_CONNECTION_SETUP_ENABLED = "true";
+    env.CREDENTIAL_SECRET_STORE_BACKEND = "gcp_secret_manager";
+    await seedCreatingCredential();
+    const providerFetch = successfulPrivyFetch();
+    const secretFactory = vi.spyOn(credentialSecretStore, "createCredentialSecretStore");
+    const installation = await getInstallation(app, token);
+    const response = await installationRequest(app, token, "complete");
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      error: { code: "CONFLICT", details: { reason: "unfinished_installation_exists" } },
+    });
+    expect(installation.status).toBe(200);
+    expect(await installation.json()).toMatchObject({
+      data: { connection: { canComplete: false } },
+    });
+    expect(providerFetch).not.toHaveBeenCalled();
+    expect(secretFactory).not.toHaveBeenCalled();
+    expect(await getState()).toMatchObject({
+      credential_status: "failed_validation",
+      connection_status: "failed",
+      last_check_status: "failed",
+    });
+  });
+
+  it("rechecks the creating submission slot after a runtime retry waits for the project lock", async () => {
+    await useRuntimeCredential();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(privyJson({ error: "invalid" }, 401)));
+    const { app, token } = buildApp();
+    expect((await installationRequest(app, token, "complete")).status).toBe(200);
+    env.SELF_HOSTED_STORED_CONNECTION_SETUP_ENABLED = "true";
+    env.CREDENTIAL_SECRET_STORE_BACKEND = "gcp_secret_manager";
+    let markReady: (() => void) | undefined;
+    let releaseCreation: (() => void) | undefined;
+    const ready = new Promise<void>((resolve) => {
+      markReady = resolve;
+    });
+    const gate = new Promise<void>((resolve) => {
+      releaseCreation = resolve;
+    });
+    const creation = getDb(env).transaction(async (tx) => {
+      await tx.queryOne("SELECT id FROM projects WHERE id = ? FOR UPDATE", [PROJECT_ID]);
+      await seedCreatingCredential(tx);
+      markReady?.();
+      await gate;
+    });
+    await ready;
+    const providerFetch = successfulPrivyFetch();
+    const retry = installationRequest(app, token, "complete");
+    try {
+      const deadline = Date.now() + 5_000;
+      while (true) {
+        const waiting = await getDb(env).queryOne<{ waiting: boolean }>(
+          `SELECT EXISTS (
+             SELECT 1 FROM pg_stat_activity
+             WHERE datname = current_database() AND wait_event_type = 'Lock'
+               AND query LIKE '%FROM projects%' AND query LIKE '%FOR UPDATE%'
+           ) AS waiting`
+        );
+        if (waiting?.waiting) break;
+        if (Date.now() >= deadline) throw new Error("Runtime retry did not reach the project lock");
+        await new Promise<void>((resolve) => setTimeout(resolve, 10));
+      }
+    } finally {
+      releaseCreation?.();
+      await Promise.all([creation, retry]);
+    }
+    const response = await retry;
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      error: { code: "CONFLICT", details: { reason: "unfinished_installation_exists" } },
+    });
+    expect(providerFetch).not.toHaveBeenCalled();
+    expect(await getState()).toMatchObject({
+      credential_status: "failed_validation",
+      connection_status: "failed",
+    });
+  });
+
+  it("does not let an unrelated creating rotation occupy the runtime installation retry slot", async () => {
+    await useRuntimeCredential();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(privyJson({ error: "invalid" }, 401)));
+    const { app, token } = buildApp();
+    expect((await installationRequest(app, token, "complete")).status).toBe(200);
+    await seedActiveFingerprintConnection({
+      credentialId: "pcred_rotation_predecessor",
+      connectionId: "cconn_rotation_predecessor",
+      fingerprint: `sha256:${"b".repeat(64)}`,
+    });
+    env.SELF_HOSTED_STORED_CONNECTION_SETUP_ENABLED = "true";
+    env.CREDENTIAL_SECRET_STORE_BACKEND = "gcp_secret_manager";
+    await seedCreatingCredential(getDb(env), "pcred_rotation_predecessor");
+    const providerFetch = successfulPrivyFetch();
+
+    expect(await (await getInstallation(app, token)).json()).toMatchObject({
+      data: { connection: { canComplete: true } },
+    });
+    const response = await installationRequest(app, token, "complete");
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      data: {
+        providerCredential: { id: CREDENTIAL_ID, status: "active" },
+        completion: { status: "success" },
+      },
+    });
+    expect(providerFetch).toHaveBeenCalledTimes(3);
   });
 
   it("cancels a runtime installation flag-off without modifying deployment credentials", async () => {

--- a/apps/sdp-api/src/routes/internal-custody/provider-credentials.test.ts
+++ b/apps/sdp-api/src/routes/internal-custody/provider-credentials.test.ts
@@ -1,17 +1,16 @@
 import { hashString } from "@sdp/payments/hash";
 import { Hono } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import { type DatabaseClient, getDb } from "@/db";
 import type { ClerkJwtPayload } from "@/lib/clerk-token";
 import { AppError, internalError } from "@/lib/errors";
 import { kvStoreMiddleware } from "@/middleware/kv-store";
 import { rootLogger } from "@/runtime/logger";
 import { AuditService } from "@/services/audit.service";
+import type { CredentialSecretStore } from "@/services/credential-secret-store";
 import * as credentialSecretStoreModule from "@/services/credential-secret-store";
-import {
-  type CredentialSecretStore,
-  CredentialSecretStoreError,
-} from "@/services/credential-secret-store";
+import { cleanupRetiredProviderCredentialSecrets } from "@/services/jobs/cleanup-provider-credential-secrets";
 import { env } from "@/test/helpers/env";
 import { seedTestDatabase } from "@/test/mocks/db";
 import { clearKVStores, seedCachedApiKey } from "@/test/mocks/kv";
@@ -295,6 +294,56 @@ async function markInitialValidationFailed(
   ]);
 }
 
+function mockSubmissionGcp(addVersion?: (versionRef: string) => Promise<Response>) {
+  env.CREDENTIAL_SECRET_STORE_BACKEND = "gcp_secret_manager";
+  env.GCP_SECRET_MANAGER_PROJECT_ID = "sdp-submission-test";
+  env.GCP_SECRET_MANAGER_SECRET_PREFIX = "sdp-provider-credentials";
+  env.GCP_SECRET_MANAGER_API_BASE_URL = "https://gcp-submission.test";
+  const requests: string[] = [];
+  const writes: string[] = [];
+  const destroys: string[] = [];
+  const versionCounts = new Map<string, number>();
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = new URL(String(input));
+    requests.push(url.href);
+    if (url.hostname === "metadata.google.internal") {
+      return url.pathname.endsWith("/numeric-project-id")
+        ? new Response("1234567890")
+        : Response.json({ access_token: "dummy-test-token", expires_in: 300 });
+    }
+    if (url.searchParams.has("secretId")) return Response.json({});
+    if (url.pathname.endsWith(":addVersion")) {
+      const parent = url.pathname
+        .slice(4, -":addVersion".length)
+        .replace("projects/sdp-submission-test/", "projects/1234567890/");
+      const version = (versionCounts.get(parent) ?? 0) + 1;
+      versionCounts.set(parent, version);
+      const versionRef = `${parent}/versions/${version}`;
+      writes.push(versionRef);
+      return addVersion ? addVersion(versionRef) : Response.json({ name: versionRef });
+    }
+    if (url.pathname.endsWith(":destroy")) {
+      const versionRef = url.pathname
+        .slice(4, -":destroy".length)
+        .replace("projects/sdp-submission-test/", "projects/1234567890/");
+      destroys.push(versionRef);
+      return Response.json({ name: versionRef, state: "DESTROYED" });
+    }
+    if (url.pathname.endsWith("/versions")) {
+      const parent = url.pathname
+        .slice(4)
+        .replace("projects/sdp-submission-test/", "projects/1234567890/");
+      return Response.json({
+        versions: writes
+          .filter((ref) => ref.startsWith(`${parent}/`) && !destroys.includes(ref))
+          .map((name) => ({ name, state: "ENABLED" })),
+      });
+    }
+    throw new Error("Unexpected provider request");
+  });
+  return { requests, writes, destroys };
+}
+
 describe("POST /internal/dashboard/custody/provider-credentials", () => {
   const original = {
     deploymentMode: env.SDP_DEPLOYMENT_MODE,
@@ -303,6 +352,9 @@ describe("POST /internal/dashboard/custody/provider-credentials", () => {
     encryptionKey: env.CUSTODY_ENCRYPTION_KEY,
     provisioningFlag: env.PRIVY_BYOK_ENABLED,
     fingerprintPepper: env.CREDENTIAL_FINGERPRINT_PEPPER,
+    gcpProjectId: env.GCP_SECRET_MANAGER_PROJECT_ID,
+    gcpSecretPrefix: env.GCP_SECRET_MANAGER_SECRET_PREFIX,
+    gcpApiBaseUrl: env.GCP_SECRET_MANAGER_API_BASE_URL,
     privyAppId: env.PRIVY_APP_ID,
     privyAppSecret: env.PRIVY_APP_SECRET,
   };
@@ -326,6 +378,9 @@ describe("POST /internal/dashboard/custody/provider-credentials", () => {
     env.CUSTODY_ENCRYPTION_KEY = original.encryptionKey;
     env.PRIVY_BYOK_ENABLED = original.provisioningFlag;
     env.CREDENTIAL_FINGERPRINT_PEPPER = original.fingerprintPepper;
+    env.GCP_SECRET_MANAGER_PROJECT_ID = original.gcpProjectId;
+    env.GCP_SECRET_MANAGER_SECRET_PREFIX = original.gcpSecretPrefix;
+    env.GCP_SECRET_MANAGER_API_BASE_URL = original.gcpApiBaseUrl;
     env.PRIVY_APP_ID = original.privyAppId;
     env.PRIVY_APP_SECRET = original.privyAppSecret;
     await clearKVStores(env);
@@ -602,6 +657,37 @@ describe("POST /internal/dashboard/custody/provider-credentials", () => {
       connections: 0,
       wallets: 0,
     });
+  });
+
+  it("accepts credential fields at the 4096-character input limit", async () => {
+    const { app, token } = buildApp();
+    const response = await submit(app, token, {
+      key: "submit-max-length-fields",
+      body: {
+        ...VALID_BODY,
+        fields: { ...VALID_BODY.fields, appId: "a".repeat(4096), appSecret: "s".repeat(4096) },
+      },
+    });
+
+    expect(response.status).toBe(201);
+  });
+
+  it.each(["appId", "appSecret"])("rejects oversized %s before secret-store I/O", async (field) => {
+    env.CREDENTIAL_SECRET_STORE_BACKEND = "gcp_secret_manager";
+    env.GCP_SECRET_MANAGER_PROJECT_ID = "sdp-submission-test";
+    env.GCP_SECRET_MANAGER_SECRET_PREFIX = "sdp-provider-credentials";
+    const providerFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 503 }));
+    const { app, token } = buildApp();
+
+    const response = await submit(app, token, {
+      key: "submit-oversized-field",
+      body: { ...VALID_BODY, fields: { ...VALID_BODY.fields, [field]: "x".repeat(4097) } },
+    });
+
+    expect(response.status).toBe(400);
+    expect(providerFetch).not.toHaveBeenCalled();
   });
 
   it("replays the committed result before current gates and keeps the secret exact", async () => {
@@ -1067,6 +1153,114 @@ describe("POST /internal/dashboard/custody/provider-credentials", () => {
         timestamp: expect.any(String),
       },
     });
+  });
+
+  it("reuses the GCP container on replacement and keeps one scan owner", async () => {
+    const { app, token } = buildApp();
+    const gcp = mockSubmissionGcp();
+    const first = await submit(app, token, { key: "shared-submission-root" });
+    expect(first.status).toBe(201);
+    const original = await first.json();
+    await markInitialValidationFailed(getDb(env), {
+      credentialId: original.data.providerCredential.id,
+      connectionId: original.data.connectionId,
+    });
+    const replaced = await replace(app, token, original.data.connectionId, {
+      key: "shared-submission-child",
+    });
+    expect(replaced.status).toBe(201);
+    const rows = await getDb(env).queryMany<{ secret_ref: string; owns_scan: boolean }>(
+      "SELECT secret_ref, secret_next_scan_at IS NOT NULL AS owns_scan FROM provider_credentials ORDER BY credential_version"
+    );
+    expect(rows[1]?.secret_ref).toBe(rows[0]?.secret_ref);
+    expect(rows.map((row) => row.owns_scan)).toEqual([true, false]);
+    expect(gcp.requests.filter((url) => url.includes("?secretId="))).toHaveLength(1);
+    expect(new Set(gcp.writes).size).toBe(2);
+  });
+
+  it("finalizes its own GCP replacement reservation on the same failed Connection", async () => {
+    const { app, token } = buildApp();
+    const first = await submit(app, token, { key: "gcp-replacement-original" });
+    expect(first.status).toBe(201);
+    const original = await first.json();
+    await markInitialValidationFailed(getDb(env), {
+      credentialId: original.data.providerCredential.id,
+      connectionId: original.data.connectionId,
+    });
+    const gcp = mockSubmissionGcp();
+    const request = {
+      key: "gcp-replacement-candidate",
+      body: {
+        ...VALID_BODY,
+        fields: {
+          ...VALID_BODY.fields,
+          credentialLabel: "Replacement GCP",
+          appSecret: "replacement secret",
+        },
+      },
+    };
+    const replacement = await replace(app, token, original.data.connectionId, request);
+    expect(replacement.status).toBe(201);
+    const created = await replacement.json();
+    expect(created.data.connectionId).toBe(original.data.connectionId);
+    expect(created.data.providerCredential).toMatchObject({
+      status: "pending",
+      label: "Replacement GCP",
+    });
+    expect(created.data.providerCredential.id).not.toBe(original.data.providerCredential.id);
+    expect(gcp.writes).toHaveLength(1);
+    expect(gcp.destroys).toEqual([]);
+    const replay = await replace(app, token, original.data.connectionId, request);
+    expect(replay.status).toBe(201);
+    expect((await replay.json()).data).toEqual(created.data);
+    const oldReplay = await submit(app, token, { key: "gcp-replacement-original" });
+    expect(oldReplay.status).toBe(201);
+    expect((await oldReplay.json()).data).toEqual({
+      connectionId: original.data.connectionId,
+      providerCredential: { ...original.data.providerCredential, status: "failed_validation" },
+    });
+    expect(gcp.writes).toHaveLength(1);
+    expect(await getDomainCounts()).toEqual({ credentials: 2, connections: 1, wallets: 0 });
+  });
+
+  it("does not reuse the version of an abandoned GCP replacement", async () => {
+    const submissionSchema = z.object({
+      data: z.object({
+        connectionId: z.string(),
+        providerCredential: z.object({ id: z.string() }),
+      }),
+    });
+    const { app, token } = buildApp();
+    const first = await submit(app, token, { key: "version-allocation-original" });
+    expect(first.status).toBe(201);
+    const original = submissionSchema.parse(await first.json()).data;
+    await markInitialValidationFailed(getDb(env), {
+      credentialId: original.providerCredential.id,
+      connectionId: original.connectionId,
+    });
+    let failWrite = true;
+    mockSubmissionGcp(async (versionRef) => {
+      if (failWrite) throw new Error("Lost addVersion response");
+      return Response.json({ name: versionRef });
+    });
+    expect(
+      await replace(app, token, original.connectionId, { key: "version-allocation-abandoned" })
+    ).toMatchObject({ status: 503 });
+    failWrite = false;
+    const replacement = await replace(app, token, original.connectionId, {
+      key: "version-allocation-next",
+    });
+    expect(replacement.status).toBe(201);
+    expect(submissionSchema.parse(await replacement.json()).data.connectionId).toBe(
+      original.connectionId
+    );
+    expect(
+      await getDb(env).queryMany<{ credential_version: number }>(
+        `SELECT credential_version FROM provider_credentials
+         WHERE organization_id = ? ORDER BY credential_version`,
+        [ORGANIZATION_ID]
+      )
+    ).toEqual([{ credential_version: 1 }, { credential_version: 2 }, { credential_version: 3 }]);
   });
 
   it("clears optional Connection settings when replacement omits them", async () => {
@@ -1611,17 +1805,73 @@ describe("POST /internal/dashboard/custody/provider-credentials", () => {
     }
   );
 
+  it("keeps an in-flight GCP creation replayable without a second external write", async () => {
+    let started: () => void = () => undefined;
+    let release: () => void = () => undefined;
+    const writing = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    const released = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const gcp = mockSubmissionGcp(async (versionRef) => {
+      if (gcp.writes.length === 1) {
+        started();
+        await released;
+      }
+      return Response.json({ name: versionRef });
+    });
+    const { app, token } = buildApp();
+    const first = submit(app, token, { key: "gcp-in-flight" });
+    try {
+      await writing;
+      const replay = await submit(app, token, { key: "gcp-in-flight" });
+      expect(replay.status).toBe(503);
+      expect(gcp.writes).toHaveLength(1);
+      const competing = await submit(app, token, { key: "gcp-in-flight-other" });
+      expect(competing.status).toBe(409);
+      expect(gcp.writes).toHaveLength(1);
+    } finally {
+      release();
+      await first;
+    }
+    const committed = await first;
+    expect(committed.status).toBe(201);
+    const committedBody = await committed.json();
+    const replay = await submit(app, token, { key: "gcp-in-flight" });
+    expect(replay.status).toBe(201);
+    expect((await replay.json()).data).toEqual(committedBody.data);
+    expect(gcp.writes).toHaveLength(1);
+  });
+
+  it("replays a successfully created GCP credential after installation cancellation", async () => {
+    const gcp = mockSubmissionGcp();
+    const { app, token } = buildApp();
+    const response = await submit(app, token, { key: "gcp-success-then-cancel" });
+    expect(response.status).toBe(201);
+    const created = await response.json();
+    const cancelled = await app.request(
+      `/internal/dashboard/custody/connections/${created.data.connectionId}/cancel`,
+      { method: "POST", headers: { Authorization: `Bearer ${token}`, "X-Project-ID": PROJECT_ID } },
+      env
+    );
+    expect(cancelled.status).toBe(200);
+    const replay = await submit(app, token, { key: "gcp-success-then-cancel" });
+    expect(replay.status).toBe(201);
+    expect((await replay.json()).data).toEqual({
+      connectionId: created.data.connectionId,
+      providerCredential: { ...created.data.providerCredential, status: "deactivated" },
+    });
+    expect(gcp.writes).toHaveLength(1);
+    expect(await getDomainCounts()).toEqual({ credentials: 1, connections: 1, wallets: 0 });
+  });
+
   it("maps an upstream secret-store failure to a safe 503 and orphan alert", async () => {
-    const store: CredentialSecretStore = {
-      storageBackend: "gcp_secret_manager",
-      write: vi
-        .fn()
-        .mockRejectedValue(new CredentialSecretStoreError("raw upstream detail", "UPSTREAM_ERROR")),
-      read: vi.fn(),
-      destroyVersion: vi.fn(),
-      predictFirstVersionRef: vi.fn(() => null),
-    };
-    vi.spyOn(credentialSecretStoreModule, "createCredentialSecretStore").mockReturnValue(store);
+    let loseResponse = true;
+    const gcp = mockSubmissionGcp(async (versionRef) => {
+      if (loseResponse) throw new Error("raw upstream detail");
+      return Response.json({ name: versionRef });
+    });
     const consoleError = vi.spyOn(rootLogger, "error").mockImplementation(() => undefined);
     const { app, token } = buildApp();
 
@@ -1639,10 +1889,28 @@ describe("POST /internal/dashboard/custody/provider-credentials", () => {
     });
     expect(JSON.stringify(body)).not.toContain("raw upstream detail");
     expect(await getDomainCounts()).toEqual({
-      credentials: 0,
+      credentials: 1,
       connections: 0,
       wallets: 0,
     });
+    const abandoned = await getDb(env)
+      .prepare(
+        `SELECT status, secret_ref, secret_version_ref, last_failure_code, secret_retention_expires_at
+       FROM provider_credentials WHERE idempotency_key = ?`
+      )
+      .bind("upstream-secret-failure")
+      .first();
+    expect(abandoned).toEqual({
+      status: "deactivated",
+      secret_ref: expect.stringMatching(
+        /^projects\/sdp-submission-test\/secrets\/sdp-provider-credentials-pcred_/
+      ),
+      secret_version_ref: null,
+      last_failure_code: "secret_creation_abandoned",
+      secret_retention_expires_at: expect.any(String),
+    });
+    expect(gcp.writes).toHaveLength(1);
+    expect(gcp.destroys).toEqual([]);
     expect(consoleError).toHaveBeenCalledOnce();
     expect(consoleError).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1657,40 +1925,38 @@ describe("POST /internal/dashboard/custody/provider-credentials", () => {
     expect(JSON.stringify(consoleError.mock.calls)).not.toContain("exact secret");
     const criticalOutcomes = await getDb(env)
       .prepare(
-        `SELECT COUNT(*) AS count
+        `SELECT status, metadata::jsonb ->> 'event' AS event
          FROM audit_logs
          WHERE metadata::jsonb ->> 'auditPhase' = 'outcome'`
       )
-      .first<{ count: number }>();
-    expect(criticalOutcomes?.count).toBe(0);
+      .all<{ status: string; event: string }>();
+    expect(criticalOutcomes.results).toEqual([
+      { status: "failure", event: "provider_credential_submission_failed" },
+    ]);
+
+    expect((await submit(app, token, { key: "upstream-secret-failure" })).status).toBe(409);
+    expect(gcp.writes).toHaveLength(1);
+    loseResponse = false;
+    expect((await submit(app, token, { key: "upstream-secret-failure-new" })).status).toBe(201);
+    expect(gcp.writes).toHaveLength(2);
+    expect(new Set(gcp.writes).size).toBe(2);
   });
 
-  it("destroys only the exact GCP version after a database rollback", async () => {
-    const destroyVersion = vi.fn().mockResolvedValue(undefined);
-    const store: CredentialSecretStore = {
-      storageBackend: "gcp_secret_manager",
-      write: vi.fn().mockResolvedValue({
-        storageBackend: "gcp_secret_manager",
-        // Deliberately omit secretRef so the domain insert violates its
-        // storage-location check after a successful external version write.
-        secretVersionRef: "projects/sdp-test/secrets/pcred-test/versions/7",
-      }),
-      read: vi.fn(),
-      destroyVersion,
-      predictFirstVersionRef: vi.fn(() => null),
-    };
-    vi.spyOn(credentialSecretStoreModule, "createCredentialSecretStore").mockReturnValue(store);
+  it("does not contact GCP when the credential reservation rolls back", async () => {
+    const gcp = mockSubmissionGcp();
+    const db = getDb(env);
+    await db.execute(`ALTER TABLE provider_credentials ADD CONSTRAINT sdp_test_reject_gcp_reservation
+      CHECK (status <> 'creating')`);
     const { app, token } = buildApp();
-
-    const response = await submit(app, token, {
-      key: "gcp-db-rollback",
-    });
-
-    expect(response.status).toBe(500);
-    expect(destroyVersion).toHaveBeenCalledOnce();
-    expect(destroyVersion).toHaveBeenCalledWith({
-      secretVersionRef: "projects/sdp-test/secrets/pcred-test/versions/7",
-    });
+    try {
+      const response = await submit(app, token, { key: "gcp-reservation-rollback" });
+      expect(response.status).toBe(500);
+      expect(gcp.requests).toEqual([]);
+    } finally {
+      await db.execute(
+        "ALTER TABLE provider_credentials DROP CONSTRAINT sdp_test_reject_gcp_reservation"
+      );
+    }
     expect(await getDomainCounts()).toEqual({
       credentials: 0,
       connections: 0,
@@ -1698,26 +1964,98 @@ describe("POST /internal/dashboard/custody/provider-credentials", () => {
     });
   });
 
-  it("reconciles a committed row before cleaning up after a lost COMMIT response", async () => {
-    const destroyVersion = vi.fn().mockResolvedValue(undefined);
-    const store: CredentialSecretStore = {
-      storageBackend: "gcp_secret_manager",
-      write: vi.fn().mockResolvedValue({
-        storageBackend: "gcp_secret_manager",
-        secretRef: "projects/sdp-test/secrets/pcred-commit-ambiguity",
-        secretVersionRef: "projects/sdp-test/secrets/pcred-commit-ambiguity/versions/9",
-      }),
-      read: vi.fn(),
-      destroyVersion,
-      predictFirstVersionRef: vi.fn(() => null),
-    };
-    vi.spyOn(credentialSecretStoreModule, "createCredentialSecretStore").mockReturnValue(store);
+  it.each(["submission", "replacement"] as const)(
+    "destroys the acknowledged GCP version after $0 SQL finalization rolls back",
+    async (operation) => {
+      const db = getDb(env);
+      const { app, token } = buildApp();
+      let original: { connectionId: string; providerCredential: { id: string } } | undefined;
+      if (operation === "replacement") {
+        const response = await submit(app, token, { key: "gcp-finalization-original" });
+        expect(response.status).toBe(201);
+        original = z
+          .object({
+            data: z.object({
+              connectionId: z.string(),
+              providerCredential: z.object({ id: z.string() }),
+            }),
+          })
+          .parse(await response.json()).data;
+        await markInitialValidationFailed(db, {
+          credentialId: original.providerCredential.id,
+          connectionId: original.connectionId,
+        });
+      }
+      const gcp = mockSubmissionGcp();
+      const request = () =>
+        original
+          ? replace(app, token, original.connectionId, { key: "gcp-finalization-rollback" })
+          : submit(app, token, { key: "gcp-finalization-rollback" });
+      await db.execute(`ALTER TABLE custody_connections ADD CONSTRAINT sdp_test_reject_gcp_connection
+      CHECK (status <> 'pending') NOT VALID`);
+      try {
+        const response = await request();
+        expect(response.status).toBe(500);
+        expect(gcp.writes).toHaveLength(1);
+        expect(gcp.destroys).toEqual([]);
+        expect(await getDomainCounts()).toEqual({
+          credentials: original ? 2 : 1,
+          connections: original ? 1 : 0,
+          wallets: 0,
+        });
+        if (original) {
+          expect(
+            await db.queryOne(
+              "SELECT status, provider_credential_id FROM custody_connections WHERE id = ?",
+              [original.connectionId]
+            )
+          ).toEqual({ status: "failed", provider_credential_id: original.providerCredential.id });
+        }
+        expect(
+          await db
+            .prepare(
+              `SELECT status, secret_ref, secret_version_ref, last_failure_code, secret_retention_expires_at
+         FROM provider_credentials WHERE idempotency_key = ?`
+            )
+            .bind("gcp-finalization-rollback")
+            .first()
+        ).toEqual({
+          status: "deactivated",
+          secret_ref: expect.stringMatching(
+            /^projects\/sdp-submission-test\/secrets\/sdp-provider-credentials-pcred_/
+          ),
+          secret_version_ref: gcp.writes[0]?.replace(
+            "projects/1234567890/",
+            "projects/sdp-submission-test/"
+          ),
+          last_failure_code: "secret_creation_abandoned",
+          secret_retention_expires_at: expect.any(String),
+        });
+        expect((await request()).status).toBe(409);
+        expect(gcp.writes).toHaveLength(1);
+        await expect(cleanupRetiredProviderCredentialSecrets(env)).resolves.toMatchObject({
+          cleaned: 1,
+          failed: 0,
+        });
+        expect(gcp.destroys).toEqual(gcp.writes);
+      } finally {
+        await db.execute(
+          "ALTER TABLE custody_connections DROP CONSTRAINT sdp_test_reject_gcp_connection"
+        );
+      }
+    }
+  );
 
+  it("reconciles a committed GCP finalization after a lost COMMIT response without destroying", async () => {
+    const gcp = mockSubmissionGcp();
     const db = getDb(env);
     const runTransaction = db.transaction.bind(db);
-    vi.spyOn(db, "transaction").mockImplementationOnce(async (callback) => {
-      await runTransaction(callback);
-      throw new Error("simulated lost COMMIT response");
+    let transactions = 0;
+    vi.spyOn(db, "transaction").mockImplementation(async (callback) => {
+      const result = await runTransaction(callback);
+      transactions += 1;
+      if (transactions === 2) throw new Error("simulated lost finalization COMMIT response");
+      return result;
     });
     const { app, token } = buildApp();
 
@@ -1726,7 +2064,13 @@ describe("POST /internal/dashboard/custody/provider-credentials", () => {
     });
 
     expect(response.status).toBe(201);
-    expect(destroyVersion).not.toHaveBeenCalled();
+    expect(gcp.writes).toHaveLength(1);
+    expect(gcp.destroys).toEqual([]);
+    const committedBody = await response.json();
+    const replay = await submit(app, token, { key: "gcp-commit-ambiguity" });
+    expect(replay.status).toBe(201);
+    expect((await replay.json()).data).toEqual(committedBody.data);
+    expect(gcp.writes).toHaveLength(1);
     expect(await getDomainCounts()).toEqual({
       credentials: 1,
       connections: 1,
@@ -1747,13 +2091,13 @@ describe("POST /internal/dashboard/custody/provider-credentials", () => {
     const destroyVersion = vi.fn();
     const store: CredentialSecretStore = {
       storageBackend: "encrypted_db",
+      predictFirstVersionRef: () => null,
       write: vi.fn().mockResolvedValue({
         storageBackend: "encrypted_db",
         // Missing ciphertext forces a database rollback.
       }),
       read: vi.fn(),
       destroyVersion,
-      predictFirstVersionRef: vi.fn(() => null),
     };
     vi.spyOn(credentialSecretStoreModule, "createCredentialSecretStore").mockReturnValue(store);
     const { app, token } = buildApp();
@@ -1771,40 +2115,40 @@ describe("POST /internal/dashboard/custody/provider-credentials", () => {
     });
   });
 
-  it("reports failed GCP cleanup without exposing the secret ref or changing the primary error", async () => {
-    const store: CredentialSecretStore = {
-      storageBackend: "gcp_secret_manager",
-      write: vi.fn().mockResolvedValue({
-        storageBackend: "gcp_secret_manager",
-        secretVersionRef: "projects/sdp-test/secrets/pcred-sensitive-name/versions/11",
-      }),
-      read: vi.fn(),
-      destroyVersion: vi.fn().mockRejectedValue(new Error("raw cleanup failure")),
-      predictFirstVersionRef: vi.fn(() => null),
-    };
-    vi.spyOn(credentialSecretStoreModule, "createCredentialSecretStore").mockReturnValue(store);
-    const consoleError = vi.spyOn(rootLogger, "error").mockImplementation(() => undefined);
+  it("does not write to GCP after an unknown reservation COMMIT and keeps the key in progress", async () => {
+    const gcp = mockSubmissionGcp();
+    const db = getDb(env);
+    const runTransaction = db.transaction.bind(db);
+    vi.spyOn(db, "transaction").mockImplementationOnce(async (callback) => {
+      await runTransaction(callback);
+      throw new Error("simulated lost reservation COMMIT response");
+    });
     const { app, token } = buildApp();
 
     const response = await submit(app, token, {
-      key: "gcp-cleanup-failure",
+      key: "gcp-reservation-unknown",
     });
-
-    expect(response.status).toBe(500);
-    expect(consoleError).toHaveBeenCalledOnce();
-    expect(consoleError).toHaveBeenCalledWith(
-      expect.objectContaining({
-        provider: "privy",
-        storageBackend: "gcp_secret_manager",
-        providerResourceVersion: 11,
-        reason: "secret_cleanup_failed",
-      }),
-      "provider_credential_orphan_risk"
-    );
-    const logged = JSON.stringify(consoleError.mock.calls);
-    expect(logged).not.toContain("pcred-sensitive-name");
-    expect(logged).not.toContain("raw cleanup failure");
-    expect(logged).not.toContain("exact secret");
+    expect(response.status).toBe(503);
+    expect((await response.json()).error.code).toBe("PROVIDER_UNAVAILABLE");
+    expect(gcp.requests).toEqual([]);
+    expect(await getDomainCounts()).toEqual({ credentials: 1, connections: 0, wallets: 0 });
+    expect(
+      await db
+        .prepare(
+          `SELECT status, secret_version_ref FROM provider_credentials WHERE idempotency_key = ?`
+        )
+        .bind("gcp-reservation-unknown")
+        .first()
+    ).toEqual({ status: "creating", secret_version_ref: null });
+    const replay = await submit(app, token, { key: "gcp-reservation-unknown" });
+    expect(replay.status).toBe(503);
+    expect(gcp.requests).toEqual([]);
+    const outcome = await db
+      .prepare(
+        `SELECT COUNT(*) AS count FROM audit_logs WHERE metadata::jsonb ->> 'auditPhase' = 'outcome'`
+      )
+      .first<{ count: number }>();
+    expect(outcome?.count).toBe(0);
   });
 
   it.each([
@@ -1872,32 +2216,8 @@ describe("POST /internal/dashboard/custody/provider-credentials", () => {
     expect(await getDomainCounts()).toEqual({ credentials: 1, connections: 1, wallets: 0 });
   });
 
-  it("compensates the losing secret write when concurrent fresh installations race", async () => {
-    let writeCount = 0;
-    let releaseWrites: (() => void) | undefined;
-    const writesReady = new Promise<void>((resolve) => {
-      releaseWrites = resolve;
-    });
-    const write = vi.fn(async ({ providerCredentialId }: { providerCredentialId: string }) => {
-      writeCount += 1;
-      if (writeCount === 2) {
-        releaseWrites?.();
-      }
-      await writesReady;
-      return {
-        storageBackend: "gcp_secret_manager" as const,
-        secretRef: `projects/sdp-test/secrets/${providerCredentialId}`,
-        secretVersionRef: `projects/sdp-test/secrets/${providerCredentialId}/versions/1`,
-      };
-    });
-    const destroyVersion = vi.fn().mockResolvedValue(undefined);
-    vi.spyOn(credentialSecretStoreModule, "createCredentialSecretStore").mockReturnValue({
-      storageBackend: "gcp_secret_manager",
-      write,
-      read: vi.fn(),
-      destroyVersion,
-      predictFirstVersionRef: vi.fn(() => null),
-    });
+  it("writes only the winning secret when concurrent fresh GCP installations race", async () => {
+    const gcp = mockSubmissionGcp();
     const { app, token } = buildApp();
 
     const responses = await Promise.all([
@@ -1912,12 +2232,12 @@ describe("POST /internal/dashboard/custody/provider-credentials", () => {
         details: { reason: "unfinished_installation_exists" },
       },
     });
-    expect(write).toHaveBeenCalledTimes(2);
-    expect(destroyVersion).toHaveBeenCalledOnce();
+    expect(gcp.writes).toHaveLength(1);
+    expect(gcp.destroys).toEqual([]);
     expect(await getDomainCounts()).toEqual({ credentials: 1, connections: 1, wallets: 0 });
   });
 
-  it("compensates the losing GCP write in a cross-project idempotency race", async () => {
+  it("rejects a cross-project idempotency race before the losing GCP secret is written", async () => {
     const otherProjectId = "prj_provider_credential_submit_other";
     const db = getDb(env);
     await db.batch([
@@ -1942,32 +2262,7 @@ describe("POST /internal/dashboard/custody/provider-credentials", () => {
         .bind("pm_provider_credential_submit_other", otherProjectId, USER_ID),
     ]);
 
-    let writeCount = 0;
-    let releaseWrites: (() => void) | undefined;
-    const writesReady = new Promise<void>((resolve) => {
-      releaseWrites = resolve;
-    });
-    const write = vi.fn(async ({ providerCredentialId }: { providerCredentialId: string }) => {
-      writeCount += 1;
-      if (writeCount === 2) {
-        releaseWrites?.();
-      }
-      await writesReady;
-      return {
-        storageBackend: "gcp_secret_manager" as const,
-        secretRef: `projects/sdp-test/secrets/${providerCredentialId}`,
-        secretVersionRef: `projects/sdp-test/secrets/${providerCredentialId}/versions/1`,
-      };
-    });
-    const destroyVersion = vi.fn().mockResolvedValue(undefined);
-    const store: CredentialSecretStore = {
-      storageBackend: "gcp_secret_manager",
-      write,
-      read: vi.fn(),
-      destroyVersion,
-      predictFirstVersionRef: vi.fn(() => null),
-    };
-    vi.spyOn(credentialSecretStoreModule, "createCredentialSecretStore").mockReturnValue(store);
+    const gcp = mockSubmissionGcp();
     const { app, token } = buildApp();
 
     const responses = await Promise.all([
@@ -1978,7 +2273,7 @@ describe("POST /internal/dashboard/custody/provider-credentials", () => {
       }),
     ]);
     expect(responses.map((response) => response.status).sort()).toEqual([201, 409]);
-    expect(write).toHaveBeenCalledTimes(2);
+    expect(gcp.writes).toHaveLength(1);
 
     const successResponse = responses.find((response) => response.status === 201);
     const successBody = (await successResponse?.json()) as
@@ -1993,22 +2288,14 @@ describe("POST /internal/dashboard/custody/provider-credentials", () => {
     const winnerProjectId = successBody?.data.providerCredential.projectId;
     expect([PROJECT_ID, otherProjectId]).toContain(winnerProjectId);
 
-    const writtenIds = write.mock.calls.map(([params]) => params.providerCredentialId);
-    expect(new Set(writtenIds).size).toBe(2);
-    expect(writtenIds).toContain(winnerId);
-    const loserId = writtenIds.find((id) => id !== winnerId);
-    if (!winnerId || !winnerProjectId || !loserId) {
-      throw new Error("Concurrent submission did not produce distinct winner and loser IDs");
+    if (!winnerId || !winnerProjectId) {
+      throw new Error("Concurrent submission did not produce a winning credential");
     }
+    const winnerVersionRef = `projects/1234567890/secrets/sdp-provider-credentials-${winnerId}/versions/1`;
+    expect(gcp.writes).toEqual([winnerVersionRef]);
     expect((await getConnectionForCredential(winnerId)).project_id).toBe(winnerProjectId);
 
-    expect(destroyVersion).toHaveBeenCalledOnce();
-    expect(destroyVersion).toHaveBeenCalledWith({
-      secretVersionRef: `projects/sdp-test/secrets/${loserId}/versions/1`,
-    });
-    expect(destroyVersion).not.toHaveBeenCalledWith({
-      secretVersionRef: `projects/sdp-test/secrets/${winnerId}/versions/1`,
-    });
+    expect(gcp.destroys).toEqual([]);
 
     const audits = await getDb(env)
       .prepare(
@@ -2018,8 +2305,12 @@ describe("POST /internal/dashboard/custody/provider-credentials", () => {
          ORDER BY action`
       )
       .all<{ action: string; resource_id: string | null }>();
-    const failedAudit = audits.results.find((audit) => audit.action === "submit_failed");
-    expect(failedAudit?.resource_id).toBe(loserId);
+    expect(audits.results.filter((audit) => audit.action === "submit")).toEqual([
+      { action: "submit", resource_id: winnerId },
+    ]);
+    const failedAudits = audits.results.filter((audit) => audit.action === "submit_failed");
+    expect(failedAudits).toHaveLength(1);
+    expect(failedAudits[0]?.resource_id).not.toBe(winnerId);
     expect(await getDomainCounts()).toEqual({
       credentials: 1,
       connections: 1,
@@ -2046,7 +2337,10 @@ describe("POST /internal/dashboard/custody/provider-credentials", () => {
     expect(persisted).toEqual({
       credential_id: winnerId,
       credential_project_id: winnerProjectId,
-      secret_version_ref: `projects/sdp-test/secrets/${winnerId}/versions/1`,
+      secret_version_ref: winnerVersionRef.replace(
+        "projects/1234567890/",
+        "projects/sdp-submission-test/"
+      ),
       connection_project_id: winnerProjectId,
       connection_credential_id: winnerId,
     });

--- a/apps/sdp-api/src/services/credential-secret-store.test.ts
+++ b/apps/sdp-api/src/services/credential-secret-store.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "@/types/env";
 import {
   CredentialSecretStoreError,
   createCredentialSecretStore,
   EncryptedDbCredentialSecretStore,
   GcpSecretManagerCredentialSecretStore,
+  prepareGcpCredentialSecret,
   RuntimeEnvCredentialSecretStore,
   resolveCredentialSecretStoreBackend,
 } from "./credential-secret-store";
@@ -36,6 +37,510 @@ const PROJECT_NUMBER = "1049637352508";
 const SECRET_ID = "sdp-dev-provider-credentials-pcred_123";
 
 describe("GcpSecretManagerCredentialSecretStore", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("prepares the same dedicated parent as a later write without contacting GCP", async () => {
+    const env = {
+      GCP_SECRET_MANAGER_PROJECT_ID: PROJECT_ID,
+      GCP_SECRET_MANAGER_SECRET_PREFIX: "sdp-dev-provider-credentials",
+    } as Env;
+    const prepared = prepareGcpCredentialSecret(env, "pcred_123");
+    expect(prepared).toEqual({
+      storageBackend: "gcp_secret_manager",
+      secretRef: `projects/${PROJECT_ID}/secrets/${SECRET_ID}`,
+    });
+    const store = new GcpSecretManagerCredentialSecretStore({
+      projectId: PROJECT_ID,
+      projectNumber: PROJECT_NUMBER,
+      secretPrefix: "sdp-dev-provider-credentials",
+      accessToken: "test-token",
+      fetcher: async (input) => {
+        if (String(input).endsWith(":addVersion")) {
+          return Response.json({
+            name: `projects/${PROJECT_NUMBER}/secrets/${SECRET_ID}/versions/1`,
+          });
+        }
+        return Response.json({ name: prepared.secretRef });
+      },
+    });
+    const stored = await store.write({
+      orgId: "org_123",
+      provider: "privy",
+      providerCredentialId: "pcred_123",
+      payload: { appSecret: "secret" },
+    });
+    expect(stored.secretRef).toBe(prepared.secretRef);
+  });
+
+  it("lists one bounded metadata page for the exact dedicated parent", async () => {
+    const secretRef = `projects/${PROJECT_ID}/secrets/${SECRET_ID}`;
+    const versionRef = `projects/${PROJECT_NUMBER}/secrets/${SECRET_ID}/versions/7`;
+    const urls: string[] = [];
+    const store = new GcpSecretManagerCredentialSecretStore({
+      projectId: PROJECT_ID,
+      projectNumber: PROJECT_NUMBER,
+      secretPrefix: "sdp-dev-provider-credentials",
+      accessToken: "test-token",
+      fetcher: async (input) => {
+        urls.push(String(input));
+        return Response.json({
+          versions: [{ name: versionRef, state: "ENABLED", createTime: "2026-01-01" }],
+          nextPageToken: "next/page=2",
+        });
+      },
+    });
+    await expect(store.listVersions({ secretRef, pageToken: "prior/page=1" })).resolves.toEqual({
+      versions: [{ secretVersionRef: versionRef, state: "ENABLED" }],
+      nextPageToken: "next/page=2",
+    });
+    expect(urls).toEqual([
+      `https://secretmanager.googleapis.com/v1/${secretRef}/versions?pageSize=25&pageToken=prior%2Fpage%3D1`,
+    ]);
+  });
+
+  it("can omit destroyed history from a live-version cleanup inventory", async () => {
+    const urls: string[] = [];
+    const store = new GcpSecretManagerCredentialSecretStore({
+      projectId: PROJECT_ID,
+      projectNumber: PROJECT_NUMBER,
+      secretPrefix: "sdp-dev-provider-credentials",
+      accessToken: "test-token",
+      fetcher: async (input) => {
+        urls.push(String(input));
+        return Response.json({});
+      },
+    });
+    await store.listVersions({
+      secretRef: `projects/${PROJECT_ID}/secrets/${SECRET_ID}`,
+      liveOnly: true,
+    });
+    expect(new URL(urls[0] ?? "").searchParams.get("filter")).toBe("state:(ENABLED OR DISABLED)");
+  });
+
+  it.each([
+    [
+      "another managed secret",
+      {
+        versions: [
+          {
+            name: `projects/${PROJECT_NUMBER}/secrets/sdp-dev-provider-credentials-other/versions/7`,
+            state: "ENABLED",
+          },
+        ],
+      },
+    ],
+    [
+      "another project",
+      {
+        versions: [
+          { name: `projects/9999999999/secrets/${SECRET_ID}/versions/7`, state: "ENABLED" },
+        ],
+      },
+    ],
+    [
+      "another prefix",
+      {
+        versions: [
+          { name: `projects/${PROJECT_NUMBER}/secrets/unmanaged/versions/7`, state: "ENABLED" },
+        ],
+      },
+    ],
+    [
+      "an alias",
+      {
+        versions: [
+          {
+            name: `projects/${PROJECT_NUMBER}/secrets/${SECRET_ID}/versions/latest`,
+            state: "ENABLED",
+          },
+        ],
+      },
+    ],
+    [
+      "an unknown state",
+      {
+        versions: [
+          { name: `projects/${PROJECT_NUMBER}/secrets/${SECRET_ID}/versions/7`, state: "UNKNOWN" },
+        ],
+      },
+    ],
+    ["a missing name", { versions: [{ state: "ENABLED" }] }],
+    ["a malformed version", { versions: [null] }],
+    ["a malformed page", { versions: {} }],
+    ["a malformed token", { nextPageToken: 7 }],
+    ["an absent body", null],
+  ])("refuses a list response containing %s", async (_reason, body) => {
+    const store = new GcpSecretManagerCredentialSecretStore({
+      projectId: PROJECT_ID,
+      projectNumber: PROJECT_NUMBER,
+      secretPrefix: "sdp-dev-provider-credentials",
+      accessToken: "test-token",
+      fetcher: async () => Response.json(body),
+    });
+    await expect(
+      store.listVersions({
+        secretRef: `projects/${PROJECT_ID}/secrets/${SECRET_ID}`,
+      })
+    ).rejects.toMatchObject({ code: "UPSTREAM_ERROR" });
+  });
+
+  it("rejects a page that exceeds the requested cleanup bound", async () => {
+    const store = new GcpSecretManagerCredentialSecretStore({
+      projectId: PROJECT_ID,
+      projectNumber: PROJECT_NUMBER,
+      secretPrefix: "sdp-dev-provider-credentials",
+      accessToken: "test-token",
+      fetcher: async () =>
+        Response.json({
+          versions: Array.from({ length: 26 }, (_, index) => ({
+            name: `projects/${PROJECT_NUMBER}/secrets/${SECRET_ID}/versions/${index + 1}`,
+            state: "ENABLED",
+          })),
+        }),
+    });
+    await expect(
+      store.listVersions({ secretRef: `projects/${PROJECT_ID}/secrets/${SECRET_ID}` })
+    ).rejects.toMatchObject({ code: "UPSTREAM_ERROR" });
+  });
+
+  it("treats an absent parent on the first inventory page as an empty observation", async () => {
+    const store = new GcpSecretManagerCredentialSecretStore({
+      projectId: PROJECT_ID,
+      projectNumber: PROJECT_NUMBER,
+      secretPrefix: "sdp-dev-provider-credentials",
+      accessToken: "test-token",
+      fetcher: async () => Response.json({ error: { status: "NOT_FOUND" } }, { status: 404 }),
+    });
+    await expect(
+      store.listVersions({
+        secretRef: `projects/${PROJECT_ID}/secrets/${SECRET_ID}`,
+      })
+    ).resolves.toEqual({ versions: [] });
+  });
+
+  it.each([
+    "not a GCP error response",
+    JSON.stringify({ error: { status: "PERMISSION_DENIED" } }),
+    JSON.stringify({ error: { status: "NOT_FOUND", code: 500 } }),
+  ])(
+    "does not treat a malformed 404 body as a successful absence observation: %s",
+    async (body) => {
+      const store = new GcpSecretManagerCredentialSecretStore({
+        projectId: PROJECT_ID,
+        projectNumber: PROJECT_NUMBER,
+        secretPrefix: "sdp-dev-provider-credentials",
+        accessToken: "test-token",
+        fetcher: async () => new Response(body, { status: 404 }),
+      });
+      await expect(
+        store.listVersions({
+          secretRef: `projects/${PROJECT_ID}/secrets/${SECRET_ID}`,
+        })
+      ).rejects.toMatchObject({ code: "UPSTREAM_ERROR" });
+    }
+  );
+
+  it("returns empty metadata pages but keeps a missing pagination parent as an upstream error", async () => {
+    const store = new GcpSecretManagerCredentialSecretStore({
+      projectId: PROJECT_ID,
+      projectNumber: PROJECT_NUMBER,
+      secretPrefix: "sdp-dev-provider-credentials",
+      accessToken: "test-token",
+      fetcher: async (input) =>
+        String(input).includes("pageToken=missing")
+          ? Response.json({ error: { status: "NOT_FOUND" } }, { status: 404 })
+          : Response.json({}),
+    });
+    const secretRef = `projects/${PROJECT_ID}/secrets/${SECRET_ID}`;
+    await expect(store.listVersions({ secretRef })).resolves.toEqual({ versions: [] });
+    await expect(store.listVersions({ secretRef, pageToken: "missing" })).rejects.toMatchObject({
+      code: "UPSTREAM_ERROR",
+    });
+  });
+
+  it.each([403, 429, 500, 503])("never treats inventory HTTP %i as absence", async (status) => {
+    const store = new GcpSecretManagerCredentialSecretStore({
+      projectId: PROJECT_ID,
+      projectNumber: PROJECT_NUMBER,
+      secretPrefix: "sdp-dev-provider-credentials",
+      accessToken: "test-token",
+      fetcher: async () => new Response(null, { status }),
+    });
+    await expect(
+      store.listVersions({
+        secretRef: `projects/${PROJECT_ID}/secrets/${SECRET_ID}`,
+      })
+    ).rejects.toMatchObject({ code: "UPSTREAM_ERROR" });
+  });
+
+  it("does not mistake a metadata-server 404 for an absent secret parent", async () => {
+    const store = new GcpSecretManagerCredentialSecretStore({
+      projectId: PROJECT_ID,
+      secretPrefix: "sdp-dev-provider-credentials",
+      metadataProjectNumberUrl: "https://metadata.test/absent-project",
+      fetcher: async () => new Response(null, { status: 404 }),
+    });
+    await expect(
+      store.listVersions({
+        secretRef: `projects/${PROJECT_ID}/secrets/${SECRET_ID}`,
+      })
+    ).rejects.toMatchObject({ code: "UPSTREAM_ERROR" });
+  });
+
+  it("makes no new requests after cancellation even with cached project metadata and token", async () => {
+    const requests: string[] = [];
+    const store = new GcpSecretManagerCredentialSecretStore({
+      projectId: PROJECT_ID,
+      secretPrefix: "sdp-dev-provider-credentials",
+      metadataProjectNumberUrl: "https://metadata.test/pre-aborted/project",
+      metadataTokenUrl: "https://metadata.test/pre-aborted/token",
+      fetcher: async (input) => {
+        const url = String(input);
+        requests.push(url);
+        if (url.endsWith("/project")) return new Response(PROJECT_NUMBER);
+        if (url.endsWith("/token"))
+          return Response.json({ access_token: "test-token", expires_in: 300 });
+        return Response.json({});
+      },
+    });
+    const secretRef = `projects/${PROJECT_ID}/secrets/${SECRET_ID}`;
+    await store.listVersions({ secretRef });
+    const count = requests.length;
+    const signal = AbortSignal.abort();
+    await expect(store.listVersions({ secretRef, signal })).rejects.toThrow();
+    await expect(
+      store.destroyVersion({ secretVersionRef: `${secretRef}/versions/7`, signal })
+    ).rejects.toThrow();
+    expect(requests).toHaveLength(count);
+  });
+
+  it.each(["project-number", "token", "secret"] as const)(
+    "bounds a stalled %s response body and reports an upstream failure",
+    async (stalled) => {
+      const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
+      const timeout = vi.spyOn(AbortSignal, "timeout").mockImplementation(() => nativeTimeout(10));
+      let observedSignal: AbortSignal | null | undefined;
+      const projectUrl = `https://metadata.test/${stalled}/project-number`;
+      const tokenUrl = `https://metadata.test/${stalled}/token`;
+      const store = new GcpSecretManagerCredentialSecretStore({
+        projectId: PROJECT_ID,
+        secretPrefix: "sdp-dev-provider-credentials",
+        metadataProjectNumberUrl: projectUrl,
+        metadataTokenUrl: tokenUrl,
+        fetcher: async (input, init) => {
+          const url = String(input);
+          const phase =
+            url === projectUrl ? "project-number" : url === tokenUrl ? "token" : "secret";
+          if (phase === stalled) {
+            observedSignal = init?.signal;
+            if (!observedSignal) throw new Error("Missing request deadline");
+            const signal = observedSignal;
+            return new Response(
+              new ReadableStream({
+                start(controller) {
+                  signal.addEventListener("abort", () => controller.error(signal.reason), {
+                    once: true,
+                  });
+                },
+              })
+            );
+          }
+          if (phase === "project-number") return new Response(PROJECT_NUMBER);
+          return Response.json({ access_token: "test-token", expires_in: 300 });
+        },
+      });
+
+      await expect(
+        store.read({
+          orgId: "org_123",
+          stored: {
+            storageBackend: "gcp_secret_manager",
+            secretVersionRef: `projects/${PROJECT_NUMBER}/secrets/${SECRET_ID}/versions/1`,
+          },
+        })
+      ).rejects.toMatchObject({ code: "UPSTREAM_ERROR" });
+      expect(timeout).toHaveBeenCalledWith(10_000);
+      expect(observedSignal?.aborted).toBe(true);
+    }
+  );
+
+  it("does not retry an add-version request after its deadline expires", async () => {
+    const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() => nativeTimeout(10));
+    const requests: string[] = [];
+    const store = new GcpSecretManagerCredentialSecretStore({
+      projectId: PROJECT_ID,
+      projectNumber: PROJECT_NUMBER,
+      secretPrefix: "sdp-dev-provider-credentials",
+      accessToken: "test-token",
+      fetcher: async (input, init) => {
+        requests.push(String(input));
+        const signal = init?.signal;
+        if (!signal) throw new Error("Missing request deadline");
+        return new Promise<Response>((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        });
+      },
+    });
+    await expect(
+      store.write({
+        orgId: "org_123",
+        provider: "privy",
+        providerCredentialId: "pcred_123",
+        existingSecretRef: `projects/${PROJECT_ID}/secrets/${SECRET_ID}`,
+        payload: { appId: "app", appSecret: "secret" },
+      })
+    ).rejects.toMatchObject({ code: "UPSTREAM_ERROR" });
+    expect(requests).toEqual([
+      `https://secretmanager.googleapis.com/v1/projects/${PROJECT_ID}/secrets/${SECRET_ID}:addVersion`,
+    ]);
+  });
+
+  it.each([false, true])(
+    "verifies a timed-out destroy with a fresh deadline (outer signal: %s)",
+    async (withOuterSignal) => {
+      const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
+      vi.spyOn(AbortSignal, "timeout").mockImplementation(() => nativeTimeout(10));
+      const versionRef = `projects/${PROJECT_NUMBER}/secrets/${SECRET_ID}/versions/7`;
+      const signals: AbortSignal[] = [];
+      const urls: string[] = [];
+      const store = new GcpSecretManagerCredentialSecretStore({
+        projectId: PROJECT_ID,
+        projectNumber: PROJECT_NUMBER,
+        secretPrefix: "sdp-dev-provider-credentials",
+        accessToken: "test-token",
+        fetcher: async (input, init) => {
+          urls.push(String(input));
+          const signal = init?.signal;
+          if (!signal) throw new Error("Missing request deadline");
+          signals.push(signal);
+          signal.throwIfAborted();
+          if (init?.method === "POST") {
+            return new Promise<Response>((_resolve, reject) => {
+              signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+            });
+          }
+          return Response.json({ name: versionRef, state: "DESTROYED" });
+        },
+      });
+      await expect(
+        store.destroyVersion({
+          secretVersionRef: versionRef,
+          ...(withOuterSignal ? { signal: new AbortController().signal } : {}),
+        })
+      ).resolves.toBeUndefined();
+      expect(urls).toEqual([
+        `https://secretmanager.googleapis.com/v1/${versionRef}:destroy`,
+        `https://secretmanager.googleapis.com/v1/${versionRef}`,
+      ]);
+      expect(signals[0]?.aborted).toBe(true);
+      expect(signals[1]).not.toBe(signals[0]);
+      expect(signals[1]?.aborted).toBe(false);
+    }
+  );
+
+  it("does not start verification after the cleanup deadline expires during destroy", async () => {
+    const controller = new AbortController();
+    const versionRef = `projects/${PROJECT_NUMBER}/secrets/${SECRET_ID}/versions/7`;
+    const requests: string[] = [];
+    const store = new GcpSecretManagerCredentialSecretStore({
+      projectId: PROJECT_ID,
+      projectNumber: PROJECT_NUMBER,
+      secretPrefix: "sdp-dev-provider-credentials",
+      accessToken: "test-token",
+      fetcher: async (input, init) => {
+        requests.push(String(input));
+        if (init?.method === "POST") {
+          controller.abort();
+          throw new Error("destroy response lost");
+        }
+        return Response.json({ name: versionRef, state: "DESTROYED" });
+      },
+    });
+    await expect(
+      store.destroyVersion({ secretVersionRef: versionRef, signal: controller.signal })
+    ).rejects.toThrow();
+    expect(requests).toEqual([`https://secretmanager.googleapis.com/v1/${versionRef}:destroy`]);
+  });
+
+  it.each(["project-number", "token", "destroy", "verification", "list"] as const)(
+    "cancels a stalled %s body at the cleanup deadline",
+    async (stalled) => {
+      const controller = new AbortController();
+      const projectUrl = `https://metadata.test/outer-abort/${stalled}/project`;
+      const tokenUrl = `https://metadata.test/outer-abort/${stalled}/token`;
+      const versionRef = `projects/${PROJECT_NUMBER}/secrets/${SECRET_ID}/versions/7`;
+      const requests: string[] = [];
+      let pendingBody: ReadableStreamDefaultController<Uint8Array> | undefined;
+      let observedSignal: AbortSignal | null | undefined;
+      let bodyReady!: () => void;
+      const ready = new Promise<void>((resolve) => {
+        bodyReady = resolve;
+      });
+      const store = new GcpSecretManagerCredentialSecretStore({
+        projectId: PROJECT_ID,
+        secretPrefix: "sdp-dev-provider-credentials",
+        metadataProjectNumberUrl: projectUrl,
+        metadataTokenUrl: tokenUrl,
+        fetcher: async (input, init) => {
+          const url = String(input);
+          requests.push(url);
+          const phase =
+            url === projectUrl
+              ? "project-number"
+              : url === tokenUrl
+                ? "token"
+                : url.includes("/versions?")
+                  ? "list"
+                  : init?.method === "POST"
+                    ? "destroy"
+                    : "verification";
+          if (phase === stalled) {
+            observedSignal = init?.signal;
+            if (!observedSignal) throw new Error("Missing request signal");
+            const signal = observedSignal;
+            return new Response(
+              new ReadableStream<Uint8Array>({
+                start(body) {
+                  pendingBody = body;
+                  signal.addEventListener("abort", () => body.error(signal.reason), { once: true });
+                  bodyReady();
+                },
+              })
+            );
+          }
+          if (phase === "project-number") return new Response(PROJECT_NUMBER);
+          if (phase === "token")
+            return Response.json({ access_token: "test-token", expires_in: 300 });
+          if (phase === "destroy")
+            return Response.json({ error: { status: "UNAVAILABLE" } }, { status: 503 });
+          return Response.json({ name: versionRef, state: "DESTROYED" });
+        },
+      });
+      const operation =
+        stalled === "list"
+          ? store.listVersions({
+              secretRef: `projects/${PROJECT_ID}/secrets/${SECRET_ID}`,
+              signal: controller.signal,
+            })
+          : store.destroyVersion({ secretVersionRef: versionRef, signal: controller.signal });
+      // Attach a rejection handler before aborting the in-flight HTTP body.
+      const outcome = operation.then(
+        () => "completed",
+        () => "rejected"
+      );
+      await ready;
+      const countAtDeadline = requests.length;
+      controller.abort();
+      const cancelled = observedSignal?.aborted;
+      // Let a broken implementation settle too, without waiting for its 10-second timer.
+      if (!cancelled) pendingBody?.error(new Error("test released ignored deadline"));
+      expect(await outcome).toBe("rejected");
+      expect(cancelled).toBe(true);
+      expect(requests).toHaveLength(countAtDeadline);
+    }
+  );
+
   it("creates, versions, reads, and destroys credential payloads by exact refs", async () => {
     const payload = {
       appId: "privy-app-id",
@@ -116,6 +621,113 @@ describe("GcpSecretManagerCredentialSecretStore", () => {
     expect(requests.map((request) => request.url).join("\n")).not.toContain(":list");
     expect(requests[0]?.body).not.toContain("privy-secret");
     expect(requests[1]?.body).toContain(encodeBase64(JSON.stringify(payload)));
+  });
+
+  it("accepts a failed destroy only after the same exact version is confirmed DESTROYED", async () => {
+    const versionRef = `projects/${PROJECT_NUMBER}/secrets/${SECRET_ID}/versions/7`;
+    const requests: { url: string; method: string }[] = [];
+    const store = new GcpSecretManagerCredentialSecretStore({
+      projectId: PROJECT_ID,
+      projectNumber: PROJECT_NUMBER,
+      secretPrefix: "sdp-dev-provider-credentials",
+      accessToken: "test-token",
+      fetcher: async (input, init) => {
+        const url = String(input);
+        const method = init?.method ?? "GET";
+        requests.push({ url, method });
+        if (method === "POST") {
+          throw new TypeError("connection reset after request");
+        }
+        return new Response(JSON.stringify({ name: versionRef, state: "DESTROYED" }));
+      },
+    });
+
+    await expect(store.destroyVersion({ secretVersionRef: versionRef })).resolves.toBeUndefined();
+    expect(requests).toEqual([
+      {
+        url: `https://secretmanager.googleapis.com/v1/${versionRef}:destroy`,
+        method: "POST",
+      },
+      { url: `https://secretmanager.googleapis.com/v1/${versionRef}`, method: "GET" },
+    ]);
+  });
+
+  it("accepts a successful delayed destruction request by default without requiring a metadata lookup", async () => {
+    const versionRef = `projects/${PROJECT_NUMBER}/secrets/${SECRET_ID}/versions/7`;
+    const fetcher = vi.fn(async () =>
+      Response.json({
+        name: versionRef,
+        state: "DISABLED",
+        scheduledDestroyTime: "2099-01-01T00:00:00Z",
+      })
+    );
+    const store = new GcpSecretManagerCredentialSecretStore({
+      projectId: PROJECT_ID,
+      projectNumber: PROJECT_NUMBER,
+      secretPrefix: "sdp-dev-provider-credentials",
+      accessToken: "test-token",
+      fetcher,
+    });
+
+    await expect(store.destroyVersion({ secretVersionRef: versionRef })).resolves.toBeUndefined();
+    expect(fetcher).toHaveBeenCalledOnce();
+  });
+
+  it("does not report delayed destruction as confirmed payload destruction when required", async () => {
+    const versionRef = `projects/${PROJECT_NUMBER}/secrets/${SECRET_ID}/versions/7`;
+    const store = new GcpSecretManagerCredentialSecretStore({
+      projectId: PROJECT_ID,
+      projectNumber: PROJECT_NUMBER,
+      secretPrefix: "sdp-dev-provider-credentials",
+      accessToken: "test-token",
+      fetcher: async () => Response.json({ name: versionRef, state: "DISABLED" }),
+    });
+    await expect(
+      store.destroyVersion({ secretVersionRef: versionRef, requireDestroyed: true })
+    ).rejects.toMatchObject({
+      code: "UPSTREAM_ERROR",
+    });
+  });
+
+  it.each(["ENABLED", "DISABLED", undefined])(
+    "keeps a failed destroy retryable when exact-version state is %s",
+    async (state) => {
+      const versionRef = `projects/${PROJECT_NUMBER}/secrets/${SECRET_ID}/versions/8`;
+      const store = new GcpSecretManagerCredentialSecretStore({
+        projectId: PROJECT_ID,
+        projectNumber: PROJECT_NUMBER,
+        secretPrefix: "sdp-dev-provider-credentials",
+        accessToken: "test-token",
+        fetcher: async (_input, init) =>
+          init?.method === "POST"
+            ? new Response(JSON.stringify({ error: { status: "FAILED_PRECONDITION" } }), {
+                status: 400,
+              })
+            : new Response(JSON.stringify(state ? { name: versionRef, state } : {})),
+      });
+
+      await expect(store.destroyVersion({ secretVersionRef: versionRef })).rejects.toMatchObject({
+        code: "UPSTREAM_ERROR",
+      });
+    }
+  );
+
+  it("keeps a failed destroy retryable when exact-version verification fails", async () => {
+    const versionRef = `projects/${PROJECT_NUMBER}/secrets/${SECRET_ID}/versions/9`;
+    const store = new GcpSecretManagerCredentialSecretStore({
+      projectId: PROJECT_ID,
+      projectNumber: PROJECT_NUMBER,
+      secretPrefix: "sdp-dev-provider-credentials",
+      accessToken: "test-token",
+      fetcher: async (_input, init) =>
+        init?.method === "POST"
+          ? new Response(JSON.stringify({ error: { status: "UNAVAILABLE" } }), { status: 503 })
+          : new Response(JSON.stringify({ error: { status: "UNAVAILABLE" } }), { status: 503 }),
+    });
+
+    await expect(store.destroyVersion({ secretVersionRef: versionRef })).rejects.toMatchObject({
+      code: "UPSTREAM_ERROR",
+    });
   });
 
   it("rejects refs outside the managed project, prefix, or exact numeric version", async () => {

--- a/apps/sdp-api/src/services/credential-secret-store.ts
+++ b/apps/sdp-api/src/services/credential-secret-store.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { getDeploymentMode } from "@/lib/runtime-env";
 import { type CustodyCipher, createCustodyCipher } from "@/services/custody-cipher/cipher-router";
 import type { Env } from "@/types/env";
@@ -5,6 +6,19 @@ import type { Env } from "@/types/env";
 export type CredentialSecretStorageBackend = "gcp_secret_manager" | "encrypted_db" | "runtime_env";
 
 export type CredentialSecretPayload = Record<string, unknown>;
+
+const gcpSecretVersionMetadataSchema = z.object({
+  name: z.string().min(1),
+  state: z.enum(["ENABLED", "DISABLED", "DESTROYED"]),
+});
+const gcpSecretVersionPageSchema = z.object({
+  // GCP's protobuf JSON omits an empty repeated field; {} is a valid empty page.
+  versions: z.array(gcpSecretVersionMetadataSchema).max(25).default([]),
+  nextPageToken: z.string().optional(),
+});
+const gcpNotFoundSchema = z.object({
+  error: z.object({ status: z.literal("NOT_FOUND"), code: z.literal(404).optional() }),
+});
 
 export interface StoredCredentialSecret {
   storageBackend: CredentialSecretStorageBackend;
@@ -29,6 +43,25 @@ export interface ReadCredentialSecretParams {
 
 export interface DestroyCredentialSecretVersionParams {
   secretVersionRef: string;
+  signal?: AbortSignal;
+  /** Require confirmed destruction; by default a successful destroy request is enough. */
+  requireDestroyed?: boolean;
+}
+
+export interface ListCredentialSecretVersionsParams {
+  secretRef: string;
+  pageToken?: string;
+  signal?: AbortSignal;
+  /** Exclude destroyed payloads from recurring scans; exact-version verification is separate. */
+  liveOnly?: boolean;
+}
+
+export interface CredentialSecretVersionPage {
+  versions: Array<{
+    secretVersionRef: string;
+    state: z.infer<typeof gcpSecretVersionMetadataSchema>["state"];
+  }>;
+  nextPageToken?: string;
 }
 
 export interface CredentialSecretStore {
@@ -44,6 +77,7 @@ export interface CredentialSecretStore {
    * Backends without an external artifact return null.
    */
   predictFirstVersionRef(params: { providerCredentialId: string }): string | null;
+  listVersions?(params: ListCredentialSecretVersionsParams): Promise<CredentialSecretVersionPage>;
 }
 
 export class CredentialSecretStoreError extends Error {
@@ -211,6 +245,7 @@ interface CachedAccessToken {
  * configured stores, which is also what keeps it inert under test.
  */
 const projectNumberCache = new Map<string, string>();
+const GCP_REQUEST_TIMEOUT_MS = 10_000;
 
 export class GcpSecretManagerCredentialSecretStore implements CredentialSecretStore {
   readonly storageBackend = "gcp_secret_manager" as const;
@@ -306,12 +341,94 @@ export class GcpSecretManagerCredentialSecretStore implements CredentialSecretSt
   }
 
   async destroyVersion(params: DestroyCredentialSecretVersionParams): Promise<void> {
-    assertManagedSecretRef(params.secretVersionRef, await this.managedRefOptions(true));
+    assertManagedSecretRef(
+      params.secretVersionRef,
+      await this.managedRefOptions(true, params.signal)
+    );
 
-    await this.request(`${params.secretVersionRef}:destroy`, {
-      method: "POST",
-      body: "{}",
+    try {
+      const destroyed = await this.request<{ state?: unknown }>(
+        `${params.secretVersionRef}:destroy`,
+        {
+          method: "POST",
+          body: "{}",
+          signal: params.signal,
+        }
+      );
+      if (params.requireDestroyed && destroyed.state !== "DESTROYED") {
+        throw new CredentialSecretStoreError(
+          "GCP secret version destruction is not confirmed",
+          "UPSTREAM_ERROR"
+        );
+      }
+    } catch (error) {
+      params.signal?.throwIfAborted();
+      if (await this.isVersionDestroyed(params.secretVersionRef, params.signal)) {
+        return;
+      }
+      throw error;
+    }
+  }
+
+  async listVersions(
+    params: ListCredentialSecretVersionsParams
+  ): Promise<CredentialSecretVersionPage> {
+    const refOptions = await this.managedRefOptions(false, params.signal);
+    const parent = assertManagedSecretRef(params.secretRef, refOptions);
+    const query = new URLSearchParams({ pageSize: "25" });
+    if (params.pageToken) query.set("pageToken", params.pageToken);
+    if (params.liveOnly) query.set("filter", "state:(ENABLED OR DISABLED)");
+    const httpResponse = await this.rawRequest(`${params.secretRef}/versions?${query}`, {
+      method: "GET",
+      signal: params.signal,
     });
+    // Only a first-page inventory miss is an absence observation. Losing a later
+    // page must fail rather than turn a partial inventory into a complete one.
+    if (httpResponse.status === 404 && !params.pageToken) {
+      const missing = gcpNotFoundSchema.safeParse(await httpResponse.json().catch(() => null));
+      if (missing.success) return { versions: [] };
+      throw new CredentialSecretStoreError(
+        "GCP Secret Manager returned an invalid not-found response",
+        "UPSTREAM_ERROR"
+      );
+    }
+    const response = await parseGcpResponse<unknown>(httpResponse);
+    try {
+      const page = gcpSecretVersionPageSchema.parse(response);
+      const versions: CredentialSecretVersionPage["versions"] = [];
+      for (const version of page.versions) {
+        const parsed = assertManagedSecretRef(version.name, {
+          ...refOptions,
+          requireVersion: true,
+        });
+        if (parsed.secretId !== parent.secretId)
+          throw new Error("Version belongs to another secret");
+        versions.push({ secretVersionRef: version.name, state: version.state });
+      }
+      const result: CredentialSecretVersionPage = { versions };
+      if (page.nextPageToken) result.nextPageToken = page.nextPageToken;
+      return result;
+    } catch {
+      throw new CredentialSecretStoreError(
+        "GCP Secret Manager returned an invalid secret version page",
+        "UPSTREAM_ERROR"
+      );
+    }
+  }
+
+  private async isVersionDestroyed(
+    secretVersionRef: string,
+    signal?: AbortSignal
+  ): Promise<boolean> {
+    try {
+      const version = await this.request<{ state?: unknown }>(secretVersionRef, {
+        method: "GET",
+        signal,
+      });
+      return version.state === "DESTROYED";
+    } catch {
+      return false;
+    }
   }
 
   predictFirstVersionRef(params: { providerCredentialId: string }): string | null {
@@ -418,10 +535,11 @@ export class GcpSecretManagerCredentialSecretStore implements CredentialSecretSt
   }
 
   private async rawRequest(path: string, init: RequestInit): Promise<Response> {
-    const accessToken = await this.getAccessToken();
+    const accessToken = await this.getAccessToken(init.signal);
     try {
       return await this.fetcher(`${this.apiBaseUrl}/v1/${path}`, {
         ...init,
+        signal: gcpRequestSignal(init.signal),
         headers: {
           Authorization: `Bearer ${accessToken}`,
           "Content-Type": "application/json",
@@ -440,10 +558,13 @@ export class GcpSecretManagerCredentialSecretStore implements CredentialSecretSt
     }
   }
 
-  private async managedRefOptions(requireVersion: boolean): Promise<ManagedSecretRefOptions> {
+  private async managedRefOptions(
+    requireVersion: boolean,
+    signal?: AbortSignal
+  ): Promise<ManagedSecretRefOptions> {
     return {
       projectId: this.options.projectId,
-      projectNumber: await this.resolveProjectNumber(),
+      projectNumber: await this.resolveProjectNumber(signal),
       secretPrefix: this.options.secretPrefix,
       requireVersion,
     };
@@ -458,7 +579,8 @@ export class GcpSecretManagerCredentialSecretStore implements CredentialSecretSt
    * request, and the number cannot change under a running revision, so an
    * instance-level cache would refetch on every credential operation.
    */
-  private async resolveProjectNumber(): Promise<string> {
+  private async resolveProjectNumber(signal?: AbortSignal): Promise<string> {
+    signal?.throwIfAborted();
     if (this.options.projectNumber) {
       return this.options.projectNumber;
     }
@@ -471,6 +593,7 @@ export class GcpSecretManagerCredentialSecretStore implements CredentialSecretSt
     let response: Response;
     try {
       response = await this.fetcher(this.metadataProjectNumberUrl, {
+        signal: gcpRequestSignal(signal),
         headers: {
           "Metadata-Flavor": "Google",
         },
@@ -493,14 +616,23 @@ export class GcpSecretManagerCredentialSecretStore implements CredentialSecretSt
       );
     }
 
-    const projectNumber = (await response.text()).trim();
+    let projectNumber: string;
+    try {
+      projectNumber = (await response.text()).trim();
+    } catch {
+      throw new CredentialSecretStoreError(
+        "GCP metadata project number response could not be read",
+        "UPSTREAM_ERROR"
+      );
+    }
     assertGcpProjectNumber(projectNumber);
     projectNumberCache.set(this.metadataProjectNumberUrl, projectNumber);
 
     return projectNumber;
   }
 
-  private async getAccessToken(): Promise<string> {
+  private async getAccessToken(signal?: AbortSignal | null): Promise<string> {
+    signal?.throwIfAborted();
     if (this.options.accessToken) {
       return this.options.accessToken;
     }
@@ -512,6 +644,7 @@ export class GcpSecretManagerCredentialSecretStore implements CredentialSecretSt
     let response: Response;
     try {
       response = await this.fetcher(this.metadataTokenUrl, {
+        signal: gcpRequestSignal(signal),
         headers: {
           "Metadata-Flavor": "Google",
         },
@@ -544,6 +677,12 @@ export class GcpSecretManagerCredentialSecretStore implements CredentialSecretSt
   }
 }
 
+function gcpRequestSignal(signal?: AbortSignal | null): AbortSignal {
+  signal?.throwIfAborted();
+  const timeout = AbortSignal.timeout(GCP_REQUEST_TIMEOUT_MS);
+  return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
 export function createCredentialSecretStore(
   env: Env,
   persistedBackend?: CredentialSecretStorageBackend
@@ -551,11 +690,7 @@ export function createCredentialSecretStore(
   const backend = persistedBackend ?? resolveCredentialSecretStoreBackend(env);
 
   if (backend === "gcp_secret_manager") {
-    return new GcpSecretManagerCredentialSecretStore({
-      projectId: requireEnv(env.GCP_SECRET_MANAGER_PROJECT_ID, "GCP_SECRET_MANAGER_PROJECT_ID"),
-      secretPrefix: env.GCP_SECRET_MANAGER_SECRET_PREFIX ?? "sdp-provider-credentials",
-      apiBaseUrl: env.GCP_SECRET_MANAGER_API_BASE_URL,
-    });
+    return new GcpSecretManagerCredentialSecretStore(gcpCredentialSecretOptions(env));
   }
 
   if (backend === "runtime_env") {
@@ -564,6 +699,25 @@ export function createCredentialSecretStore(
 
   requireEnv(env.CUSTODY_ENCRYPTION_KEY, "CUSTODY_ENCRYPTION_KEY");
   return new EncryptedDbCredentialSecretStore(createCustodyCipher(env));
+}
+
+/** Reserve this location durably before the first external write for this credential ID. */
+export function prepareGcpCredentialSecret(
+  env: Env,
+  providerCredentialId: string
+): StoredCredentialSecret {
+  return {
+    storageBackend: "gcp_secret_manager",
+    secretRef: buildGcpSecretRef({ ...gcpCredentialSecretOptions(env), providerCredentialId }),
+  };
+}
+
+function gcpCredentialSecretOptions(env: Env): GcpSecretManagerCredentialSecretStoreOptions {
+  const projectId = requireEnv(env.GCP_SECRET_MANAGER_PROJECT_ID, "GCP_SECRET_MANAGER_PROJECT_ID");
+  const secretPrefix = env.GCP_SECRET_MANAGER_SECRET_PREFIX ?? "sdp-provider-credentials";
+  assertGcpProjectId(projectId);
+  assertGcpSecretPrefix(secretPrefix);
+  return { projectId, secretPrefix, apiBaseUrl: env.GCP_SECRET_MANAGER_API_BASE_URL };
 }
 
 export function resolveCredentialSecretStoreBackend(env: Env): CredentialSecretStorageBackend {

--- a/apps/sdp-api/src/services/jobs/cleanup-provider-credential-secrets.test.ts
+++ b/apps/sdp-api/src/services/jobs/cleanup-provider-credential-secrets.test.ts
@@ -1,0 +1,480 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getDb } from "@/db";
+import { rootLogger } from "@/runtime/logger";
+import type { CredentialSecretStore } from "@/services/credential-secret-store";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import { cleanupRetiredProviderCredentialSecrets } from "./cleanup-provider-credential-secrets";
+
+const createCredentialSecretStore = vi.hoisted(() => vi.fn());
+const destroyVersion = vi.hoisted(() => vi.fn());
+const listVersions = vi.hoisted(() => vi.fn());
+
+vi.mock("@/services/credential-secret-store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/credential-secret-store")>()),
+  createCredentialSecretStore,
+}));
+
+const ORGANIZATION_ID = "org_credential_cleanup";
+const PROJECT_ID = "prj_credential_cleanup";
+const USER_ID = "usr_credential_cleanup";
+
+async function insertCredential(params: {
+  id: string;
+  status?: "creating" | "pending" | "active" | "failed_validation" | "retired" | "deactivated";
+  backend?: "encrypted_db" | "gcp_secret_manager";
+  retentionExpiresAt?: string | null;
+  rotatedFromId?: string | null;
+  createdAt?: string;
+}): Promise<void> {
+  const backend = params.backend ?? "encrypted_db";
+  const status = params.status ?? "retired";
+  const gcp = backend === "gcp_secret_manager";
+  await getDb(env)
+    .prepare(
+      `INSERT INTO provider_credentials (
+         id, organization_id, provider, label, scope, source, storage_backend,
+         secret_ref, secret_version_ref, encrypted_secret_payload, status,
+         rotated_from_provider_credential_id, secret_retention_expires_at,
+         deactivated_at, created_by, created_at, secret_next_scan_at
+       ) VALUES (
+         ?, ?, 'privy', 'Privy', 'organization', 'stored', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::timestamptz
+       )`
+    )
+    .bind(
+      params.id,
+      ORGANIZATION_ID,
+      backend,
+      gcp ? `projects/p/secrets/sdp-provider-credentials-${params.id}` : null,
+      gcp && status !== "creating"
+        ? `projects/p/secrets/sdp-provider-credentials-${params.id}/versions/7`
+        : null,
+      gcp ? null : "v2.ciphertext",
+      status,
+      params.rotatedFromId ?? null,
+      params.retentionExpiresAt ?? null,
+      status === "deactivated" ? "2026-09-04T10:00:00.000Z" : null,
+      USER_ID,
+      params.createdAt ?? new Date().toISOString(),
+      gcp ? "2020-01-01T00:00:00.000Z" : null
+    )
+    .run();
+}
+
+async function credentialState(id: string): Promise<{
+  status: string;
+  encrypted_secret_payload: string | null;
+  secret_retention_expires_at: string | null;
+}> {
+  const row = await getDb(env)
+    .prepare(
+      `SELECT status, encrypted_secret_payload, secret_retention_expires_at
+       FROM provider_credentials WHERE id = ?`
+    )
+    .bind(id)
+    .first<{
+      status: string;
+      encrypted_secret_payload: string | null;
+      secret_retention_expires_at: string | null;
+    }>();
+  if (!row) throw new Error(`Missing test Credential: ${id}`);
+  return row;
+}
+
+async function makeCleanupDue(id: string): Promise<void> {
+  await getDb(env).execute(
+    "UPDATE provider_credentials SET secret_next_scan_at = clock_timestamp() - interval '1 second' WHERE id = ?",
+    [id]
+  );
+}
+
+async function insertConnection(id: string, credentialId: string): Promise<void> {
+  await getDb(env)
+    .prepare(
+      `INSERT INTO custody_connections (
+         id, organization_id, project_id, provider, scope, provider_credential_id,
+         provider_credential_scope_key, status, created_by
+       ) VALUES (?, ?, ?, 'privy', 'project', ?, '__organization__', 'pending', ?)`
+    )
+    .bind(id, ORGANIZATION_ID, PROJECT_ID, credentialId, USER_ID)
+    .run();
+}
+
+describe("cleanupRetiredProviderCredentialSecrets", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    createCredentialSecretStore.mockReset().mockReturnValue({
+      predictFirstVersionRef: () => null,
+      storageBackend: "gcp_secret_manager",
+      write: vi.fn(),
+      read: vi.fn(),
+      destroyVersion: destroyVersion.mockReset().mockResolvedValue(undefined),
+      listVersions: listVersions.mockReset().mockResolvedValue({ versions: [] }),
+    } satisfies CredentialSecretStore);
+    await seedTestDatabase(env);
+    await getDb(env).batch([
+      getDb(env)
+        .prepare(
+          `INSERT INTO organizations (id, name, slug, tier, status)
+           VALUES (?, 'Credential cleanup', 'credential-cleanup', 'enterprise', 'active')`
+        )
+        .bind(ORGANIZATION_ID),
+      getDb(env)
+        .prepare(
+          `INSERT INTO users (id, email, email_verified, status)
+           VALUES (?, 'credential-cleanup@example.test', 1, 'active')`
+        )
+        .bind(USER_ID),
+      getDb(env)
+        .prepare(
+          `INSERT INTO projects
+             (id, organization_id, name, slug, environment, status, created_by)
+           VALUES (?, ?, 'Credential cleanup', 'credential-cleanup', 'sandbox', 'active', ?)`
+        )
+        .bind(PROJECT_ID, ORGANIZATION_ID, USER_ID),
+    ]);
+  });
+
+  it("does not start cleanup when the shared deadline has already expired", async () => {
+    const logWarning = vi.spyOn(rootLogger, "warn").mockImplementation(() => rootLogger);
+    await insertCredential({
+      id: "pcred_no_budget",
+      backend: "gcp_secret_manager",
+      retentionExpiresAt: "2020-01-01T00:00:00.000Z",
+    });
+    await expect(
+      cleanupRetiredProviderCredentialSecrets(env, {
+        deadlineMs: performance.now() - 1,
+      })
+    ).resolves.toMatchObject({ cleaned: 0, deadlineReached: true });
+    expect(destroyVersion).not.toHaveBeenCalled();
+    expect(logWarning).not.toHaveBeenCalled();
+    expect((await credentialState("pcred_no_budget")).secret_retention_expires_at).not.toBeNull();
+  });
+
+  it("retries destruction after failed initial validation despite its failed connection", async () => {
+    const id = "pcred_rejected_initial";
+    const versionRef = `projects/p/secrets/sdp-provider-credentials-${id}/versions/7`;
+    await insertCredential({ id, status: "failed_validation", backend: "gcp_secret_manager" });
+    await insertConnection("ccn_rejected_initial", id);
+    await getDb(env).execute(
+      "UPDATE custody_connections SET status = 'failed', last_check_status = 'failed', last_check_at = sdp_iso_now(), last_check_failure_code = 'invalid_credentials' WHERE id = ?",
+      ["ccn_rejected_initial"]
+    );
+    listVersions.mockResolvedValue({
+      versions: [{ secretVersionRef: versionRef, state: "ENABLED" }],
+    });
+
+    await expect(cleanupRetiredProviderCredentialSecrets(env)).resolves.toMatchObject({
+      cleaned: 1,
+    });
+    expect(destroyVersion).toHaveBeenCalledExactlyOnceWith({
+      secretVersionRef: versionRef,
+      signal: expect.any(AbortSignal),
+      requireDestroyed: true,
+    });
+  });
+
+  it("defers a slow in-flight deletion and the rest of the batch without losing work", async () => {
+    const logWarning = vi.spyOn(rootLogger, "warn").mockImplementation(() => rootLogger);
+    for (const id of ["pcred_budget_first", "pcred_budget_second"]) {
+      await insertCredential({
+        id,
+        backend: "gcp_secret_manager",
+        retentionExpiresAt: "2020-01-01T00:00:00.000Z",
+      });
+    }
+    destroyVersion.mockImplementationOnce(
+      ({ signal }: { signal: AbortSignal }) =>
+        new Promise<void>((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        })
+    );
+    await expect(
+      cleanupRetiredProviderCredentialSecrets(env, {
+        deadlineMs: performance.now() + 500,
+      })
+    ).resolves.toMatchObject({ cleaned: 0, failed: 0, deferred: 2, deadlineReached: true });
+    expect(destroyVersion).toHaveBeenCalledOnce();
+    expect(logWarning).toHaveBeenCalledWith(
+      {
+        organizationId: ORGANIZATION_ID,
+        containerOwnerCredentialId: "pcred_budget_first",
+        provider: "privy",
+        storageBackend: "gcp_secret_manager",
+        reason: "cleanup_deadline_reached",
+        outcome: "scan_incomplete",
+      },
+      "provider_credential_cleanup_interrupted"
+    );
+    expect(logWarning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: ORGANIZATION_ID,
+        secretVersionRef:
+          "projects/p/secrets/sdp-provider-credentials-pcred_budget_first/versions/7",
+        outcome: "destruction_unconfirmed",
+      }),
+      "provider_credential_secret_destruction_unconfirmed"
+    );
+    expect(
+      (await credentialState("pcred_budget_first")).secret_retention_expires_at
+    ).not.toBeNull();
+    expect(
+      (await credentialState("pcred_budget_second")).secret_retention_expires_at
+    ).not.toBeNull();
+
+    await makeCleanupDue("pcred_budget_first");
+    await expect(cleanupRetiredProviderCredentialSecrets(env)).resolves.toMatchObject({
+      cleaned: 2,
+    });
+  });
+
+  it("atomically clears an expired encrypted-db secret and its retention marker", async () => {
+    await insertCredential({
+      id: "pcred_expired_encrypted",
+      retentionExpiresAt: "2020-01-01T00:00:00.000Z",
+    });
+
+    await expect(cleanupRetiredProviderCredentialSecrets(env)).resolves.toEqual({
+      cleaned: 1,
+      skipped: 0,
+      failed: 0,
+    });
+    await expect(credentialState("pcred_expired_encrypted")).resolves.toEqual({
+      status: "retired",
+      encrypted_secret_payload: null,
+      secret_retention_expires_at: null,
+    });
+    expect(createCredentialSecretStore).not.toHaveBeenCalled();
+  });
+
+  it("retains a future rollback target only while its direct child is active", async () => {
+    await insertCredential({
+      id: "pcred_future_predecessor",
+      retentionExpiresAt: "2099-01-01T00:00:00.000Z",
+    });
+    await insertCredential({
+      id: "pcred_active_child",
+      status: "active",
+      rotatedFromId: "pcred_future_predecessor",
+    });
+
+    await expect(cleanupRetiredProviderCredentialSecrets(env)).resolves.toEqual({
+      cleaned: 0,
+      skipped: 0,
+      failed: 0,
+    });
+    expect((await credentialState("pcred_future_predecessor")).encrypted_secret_payload).toBe(
+      "v2.ciphertext"
+    );
+
+    await getDb(env)
+      .prepare(
+        `UPDATE provider_credentials
+         SET status = 'deactivated', deactivated_at = sdp_iso_now()
+         WHERE id = ?`
+      )
+      .bind("pcred_active_child")
+      .run();
+
+    await expect(cleanupRetiredProviderCredentialSecrets(env)).resolves.toEqual({
+      cleaned: 1,
+      skipped: 0,
+      failed: 0,
+    });
+    expect((await credentialState("pcred_future_predecessor")).encrypted_secret_payload).toBeNull();
+  });
+
+  it("cleans an expired predecessor even while its direct child is active", async () => {
+    await insertCredential({
+      id: "pcred_expired_predecessor",
+      retentionExpiresAt: "2020-01-01T00:00:00.000Z",
+    });
+    await insertCredential({
+      id: "pcred_current_child",
+      status: "active",
+      rotatedFromId: "pcred_expired_predecessor",
+    });
+
+    await expect(cleanupRetiredProviderCredentialSecrets(env)).resolves.toEqual({
+      cleaned: 1,
+      skipped: 0,
+      failed: 0,
+    });
+  });
+
+  it("does not clean a credential referenced by a non-deactivated connection", async () => {
+    await insertCredential({
+      id: "pcred_still_referenced",
+      retentionExpiresAt: "2020-01-01T00:00:00.000Z",
+    });
+    await getDb(env)
+      .prepare(
+        `INSERT INTO custody_connections (
+           id, organization_id, project_id, provider, scope, provider_credential_id,
+           provider_credential_scope_key, status, created_by
+         ) VALUES (?, ?, ?, 'privy', 'project', ?, '__organization__', 'pending', ?)`
+      )
+      .bind(
+        "conn_credential_cleanup",
+        ORGANIZATION_ID,
+        PROJECT_ID,
+        "pcred_still_referenced",
+        USER_ID
+      )
+      .run();
+
+    await expect(cleanupRetiredProviderCredentialSecrets(env)).resolves.toEqual({
+      cleaned: 0,
+      skipped: 0,
+      failed: 0,
+    });
+    expect((await credentialState("pcred_still_referenced")).encrypted_secret_payload).toBe(
+      "v2.ciphertext"
+    );
+  });
+
+  it("destroys the exact GCP version before clearing the retention marker", async () => {
+    await insertCredential({
+      id: "pcred_expired_gcp",
+      backend: "gcp_secret_manager",
+      retentionExpiresAt: "2020-01-01T00:00:00.000Z",
+    });
+
+    await expect(cleanupRetiredProviderCredentialSecrets(env)).resolves.toEqual({
+      cleaned: 1,
+      skipped: 0,
+      failed: 0,
+    });
+    expect(createCredentialSecretStore).toHaveBeenCalledOnce();
+    expect(createCredentialSecretStore).toHaveBeenCalledWith(env, "gcp_secret_manager");
+    expect(destroyVersion).toHaveBeenCalledWith({
+      secretVersionRef: "projects/p/secrets/sdp-provider-credentials-pcred_expired_gcp/versions/7",
+      signal: expect.any(AbortSignal),
+      requireDestroyed: true,
+    });
+    expect((await credentialState("pcred_expired_gcp")).secret_retention_expires_at).toBeNull();
+  });
+
+  it("isolates GCP failures, keeps their marker, and rejects once with redacted telemetry", async () => {
+    const rawFailure =
+      "raw upstream detail for projects/p/secrets/sdp-provider-credentials-pcred_a_failure/versions/7";
+    destroyVersion.mockRejectedValueOnce(new Error(rawFailure)).mockResolvedValueOnce(undefined);
+    const logError = vi.spyOn(rootLogger, "error").mockImplementation(() => rootLogger);
+    await insertCredential({
+      id: "pcred_a_failure",
+      backend: "gcp_secret_manager",
+      retentionExpiresAt: "2020-01-01T00:00:00.000Z",
+    });
+    await insertCredential({
+      id: "pcred_b_success",
+      backend: "gcp_secret_manager",
+      retentionExpiresAt: "2020-01-01T00:00:00.000Z",
+    });
+
+    await expect(cleanupRetiredProviderCredentialSecrets(env)).rejects.toThrow(
+      "Provider Credential secret cleanup failed for 1 row(s)"
+    );
+
+    expect(destroyVersion).toHaveBeenCalledTimes(2);
+    expect(createCredentialSecretStore).toHaveBeenCalledOnce();
+    expect((await credentialState("pcred_a_failure")).secret_retention_expires_at).not.toBeNull();
+    expect((await credentialState("pcred_b_success")).secret_retention_expires_at).toBeNull();
+    expect(logError).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        containerOwnerCredentialId: "pcred_a_failure",
+        provider: "privy",
+        storageBackend: "gcp_secret_manager",
+        secretVersionRef: "projects/p/secrets/sdp-provider-credentials-pcred_a_failure/versions/7",
+        reason: "secret_cleanup_failed",
+      }),
+      "provider_credential_orphan_risk"
+    );
+    expect(JSON.stringify(logError.mock.calls)).not.toContain(rawFailure);
+    expect(JSON.stringify(logError.mock.calls)).not.toContain("raw upstream detail");
+  });
+
+  it("does not clear a GCP marker that changed while the destroy was in flight", async () => {
+    await insertCredential({
+      id: "pcred_gcp_cas",
+      backend: "gcp_secret_manager",
+      retentionExpiresAt: "2020-01-01T00:00:00.000Z",
+    });
+    destroyVersion.mockImplementationOnce(async () => {
+      await getDb(env)
+        .prepare(`UPDATE provider_credentials SET secret_retention_expires_at = ? WHERE id = ?`)
+        .bind("2020-01-02T00:00:00.000Z", "pcred_gcp_cas")
+        .run();
+    });
+
+    await expect(cleanupRetiredProviderCredentialSecrets(env)).resolves.toEqual({
+      cleaned: 0,
+      skipped: 1,
+      failed: 0,
+    });
+    expect((await credentialState("pcred_gcp_cas")).secret_retention_expires_at).toBe(
+      "2020-01-02T00:00:00.000Z"
+    );
+  });
+
+  it("processes at most 25 rows per tick", async () => {
+    for (let index = 0; index < 26; index += 1) {
+      await insertCredential({
+        id: `pcred_batch_${index.toString().padStart(2, "0")}`,
+        retentionExpiresAt: "2020-01-01T00:00:00.000Z",
+      });
+    }
+
+    await expect(cleanupRetiredProviderCredentialSecrets(env)).resolves.toEqual({
+      cleaned: 25,
+      skipped: 0,
+      failed: 0,
+    });
+    const remaining = await getDb(env)
+      .prepare(
+        `SELECT COUNT(*) AS count FROM provider_credentials
+         WHERE secret_retention_expires_at IS NOT NULL`
+      )
+      .first<{ count: number }>();
+    expect(remaining?.count).toBe(1);
+  });
+
+  it("does not let 25 persistently failing rows starve later cleanup", async () => {
+    destroyVersion.mockRejectedValue(new Error("persistent GCP failure"));
+    for (let index = 0; index < 25; index += 1) {
+      const id = `pcred_failure_${index.toString().padStart(2, "0")}`;
+      await insertCredential({
+        id,
+        backend: "gcp_secret_manager",
+        retentionExpiresAt: "2020-01-01T00:00:00.000Z",
+      });
+      await getDb(env)
+        .prepare(
+          "UPDATE provider_credentials SET updated_at = '2020-01-01T00:00:00.000Z' WHERE id = ?"
+        )
+        .bind(id)
+        .run();
+    }
+    await insertCredential({
+      id: "pcred_later_encrypted",
+      retentionExpiresAt: "2020-01-01T00:00:00.000Z",
+    });
+    await getDb(env)
+      .prepare(
+        "UPDATE provider_credentials SET updated_at = '2020-01-02T00:00:00.000Z' WHERE id = ?"
+      )
+      .bind("pcred_later_encrypted")
+      .run();
+
+    await expect(cleanupRetiredProviderCredentialSecrets(env)).rejects.toThrow(
+      "failed for 25 row(s)"
+    );
+    expect((await credentialState("pcred_later_encrypted")).secret_retention_expires_at).toBeNull();
+    await expect(cleanupRetiredProviderCredentialSecrets(env)).resolves.toMatchObject({
+      cleaned: 0,
+      failed: 0,
+    });
+
+    expect((await credentialState("pcred_later_encrypted")).secret_retention_expires_at).toBeNull();
+  });
+});

--- a/apps/sdp-api/src/services/jobs/cleanup-provider-credential-secrets.ts
+++ b/apps/sdp-api/src/services/jobs/cleanup-provider-credential-secrets.ts
@@ -1,0 +1,63 @@
+import { getDb } from "@/db";
+import { getLogger } from "@/runtime/logger";
+import { createCredentialSecretStore } from "@/services/credential-secret-store";
+import { ProviderCredentialSecretCleanupStore } from "@/services/stores/provider-credential-secret-cleanup.store";
+import type { Env } from "@/types/env";
+import { scanGcpCredentialContainers } from "./provider-credential-container-cleanup";
+
+export interface CleanupProviderCredentialSecretsResult {
+  cleaned: number;
+  skipped: number;
+  failed: number;
+  deferred?: number;
+  deadlineReached?: true;
+}
+
+export async function cleanupRetiredProviderCredentialSecrets(
+  env: Env,
+  options: { deadlineMs?: number } = {}
+): Promise<CleanupProviderCredentialSecretsResult> {
+  const deadlineMs = options.deadlineMs ?? performance.now() + 100_000;
+  if (!Number.isFinite(deadlineMs)) throw new Error("Cleanup deadline must be finite");
+  const result: CleanupProviderCredentialSecretsResult = { cleaned: 0, skipped: 0, failed: 0 };
+  // ponytail: SQL waits retain the existing client behavior; admission and HTTP,
+  // not an outstanding SQL wait, are bounded by this deadline.
+  const store = new ProviderCredentialSecretCleanupStore(getDb(env));
+  if (performance.now() < deadlineMs) {
+    const rows = await store.listDueEncrypted(25);
+    for (const row of rows) {
+      if (performance.now() >= deadlineMs) break;
+      try {
+        const cleaned =
+          row.secret_retention_expires_at &&
+          (await store.cleanupEncryptedDb({
+            id: row.id,
+            expectedRetentionExpiresAt: row.secret_retention_expires_at,
+          }));
+        result[cleaned ? "cleaned" : "skipped"] += 1;
+      } catch {
+        result.failed += 1;
+        getLogger().error(
+          { providerCredentialId: row.id, reason: "secret_cleanup_failed" },
+          "provider_credential_orphan_risk"
+        );
+      }
+    }
+  }
+  const scanned = await scanGcpCredentialContainers(
+    env,
+    () => createCredentialSecretStore(env, "gcp_secret_manager"),
+    { deadlineMs }
+  );
+  result.cleaned += scanned.cleaned;
+  result.skipped += scanned.skipped;
+  result.failed += scanned.failed.length;
+  if (scanned.deadlineReached) {
+    result.deadlineReached = true;
+    result.deferred = scanned.deferred;
+    getLogger().info({ ...result }, "provider_credential_cleanup_deferred");
+  }
+  if (result.failed > 0)
+    throw new Error(`Provider Credential secret cleanup failed for ${result.failed} row(s)`);
+  return result;
+}

--- a/apps/sdp-api/src/services/jobs/provider-credential-container-cleanup.test.ts
+++ b/apps/sdp-api/src/services/jobs/provider-credential-container-cleanup.test.ts
@@ -1,0 +1,466 @@
+// Real PostgreSQL and the external GCP secret-store seam.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getDb } from "@/db";
+import { rootLogger } from "@/runtime/logger";
+import {
+  type CredentialSecretStore,
+  type CredentialSecretVersionPage,
+  GcpSecretManagerCredentialSecretStore,
+} from "@/services/credential-secret-store";
+import { ProviderCredentialStore } from "@/services/stores/provider-credential.store";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import { scanGcpCredentialContainers } from "./provider-credential-container-cleanup";
+
+const ORG = "org_shared_cleanup_prototype";
+const USER = "usr_shared_cleanup_prototype";
+const PARENT = "projects/1234567890/secrets/sdp-provider-credentials-prototype";
+const ref = (version: number) => `${PARENT}/versions/${version}`;
+
+function fakeGcp() {
+  const versions = new Map<string, "ENABLED" | "DESTROYED">();
+  const listVersions = vi.fn(
+    async (): Promise<CredentialSecretVersionPage> => ({
+      versions: [...versions].map(([secretVersionRef, state]) => ({ secretVersionRef, state })),
+    })
+  );
+  const destroyVersion = vi.fn(async ({ secretVersionRef }: { secretVersionRef: string }) => {
+    const canonicalRef = secretVersionRef.replace("projects/test-project/", "projects/1234567890/");
+    if (!versions.has(canonicalRef)) throw new Error("GCP version not found");
+    versions.set(canonicalRef, "DESTROYED");
+  });
+  const secrets: CredentialSecretStore = {
+    storageBackend: "gcp_secret_manager",
+    predictFirstVersionRef: () => null,
+    write: vi.fn(async () => {
+      throw new Error("Use controlled writes in this prototype");
+    }),
+    read: vi.fn(async () => {
+      throw new Error("Cleanup must not read payloads");
+    }),
+    listVersions,
+    destroyVersion,
+  };
+  return { versions, listVersions, destroyVersion, secrets };
+}
+
+async function reserve(id: string, version: number, predecessor: string | null = null) {
+  const row = await new ProviderCredentialStore(getDb(env)).insertCredential({
+    id,
+    organizationId: ORG,
+    projectId: null,
+    provider: "privy",
+    label: "Prototype",
+    scope: "organization",
+    source: "stored",
+    status: "creating",
+    stored: { storageBackend: "gcp_secret_manager", secretRef: PARENT },
+    displayMetadata: {},
+    version,
+    rotatedFromId: predecessor,
+    idempotencyKey: id,
+    idempotencyFingerprint: id,
+    createdBy: USER,
+    ownsGcpContainer: version === 1,
+  });
+  if (version === 1) {
+    await getDb(env).execute(
+      "UPDATE provider_credentials SET secret_next_scan_at = '2020-01-01' WHERE id = ?",
+      [id]
+    );
+  }
+  return row;
+}
+
+async function finalize(id: string, version: number) {
+  return new ProviderCredentialStore(getDb(env)).finalizeCredentialCreation({
+    organizationId: ORG,
+    credentialId: id,
+    secretRef: PARENT,
+    secretVersionRef: ref(version),
+  });
+}
+
+describe("shared-container orphan cleanup", () => {
+  afterEach(() => vi.restoreAllMocks());
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    await getDb(env).execute(
+      "INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, 'Prototype', 'shared-prototype', 'enterprise', 'active')",
+      [ORG]
+    );
+    await getDb(env).execute(
+      "INSERT INTO users (id, email, email_verified, status) VALUES (?, 'shared-prototype@example.test', 1, 'active')",
+      [USER]
+    );
+  });
+
+  it("destroys an unreferenced version while preserving active and retained rollback versions", async () => {
+    const log = vi.spyOn(rootLogger, "info").mockImplementation(() => rootLogger);
+    const gcp = fakeGcp();
+    await reserve("pcred_proto_previous", 1);
+    await finalize("pcred_proto_previous", 1);
+    await getDb(env).execute(
+      "UPDATE provider_credentials SET status = 'retired', secret_retention_expires_at = '2099-01-01T00:00:00.000Z' WHERE id = ?",
+      ["pcred_proto_previous"]
+    );
+    await reserve("pcred_proto_current", 2, "pcred_proto_previous");
+    await finalize("pcred_proto_current", 2);
+    await getDb(env).execute("UPDATE provider_credentials SET status = 'active' WHERE id = ?", [
+      "pcred_proto_current",
+    ]);
+    for (const version of [1, 2, 3]) gcp.versions.set(ref(version), "ENABLED");
+
+    await scanGcpCredentialContainers(env, () => gcp.secrets);
+
+    expect([...gcp.versions.values()]).toEqual(["ENABLED", "ENABLED", "DESTROYED"]);
+    expect(log).toHaveBeenCalledWith(
+      {
+        organizationId: ORG,
+        containerOwnerCredentialId: "pcred_proto_previous",
+        providerCredentialId: undefined,
+        secretRef: PARENT,
+        secretVersionRef: ref(3),
+        outcome: "confirmed_destroyed",
+        kind: "unreferenced_version",
+      },
+      "provider_credential_secret_destroyed"
+    );
+  });
+
+  it("preserves an active project-ID version when GCP inventory uses the project number", async () => {
+    const gcp = fakeGcp();
+    await reserve("pcred_alias_active", 1);
+    await finalize("pcred_alias_active", 1);
+    await getDb(env).execute(
+      "UPDATE provider_credentials SET status = 'active', secret_ref = ?, secret_version_ref = ? WHERE id = ?",
+      [
+        PARENT.replace("1234567890", "test-project"),
+        ref(1).replace("1234567890", "test-project"),
+        "pcred_alias_active",
+      ]
+    );
+    for (const version of [1, 2]) gcp.versions.set(ref(version), "ENABLED");
+
+    const result = await scanGcpCredentialContainers(env, () => gcp.secrets);
+
+    expect(gcp.versions.get(ref(1))).toBe("ENABLED");
+    expect(gcp.versions.get(ref(2))).toBe("DESTROYED");
+    expect(result).toMatchObject({ cleaned: 1, failed: [] });
+  });
+
+  it("does not destroy a retained version also referenced through its project-number alias", async () => {
+    const gcp = fakeGcp();
+    await reserve("pcred_alias_retired", 1);
+    await finalize("pcred_alias_retired", 1);
+    await getDb(env).execute(
+      "UPDATE provider_credentials SET status = 'retired', secret_retention_expires_at = '2020-01-01T00:00:00.000Z', secret_version_ref = ? WHERE id = ?",
+      [ref(1).replace("1234567890", "test-project"), "pcred_alias_retired"]
+    );
+    await reserve("pcred_alias_duplicate", 2, "pcred_alias_retired");
+    await finalize("pcred_alias_duplicate", 1);
+    await getDb(env).execute("UPDATE provider_credentials SET status = 'active' WHERE id = ?", [
+      "pcred_alias_duplicate",
+    ]);
+    gcp.versions.set(ref(1), "ENABLED");
+
+    const result = await scanGcpCredentialContainers(env, () => gcp.secrets);
+
+    expect(gcp.destroyVersion).not.toHaveBeenCalled();
+    expect(gcp.versions.get(ref(1))).toBe("ENABLED");
+    expect(result.failed).toEqual([PARENT]);
+  });
+
+  it("preserves a written version while its acknowledged writer has not finalized", async () => {
+    const gcp = fakeGcp();
+    await reserve("pcred_proto_inflight", 1);
+    gcp.versions.set(ref(1), "ENABLED");
+
+    const result = await scanGcpCredentialContainers(env, () => gcp.secrets);
+
+    expect(gcp.versions.get(ref(1))).toBe("ENABLED");
+    expect(result.skipped).toBe(1);
+    expect(await finalize("pcred_proto_inflight", 1)).toMatchObject({ status: "pending" });
+  });
+
+  it("retains cleanup work and never confirms retained or orphan destruction while GCP only schedules it", async () => {
+    const log = vi.spyOn(rootLogger, "info").mockImplementation(() => rootLogger);
+    await reserve("pcred_delayed_destroy", 1);
+    await finalize("pcred_delayed_destroy", 1);
+    await getDb(env).execute(
+      "UPDATE provider_credentials SET status = 'retired', secret_retention_expires_at = '2020-01-01T00:00:00.000Z' WHERE id = ?",
+      ["pcred_delayed_destroy"]
+    );
+    let destroyed = false;
+    const secrets = new GcpSecretManagerCredentialSecretStore({
+      projectId: "test-project",
+      projectNumber: "1234567890",
+      secretPrefix: "sdp-provider-credentials",
+      accessToken: "test-token",
+      fetcher: async (input) => {
+        const url = new URL(String(input));
+        const state = destroyed ? "DESTROYED" : "DISABLED";
+        if (url.pathname.endsWith("/versions")) {
+          return Response.json({
+            versions: destroyed ? [] : [1, 2].map((n) => ({ name: ref(n), state })),
+          });
+        }
+        return Response.json({
+          name: url.pathname.slice(4).replace(/:destroy$/, ""),
+          state,
+          ...(destroyed ? {} : { scheduledDestroyTime: "2099-01-01T00:00:00Z" }),
+        });
+      },
+    });
+
+    const marker = () =>
+      getDb(env).queryOne<{ pending: boolean }>(
+        "SELECT secret_retention_expires_at IS NOT NULL AS pending FROM provider_credentials WHERE id = ?",
+        ["pcred_delayed_destroy"]
+      );
+    await expect(scanGcpCredentialContainers(env, () => secrets)).resolves.toMatchObject({
+      cleaned: 0,
+      failed: [PARENT],
+    });
+    expect(await marker()).toEqual({ pending: true });
+    expect(log).not.toHaveBeenCalledWith(expect.anything(), "provider_credential_secret_destroyed");
+
+    destroyed = true;
+    await expect(
+      scanGcpCredentialContainers(env, () => secrets, {
+        now: new Date(Date.now() + 6 * 60_000),
+      })
+    ).resolves.toMatchObject({ cleaned: 1, failed: [] });
+    expect(await marker()).toEqual({ pending: false });
+    expect(log).toHaveBeenCalledWith(
+      expect.objectContaining({ secretVersionRef: ref(1), outcome: "confirmed_destroyed" }),
+      "provider_credential_secret_destroyed"
+    );
+  });
+
+  it("cancels stale creation before destruction and rejects its late finalization", async () => {
+    const gcp = fakeGcp();
+    await reserve("pcred_proto_stale", 1);
+    await getDb(env).execute(
+      "UPDATE provider_credentials SET created_at = '2020-01-01T00:00:00.000Z' WHERE id = ?",
+      ["pcred_proto_stale"]
+    );
+    gcp.versions.set(ref(1), "ENABLED");
+    gcp.destroyVersion.mockImplementationOnce(async ({ secretVersionRef }) => {
+      expect(await finalize("pcred_proto_stale", 1)).toBeNull();
+      gcp.versions.set(secretVersionRef, "DESTROYED");
+    });
+
+    await scanGcpCredentialContainers(env, () => gcp.secrets);
+
+    expect(gcp.versions.get(ref(1))).toBe("DESTROYED");
+    expect(await finalize("pcred_proto_stale", 1)).toBeNull();
+  });
+
+  it("collects orphan versions from every inventory page", async () => {
+    const gcp = fakeGcp();
+    await reserve("pcred_proto_pages", 1);
+    await finalize("pcred_proto_pages", 1);
+    for (const version of [1, 2, 3]) gcp.versions.set(ref(version), "ENABLED");
+    gcp.listVersions
+      .mockResolvedValueOnce({
+        versions: [
+          { secretVersionRef: ref(1), state: "ENABLED" },
+          { secretVersionRef: ref(2), state: "ENABLED" },
+        ],
+        nextPageToken: "page-2",
+      })
+      .mockResolvedValueOnce({ versions: [{ secretVersionRef: ref(3), state: "ENABLED" }] });
+
+    await scanGcpCredentialContainers(env, () => gcp.secrets);
+
+    expect([...gcp.versions.values()]).toEqual(["ENABLED", "DESTROYED", "DESTROYED"]);
+  });
+
+  it("uses DB references committed during inventory instead of a stale pre-inventory view", async () => {
+    const gcp = fakeGcp();
+    await reserve("pcred_proto_existing", 1);
+    await finalize("pcred_proto_existing", 1);
+    gcp.versions.set(ref(1), "ENABLED");
+    gcp.listVersions.mockImplementationOnce(async () => {
+      await reserve("pcred_proto_during_list", 2, "pcred_proto_existing");
+      gcp.versions.set(ref(2), "ENABLED");
+      await finalize("pcred_proto_during_list", 2);
+      return {
+        versions: [...gcp.versions].map(([secretVersionRef, state]) => ({
+          secretVersionRef,
+          state,
+        })),
+      };
+    });
+
+    await scanGcpCredentialContainers(env, () => gcp.secrets);
+
+    expect([...gcp.versions.values()]).toEqual(["ENABLED", "ENABLED"]);
+  });
+
+  it("recovers a version whose add response was lost after the attempt was cancelled", async () => {
+    const gcp = fakeGcp();
+    await reserve("pcred_proto_lost_reply", 1);
+    vi.mocked(gcp.secrets.write).mockImplementationOnce(async () => {
+      gcp.versions.set(ref(1), "ENABLED");
+      throw new Error("Response lost after GCP accepted the write");
+    });
+    await expect(
+      gcp.secrets.write({
+        orgId: ORG,
+        provider: "privy",
+        providerCredentialId: "pcred_proto_lost_reply",
+        existingSecretRef: PARENT,
+        payload: { appId: "test", appSecret: "test-only" },
+      })
+    ).rejects.toThrow("Response lost");
+    await new ProviderCredentialStore(getDb(env)).abandonCredentialCreation({
+      organizationId: ORG,
+      credentialId: "pcred_proto_lost_reply",
+    });
+
+    await scanGcpCredentialContainers(env, () => gcp.secrets);
+
+    expect(gcp.versions.get(ref(1))).toBe("DESTROYED");
+  });
+
+  it("finds a late version even after the attempt's absence marker was closed", async () => {
+    const gcp = fakeGcp();
+    await reserve("pcred_proto_late", 1);
+    await new ProviderCredentialStore(getDb(env)).abandonCredentialCreation({
+      organizationId: ORG,
+      credentialId: "pcred_proto_late",
+    });
+    await getDb(env).execute(
+      `UPDATE provider_credentials SET secret_retention_expires_at = NULL,
+         secret_cleanup_outcome = 'assumed_absent', secret_cleanup_absent_since = '2020-01-01T00:00:00.000Z'
+       WHERE id = ?`,
+      ["pcred_proto_late"]
+    );
+    await scanGcpCredentialContainers(env, () => gcp.secrets);
+    // No request-local version ref or cleanup queue survives into the next pass.
+    // The persisted container is the reason this location is still visited.
+    gcp.versions.set(ref(1), "ENABLED");
+
+    await scanGcpCredentialContainers(env, () => gcp.secrets, {
+      now: new Date(Date.now() + 6 * 60_000),
+    });
+
+    expect(gcp.versions.get(ref(1))).toBe("DESTROYED");
+  });
+
+  it("does not destroy a rotation started after the inventory was captured", async () => {
+    const gcp = fakeGcp();
+    await reserve("pcred_proto_before_sweep", 1);
+    await finalize("pcred_proto_before_sweep", 1);
+    gcp.versions.set(ref(1), "ENABLED");
+    gcp.versions.set(ref(2), "ENABLED");
+    gcp.destroyVersion.mockImplementationOnce(async ({ secretVersionRef }) => {
+      await reserve("pcred_proto_during_sweep", 3, "pcred_proto_before_sweep");
+      gcp.versions.set(ref(3), "ENABLED");
+      await finalize("pcred_proto_during_sweep", 3);
+      gcp.versions.set(secretVersionRef, "DESTROYED");
+    });
+
+    await scanGcpCredentialContainers(env, () => gcp.secrets);
+
+    expect([...gcp.versions.values()]).toEqual(["ENABLED", "DESTROYED", "ENABLED"]);
+  });
+
+  it("converges after a lost destroy reply and a failed verification", async () => {
+    const errorLog = vi.spyOn(rootLogger, "error").mockImplementation(() => rootLogger);
+    const successLog = vi.spyOn(rootLogger, "info").mockImplementation(() => rootLogger);
+    const gcp = fakeGcp();
+    await reserve("pcred_proto_destroy_reply", 1);
+    await new ProviderCredentialStore(getDb(env)).abandonCredentialCreation({
+      organizationId: ORG,
+      credentialId: "pcred_proto_destroy_reply",
+    });
+    gcp.versions.set(ref(1), "ENABLED");
+    gcp.destroyVersion.mockImplementationOnce(async ({ secretVersionRef }) => {
+      gcp.versions.set(secretVersionRef, "DESTROYED");
+      throw new Error("Destroy reply and follow-up verification lost");
+    });
+
+    await expect(scanGcpCredentialContainers(env, () => gcp.secrets)).resolves.toMatchObject({
+      failed: [PARENT],
+    });
+    expect(errorLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: ORG,
+        secretRef: PARENT,
+        secretVersionRef: ref(1),
+        reason: "secret_cleanup_failed",
+      }),
+      "provider_credential_orphan_risk"
+    );
+    expect(successLog).not.toHaveBeenCalledWith(
+      expect.anything(),
+      "provider_credential_secret_destroyed"
+    );
+    await expect(
+      scanGcpCredentialContainers(env, () => gcp.secrets, {
+        now: new Date(Date.now() + 6 * 60_000),
+      })
+    ).resolves.toMatchObject({ cleaned: 0, failed: [] });
+
+    expect(gcp.versions.get(ref(1))).toBe("DESTROYED");
+  });
+
+  it("cancels stale creation even when GCP inventory is unavailable", async () => {
+    const gcp = fakeGcp();
+    await reserve("pcred_proto_inventory_down", 1);
+    await getDb(env).execute(
+      "UPDATE provider_credentials SET created_at = '2020-01-01T00:00:00.000Z' WHERE id = ?",
+      ["pcred_proto_inventory_down"]
+    );
+    gcp.listVersions.mockRejectedValueOnce(new Error("GCP unavailable"));
+
+    await expect(scanGcpCredentialContainers(env, () => gcp.secrets)).resolves.toMatchObject({
+      failed: [PARENT],
+    });
+
+    expect(
+      await new ProviderCredentialStore(getDb(env)).findLifecycleCredential(
+        ORG,
+        "pcred_proto_inventory_down"
+      )
+    ).toMatchObject({ status: "deactivated" });
+  });
+
+  it("logs the exact orphan version when its destroy reply is lost at the deadline", async () => {
+    const warning = vi.spyOn(rootLogger, "warn").mockImplementation(() => rootLogger);
+    const info = vi.spyOn(rootLogger, "info").mockImplementation(() => rootLogger);
+    const gcp = fakeGcp();
+    await reserve("pcred_deadline_audit", 1);
+    await finalize("pcred_deadline_audit", 1);
+    gcp.versions.set(ref(2), "ENABLED");
+    // Advance the monotonic clock only inside the actual destroy call.
+    const time = performance.now();
+    const clock = vi.spyOn(performance, "now").mockReturnValue(time);
+    gcp.destroyVersion.mockImplementationOnce(async ({ secretVersionRef }) => {
+      gcp.versions.set(secretVersionRef, "DESTROYED");
+      clock.mockReturnValue(time + 101_000);
+      throw new Error("Response lost after destruction");
+    });
+    await expect(scanGcpCredentialContainers(env, () => gcp.secrets)).resolves.toMatchObject({
+      deadlineReached: true,
+      cleaned: 0,
+      failed: [],
+    });
+    expect(warning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: ORG,
+        secretRef: PARENT,
+        secretVersionRef: ref(2),
+        outcome: "destruction_unconfirmed",
+      }),
+      "provider_credential_secret_destruction_unconfirmed"
+    );
+    expect(info).not.toHaveBeenCalledWith(
+      expect.anything(),
+      "provider_credential_secret_destroyed"
+    );
+  });
+});

--- a/apps/sdp-api/src/services/jobs/provider-credential-container-cleanup.ts
+++ b/apps/sdp-api/src/services/jobs/provider-credential-container-cleanup.ts
@@ -1,0 +1,272 @@
+import { getDb } from "@/db";
+import { getLogger } from "@/runtime/logger";
+import type { CredentialSecretStore } from "@/services/credential-secret-store";
+import {
+  type CredentialSecretContainerRow,
+  ProviderCredentialSecretCleanupStore,
+  type RetainedProviderCredentialSecretRow,
+} from "@/services/stores/provider-credential-secret-cleanup.store";
+import type { Env } from "@/types/env";
+
+export interface GcpContainerScanResult {
+  scanned: string[];
+  failed: string[];
+  cleaned: number;
+  skipped: number;
+  deferred?: number;
+  deadlineReached?: true;
+}
+
+// Inventory validates the GCP project; references within its container may
+// spell that project as either its ID or number.
+function relativeVersionRef(ref: string): string {
+  return ref.replace(/^projects\/[^/]+\//, "");
+}
+
+/** One retained owner schedules a container; cancelled attempts never close its inventory. */
+export async function scanGcpCredentialContainers(
+  env: Env,
+  createSecrets: () => CredentialSecretStore,
+  options: { now?: Date; limit?: number; deadlineMs?: number } = {}
+): Promise<GcpContainerScanResult> {
+  const deadlineMs = options.deadlineMs ?? performance.now() + 100_000;
+  if (!Number.isFinite(deadlineMs)) throw new Error("Cleanup deadline must be finite");
+  const signal = AbortSignal.timeout(Math.max(1, Math.ceil(deadlineMs - performance.now())));
+  const store = new ProviderCredentialSecretCleanupStore(getDb(env));
+  const result: GcpContainerScanResult = { scanned: [], failed: [], cleaned: 0, skipped: 0 };
+  const failed = new Set<string>();
+  let secrets: CredentialSecretStore | undefined;
+  function resolveSecrets(): CredentialSecretStore {
+    secrets ??= createSecrets();
+    return secrets;
+  }
+  function assertContainerOwnership(
+    owner: CredentialSecretContainerRow,
+    rows: RetainedProviderCredentialSecretRow[]
+  ): void {
+    if (
+      rows.some(
+        (row) =>
+          row.organization_id !== owner.organization_id ||
+          row.provider !== "privy" ||
+          row.storage_backend !== "gcp_secret_manager"
+      )
+    ) {
+      throw new Error("Managed container has inconsistent Credential ownership");
+    }
+  }
+  const expired = () => performance.now() >= deadlineMs || signal.aborted;
+  function checkDeadline(): void {
+    if (expired()) throw new DOMException("Cleanup deadline reached", "TimeoutError");
+  }
+  function failure(owner: CredentialSecretContainerRow, error: unknown, versionRef?: string): void {
+    failed.add(owner.secret_ref);
+    getLogger().error(
+      {
+        organizationId: owner.organization_id,
+        containerOwnerCredentialId: owner.id,
+        secretRef: owner.secret_ref,
+        secretVersionRef: versionRef,
+        provider: "privy",
+        storageBackend: "gcp_secret_manager",
+        reason: "secret_cleanup_failed",
+        errorName: error instanceof Error ? error.name : "UnknownError",
+      },
+      "provider_credential_orphan_risk"
+    );
+  }
+  async function destroyVersion(
+    owner: CredentialSecretContainerRow,
+    versionRef: string,
+    credentialId?: string
+  ): Promise<void> {
+    try {
+      await resolveSecrets().destroyVersion({
+        secretVersionRef: versionRef,
+        signal,
+        requireDestroyed: true,
+      });
+    } catch (error) {
+      if (expired()) {
+        getLogger().warn(
+          {
+            organizationId: owner.organization_id,
+            containerOwnerCredentialId: owner.id,
+            providerCredentialId: credentialId,
+            secretRef: owner.secret_ref,
+            secretVersionRef: versionRef,
+            outcome: "destruction_unconfirmed",
+            reason: "cleanup_deadline_reached",
+          },
+          "provider_credential_secret_destruction_unconfirmed"
+        );
+      }
+      throw error;
+    }
+    getLogger().info(
+      {
+        organizationId: owner.organization_id,
+        containerOwnerCredentialId: owner.id,
+        providerCredentialId: credentialId,
+        secretRef: owner.secret_ref,
+        secretVersionRef: versionRef,
+        outcome: "confirmed_destroyed",
+        kind: credentialId ? "retained_version" : "unreferenced_version",
+      },
+      "provider_credential_secret_destroyed"
+    );
+  }
+  async function destroyKnown(
+    owner: CredentialSecretContainerRow,
+    row: RetainedProviderCredentialSecretRow
+  ): Promise<void> {
+    if (!row.secret_version_ref) return;
+    checkDeadline();
+    const candidate = await store.fenceGcpCleanupCandidate({
+      id: row.id,
+      expectedSecretVersionRef: row.secret_version_ref,
+    });
+    checkDeadline();
+    if (!candidate) {
+      result.skipped += 1;
+      return;
+    }
+    // Record acknowledged destruction even if there is no time left to clear its marker.
+    await destroyVersion(owner, row.secret_version_ref, row.id);
+    checkDeadline();
+    const cleared = await store.clearGcpRetentionMarker({
+      id: candidate.id,
+      expectedSecretVersionRef: row.secret_version_ref,
+      expectedRetentionExpiresAt: candidate.secret_retention_expires_at,
+    });
+    result[cleared ? "cleaned" : "skipped"] += 1;
+    checkDeadline();
+  }
+  async function cleanupPending(
+    owner: CredentialSecretContainerRow,
+    handled: Set<string>
+  ): Promise<void> {
+    // Exact retained refs remain retryable even when list omits an already-destroyed version.
+    const pending = await store.listPendingDestructions(owner, 25);
+    checkDeadline();
+    for (const row of pending) {
+      if (!row.secret_version_ref) continue;
+      handled.add(row.secret_version_ref);
+      try {
+        await destroyKnown(owner, row);
+      } catch (error) {
+        if (expired()) throw error;
+        failure(owner, error, row.secret_version_ref);
+      }
+    }
+  }
+
+  async function cleanupListedVersion(
+    owner: CredentialSecretContainerRow,
+    versionRef: string,
+    credentials: RetainedProviderCredentialSecretRow[]
+  ): Promise<void> {
+    const references = credentials.filter(
+      (row) =>
+        row.secret_version_ref !== null &&
+        relativeVersionRef(row.secret_version_ref) === relativeVersionRef(versionRef)
+    );
+    if (references.length > 1) throw new Error("GCP version has multiple Credential owners");
+    if (references[0]) return destroyKnown(owner, references[0]);
+    if (credentials.some((row) => row.status === "creating")) {
+      result.skipped += 1;
+      return;
+    }
+    // Only SDP writes this namespace; a later writer creates a new version outside
+    // this page, and cancelled writers cannot adopt a version from it.
+    await destroyVersion(owner, versionRef);
+    result.cleaned += 1;
+  }
+
+  async function scan(owner: CredentialSecretContainerRow): Promise<void> {
+    await store.cancelStaleCreations(owner);
+    checkDeadline();
+    assertContainerOwnership(owner, await store.listContainerCredentials(owner.secret_ref));
+    checkDeadline();
+    const secretStore = resolveSecrets();
+    const listVersions = secretStore.listVersions?.bind(secretStore);
+    if (!listVersions) throw new Error("Managed version inventory is unavailable");
+    const handled = new Set<string>();
+    await cleanupPending(owner, handled);
+
+    const pageTokens = new Set<string>();
+    let pageToken: string | undefined;
+    do {
+      checkDeadline();
+      const page = await listVersions({
+        secretRef: owner.secret_ref,
+        pageToken,
+        signal,
+        liveOnly: true,
+      });
+      checkDeadline();
+      // Each page's decisions use a fresh primary-DB snapshot AFTER that page.
+      const credentials = await store.listContainerCredentials(owner.secret_ref);
+      checkDeadline();
+      assertContainerOwnership(owner, credentials);
+      for (const version of page.versions) {
+        checkDeadline();
+        if (version.state === "DESTROYED" || handled.has(version.secretVersionRef)) continue;
+        handled.add(version.secretVersionRef);
+        try {
+          await cleanupListedVersion(owner, version.secretVersionRef, credentials);
+        } catch (error) {
+          if (expired()) throw error;
+          failure(owner, error, version.secretVersionRef);
+        }
+      }
+      if (page.nextPageToken && pageTokens.has(page.nextPageToken))
+        throw new Error("Repeated GCP inventory page token");
+      pageToken = page.nextPageToken;
+      if (pageToken) pageTokens.add(pageToken);
+      // Live-only listing means destroyed history cannot monopolize every later
+      // bounded pass. Pagination changes may omit a version this pass, never close it.
+    } while (pageToken);
+  }
+
+  if (expired()) return { ...result, deadlineReached: true, deferred: 0 };
+  const now = options.now ?? new Date();
+  let owners: CredentialSecretContainerRow[];
+  try {
+    owners = await store.listDueContainers(now, Math.min(options.limit ?? 25, 25));
+  } catch (error) {
+    if (expired()) return { ...result, deadlineReached: true, deferred: 0 };
+    throw error;
+  }
+  if (expired()) return { ...result, deadlineReached: true, deferred: owners.length };
+  for (const [index, owner] of owners.entries()) {
+    try {
+      checkDeadline();
+      // Fixed revisit time, not a lease: no completion write can clobber a later scan.
+      if (!(await store.advanceContainerScan(owner, now))) continue;
+      checkDeadline();
+      await scan(owner);
+      result.scanned.push(owner.secret_ref);
+    } catch (error) {
+      if (expired()) {
+        result.deadlineReached = true;
+        result.deferred = owners.length - index;
+        getLogger().warn(
+          {
+            organizationId: owner.organization_id,
+            containerOwnerCredentialId: owner.id,
+            provider: "privy",
+            storageBackend: "gcp_secret_manager",
+            reason: "cleanup_deadline_reached",
+            outcome: "scan_incomplete",
+          },
+          "provider_credential_cleanup_interrupted"
+        );
+        break;
+      }
+      failure(owner, error);
+    }
+  }
+  result.failed = [...failed];
+  return result;
+}

--- a/apps/sdp-api/src/services/jobs/provider-credential-container-schedule.test.ts
+++ b/apps/sdp-api/src/services/jobs/provider-credential-container-schedule.test.ts
@@ -1,0 +1,290 @@
+// Uses the production scan-owner migration in the test database.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getDb } from "@/db";
+import type {
+  CredentialSecretStore,
+  ListCredentialSecretVersionsParams,
+} from "@/services/credential-secret-store";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import { scanGcpCredentialContainers } from "./provider-credential-container-cleanup";
+
+const ORG = "org_scan_schedule_prototype";
+const USER = "usr_scan_schedule_prototype";
+const NOW = new Date("2030-01-01T10:00:00.000Z");
+const later = (minutes: number) => new Date(NOW.getTime() + minutes * 60_000);
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function fakeGcp() {
+  const versions = new Map<string, "ENABLED" | "DESTROYED">();
+  const listVersions = vi.fn(async ({ secretRef }: ListCredentialSecretVersionsParams) => ({
+    versions: [...versions]
+      .filter(([name]) => name.startsWith(`${secretRef}/versions/`))
+      .map(([secretVersionRef, state]) => ({ secretVersionRef, state })),
+  }));
+  const secrets: CredentialSecretStore = {
+    storageBackend: "gcp_secret_manager",
+    predictFirstVersionRef: () => null,
+    write: async () => {
+      throw new Error("No payload writes in a scheduling test");
+    },
+    read: async () => {
+      throw new Error("No payload reads in a scheduling test");
+    },
+    listVersions,
+    destroyVersion: async ({ secretVersionRef }) => {
+      if (!versions.has(secretVersionRef)) throw new Error("Missing GCP version");
+      versions.set(secretVersionRef, "DESTROYED");
+    },
+  };
+  return { versions, listVersions, secrets };
+}
+
+async function seedContainer(suffix: string, due = NOW): Promise<string> {
+  const id = `pcred_scan_schedule_${suffix}`;
+  const parent = `projects/p/secrets/sdp-provider-credentials-${id}`;
+  await getDb(env).execute(
+    `INSERT INTO provider_credentials
+       (id, organization_id, provider, label, scope, source, storage_backend,
+        secret_ref, secret_version_ref, status, created_by, secret_next_scan_at)
+     VALUES (?, ?, 'privy', 'Schedule prototype', 'organization', 'stored',
+             'gcp_secret_manager', ?, ?, 'pending', ?, ?::timestamptz)`,
+    [id, ORG, parent, `${parent}/versions/1`, USER, due.toISOString()]
+  );
+  return parent;
+}
+
+describe("single-column container scan scheduling", () => {
+  afterEach(() => vi.restoreAllMocks());
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    await getDb(env).execute(
+      "INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, 'Schedule prototype', 'scan-schedule-prototype', 'enterprise', 'active')",
+      [ORG]
+    );
+    await getDb(env).execute(
+      "INSERT INTO users (id, email, email_verified, status) VALUES (?, 'scan-schedule-prototype@example.test', 1, 'active')",
+      [USER]
+    );
+  });
+
+  it("scans a due container, skips it before the next interval, then finds a later orphan", async () => {
+    const gcp = fakeGcp();
+    const parent = await seedContainer("due");
+    gcp.versions.set(`${parent}/versions/1`, "ENABLED");
+    gcp.versions.set(`${parent}/versions/2`, "ENABLED");
+
+    await scanGcpCredentialContainers(env, () => gcp.secrets, { now: NOW });
+    expect(gcp.versions.get(`${parent}/versions/2`)).toBe("DESTROYED");
+    gcp.versions.set(`${parent}/versions/3`, "ENABLED");
+    await scanGcpCredentialContainers(env, () => gcp.secrets, { now: later(1) });
+    expect(gcp.versions.get(`${parent}/versions/3`)).toBe("ENABLED");
+    await scanGcpCredentialContainers(env, () => gcp.secrets, { now: later(5) });
+    expect(gcp.versions.get(`${parent}/versions/3`)).toBe("DESTROYED");
+    expect(gcp.versions.get(`${parent}/versions/1`)).toBe("ENABLED");
+  });
+
+  it("continues past a failed container and does not starve later containers in a bounded batch", async () => {
+    const gcp = fakeGcp();
+    const first = await seedContainer("a", later(-2));
+    const second = await seedContainer("b", later(-1));
+    const third = await seedContainer("c");
+    for (const parent of [first, second, third])
+      gcp.versions.set(`${parent}/versions/2`, "ENABLED");
+    gcp.listVersions.mockRejectedValueOnce(new Error("First container unavailable"));
+
+    const result = await scanGcpCredentialContainers(env, () => gcp.secrets, {
+      now: NOW,
+      limit: 2,
+    });
+
+    expect(result).toMatchObject({ scanned: [second], failed: [first] });
+    expect(gcp.versions.get(`${third}/versions/2`)).toBe("ENABLED");
+    expect(
+      await scanGcpCredentialContainers(env, () => gcp.secrets, { now: NOW, limit: 2 })
+    ).toMatchObject({ scanned: [third], failed: [] });
+    expect(gcp.versions.get(`${third}/versions/2`)).toBe("DESTROYED");
+  });
+
+  it("retries without the first worker finishing and ignores that worker's late completion", async () => {
+    const gcp = fakeGcp();
+    const parent = await seedContainer("interrupted");
+    gcp.versions.set(`${parent}/versions/2`, "ENABLED");
+    const started = deferred();
+    const release = deferred();
+    gcp.listVersions.mockImplementationOnce(async () => {
+      started.resolve();
+      await release.promise;
+      throw new Error("First worker never completed its GCP read");
+    });
+    const first = scanGcpCredentialContainers(env, () => gcp.secrets, { now: NOW });
+    try {
+      await started.promise;
+      expect(
+        await scanGcpCredentialContainers(env, () => gcp.secrets, { now: later(1) })
+      ).toMatchObject({ scanned: [], failed: [] });
+      // No completion from the first worker is needed to make the location due again.
+      expect(
+        await scanGcpCredentialContainers(env, () => gcp.secrets, { now: later(5) })
+      ).toMatchObject({ scanned: [parent], failed: [] });
+    } finally {
+      release.resolve();
+      await first;
+    }
+    expect((await first).failed).toEqual([parent]);
+    expect(gcp.versions.get(`${parent}/versions/2`)).toBe("DESTROYED");
+    gcp.versions.set(`${parent}/versions/3`, "ENABLED");
+    await scanGcpCredentialContainers(env, () => gcp.secrets, { now: later(6) });
+    expect(gcp.versions.get(`${parent}/versions/3`)).toBe("ENABLED");
+    await scanGcpCredentialContainers(env, () => gcp.secrets, { now: later(10) });
+    expect(gcp.versions.get(`${parent}/versions/3`)).toBe("DESTROYED");
+  });
+
+  it("admits one of two workers that both selected the same due owner", async () => {
+    const gcp = fakeGcp();
+    const parent = await seedContainer("concurrent");
+    gcp.versions.set(`${parent}/versions/2`, "ENABLED");
+    const db = getDb(env);
+    const queryMany = db.queryMany.bind(db);
+    const bothSelected = deferred();
+    let selected = 0;
+    // Hold two real PostgreSQL SELECT replies at the DB transport seam.
+    // Rows and competing UPDATE statements are never fabricated.
+    vi.spyOn(db, "queryMany").mockImplementation(
+      async <T>(query: string, params?: readonly unknown[]) => {
+        const rows = await queryMany<T>(query, params);
+        if (query.includes("secret_next_scan_at")) {
+          if (++selected === 2) bothSelected.resolve();
+          await bothSelected.promise;
+        }
+        return rows;
+      }
+    );
+
+    const results = await Promise.all([
+      scanGcpCredentialContainers(env, () => gcp.secrets, { now: NOW }),
+      scanGcpCredentialContainers(env, () => gcp.secrets, { now: NOW }),
+    ]);
+
+    expect(results.flatMap((result) => result.scanned)).toEqual([parent]);
+    expect(gcp.versions.get(`${parent}/versions/2`)).toBe("DESTROYED");
+  });
+
+  it("does not advance unstarted containers when the job admission budget ends", async () => {
+    const gcp = fakeGcp();
+    const first = await seedContainer("budget_a", later(-1));
+    const second = await seedContainer("budget_b");
+    for (const parent of [first, second]) gcp.versions.set(`${parent}/versions/2`, "ENABLED");
+    expect(
+      await scanGcpCredentialContainers(env, () => gcp.secrets, {
+        now: NOW,
+        deadlineMs: performance.now() - 1,
+      })
+    ).toMatchObject({ scanned: [], failed: [], deadlineReached: true });
+
+    const deadline = performance.now() + 100_000;
+    gcp.listVersions.mockImplementationOnce(async () => {
+      vi.spyOn(performance, "now").mockReturnValue(deadline + 1);
+      return { versions: [{ secretVersionRef: `${first}/versions/2`, state: "ENABLED" }] };
+    });
+    expect(
+      await scanGcpCredentialContainers(env, () => gcp.secrets, {
+        now: NOW,
+        deadlineMs: deadline,
+      })
+    ).toMatchObject({ scanned: [], failed: [], deadlineReached: true });
+    vi.restoreAllMocks();
+    expect(gcp.versions.get(`${second}/versions/2`)).toBe("ENABLED");
+    expect(await scanGcpCredentialContainers(env, () => gcp.secrets, { now: NOW })).toMatchObject({
+      scanned: [second],
+      failed: [],
+    });
+    expect(gcp.versions.get(`${second}/versions/2`)).toBe("DESTROYED");
+  });
+
+  it.each([true, false])(
+    "recovers after losing the scheduling UPDATE response (committed: %s)",
+    async (committed) => {
+      const gcp = fakeGcp();
+      const parent = await seedContainer("update_reply");
+      gcp.versions.set(`${parent}/versions/2`, "ENABLED");
+      const db = getDb(env);
+      const execute = db.execute.bind(db);
+      vi.spyOn(db, "execute").mockImplementationOnce(async (sql, params) => {
+        if (committed) await execute(sql, params);
+        throw new Error("Scheduling UPDATE response lost");
+      });
+
+      await expect(
+        scanGcpCredentialContainers(env, () => gcp.secrets, { now: NOW })
+      ).resolves.toMatchObject({ failed: [parent] });
+      expect(gcp.versions.get(`${parent}/versions/2`)).toBe("ENABLED");
+      expect(await scanGcpCredentialContainers(env, () => gcp.secrets, { now: NOW })).toMatchObject(
+        {
+          scanned: committed ? [] : [parent],
+          failed: [],
+        }
+      );
+      await scanGcpCredentialContainers(env, () => gcp.secrets, { now: later(5) });
+      expect(gcp.versions.get(`${parent}/versions/2`)).toBe("DESTROYED");
+    }
+  );
+
+  it("keeps scheduling on the retired owner after rotation and organization soft deletion", async () => {
+    const gcp = fakeGcp();
+    const parent = await seedContainer("retired_owner");
+    await getDb(env).execute(
+      "UPDATE provider_credentials SET status = 'retired', secret_retention_expires_at = '2099-01-01T00:00:00.000Z' WHERE secret_ref = ?",
+      [parent]
+    );
+    await getDb(env).execute(
+      `INSERT INTO provider_credentials
+         (id, organization_id, provider, label, scope, source, storage_backend,
+          secret_ref, secret_version_ref, status, created_by, credential_version, rotated_from_provider_credential_id)
+       VALUES ('pcred_scan_schedule_current', ?, 'privy', 'Current', 'organization', 'stored',
+               'gcp_secret_manager', ?, ?, 'active', ?, 2, 'pcred_scan_schedule_retired_owner')`,
+      [ORG, parent, `${parent}/versions/2`, USER]
+    );
+    await getDb(env).execute("UPDATE organizations SET status = 'deleted' WHERE id = ?", [ORG]);
+    for (const version of [1, 2, 3]) gcp.versions.set(`${parent}/versions/${version}`, "ENABLED");
+
+    expect(await scanGcpCredentialContainers(env, () => gcp.secrets, { now: NOW })).toMatchObject({
+      scanned: [parent],
+      failed: [],
+    });
+
+    expect([...gcp.versions.values()]).toEqual(["ENABLED", "ENABLED", "DESTROYED"]);
+  });
+
+  it("does not start GCP when the scheduling UPDATE returns after the admission deadline", async () => {
+    const gcp = fakeGcp();
+    const parent = await seedContainer("slow_update");
+    gcp.versions.set(`${parent}/versions/2`, "ENABLED");
+    const db = getDb(env);
+    const execute = db.execute.bind(db);
+    const deadline = performance.now() + 100_000;
+    vi.spyOn(db, "execute").mockImplementationOnce(async (sql, params) => {
+      const changed = await execute(sql, params);
+      vi.spyOn(performance, "now").mockReturnValue(deadline + 1);
+      return changed;
+    });
+
+    expect(
+      await scanGcpCredentialContainers(env, () => gcp.secrets, {
+        now: NOW,
+        deadlineMs: deadline,
+      })
+    ).toMatchObject({ scanned: [], failed: [], deadlineReached: true });
+    vi.restoreAllMocks();
+    expect(gcp.versions.get(`${parent}/versions/2`)).toBe("ENABLED");
+    await scanGcpCredentialContainers(env, () => gcp.secrets, { now: later(5) });
+    expect(gcp.versions.get(`${parent}/versions/2`)).toBe("DESTROYED");
+  });
+});

--- a/apps/sdp-api/src/services/jobs/retire-workflow-secrets.test.ts
+++ b/apps/sdp-api/src/services/jobs/retire-workflow-secrets.test.ts
@@ -180,6 +180,16 @@ describe("orphaned workflow secret retirement", () => {
     expect(new Date(queued[0]?.next_attempt_at ?? 0).getTime()).toBeGreaterThan(sweptAt.getTime());
   });
 
+  it("does not infer destruction from a FAILED_PRECONDITION error", async () => {
+    secretStore.destroyVersion.mockRejectedValue(new Error("FAILED_PRECONDITION"));
+    await destroyActionSecret(env, storedSecret(), { orgId: "org_1", workflowId: "wf_1" });
+
+    const result = await retireOrphanedActionSecrets(env, new Date(Date.now() + 1_000));
+
+    expect(result).toEqual({ retired: 0, failed: 1 });
+    expect(await queuedRetirements()).toHaveLength(1);
+  });
+
   // Backoff has to actually hold the row back, or the sweep is a busy loop.
   it("leaves a not-yet-due row alone", async () => {
     secretStore.destroyVersion.mockRejectedValue(new Error("permission denied"));

--- a/apps/sdp-api/src/services/jobs/retire-workflow-secrets.ts
+++ b/apps/sdp-api/src/services/jobs/retire-workflow-secrets.ts
@@ -34,11 +34,8 @@ function nextAttemptIso(now: Date, attemptCount: number): string {
   return new Date(now.getTime() + minutes * 60 * 1000).toISOString();
 }
 
-function isAlreadyDestroyed(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    (error.message.includes("FAILED_PRECONDITION") || error.message.includes("NOT_FOUND"))
-  );
+function isMissingVersion(error: unknown): boolean {
+  return error instanceof Error && error.message.includes("NOT_FOUND");
 }
 
 function isKnownBackend(value: string): value is CredentialSecretStorageBackend {
@@ -124,11 +121,10 @@ export async function retireOrphanedActionSecrets(
       await repo.deleteRetirement(row.id);
       result.retired += 1;
     } catch (error) {
-      // A version that is already gone is the outcome this row wanted. Secret Manager
-      // answers FAILED_PRECONDITION for destroying one twice, which is exactly what a row
-      // left behind by a successful request-time destroy looks like — clearing it beats
-      // retrying it to the backoff cap forever.
-      if (isAlreadyDestroyed(error)) {
+      // Predicted versions can remain absent when their write never happened.
+      // An already-destroyed version is confirmed by the store, not by a
+      // FAILED_PRECONDITION message, which can have other causes.
+      if (isMissingVersion(error)) {
         await repo.deleteRetirement(row.id);
         result.retired += 1;
         continue;

--- a/apps/sdp-api/src/services/provider-credential-creation.ts
+++ b/apps/sdp-api/src/services/provider-credential-creation.ts
@@ -1,0 +1,83 @@
+import type { Context } from "hono";
+import { getDb } from "@/db";
+import { conflict, providerUnavailable } from "@/lib/errors";
+import { describeError, logEvent } from "@/runtime/money-path-events";
+import type { StoredCredentialSecret } from "@/services/credential-secret-store";
+import {
+  type ProviderCredentialRow,
+  ProviderCredentialStore,
+} from "@/services/stores/provider-credential.store";
+import { ProviderCredentialSecretCleanupStore } from "@/services/stores/provider-credential-secret-cleanup.store";
+import type { Env } from "@/types/env";
+
+/** A reserved write is not a successful submission and must never be replayed as one. */
+export function assertCredentialCreationSettled(credential: ProviderCredentialRow): void {
+  if (credential.status === "creating") {
+    throw providerUnavailable("Credential creation has not completed; retry the same request");
+  }
+  if (
+    credential.status === "deactivated" &&
+    credential.last_failure_code === "secret_creation_abandoned"
+  ) {
+    throw conflict("Credential creation was cancelled; start a new attempt");
+  }
+}
+
+/**
+ * The conditional UPDATE waits for any uncertain finalization COMMIT and cannot
+ * cancel an adopted secret. No external destroy is safe merely because a read failed.
+ * If this write fails too, the persisted creating row remains recoverable by cleanup.
+ */
+export async function recoverCredentialCreation(
+  c: Context<{ Bindings: Env }>,
+  organizationId: string,
+  credentialId: string,
+  written?: StoredCredentialSecret
+): Promise<
+  | { kind: "adopted"; credential: ProviderCredentialRow }
+  | { kind: "abandoned" }
+  | { kind: "unknown" }
+> {
+  try {
+    return await getDb(c.env).transaction(async (tx) => {
+      const store = new ProviderCredentialStore(tx);
+      const credential = await store.findCredential(credentialId, { lock: true });
+      if (!credential || credential.organization_id !== organizationId) {
+        return { kind: "unknown" as const };
+      }
+      if (
+        credential.status === "creating" ||
+        credential.last_failure_code === "secret_creation_abandoned"
+      ) {
+        if (credential.status === "creating") {
+          if (!(await store.abandonCredentialCreation({ organizationId, credentialId }))) {
+            throw new Error("Credential creation could not be cancelled under its lock");
+          }
+        }
+        if (
+          written?.storageBackend === "gcp_secret_manager" &&
+          written.secretRef &&
+          written.secretVersionRef
+        ) {
+          await new ProviderCredentialSecretCleanupStore(tx).recordAcknowledgedGcpVersion({
+            id: credentialId,
+            secretRef: written.secretRef,
+            secretVersionRef: written.secretVersionRef,
+          });
+        }
+        return { kind: "abandoned" as const };
+      }
+      return { kind: "adopted" as const, credential };
+    });
+  } catch (error) {
+    logEvent("error", {
+      event: "sdp_api_credential_creation_failure",
+      stage: "abandon",
+      organization_id: organizationId,
+      provider_credential_id: credentialId,
+      request_id: c.get("requestId"),
+      ...describeError(error),
+    });
+    return { kind: "unknown" };
+  }
+}

--- a/apps/sdp-api/src/services/provider-credential-submission.service.ts
+++ b/apps/sdp-api/src/services/provider-credential-submission.service.ts
@@ -3,7 +3,6 @@ import { requireEnv } from "@sdp/payments/ramps/shared";
 import type { Context } from "hono";
 import { type DatabaseClient, getDb } from "@/db";
 import { isPostgresUniqueViolation, parsePostgresJsonOr } from "@/db/postgres-utils";
-import { createWorkflowSecretRetirementsRepository } from "@/db/repositories";
 import { getAuth, requireProjectId } from "@/lib/auth";
 import {
   AppError,
@@ -26,15 +25,14 @@ import {
 } from "@/services/credential-secret-store";
 import { isPersistedCustodyCompletionEnabled } from "@/services/provider-availability.service";
 import {
+  assertCredentialCreationSettled,
+  recoverCredentialCreation,
+} from "@/services/provider-credential-creation";
+import {
   decideInstallation,
   type InstallationConflictReason,
   installationFactsFromConnection,
 } from "@/services/provider-credential-installation";
-import {
-  clearQueuedSecretVersion,
-  queuePendingSecretVersion,
-  reserveSecretVersionIntent,
-} from "@/services/secret-retirement";
 import {
   type ProjectConnectionState,
   type ProviderCredentialRow,
@@ -94,7 +92,7 @@ type TransactionResult =
   | { kind: "committed"; result: ProviderCredentialSubmissionResult }
   | { kind: "replay"; result: ProviderCredentialSubmissionResult };
 
-type CompensationOutcome = "not_required" | "succeeded" | "failed" | "deferred";
+type CompensationOutcome = "not_required" | "deferred";
 
 type SubmissionAuditBase = {
   organizationId: string;
@@ -128,6 +126,7 @@ interface PersistedSubmission extends PreparedSubmission {
   connectionId: string;
   secretStore?: CredentialSecretStore;
   stored: StoredCredentialSecret;
+  existingSecretRef?: string;
 }
 
 class SetupConflict extends Error {
@@ -391,51 +390,25 @@ async function persistPreparedSubmission(
   try {
     let secretStore: CredentialSecretStore | undefined;
     let stored: StoredCredentialSecret;
+    let existingSecretRef: string | undefined;
     if (prepared.credentialSource === "stored") {
       secretStore = await createSubmissionSecretStore(prepared, providerCredentialId, connectionId);
-      const retirementContext = {
-        provider: "privy",
-        orgId: prepared.organizationId,
-        sourceId: providerCredentialId,
-      };
-      // The obligation is recorded BEFORE the write: with the coming version
-      // ref known up front, a durable row exists before anything external
-      // does, so no crash between the write and any later bookkeeping can
-      // leave a readable credential without a record the sweeper drains. If it
-      // cannot be recorded, the request is refused while the backend still
-      // holds nothing.
-      const predictedVersionRef = secretStore.predictFirstVersionRef({ providerCredentialId });
-      if (predictedVersionRef) {
-        await reserveSecretVersionIntent(
-          prepared.c.env,
-          {
-            storageBackend: secretStore.storageBackend,
-            secretRef: null,
-            secretVersionRef: predictedVersionRef,
-          },
-          retirementContext
-        );
+      if (
+        secretStore.storageBackend === "gcp_secret_manager" &&
+        prepared.preflightPlan.kind === "replacement"
+      ) {
+        existingSecretRef =
+          (await prepared.store.findGcpContainerRef(
+            prepared.organizationId,
+            prepared.preflightPlan.currentCredential.id
+          )) ?? undefined;
       }
-      stored = await writeSubmissionSecret(
-        prepared,
-        providerCredentialId,
-        connectionId,
-        secretStore
-      );
-      // The reservation covers the predicted ref; only a write that landed on
-      // a different version (a pre-existing secret, which a freshly minted
-      // credential id should never have) still needs its own record. The
-      // now-pointless reservation is released best-effort: left standing it
-      // only costs the sweeper one NOT_FOUND destroy of a version that was
-      // never written.
-      if (stored.secretVersionRef !== predictedVersionRef) {
-        await queuePendingSecretVersion(prepared.c.env, stored, retirementContext);
-        if (predictedVersionRef) {
-          await createWorkflowSecretRetirementsRepository(prepared.c.env)
-            .deleteRetirementByVersionRef(predictedVersionRef)
-            .catch(() => undefined);
-        }
-      }
+      stored =
+        secretStore.storageBackend === "gcp_secret_manager"
+          ? existingSecretRef
+            ? { storageBackend: "gcp_secret_manager", secretRef: existingSecretRef }
+            : credentialSecretStore.prepareGcpCredentialSecret(prepared.c.env, providerCredentialId)
+          : await writeSubmissionSecret(prepared, providerCredentialId, connectionId, secretStore);
     } else {
       stored = { storageBackend: "runtime_env" };
     }
@@ -446,6 +419,7 @@ async function persistPreparedSubmission(
       connectionId,
       ...(secretStore ? { secretStore } : {}),
       stored,
+      existingSecretRef,
     });
 
     if (transaction.kind === "committed") {
@@ -526,7 +500,8 @@ async function writeSubmissionSecret(
   context: SubmissionContext,
   providerCredentialId: string,
   connectionId: string,
-  secretStore: CredentialSecretStore
+  secretStore: CredentialSecretStore,
+  existingSecretRef?: string
 ): Promise<StoredCredentialSecret> {
   const fields = requireStoredFields(context.input);
   try {
@@ -534,6 +509,7 @@ async function writeSubmissionSecret(
       orgId: context.organizationId,
       provider: context.input.provider,
       providerCredentialId,
+      existingSecretRef,
       payload: {
         appId: fields.appId,
         appSecret: fields.appSecret,
@@ -565,28 +541,69 @@ async function writeSubmissionSecret(
 }
 
 async function commitSubmission(submission: PersistedSubmission): Promise<TransactionResult> {
-  let transactionResult: TransactionResult;
+  let transactionResult: TransactionResult | { kind: "reserved" };
   try {
-    transactionResult = await runSubmissionTransaction(submission);
+    transactionResult = await runSubmissionTransaction(
+      submission,
+      submission.stored.storageBackend === "gcp_secret_manager" ? "reserve" : "commit"
+    );
   } catch (error) {
     return recoverTransactionFailure(submission, error);
   }
 
-  if (transactionResult.kind === "replay" && submission.secretStore) {
-    await compensateSecretWrite(
-      submission.c,
-      submission.secretStore,
-      submission.stored,
-      submission.providerCredentialId
-    );
+  if (transactionResult.kind === "reserved") {
+    let stored: StoredCredentialSecret | undefined;
+    try {
+      if (!submission.secretStore) throw internalError();
+      stored = await writeSubmissionSecret(
+        submission,
+        submission.providerCredentialId,
+        submission.connectionId,
+        submission.secretStore,
+        submission.existingSecretRef
+      );
+      if (!stored.secretRef || !stored.secretVersionRef) throw internalError();
+      const finalized = await runSubmissionTransaction({ ...submission, stored }, "finalize");
+      if (finalized.kind === "reserved") throw internalError();
+      return finalized;
+    } catch (error) {
+      const recovered = await recoverCredentialCreation(
+        submission.c,
+        submission.organizationId,
+        submission.providerCredentialId,
+        stored
+      );
+      if (recovered.kind === "adopted") {
+        return {
+          kind: "committed",
+          result: await resolveReplay(submission, recovered.credential, submission.fingerprint),
+        };
+      }
+      if (recovered.kind === "unknown") {
+        throw new SubmissionOutcomeUnknown(
+          providerUnavailable("Credential creation outcome is temporarily unknown")
+        );
+      }
+      if (error instanceof SubmissionOutcomeUnknown) throw error.responseError;
+      if (error instanceof SetupConflict) throw setupConflictResponse(error);
+      if (error instanceof AppError) throw error;
+      await auditFailure(submission.c, submission.audit, submission.auditBase, {
+        reason: "database_failure",
+        resourceId: submission.providerCredentialId,
+        storageBackend: "gcp_secret_manager",
+        compensationOutcome: "deferred",
+      });
+      throw internalError();
+    }
   }
 
   return transactionResult;
 }
 
 async function runSubmissionTransaction(
-  submission: PersistedSubmission
-): Promise<TransactionResult> {
+  submission: PersistedSubmission,
+  phase: "reserve" | "finalize" | "commit"
+): Promise<TransactionResult | { kind: "reserved" }> {
   return submission.db.transaction(async (tx) => {
     const txStore = new ProviderCredentialStore(tx);
     if (!(await txStore.lockProject(submission.organizationId, submission.projectId))) {
@@ -597,7 +614,14 @@ async function runSubmissionTransaction(
       submission.organizationId,
       submission.idempotencyKey
     );
-    if (concurrentReplay) {
+    if (
+      concurrentReplay &&
+      !(
+        phase === "finalize" &&
+        concurrentReplay.id === submission.providerCredentialId &&
+        concurrentReplay.status === "creating"
+      )
+    ) {
       return {
         kind: "replay",
         result: await resolveReplay(
@@ -608,50 +632,66 @@ async function runSubmissionTransaction(
       };
     }
 
-    const lockedPlan = await classifySetup({ ...submission, store: txStore }, true);
+    const lockedPlan = await classifySetup(
+      { ...submission, store: txStore },
+      true,
+      phase === "finalize" ? submission.providerCredentialId : undefined
+    );
     assertSameSetupPlan(submission.preflightPlan, lockedPlan);
 
     if (submission.credentialSource === "runtime" && lockedPlan.kind === "replacement") {
       throw new SetupConflict(undefined, lockedPlan.connection.id);
     }
-    const fields =
-      submission.credentialSource === "stored" ? requireStoredFields(submission.input) : null;
-    const version =
-      lockedPlan.kind === "replacement" ? lockedPlan.currentCredential.credential_version + 1 : 1;
-    const rotatedFromId =
-      lockedPlan.kind === "replacement" ? lockedPlan.currentCredential.id : null;
-    const displayMetadata: Record<string, string> =
-      fields && fields.appId.length > 4 ? { appIdSuffix: fields.appId.slice(-4) } : {};
-
-    const providerCredential = await txStore.insertCredential({
-      id: submission.providerCredentialId,
-      organizationId: submission.organizationId,
-      projectId: submission.projectId,
-      provider: "privy",
-      label: fields?.credentialLabel ?? RUNTIME_CREDENTIAL_LABEL,
-      scope: "project",
-      source: submission.credentialSource,
-      stored: submission.stored,
-      displayMetadata,
-      version,
-      rotatedFromId,
-      idempotencyKey: submission.idempotencyKey,
-      idempotencyFingerprint: submission.fingerprint,
-      createdBy: submission.userId,
-    });
+    const providerCredential =
+      phase === "finalize"
+        ? await txStore.finalizeCredentialCreation({
+            organizationId: submission.organizationId,
+            credentialId: submission.providerCredentialId,
+            secretRef: submission.stored.secretRef ?? "",
+            secretVersionRef: submission.stored.secretVersionRef ?? "",
+          })
+        : await insertSubmissionCredential(txStore, submission, lockedPlan, phase === "reserve");
+    if (!providerCredential)
+      throw conflict("Credential creation was cancelled; start a new attempt");
+    if (phase === "reserve") return { kind: "reserved" };
     await persistConnection(txStore, submission, lockedPlan, providerCredential);
-
-    // The credential row now references the version; the same commit cancels
-    // the provisional retirement queued before this transaction started. A
-    // rollback keeps the obligation, which is the point — even when the
-    // outcome of this transaction is unknowable to the request, the queue and
-    // the row can never BOTH be lost.
-    await clearQueuedSecretVersion(tx, submission.stored);
 
     return {
       kind: "committed",
       result: mapSubmissionResult(providerCredential, submission.connectionId),
     };
+  });
+}
+
+async function insertSubmissionCredential(
+  store: ProviderCredentialStore,
+  submission: PersistedSubmission,
+  plan: SetupPlan,
+  creating: boolean
+): Promise<ProviderCredentialRow> {
+  const fields =
+    submission.credentialSource === "stored" ? requireStoredFields(submission.input) : null;
+  return store.insertCredential({
+    id: submission.providerCredentialId,
+    organizationId: submission.organizationId,
+    projectId: submission.projectId,
+    provider: "privy",
+    label: fields?.credentialLabel ?? RUNTIME_CREDENTIAL_LABEL,
+    scope: "project",
+    source: submission.credentialSource,
+    stored: submission.stored,
+    displayMetadata:
+      fields && fields.appId.length > 4 ? { appIdSuffix: fields.appId.slice(-4) } : {},
+    version:
+      plan.kind === "replacement"
+        ? await store.nextCredentialVersion(submission.organizationId, plan.currentCredential.id)
+        : 1,
+    rotatedFromId: plan.kind === "replacement" ? plan.currentCredential.id : null,
+    idempotencyKey: submission.idempotencyKey,
+    idempotencyFingerprint: submission.fingerprint,
+    createdBy: submission.userId,
+    status: creating ? "creating" : "pending",
+    ownsGcpContainer: creating && !submission.existingSecretRef,
   });
 }
 
@@ -707,7 +747,7 @@ async function recoverTransactionFailure(
       }
     }
 
-    const compensationOutcome = await compensateSubmissionSecret(submission);
+    const compensationOutcome = "not_required";
     return {
       kind: "replay",
       result: await resolveReplayWithAudit(
@@ -723,11 +763,11 @@ async function recoverTransactionFailure(
   }
 
   if (reconciliation.kind === "unknown") {
-    reportManualSecretCleanupRequired(submission);
     throw new SubmissionOutcomeUnknown(internalError());
   }
 
-  const compensationOutcome = await compensateSubmissionSecret(submission);
+  // This transaction precedes every GCP write; local ciphertext needs no external undo.
+  const compensationOutcome = "not_required";
 
   if (error instanceof SetupConflict) {
     await auditFailure(submission.c, submission.audit, submission.auditBase, {
@@ -799,35 +839,6 @@ async function reconcileTransactionOutcome(
   }
 }
 
-function reportManualSecretCleanupRequired(submission: PersistedSubmission): void {
-  if (submission.stored.storageBackend !== "gcp_secret_manager") {
-    return;
-  }
-
-  logOrphanRisk({
-    providerCredentialId: submission.providerCredentialId,
-    storageBackend: submission.stored.storageBackend,
-    providerResourceVersion: submission.stored.secretVersionRef
-      ? parseProviderResourceVersion(submission.stored.secretVersionRef)
-      : undefined,
-    requestId: submission.c.get("requestId"),
-    reason: "secret_cleanup_failed",
-  });
-}
-
-async function compensateSubmissionSecret(
-  submission: PersistedSubmission
-): Promise<CompensationOutcome> {
-  return submission.secretStore
-    ? compensateSecretWrite(
-        submission.c,
-        submission.secretStore,
-        submission.stored,
-        submission.providerCredentialId
-      )
-    : "not_required";
-}
-
 async function buildProviderCredentialSubmissionFingerprint(params: {
   organizationId: string;
   projectId: string;
@@ -868,6 +879,7 @@ async function resolveReplay(
   fingerprint: string
 ): Promise<ProviderCredentialSubmissionResult> {
   await resolveIdempotencyReplay(async () => replay, fingerprint);
+  assertCredentialCreationSettled(replay);
   const connectionIds = await context.store.findConnectionIdsForCredentialLineage(
     context.organizationId,
     context.projectId,
@@ -894,7 +906,11 @@ async function resolveReplayWithAudit(
   try {
     return await resolveReplay(context, replay, fingerprint);
   } catch (error) {
-    if (error instanceof AppError && error.code === "CONFLICT") {
+    if (
+      error instanceof AppError &&
+      error.code === "CONFLICT" &&
+      replay.idempotency_fingerprint !== fingerprint
+    ) {
       await auditFailure(context.c, context.audit, context.auditBase, {
         reason: "idempotency_key_reused",
         resourceId: failure?.failureResourceId,
@@ -940,8 +956,19 @@ async function classifySetup(
     SubmissionContext,
     "store" | "organizationId" | "projectId" | "replacementConnectionId"
   >,
-  lock = false
+  lock = false,
+  creatingCredentialId?: string
 ): Promise<SetupPlan> {
+  const creating = await context.store.findCreatingSubmission(
+    context.organizationId,
+    context.projectId
+  );
+  if (creating && creating.id !== creatingCredentialId) {
+    throw new SetupConflict(
+      "unfinished_installation_exists",
+      context.replacementConnectionId ?? undefined
+    );
+  }
   if (!context.replacementConnectionId) {
     const connections = await context.store.listProjectConnections(
       context.organizationId,
@@ -961,7 +988,7 @@ async function classifySetup(
     context.organizationId,
     context.projectId,
     context.replacementConnectionId,
-    { lock }
+    { lock, excludedCreatingCredentialId: creatingCredentialId }
   );
   if (!connection) {
     throw notFound("Custody Connection");
@@ -1038,57 +1065,6 @@ export function mapProviderCredential(row: ProviderCredentialRow): SafeProviderC
     createdAt: row.created_at,
     displayMetadata: appIdSuffix ? { appIdSuffix } : {},
   };
-}
-
-async function compensateSecretWrite(
-  c: Context<{ Bindings: Env }>,
-  store: CredentialSecretStore,
-  stored: StoredCredentialSecret,
-  providerCredentialId: string
-): Promise<CompensationOutcome> {
-  if (stored.storageBackend !== "gcp_secret_manager" || !stored.secretVersionRef) {
-    return "not_required";
-  }
-
-  try {
-    await store.destroyVersion({ secretVersionRef: stored.secretVersionRef });
-  } catch {
-    logOrphanRisk({
-      providerCredentialId,
-      storageBackend: stored.storageBackend,
-      providerResourceVersion: parseProviderResourceVersion(stored.secretVersionRef),
-      requestId: c.get("requestId"),
-      reason: "secret_cleanup_failed",
-    });
-    // The pre-commit queue row for this version is still standing (only the
-    // committing transaction clears it), so the sweeper retries this destroy;
-    // "failed" reports this request's own attempt, not the version's fate.
-    return "failed";
-  }
-  // Destroyed: discharge the provisional obligation recorded before the
-  // transaction was attempted. Best effort — a row left behind costs one
-  // sweep that finds the version already gone.
-  await destroySecretVersionObligation(c.env, stored.secretVersionRef);
-  return "succeeded";
-}
-
-async function destroySecretVersionObligation(env: Env, secretVersionRef: string): Promise<void> {
-  try {
-    await createWorkflowSecretRetirementsRepository(env).deleteRetirementByVersionRef(
-      secretVersionRef
-    );
-  } catch {
-    // The sweeper reconciles it: a destroyed version reads as FAILED_PRECONDITION,
-    // which the sweep treats as success.
-  }
-}
-
-function parseProviderResourceVersion(secretVersionRef: string): number | undefined {
-  const value = secretVersionRef.split("/").at(-1);
-  if (!value || !/^[1-9][0-9]*$/.test(value)) {
-    return undefined;
-  }
-  return Number(value);
 }
 
 function logOrphanRisk(params: {

--- a/apps/sdp-api/src/services/provider-setup-registry.ts
+++ b/apps/sdp-api/src/services/provider-setup-registry.ts
@@ -61,8 +61,8 @@ const privyCredentialFieldsSchema = z
   .object({
     credentialLabel: z.string().trim().min(1),
     scope: z.literal("project"),
-    appId: z.string().trim().min(1),
-    appSecret: z.string().min(1),
+    appId: z.string().trim().min(1).max(4096),
+    appSecret: z.string().min(1).max(4096),
   })
   .strict();
 

--- a/apps/sdp-api/src/services/stores/provider-credential-secret-cleanup.store.ts
+++ b/apps/sdp-api/src/services/stores/provider-credential-secret-cleanup.store.ts
@@ -1,0 +1,193 @@
+import type { DatabaseExecutor } from "@/db";
+
+export interface RetainedProviderCredentialSecretRow {
+  id: string;
+  organization_id: string;
+  provider: string;
+  storage_backend: "encrypted_db" | "gcp_secret_manager";
+  status: string;
+  secret_ref: string | null;
+  secret_version_ref: string | null;
+  secret_retention_expires_at: string | null;
+}
+
+export interface CredentialSecretContainerRow {
+  id: string;
+  organization_id: string;
+  secret_ref: string;
+}
+
+const UNREFERENCED = `NOT EXISTS (
+  SELECT 1 FROM custody_connections c
+  WHERE c.provider_credential_id = pc.id AND c.status <> 'deactivated'
+)`;
+// Failed installation keeps its connection for replacement/history, but its
+// rejected stored Credential is immutable and must no longer retain a payload.
+const GCP_UNREFERENCED = `NOT EXISTS (
+  SELECT 1 FROM custody_connections c
+  WHERE c.provider_credential_id = pc.id AND c.status <> 'deactivated'
+    AND NOT (pc.status = 'failed_validation' AND c.status = 'failed')
+)`;
+const RETENTION_DUE = `(pc.secret_retention_expires_at::timestamptz <= clock_timestamp()
+  OR NOT EXISTS (SELECT 1 FROM provider_credentials child
+    WHERE child.rotated_from_provider_credential_id = pc.id AND child.status = 'active'))`;
+const GCP_TERMINAL = `(pc.status IN ('failed_validation', 'deactivated')
+  OR (pc.status = 'retired' AND (pc.secret_retention_expires_at IS NULL OR ${RETENTION_DUE})))`;
+const COLUMNS = `pc.id, pc.organization_id, pc.provider, pc.storage_backend, pc.status,
+  pc.secret_ref, pc.secret_version_ref, pc.secret_retention_expires_at`;
+
+export class ProviderCredentialSecretCleanupStore {
+  constructor(private readonly db: DatabaseExecutor) {}
+
+  async listDueEncrypted(limit: number): Promise<RetainedProviderCredentialSecretRow[]> {
+    return this.db.queryMany(
+      `SELECT ${COLUMNS} FROM provider_credentials pc
+       WHERE pc.source = 'stored' AND pc.storage_backend = 'encrypted_db'
+         AND pc.status = 'retired' AND pc.secret_retention_expires_at IS NOT NULL
+         AND ${RETENTION_DUE} AND ${UNREFERENCED}
+       ORDER BY pc.updated_at, pc.id LIMIT ?`,
+      [limit]
+    );
+  }
+
+  async cleanupEncryptedDb(params: {
+    id: string;
+    expectedRetentionExpiresAt: string;
+  }): Promise<boolean> {
+    return (
+      (await this.db.execute(
+        `UPDATE provider_credentials pc SET encrypted_secret_payload = NULL,
+         secret_retention_expires_at = NULL, updated_at = sdp_iso_now()
+       WHERE pc.id = ? AND pc.source = 'stored' AND pc.storage_backend = 'encrypted_db'
+         AND pc.status = 'retired' AND pc.secret_retention_expires_at = ?
+         AND ${RETENTION_DUE} AND ${UNREFERENCED}`,
+        [params.id, params.expectedRetentionExpiresAt]
+      )) === 1
+    );
+  }
+
+  async listDueContainers(now: Date, limit: number): Promise<CredentialSecretContainerRow[]> {
+    return this.db.queryMany(
+      `SELECT id, organization_id, secret_ref FROM provider_credentials
+       WHERE provider = 'privy' AND source = 'stored' AND storage_backend = 'gcp_secret_manager'
+         AND secret_next_scan_at <= ?::timestamptz
+       ORDER BY secret_next_scan_at, id LIMIT ?`,
+      [now.toISOString(), limit]
+    );
+  }
+
+  async advanceContainerScan(owner: CredentialSecretContainerRow, now: Date): Promise<boolean> {
+    const next = new Date(now.getTime() + 5 * 60_000).toISOString();
+    return (
+      (await this.db.execute(
+        `UPDATE provider_credentials SET secret_next_scan_at = ?::timestamptz
+       WHERE id = ? AND organization_id = ? AND secret_ref = ?
+         AND provider = 'privy' AND source = 'stored' AND storage_backend = 'gcp_secret_manager'
+         AND secret_next_scan_at <= ?::timestamptz`,
+        [next, owner.id, owner.organization_id, owner.secret_ref, now.toISOString()]
+      )) === 1
+    );
+  }
+
+  async cancelStaleCreations(owner: CredentialSecretContainerRow): Promise<void> {
+    // Two minutes permits cancellation; it does not prove GCP has stopped.
+    await this.db.execute(
+      `UPDATE provider_credentials pc SET status = 'deactivated',
+         deactivated_at = sdp_iso_now(), last_failed_at = sdp_iso_now(),
+         last_failure_code = 'secret_creation_abandoned',
+         secret_retention_expires_at = sdp_iso_now(), updated_at = sdp_iso_now()
+       WHERE pc.organization_id = ? AND pc.secret_ref = ? AND pc.provider = 'privy'
+         AND pc.source = 'stored' AND pc.storage_backend = 'gcp_secret_manager'
+         AND pc.status = 'creating'
+         AND pc.created_at::timestamptz <= clock_timestamp() - interval '2 minutes'
+         AND ${UNREFERENCED}`,
+      [owner.organization_id, owner.secret_ref]
+    );
+  }
+
+  async listContainerCredentials(
+    secretRef: string
+  ): Promise<RetainedProviderCredentialSecretRow[]> {
+    // Deliberately includes every reference, not just active rows or the owner.
+    return this.db.queryMany(
+      `SELECT ${COLUMNS} FROM provider_credentials pc WHERE secret_ref = ?`,
+      [secretRef]
+    );
+  }
+
+  async listPendingDestructions(
+    owner: CredentialSecretContainerRow,
+    limit: number
+  ): Promise<RetainedProviderCredentialSecretRow[]> {
+    return this.db.queryMany(
+      `SELECT ${COLUMNS} FROM provider_credentials pc
+       WHERE pc.organization_id = ? AND pc.secret_ref = ? AND pc.provider = 'privy'
+         AND pc.source = 'stored' AND pc.storage_backend = 'gcp_secret_manager'
+         AND pc.secret_version_ref IS NOT NULL AND pc.secret_retention_expires_at IS NOT NULL
+         AND ${GCP_TERMINAL} AND ${GCP_UNREFERENCED}
+       ORDER BY pc.updated_at, pc.id LIMIT ?`,
+      [owner.organization_id, owner.secret_ref, limit]
+    );
+  }
+
+  async fenceGcpCleanupCandidate(params: {
+    id: string;
+    expectedSecretVersionRef: string;
+  }): Promise<RetainedProviderCredentialSecretRow | null> {
+    return this.db.queryOne(
+      `UPDATE provider_credentials pc SET updated_at = sdp_iso_now()
+       WHERE pc.id = ? AND pc.provider = 'privy' AND pc.source = 'stored'
+         AND pc.storage_backend = 'gcp_secret_manager' AND pc.secret_version_ref = ?
+         AND ${GCP_TERMINAL} AND ${GCP_UNREFERENCED}
+         AND NOT EXISTS (SELECT 1 FROM provider_credentials other
+           WHERE other.id <> pc.id
+             AND regexp_replace(other.secret_version_ref, '^projects/[^/]+/', '') =
+                 regexp_replace(pc.secret_version_ref, '^projects/[^/]+/', ''))
+       RETURNING ${COLUMNS}`,
+      [params.id, params.expectedSecretVersionRef]
+    );
+  }
+
+  async clearGcpRetentionMarker(params: {
+    id: string;
+    expectedRetentionExpiresAt: string | null;
+    expectedSecretVersionRef: string;
+  }): Promise<boolean> {
+    if (params.expectedRetentionExpiresAt === null) return true;
+    return (
+      (await this.db.execute(
+        `UPDATE provider_credentials pc SET secret_retention_expires_at = NULL,
+         secret_cleanup_next_attempt_at = NULL, updated_at = sdp_iso_now()
+       WHERE pc.id = ? AND pc.provider = 'privy' AND pc.source = 'stored'
+         AND pc.storage_backend = 'gcp_secret_manager' AND pc.secret_version_ref = ?
+         AND pc.secret_retention_expires_at = ? AND ${GCP_TERMINAL} AND ${GCP_UNREFERENCED}`,
+        [params.id, params.expectedSecretVersionRef, params.expectedRetentionExpiresAt]
+      )) === 1
+    );
+  }
+
+  async recordAcknowledgedGcpVersion(params: {
+    id: string;
+    secretRef: string;
+    secretVersionRef: string;
+  }): Promise<void> {
+    // Only the writer's exact acknowledgement can bind a version to an attempt.
+    // Clear legacy absence fields when late positive evidence disproves them;
+    // existing observations remain historical, not a parallel cleanup protocol.
+    const changed = await this.db.execute(
+      `UPDATE provider_credentials SET
+         secret_retention_expires_at = CASE WHEN secret_version_ref IS NULL
+           THEN COALESCE(secret_retention_expires_at, sdp_iso_now()) ELSE secret_retention_expires_at END,
+         secret_cleanup_outcome = CASE WHEN secret_version_ref IS NULL THEN NULL ELSE secret_cleanup_outcome END,
+         secret_cleanup_absent_since = CASE WHEN secret_version_ref IS NULL THEN NULL ELSE secret_cleanup_absent_since END,
+         secret_version_ref = COALESCE(secret_version_ref, ?), updated_at = sdp_iso_now()
+       WHERE id = ? AND secret_ref = ? AND provider = 'privy' AND source = 'stored'
+         AND storage_backend = 'gcp_secret_manager' AND status = 'deactivated'
+         AND last_failure_code = 'secret_creation_abandoned'
+         AND (secret_version_ref IS NULL OR secret_version_ref = ?)`,
+      [params.secretVersionRef, params.id, params.secretRef, params.secretVersionRef]
+    );
+    if (changed !== 1)
+      throw new Error("Abandoned Credential changed while recording its acknowledged version");
+  }
+}

--- a/apps/sdp-api/src/services/stores/provider-credential.store.ts
+++ b/apps/sdp-api/src/services/stores/provider-credential.store.ts
@@ -4,6 +4,7 @@ import { parsePostgresJsonOr } from "@/db/postgres-utils";
 import type { StoredCredentialSecret } from "@/services/credential-secret-store";
 
 export type ProviderCredentialStatus =
+  | "creating"
   | "pending"
   | "active"
   | "failed_validation"
@@ -27,7 +28,17 @@ export interface ProviderCredentialRow {
   rotated_from_provider_credential_id: string | null;
   idempotency_key: string | null;
   idempotency_fingerprint: string | null;
+  last_failure_code: string | null;
   created_at: string;
+}
+
+export interface LifecycleCredentialRow extends ProviderCredentialRow {
+  source: "stored" | "runtime";
+  storage_backend: StoredCredentialSecret["storageBackend"];
+  deactivated_at: string | null;
+  last_validated_at: string | null;
+  last_failed_at: string | null;
+  secret_retention_expires_at: string | null;
 }
 
 export interface CustodyConnectionRow {
@@ -95,6 +106,26 @@ export interface InstallationConnectionState extends CustodyConnectionRow {
   is_selected: boolean;
 }
 
+const CREATING_SUBMISSION = `creating.status = 'creating'
+  AND (creating.rotated_from_provider_credential_id IS NULL OR EXISTS (
+    SELECT 1 FROM provider_credentials predecessor
+    WHERE predecessor.id = creating.rotated_from_provider_credential_id
+      AND predecessor.status = 'failed_validation'
+  ))`;
+
+const CREDENTIAL_LINEAGE_SQL = `WITH RECURSIVE credential_lineage(id, rotated_from_provider_credential_id, credential_version) AS (
+  SELECT id, rotated_from_provider_credential_id, credential_version
+  FROM provider_credentials
+  WHERE id = ? AND organization_id = ? AND provider = 'privy'
+  UNION
+  SELECT related.id, related.rotated_from_provider_credential_id, related.credential_version
+  FROM provider_credentials related
+  JOIN credential_lineage member
+    ON related.rotated_from_provider_credential_id = member.id
+    OR related.id = member.rotated_from_provider_credential_id
+  WHERE related.organization_id = ? AND related.provider = 'privy'
+)`;
+
 export class ProviderCredentialStore {
   constructor(private readonly db: DatabaseExecutor) {}
 
@@ -116,7 +147,7 @@ export class ProviderCredentialStore {
       `SELECT id, organization_id, project_id, provider, label, scope, scope_key,
               display_metadata, status, credential_version,
               rotated_from_provider_credential_id, idempotency_key,
-              idempotency_fingerprint, created_at
+              idempotency_fingerprint, last_failure_code, created_at
        FROM provider_credentials
        WHERE organization_id = ? AND idempotency_key = ?`,
       [organizationId, idempotencyKey]
@@ -169,12 +200,52 @@ export class ProviderCredentialStore {
       `SELECT id, organization_id, project_id, provider, label, scope, scope_key,
               display_metadata, status, credential_version,
               rotated_from_provider_credential_id, idempotency_key,
-              idempotency_fingerprint, created_at
+              idempotency_fingerprint, last_failure_code, created_at
        FROM provider_credentials
        WHERE id = ?
        ${options.lock ? "FOR UPDATE" : ""}`,
       [id]
     );
+  }
+
+  async findLifecycleCredential(
+    organizationId: string,
+    id: string,
+    options: { lock?: boolean } = {}
+  ): Promise<LifecycleCredentialRow | null> {
+    return this.db.queryOne<LifecycleCredentialRow>(
+      `SELECT id, organization_id, project_id, provider, label, scope, scope_key,
+              source, storage_backend, display_metadata, status, credential_version,
+              rotated_from_provider_credential_id, idempotency_key,
+              idempotency_fingerprint, deactivated_at, last_validated_at,
+              last_failed_at, last_failure_code, secret_retention_expires_at, created_at
+       FROM provider_credentials
+       WHERE id = ? AND organization_id = ? AND provider = 'privy'
+       ${options.lock ? "FOR UPDATE" : ""}`,
+      [id, organizationId]
+    );
+  }
+
+  async findGcpContainerRef(organizationId: string, credentialId: string): Promise<string | null> {
+    const row = await this.db.queryOne<{ secret_ref: string }>(
+      `SELECT secret_ref FROM provider_credentials
+       WHERE id = ? AND organization_id = ? AND provider = 'privy'
+         AND source = 'stored' AND storage_backend = 'gcp_secret_manager'
+         AND secret_ref IS NOT NULL AND secret_version_ref IS NOT NULL`,
+      [credentialId, organizationId]
+    );
+    return row?.secret_ref ?? null;
+  }
+
+  /** The caller holds the existing Project/current-Credential admission locks. */
+  async nextCredentialVersion(organizationId: string, predecessorId: string): Promise<number> {
+    const row = await this.db.queryOne<{ next_version: number | null }>(
+      `${CREDENTIAL_LINEAGE_SQL}
+       SELECT MAX(credential_version) + 1 AS next_version FROM credential_lineage`,
+      [predecessorId, organizationId, organizationId]
+    );
+    if (!row || row.next_version === null) throw new Error("Credential lineage was not found");
+    return row.next_version;
   }
 
   /**
@@ -279,7 +350,7 @@ export class ProviderCredentialStore {
     organizationId: string,
     projectId: string,
     connectionId: string,
-    options: { lock?: boolean } = {}
+    options: { lock?: boolean; excludedCreatingCredentialId?: string } = {}
   ): Promise<InstallationConnectionState | null> {
     return this.db.queryOne<InstallationConnectionState>(
       `SELECT c.id, c.organization_id, c.project_id, c.provider, c.scope,
@@ -304,14 +375,21 @@ export class ProviderCredentialStore {
                 SELECT 1 FROM custody_wallets owned
                 WHERE owned.custody_connection_id = c.id
               ) AS has_owned_wallet,
-              EXISTS (
+              (EXISTS (
                 SELECT 1 FROM custody_connections sibling
                 WHERE sibling.organization_id = c.organization_id
                   AND sibling.project_id = c.project_id
                   AND sibling.provider = c.provider
                   AND sibling.id <> c.id
                   AND sibling.status IN ('pending', 'checking')
-              ) AS has_sibling_unfinished,
+              ) OR EXISTS (
+                SELECT 1 FROM provider_credentials creating
+                WHERE creating.organization_id = c.organization_id
+                  AND creating.project_id = c.project_id
+                  AND creating.provider = c.provider
+                  AND creating.id IS DISTINCT FROM ?
+                  AND ${CREATING_SUBMISSION}
+              )) AS has_sibling_unfinished,
               EXISTS (
                 SELECT 1 FROM custody_scope_defaults selected
                 WHERE selected.organization_id = c.organization_id
@@ -325,7 +403,7 @@ export class ProviderCredentialStore {
          AND c.project_id = ?
          AND c.provider = 'privy'
        ${options.lock ? "FOR UPDATE OF c, pc" : ""}`,
-      [connectionId, organizationId, projectId]
+      [options.excludedCreatingCredentialId ?? null, connectionId, organizationId, projectId]
     );
   }
 
@@ -424,6 +502,13 @@ export class ProviderCredentialStore {
              AND sibling.provider = c.provider
              AND sibling.id <> c.id
              AND sibling.status IN ('pending', 'checking')
+         )
+         AND NOT EXISTS (
+           SELECT 1 FROM provider_credentials creating
+           WHERE creating.organization_id = c.organization_id
+             AND creating.project_id = c.project_id
+             AND creating.provider = c.provider
+             AND ${CREATING_SUBMISSION}
          )
          AND EXISTS (
            SELECT 1 FROM provider_credentials pc
@@ -546,7 +631,7 @@ export class ProviderCredentialStore {
        RETURNING id, organization_id, project_id, provider, label, scope, scope_key,
                  display_metadata, status, credential_version,
                  rotated_from_provider_credential_id, idempotency_key,
-                 idempotency_fingerprint, created_at`,
+                 idempotency_fingerprint, last_failure_code, created_at`,
       [params.providerCredentialId]
     );
   }
@@ -593,7 +678,7 @@ export class ProviderCredentialStore {
        RETURNING id, organization_id, project_id, provider, label, scope, scope_key,
                  display_metadata, status, credential_version,
                  rotated_from_provider_credential_id, idempotency_key,
-                 idempotency_fingerprint, created_at`,
+                 idempotency_fingerprint, last_failure_code, created_at`,
       [params.failureCode, params.providerCredentialId]
     );
     if (!credential) {
@@ -705,6 +790,7 @@ export class ProviderCredentialStore {
     label: string;
     scope: "organization" | "project";
     source: "stored" | "runtime";
+    status?: "creating" | "pending";
     stored: StoredCredentialSecret;
     displayMetadata: Record<string, string>;
     version: number;
@@ -712,6 +798,7 @@ export class ProviderCredentialStore {
     idempotencyKey: string;
     idempotencyFingerprint: string;
     createdBy: string;
+    ownsGcpContainer?: boolean;
   }): Promise<ProviderCredentialRow> {
     const scopeKey = params.scope === "organization" ? "__organization__" : params.projectId;
     const row = await this.db.queryOne<ProviderCredentialRow>(
@@ -720,15 +807,15 @@ export class ProviderCredentialStore {
          storage_backend, secret_ref, secret_version_ref, encrypted_secret_payload,
          display_metadata, status, credential_version,
          rotated_from_provider_credential_id, idempotency_key,
-         idempotency_fingerprint, created_by
+         idempotency_fingerprint, created_by, secret_next_scan_at
        ) VALUES (
          ?, ?, ?, ?, ?, ?, ?,
-         ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?
+         ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CASE WHEN ? THEN clock_timestamp() ELSE NULL END
        )
        RETURNING id, organization_id, project_id, provider, label, scope, scope_key,
                  display_metadata, status, credential_version,
                  rotated_from_provider_credential_id, idempotency_key,
-                 idempotency_fingerprint, created_at`,
+                 idempotency_fingerprint, last_failure_code, created_at`,
       [
         params.id,
         params.organizationId,
@@ -742,11 +829,13 @@ export class ProviderCredentialStore {
         params.stored.secretVersionRef ?? null,
         params.stored.encryptedSecretPayload ?? null,
         JSON.stringify(params.displayMetadata),
+        params.status ?? "pending",
         params.version,
         params.rotatedFromId,
         params.idempotencyKey,
         params.idempotencyFingerprint,
         params.createdBy,
+        params.ownsGcpContainer ?? false,
       ]
     );
 
@@ -754,6 +843,66 @@ export class ProviderCredentialStore {
       throw new Error("Provider credential insert did not return the expected scope");
     }
     return row;
+  }
+
+  async findCreatingSubmission(
+    organizationId: string,
+    projectId: string
+  ): Promise<ProviderCredentialRow | null> {
+    return this.db.queryOne<ProviderCredentialRow>(
+      `SELECT creating.id, creating.organization_id, creating.project_id, creating.provider,
+              creating.label, creating.scope, creating.scope_key, creating.display_metadata,
+              creating.status, creating.credential_version, creating.rotated_from_provider_credential_id,
+              creating.idempotency_key, creating.idempotency_fingerprint,
+              creating.last_failure_code, creating.created_at
+       FROM provider_credentials creating
+       WHERE creating.organization_id = ? AND creating.project_id = ? AND creating.provider = 'privy'
+         AND ${CREATING_SUBMISSION}
+       ORDER BY creating.created_at, creating.id LIMIT 1`,
+      [organizationId, projectId]
+    );
+  }
+
+  async finalizeCredentialCreation(params: {
+    organizationId: string;
+    credentialId: string;
+    secretRef: string;
+    secretVersionRef: string;
+  }): Promise<ProviderCredentialRow | null> {
+    if (!params.secretVersionRef.trim()) return null;
+    return this.db.queryOne<ProviderCredentialRow>(
+      `UPDATE provider_credentials
+       SET status = 'pending', secret_version_ref = ?, updated_at = sdp_iso_now()
+       WHERE id = ? AND organization_id = ? AND provider = 'privy'
+         AND status = 'creating' AND source = 'stored' AND storage_backend = 'gcp_secret_manager'
+         AND secret_ref = ? AND secret_version_ref IS NULL
+       RETURNING id, organization_id, project_id, provider, label, scope, scope_key,
+                 display_metadata, status, credential_version,
+                 rotated_from_provider_credential_id, idempotency_key,
+                 idempotency_fingerprint, last_failure_code, created_at`,
+      [params.secretVersionRef, params.credentialId, params.organizationId, params.secretRef]
+    );
+  }
+
+  async abandonCredentialCreation(params: {
+    organizationId: string;
+    credentialId: string;
+  }): Promise<boolean> {
+    return (
+      (await this.db.execute(
+        `UPDATE provider_credentials pc
+         SET status = 'deactivated', deactivated_at = sdp_iso_now(),
+             last_failed_at = sdp_iso_now(), last_failure_code = 'secret_creation_abandoned',
+             secret_retention_expires_at = sdp_iso_now(), updated_at = sdp_iso_now()
+         WHERE pc.id = ? AND pc.organization_id = ? AND pc.provider = 'privy'
+           AND pc.status = 'creating' AND pc.storage_backend = 'gcp_secret_manager'
+           AND NOT EXISTS (
+             SELECT 1 FROM custody_connections c
+             WHERE c.provider_credential_id = pc.id AND c.status <> 'deactivated'
+           )`,
+        [params.credentialId, params.organizationId]
+      )) === 1
+    );
   }
 
   async insertConnection(params: {

--- a/packages/sdp-types/src/custody.ts
+++ b/packages/sdp-types/src/custody.ts
@@ -730,6 +730,7 @@ export type CustodyConnectionFailureCode = (typeof CUSTODY_CONNECTION_FAILURE_CO
 
 /** Lifecycle of the stored provider credential backing a connection. */
 export const PROVIDER_CREDENTIAL_STATUSES = [
+  "creating",
   "pending",
   "active",
   "failed_validation",


### PR DESCRIPTION
**What changed**

- Persist a `creating` Credential and its intended GCP location before writing the secret during setup or replacement.
- Finalize the Credential with the exact acknowledged GCP version, preserving recoverable state when a write or database commit has an unknown outcome.
- Reuse the predecessor's GCP container for GCP-backed replacements, while retaining a separate Credential ID and exact version reference for each attempt.
- Add recurring cleanup for retained secrets and unreferenced GCP versions, with one persisted scan schedule per container.
- Bound GCP requests, verify failed destroy outcomes, and require confirmed destruction before custody cleanup clears its marker.

**Why**

Writing to GCP before recording the attempt in PostgreSQL could leave a live secret without a durable recovery record.

Recurring container inventory also handles versions whose write responses were lost and which become visible after the original request has failed.

**Impact**

Existing setup and replacement use the new GCP persistence protocol. Managed secret payloads remain in GCP; the existing encrypted-database backend remains supported.

Migrations `0080`, `0082`, `0083`, and `0084` add Credential creation, retention, cleanup metadata, and container scheduling state.

Privy `appId` and `appSecret` now have a 4,096-character limit, enforced before secret-store I/O.

Cleanup is integrated into the existing managed job and self-hosted cron. Managed cleanup runs alongside the existing reconciliation sequence; both settle before collected failures are reported.

**Pre/post release actions**

1. Apply the included migrations before deploying the new writers and cleanup code.
2. Before managed rollout, confirm version inventory and metadata access (`secretmanager.versions.list` and `secretmanager.versions.get`), alongside the existing secret read/write/destroy permissions.
3. After rollout, monitor cleanup failures, deferred scans, and confirmed-destruction logs. Validate setup/replacement recovery in an isolated GCP environment.

**Result Validation**

- `pnpm --filter @sdp/api typecheck` and `pnpm --filter @sdp/api build` — passed.
- 315 targeted tests — passed, covering migrations, setup/replacement, lost responses, cleanup races, scheduling, RPC, workflow retirement, and job integration.
- Migration tests ran against test PostgreSQL.

**Does it affect current flows & behavior and how**

**Before — GCP:** write the secret → insert the Credential/Connection → attempt immediate compensation if persistence fails.

**After — GCP:**

1. Commit the Credential reservation and, for a new container, its scan schedule.
2. Write one GCP version.
3. Persist its exact reference and finalize the pending Credential and Connection.
4. On failure, reconcile the result or retain durable recovery work. A canceled writer cannot finalize later.

Each scan cancels stale creation attempts, reads version metadata, and refreshes database references after each inventory page.

Active/pending credentials, versions still required by Connections, and eligible rollback predecessors are protected. A failed Connection retained after rejected installation does not prevent cleanup of the rejected secret.

Empty inventory or a first-page `404` does not stop future scans. Backend changes can create another container; each existing container keeps its own scan owner.

RPC and workflow do not adopt custody's shared-container reconciliation. Their shared GCP client does gain 10-second per-request timeouts. Successful destroy requests retain their previous default semantics; failed requests are accepted only if the exact version is confirmed `DESTROYED`. Workflow retirement no longer treats `FAILED_PRECONDITION` alone as proof of destruction.

**Known gaps**

- Cleanup does not delete GCP containers or revoke credentials at the provider.
- The cleanup deadline bounds admission and HTTP work, not an outstanding SQL wait.
- Repeated slow destruction attempts can delay inventory within a container. Its persisted schedule remains available for later scans.
- Real GCP behavior and permissions remain unverified.

**Notes**

Part 2 of 4, based on the entitlement PR. Existing setup/replacement are its immediate consumers; rotation and rollback arrive in the next PR.

Container scanning uses a fixed five-minute revisit schedule, not an assumed-absence cutoff.