### PR TITLE
fix(ci): pass turbo --cache-dir so the runner cache actually persists

### DIFF
--- a/scripts/run-workspace-tests.mjs
+++ b/scripts/run-workspace-tests.mjs
@@ -120,11 +120,13 @@ try {
             : changedSince
               ? [`--filter=...[${changedSince}]`, "--filter=!@sdp/api-integration"]
               : ["--filter=!@sdp/api-integration"];
+    const cacheDir = process.env.TURBO_CACHE_DIR?.trim();
     await run("pnpm", [
       "exec",
       "turbo",
       "run",
       "test",
+      ...(cacheDir ? [`--cache-dir=${cacheDir}`] : []),
       ...filters,
       ...(forwardedArgs.length > 0 ? ["--", ...forwardedArgs] : []),
     ]);


### PR DESCRIPTION
Unit tests re-ran the full `@sdp/api` suite on every job even when nothing in its graph changed, because turbo never had a persistent cache: the default cache lives inside the job workspace (wiped by every checkout), and turbo 2.10 **ignores the `TURBO_CACHE_DIR` env var** — verified: `/opt/turbo-cache` on the runner stayed empty with the env set; the CLI only exposes `--cache-dir`.

- `run-workspace-tests.mjs` now passes `--cache-dir=$TURBO_CACHE_DIR` when the env var is set (it is, in the self-hosted runner's `.env`). Unchanged packages replay from cache (`FULL TURBO`) instead of re-running — a no-code-change PR's unit tests drop from ~4–19 min to seconds after the first cache-populating run.
- GitHub-hosted (fork) runs have no such env var and keep today's cold behavior.
- Cache correctness is turbo's content hashing: package sources + `globalEnv` values (stable per Doppler config) — it re-runs exactly when `@sdp/api`'s graph actually changes.

**Verification**
- `turbo run test --filter=@sdp/api --cache-dir=/opt/turbo-cache --dry=json` on the runner: task cacheable, deterministic hash, status MISS (nothing populated yet — this PR is what makes population possible)
- `node --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)