### PR TITLE
ci(tests): drop unused postgres/redis service containers from the unit-test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,33 +181,8 @@ jobs:
     env:
       CI_HAS_DOPPLER_TOKEN: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       TEST_WORKSPACE_SPLIT: api
-      TEST_DATABASE_URL: postgresql://sdp:sdp@127.0.0.1:5432/sdp_test
-      REDIS_URL: redis://127.0.0.1:6379
       TEST_CHANGED_SINCE: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || '' }}
-      DOPPLER_PRESERVE_ENV: TEST_DATABASE_URL,REDIS_URL,TEST_CHANGED_SINCE,TEST_WORKSPACE_SPLIT
-    services:
-      postgres:
-        image: postgres:16-alpine
-        env:
-          POSTGRES_DB: sdp
-          POSTGRES_USER: sdp
-          POSTGRES_PASSWORD: sdp
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U sdp -d sdp"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 20
-      redis:
-        image: redis:7-alpine
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 20
+      DOPPLER_PRESERVE_ENV: TEST_CHANGED_SINCE,TEST_WORKSPACE_SPLIT
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -269,33 +244,8 @@ jobs:
     env:
       CI_HAS_DOPPLER_TOKEN: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       TEST_WORKSPACE_SPLIT: rest
-      TEST_DATABASE_URL: postgresql://sdp:sdp@127.0.0.1:5432/sdp_test
-      REDIS_URL: redis://127.0.0.1:6379
       TEST_CHANGED_SINCE: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || '' }}
-      DOPPLER_PRESERVE_ENV: TEST_DATABASE_URL,REDIS_URL,TEST_CHANGED_SINCE,TEST_WORKSPACE_SPLIT
-    services:
-      postgres:
-        image: postgres:16-alpine
-        env:
-          POSTGRES_DB: sdp
-          POSTGRES_USER: sdp
-          POSTGRES_PASSWORD: sdp
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U sdp -d sdp"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 20
-      redis:
-        image: redis:7-alpine
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 20
+      DOPPLER_PRESERVE_ENV: TEST_CHANGED_SINCE,TEST_WORKSPACE_SPLIT
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
- The `test` and `test_packages` jobs no longer start postgres/redis service containers or export `TEST_DATABASE_URL`/`REDIS_URL`; nothing in either split reads them.
- `@sdp/api` unit tests provision their own postgres+redis via testcontainers on random host ports in vitest global setup (`apps/sdp-api/src/test/node-global-setup.ts`), which overwrites both variables before any test runs and clones one database per vitest worker.
- The `rest` split has no database consumer: no package outside `@sdp/api` / `@sdp/api-integration` reads `TEST_DATABASE_URL` or `REDIS_URL`.
- Fixes the warm-runner startup collision and stops publishing postgres with static `sdp/sdp` credentials on `0.0.0.0`.
- `integration_tests_shard` and `browser_e2e` keep their service containers: they run on `ubuntu-latest`, and their tests genuinely connect to them.

**before** — unit-test job startup on the warm `sdp-ci` runner:

1. Actions creates postgres/redis service containers published on fixed host ports `5432`/`6379`, bound to `0.0.0.0`.
2. A concurrent unit-test job — or a container left by a cancelled run — already holds `5432`, so `docker start` fails: `Bind for 0.0.0.0:5432 failed: port is already allocated`.
3. The job dies before checkout. Even on success the containers sat idle: vitest global setup overwrites `TEST_DATABASE_URL`/`REDIS_URL` with its own testcontainers before any test connects.

**after** — same job:

1. No service containers; the job goes straight to checkout.
2. `@sdp/api` global setup starts job-private postgres+redis testcontainers on random ports, runs migrations, and clones per-worker databases — unchanged, now the only database in play.
3. Concurrent jobs cannot collide (no fixed host ports), and no database listens on the VM's external interfaces.

**Verification**

- `node -e "yaml.parse(...ci.yml)"` — parses clean.
- `grep -rn "TEST_DATABASE_URL\|REDIS_URL"` across `apps`/`packages`/`scripts` — consumers are only `apps/sdp-api/src/test/*` (overwritten by testcontainers) and `packages/sdp-api-integration` (excluded from both unit splits).
- This PR's own `test` / `test_packages` runs exercise the change end-to-end on the self-hosted runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)