### PR TITLE
feat(custody): add Privy credential rotation and rollback

### DIFF
--- a/apps/sdp-api/src/routes/custody-connection-wallets.test.ts
+++ b/apps/sdp-api/src/routes/custody-connection-wallets.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
 import app from "@/index";
 import { getLogger } from "@/runtime/logger";
+import { createCredentialSecretStore } from "@/services/credential-secret-store";
 import { getPrivyProviderAccountFingerprint } from "@/services/custody/privy-credential";
 import * as custodyProvisioning from "@/services/custody/provisioning";
 import { CustodyRuntimeTargets } from "@/services/domain/signing/custody-runtime-target";
@@ -47,6 +48,7 @@ const originalEnv = {
   byok: env.PRIVY_BYOK_ENABLED,
   appId: env.PRIVY_APP_ID,
   appSecret: env.PRIVY_APP_SECRET,
+  encryptionKey: env.CUSTODY_ENCRYPTION_KEY,
 };
 
 async function seedFixture(): Promise<void> {
@@ -166,6 +168,7 @@ describe("Connection-owned wallet control plane", () => {
     env.PRIVY_BYOK_ENABLED = originalEnv.byok;
     env.PRIVY_APP_ID = originalEnv.appId;
     env.PRIVY_APP_SECRET = originalEnv.appSecret;
+    env.CUSTODY_ENCRYPTION_KEY = originalEnv.encryptionKey;
     await clearKVStores(env);
   });
 
@@ -238,6 +241,104 @@ describe("Connection-owned wallet control plane", () => {
         .bind(CONNECTION_ID)
         .first()
     ).toEqual({ default_custody_wallet_id: body.data.wallet.id });
+  });
+
+  it("persists a wallet when its Connection moves to a replacement Credential during Provider creation", async () => {
+    env.CUSTODY_ENCRYPTION_KEY = Buffer.alloc(32, 19).toString("base64");
+    const secretStore = createCredentialSecretStore(env, "encrypted_db");
+    const predecessorSecret = await secretStore.write({
+      orgId: ORGANIZATION_ID,
+      provider: "privy",
+      providerCredentialId: CREDENTIAL_ID,
+      payload: {
+        appId: env.PRIVY_APP_ID as string,
+        appSecret: env.PRIVY_APP_SECRET as string,
+      },
+    });
+    await getDb(env).execute(
+      `UPDATE provider_credentials
+       SET source = 'stored', storage_backend = 'encrypted_db',
+           encrypted_secret_payload = ?, credential_version = 1
+       WHERE id = ?`,
+      [predecessorSecret.encryptedSecretPayload, CREDENTIAL_ID]
+    );
+
+    let markProviderCreationStarted!: () => void;
+    const providerCreationStarted = new Promise<void>((resolve) => {
+      markProviderCreationStarted = resolve;
+    });
+    let releaseProviderCreation!: () => void;
+    const providerCreationReleased = new Promise<void>((resolve) => {
+      releaseProviderCreation = resolve;
+    });
+    provisionPrivyWalletMock.mockImplementationOnce(async () => {
+      markProviderCreationStarted();
+      await providerCreationReleased;
+      return {
+        walletId: "rotated_credential",
+        address: "Vote111111111111111111111111111111111111111",
+      };
+    });
+
+    const creation = request("", "POST", { connectionId: CONNECTION_ID });
+    await providerCreationStarted;
+    const rotatedCredentialId = "pcred_connection_wallets_rotated";
+    const replacementSecret = await secretStore.write({
+      orgId: ORGANIZATION_ID,
+      provider: "privy",
+      providerCredentialId: rotatedCredentialId,
+      payload: {
+        appId: env.PRIVY_APP_ID as string,
+        appSecret: env.PRIVY_APP_SECRET as string,
+      },
+    });
+    try {
+      await getDb(env).transaction(async (tx) => {
+        await tx.execute(
+          `INSERT INTO provider_credentials (
+             id, organization_id, project_id, provider, label, scope, source,
+             storage_backend, encrypted_secret_payload, status, credential_version,
+             rotated_from_provider_credential_id, created_by
+           ) VALUES (?, ?, ?, 'privy', 'Rotated Privy', 'project', 'stored',
+                     'encrypted_db', ?, 'active', 2, ?, ?)`,
+          [
+            rotatedCredentialId,
+            ORGANIZATION_ID,
+            PROJECT_ID,
+            replacementSecret.encryptedSecretPayload,
+            CREDENTIAL_ID,
+            USER_ID,
+          ]
+        );
+        await tx.execute(
+          `UPDATE custody_connections
+           SET provider_credential_id = ?, updated_at = sdp_iso_now()
+           WHERE id = ?`,
+          [rotatedCredentialId, CONNECTION_ID]
+        );
+        await tx.execute(
+          `UPDATE provider_credentials
+           SET status = 'retired', secret_retention_expires_at = '2099-01-01T00:00:00.000Z',
+               updated_at = sdp_iso_now()
+           WHERE id = ?`,
+          [CREDENTIAL_ID]
+        );
+      });
+    } finally {
+      releaseProviderCreation();
+    }
+
+    const response = await creation;
+
+    expect(response.status).toBe(201);
+    expect(await response.json()).toMatchObject({
+      data: {
+        wallet: {
+          custodyConnectionId: CONNECTION_ID,
+          walletId: "privy_rotated_credential",
+        },
+      },
+    });
   });
 
   it("rejects Connection wallet creation before Provider access when entitlement is revoked", async () => {

--- a/apps/sdp-api/src/routes/internal-custody/index.ts
+++ b/apps/sdp-api/src/routes/internal-custody/index.ts
@@ -8,6 +8,7 @@ import { isCustodyConnectionRuntimeEnabled } from "@/lib/feature-flags";
 import { created, success } from "@/lib/response";
 import { credentialAdminAuthMiddleware } from "@/middleware/credential-admin-auth";
 import { idempotencyKeyMiddleware } from "@/middleware/idempotency-key";
+import { enforceMeteredQuota } from "@/middleware/metered-quota";
 import { projectContextMiddleware } from "@/middleware/project-context";
 import { getCustodySetupStatus } from "@/services/custody-setup-status.service";
 import { isCustodyConnectionRuntimeAvailable } from "@/services/domain/signing/custody-runtime-target";
@@ -16,6 +17,13 @@ import {
   isCustodyProviderEntitled,
 } from "@/services/provider-availability.service";
 import { getProviderCredentialInstallation } from "@/services/provider-credential-installation.service";
+import {
+  completeRotationCandidate,
+  deactivateRotationCandidate,
+  getProviderCredentialLifecycle,
+  rollbackProviderCredential,
+  rotateProviderCredential,
+} from "@/services/provider-credential-lifecycle.service";
 import { getProviderSetupDefinition } from "@/services/provider-setup-registry";
 import {
   getPendingWalletLabel,
@@ -24,7 +32,21 @@ import {
 import type { Env } from "@/types/env";
 
 const connectionParamsSchema = z.object({ connectionId: z.string().trim().min(1) }).strict();
+const credentialParamsSchema = z.object({ credentialId: z.string().trim().min(1) }).strict();
+const rotationBodySchema = z
+  .object({
+    fields: z
+      .object({
+        appId: z.string().trim().min(1).max(4096),
+        appSecret: z.string().min(1).max(4096),
+      })
+      .strict(),
+  })
+  .strict();
 const privySetup = getProviderSetupDefinition("custody", "privy");
+const rotationQuota = { name: "credential-rotation", actorMax: 5, orgMax: 20 };
+// Rotation retries must not consume the budget for rollback or candidate cancellation.
+const recoveryQuota = { name: "credential-recovery", actorMax: 5, orgMax: 20 };
 
 const internalCustody = new Hono<{ Bindings: Env }>();
 
@@ -153,6 +175,61 @@ internalCustody.get("/connections/:connectionId", async (c) => {
     throw badRequestParams({ errors: z.flattenError(params.error).fieldErrors });
   }
   return success(c, await getProviderCredentialInstallation(c, params.data.connectionId));
+});
+
+internalCustody.get("/connections/:connectionId/provider-credential", async (c) => {
+  const params = connectionParamsSchema.safeParse(c.req.param());
+  if (!params.success) {
+    throw badRequestParams({ errors: z.flattenError(params.error).fieldErrors });
+  }
+  return success(c, await getProviderCredentialLifecycle(c, params.data.connectionId));
+});
+
+internalCustody.post("/provider-credentials/:credentialId/rotate", async (c) => {
+  const params = credentialParamsSchema.safeParse(c.req.param());
+  if (!params.success) {
+    throw badRequestParams({ errors: z.flattenError(params.error).fieldErrors });
+  }
+  const body = rotationBodySchema.safeParse(await c.req.json().catch(() => null));
+  if (!body.success) {
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(body.error).fieldErrors,
+    });
+  }
+  const idempotencyKey = c.req.header("Idempotency-Key");
+  if (!idempotencyKey) throw badRequest("Idempotency-Key is required");
+  await enforceMeteredQuota(c, rotationQuota);
+  return success(
+    c,
+    await rotateProviderCredential(c, params.data.credentialId, body.data.fields, idempotencyKey)
+  );
+});
+
+internalCustody.post("/provider-credentials/:credentialId/complete-rotation", async (c) => {
+  const params = credentialParamsSchema.safeParse(c.req.param());
+  if (!params.success) {
+    throw badRequestParams({ errors: z.flattenError(params.error).fieldErrors });
+  }
+  await enforceMeteredQuota(c, rotationQuota);
+  return success(c, await completeRotationCandidate(c, params.data.credentialId));
+});
+
+internalCustody.post("/provider-credentials/:credentialId/rollback", async (c) => {
+  const params = credentialParamsSchema.safeParse(c.req.param());
+  if (!params.success) {
+    throw badRequestParams({ errors: z.flattenError(params.error).fieldErrors });
+  }
+  await enforceMeteredQuota(c, recoveryQuota);
+  return success(c, await rollbackProviderCredential(c, params.data.credentialId));
+});
+
+internalCustody.post("/provider-credentials/:credentialId/deactivate", async (c) => {
+  const params = credentialParamsSchema.safeParse(c.req.param());
+  if (!params.success) {
+    throw badRequestParams({ errors: z.flattenError(params.error).fieldErrors });
+  }
+  await enforceMeteredQuota(c, recoveryQuota);
+  return success(c, await deactivateRotationCandidate(c, params.data.credentialId));
 });
 
 internalCustody.post("/connections/:connectionId/complete", async (c) => {

--- a/apps/sdp-api/src/routes/internal-custody/provider-credential-lifecycle.test.ts
+++ b/apps/sdp-api/src/routes/internal-custody/provider-credential-lifecycle.test.ts
@@ -1,0 +1,2653 @@
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { getDb } from "@/db";
+import type { ClerkJwtPayload } from "@/lib/clerk-token";
+import { AppError } from "@/lib/errors";
+import { databaseIdentityBoundary } from "@/middleware/database-identity";
+import { kvStoreMiddleware } from "@/middleware/kv-store";
+import { RedisKVStore } from "@/runtime/kv-redis";
+import { getLogger } from "@/runtime/logger";
+import { createCredentialSecretStore } from "@/services/credential-secret-store";
+import { getPrivyProviderAccountFingerprint } from "@/services/custody/privy-credential";
+import { cleanupRetiredProviderCredentialSecrets } from "@/services/jobs/cleanup-provider-credential-secrets";
+import { scanGcpCredentialContainers } from "@/services/jobs/provider-credential-container-cleanup";
+import { ProviderCredentialStore } from "@/services/stores/provider-credential.store";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import { clearKVStores, seedRateLimit } from "@/test/mocks/kv";
+import type { Env } from "@/types/env";
+import internalCustody from "./index";
+
+const ORGANIZATION_ID = "org_provider_credential_lifecycle";
+const USER_ID = "usr_provider_credential_lifecycle";
+const PROJECT_A_ID = "prj_provider_credential_lifecycle_a";
+const PROJECT_B_ID = "prj_provider_credential_lifecycle_b";
+const CREDENTIAL_ID = "pcred_provider_credential_lifecycle";
+const CONNECTION_A_ID = "cconn_provider_credential_lifecycle_a";
+const CONNECTION_B_ID = "cconn_provider_credential_lifecycle_b";
+const APP_ID = "privy-lifecycle-app";
+const APP_SECRET = "privy-lifecycle-secret";
+const ORIGINAL_SECRET_BACKEND = env.CREDENTIAL_SECRET_STORE_BACKEND;
+const ORIGINAL_ENCRYPTION_KEY = env.CUSTODY_ENCRYPTION_KEY;
+const ORIGINAL_GCP_PROJECT_ID = env.GCP_SECRET_MANAGER_PROJECT_ID;
+const ORIGINAL_GCP_PREFIX = env.GCP_SECRET_MANAGER_SECRET_PREFIX;
+const ORIGINAL_GCP_API_BASE_URL = env.GCP_SECRET_MANAGER_API_BASE_URL;
+const credentialResponseSchema = z.object({
+  data: z.object({ providerCredential: z.object({ id: z.string().min(1) }) }),
+});
+
+function encodeJwtPart(value: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function buildApp() {
+  const payload: ClerkJwtPayload = {
+    sub: "clerk_provider_credential_lifecycle",
+    org_id: "clerk_org_provider_credential_lifecycle",
+    org_role: "org:admin",
+    email: "provider-credential-lifecycle@example.com",
+  };
+  const token = `${encodeJwtPart({ alg: "RS256", typ: "JWT" })}.${encodeJwtPart(payload)}.signature`;
+  const app = new Hono<{ Bindings: Env }>();
+
+  app.use("*", databaseIdentityBoundary());
+  app.use("*", kvStoreMiddleware());
+  app.use("*", async (c, next) => {
+    c.set("verifiedClerkJwt", { token, payload });
+    c.set("requestId", "req_provider_credential_lifecycle");
+    await next();
+  });
+  app.route("/internal/dashboard/custody", internalCustody);
+  app.onError((error, c) => {
+    if (error instanceof AppError) {
+      return c.json(
+        { error: error.toResponse().error, meta: { requestId: c.get("requestId") } },
+        error.statusCode as 400
+      );
+    }
+    throw error;
+  });
+
+  return { app, token };
+}
+
+async function seedProject(id: string, suffix: string, member = true): Promise<void> {
+  const db = getDb(env);
+  await db
+    .prepare(
+      `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+       VALUES (?, ?, ?, ?, 'sandbox', 'active', ?)`
+    )
+    .bind(id, ORGANIZATION_ID, `Lifecycle ${suffix}`, `lifecycle-${suffix}`, USER_ID)
+    .run();
+  if (member) {
+    await db
+      .prepare(
+        `INSERT INTO project_members (id, project_id, user_id, role)
+         VALUES (?, ?, ?, 'admin')`
+      )
+      .bind(`pm_lifecycle_${suffix}`, id, USER_ID)
+      .run();
+  }
+}
+
+async function seedActor(secondProjectMember = true): Promise<void> {
+  const db = getDb(env);
+  await db.batch([
+    db
+      .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
+      .bind(
+        ORGANIZATION_ID,
+        "Credential Lifecycle",
+        "credential-lifecycle",
+        "enterprise",
+        "active"
+      ),
+    db
+      .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')")
+      .bind(USER_ID, "provider-credential-lifecycle@example.com"),
+    db
+      .prepare(
+        `INSERT INTO auth_user_identities (id, provider, provider_user_id, user_id, email)
+         VALUES (?, 'clerk', ?, ?, ?)`
+      )
+      .bind(
+        "aui_provider_credential_lifecycle",
+        "clerk_provider_credential_lifecycle",
+        USER_ID,
+        "provider-credential-lifecycle@example.com"
+      ),
+    db
+      .prepare(
+        `INSERT INTO auth_organization_identities
+           (id, provider, provider_org_id, organization_id, slug)
+         VALUES (?, 'clerk', ?, ?, ?)`
+      )
+      .bind(
+        "aoi_provider_credential_lifecycle",
+        "clerk_org_provider_credential_lifecycle",
+        ORGANIZATION_ID,
+        "credential-lifecycle"
+      ),
+    db
+      .prepare(
+        `INSERT INTO organization_members (id, organization_id, user_id, role, status)
+         VALUES (?, ?, ?, 'admin', 'active')`
+      )
+      .bind("mem_provider_credential_lifecycle", ORGANIZATION_ID, USER_ID),
+  ]);
+  await seedProject(PROJECT_A_ID, "a");
+  await seedProject(PROJECT_B_ID, "b", secondProjectMember);
+}
+
+async function seedActiveSharedCredential(): Promise<void> {
+  const stored = await createCredentialSecretStore(env).write({
+    orgId: ORGANIZATION_ID,
+    provider: "privy",
+    providerCredentialId: CREDENTIAL_ID,
+    payload: { appId: APP_ID, appSecret: APP_SECRET },
+  });
+  const fingerprint = await getPrivyProviderAccountFingerprint(APP_ID);
+  const db = getDb(env);
+  await db
+    .prepare(
+      `INSERT INTO provider_credentials (
+           id, organization_id, project_id, provider, label, scope, source,
+           storage_backend, secret_ref, secret_version_ref, encrypted_secret_payload,
+           display_metadata, status, credential_version, created_by, last_validated_at
+         ) VALUES (
+           ?, ?, NULL, 'privy', 'Shared Privy', 'organization', 'stored',
+           ?, ?, ?, ?, ?::jsonb, 'active', 1, ?, sdp_iso_now()
+         )`
+    )
+    .bind(
+      CREDENTIAL_ID,
+      ORGANIZATION_ID,
+      stored.storageBackend,
+      stored.secretRef ?? null,
+      stored.secretVersionRef ?? null,
+      stored.encryptedSecretPayload ?? null,
+      JSON.stringify({ appIdSuffix: APP_ID.slice(-4) }),
+      USER_ID
+    )
+    .run();
+  for (const [connectionId, projectId, walletId] of [
+    [CONNECTION_A_ID, PROJECT_A_ID, "cwlt_provider_credential_lifecycle_a"],
+    [CONNECTION_B_ID, PROJECT_B_ID, "cwlt_provider_credential_lifecycle_b"],
+  ] as const) {
+    await db
+      .prepare(
+        `INSERT INTO custody_connections (
+             id, organization_id, project_id, provider, scope, provider_credential_id,
+             provider_credential_scope_key, provider_account_fingerprint, status, created_by
+           ) VALUES (
+             ?, ?, ?, 'privy', 'project', ?, '__organization__', ?, 'pending', ?
+           )`
+      )
+      .bind(connectionId, ORGANIZATION_ID, projectId, CREDENTIAL_ID, fingerprint, USER_ID)
+      .run();
+    await db
+      .prepare(
+        `INSERT INTO custody_wallets
+           (id, custody_connection_id, wallet_id, public_key, status)
+         VALUES (?, ?, ?, ?, 'active')`
+      )
+      .bind(walletId, connectionId, `provider-${walletId}`, `address-${walletId}`)
+      .run();
+    await db
+      .prepare(
+        `UPDATE custody_connections
+         SET status = 'active', last_check_status = 'success', last_check_at = sdp_iso_now(),
+             default_custody_wallet_id = ?, activated_at = sdp_iso_now()
+         WHERE id = ?`
+      )
+      .bind(walletId, connectionId)
+      .run();
+  }
+}
+
+async function lifecycleRequest(
+  path: string,
+  options: { method?: "GET" | "POST"; body?: unknown; key?: string } = {}
+): Promise<Response> {
+  const { app, token } = buildApp();
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    "X-Project-ID": PROJECT_A_ID,
+  };
+  if (options.body !== undefined) headers["Content-Type"] = "application/json";
+  if (options.key) headers["Idempotency-Key"] = options.key;
+  return app.request(
+    `/internal/dashboard/custody${path}`,
+    {
+      method: options.method ?? "GET",
+      headers,
+      body: options.body === undefined ? undefined : JSON.stringify(options.body),
+    },
+    env
+  );
+}
+
+async function rotationFailureEvents() {
+  return getDb(env).queryMany<{
+    resource_id: string;
+    status: string;
+    failure_code: string;
+  }>(
+    `SELECT resource_id, status, metadata::jsonb ->> 'failureCode' AS failure_code
+     FROM audit_logs
+     WHERE organization_id = ? AND action = 'rotate'
+       AND metadata::jsonb ->> 'event' = 'provider_credential_rotation_rejected'`,
+    [ORGANIZATION_ID]
+  );
+}
+
+function mockGcpRotation(
+  options: {
+    beforeAddResponse?: () => Promise<void>;
+    inventory?: (secretRef: string) => Response | Promise<Response>;
+    destroyFailure?: boolean;
+    writeFailure?: "create" | "lost_response";
+    privyStatus?: number;
+  } = {}
+) {
+  env.CREDENTIAL_SECRET_STORE_BACKEND = "gcp_secret_manager";
+  env.GCP_SECRET_MANAGER_PROJECT_ID = "sdp-lifecycle-test";
+  env.GCP_SECRET_MANAGER_SECRET_PREFIX = "sdp-provider-credentials";
+  env.GCP_SECRET_MANAGER_API_BASE_URL = "https://gcp-lifecycle.test";
+  const requests: Array<{ url: string; method: string }> = [];
+  const versions = new Map<string, string>();
+  const destroyedVersions = new Set<string>();
+  const fetcher: typeof fetch = async (input, init) => {
+    const url = new URL(String(input));
+    requests.push({ url: url.href, method: init?.method ?? "GET" });
+    if (url.hostname === "metadata.google.internal") {
+      return url.pathname.endsWith("/numeric-project-id")
+        ? new Response("1234567890")
+        : Response.json({ access_token: "gcp-test-token", expires_in: 300 });
+    }
+    if (url.hostname === "api.privy.io") {
+      return Response.json({ data: [] }, { status: options.privyStatus ?? 200 });
+    }
+    if (url.hostname !== "gcp-lifecycle.test") throw new Error("Unexpected provider request");
+    // Accept either project spelling while GCP responses and inventory stay canonical.
+    const resourceRef = url.pathname
+      .slice(4)
+      .replace("projects/sdp-lifecycle-test/", "projects/1234567890/");
+    const secretId = url.searchParams.get("secretId");
+    if (secretId) {
+      if (options.writeFailure === "create") return new Response(null, { status: 503 });
+      return Response.json({ name: `projects/1234567890/secrets/${secretId}` });
+    }
+    if (url.pathname.endsWith(":addVersion")) {
+      const parent = resourceRef.slice(0, -":addVersion".length);
+      const priorVersions = [...versions.keys()]
+        .filter((ref) => ref.startsWith(`${parent}/versions/`))
+        .map((ref) => Number(ref.split("/").at(-1)));
+      const versionRef = `${parent}/versions/${Math.max(6, ...priorVersions) + 1}`;
+      const body = JSON.parse(String(init?.body)) as { payload: { data: string } };
+      versions.set(versionRef, body.payload.data);
+      await options.beforeAddResponse?.();
+      if (options.writeFailure === "lost_response") throw new Error("Lost GCP response");
+      return Response.json({ name: versionRef });
+    }
+    if (url.pathname.endsWith(":access")) {
+      const versionRef = resourceRef.slice(0, -":access".length);
+      return Response.json({ payload: { data: versions.get(versionRef) } });
+    }
+    if (url.pathname.endsWith("/versions")) {
+      const secretRef = resourceRef.slice(0, -"/versions".length);
+      if (options.inventory) return options.inventory(secretRef);
+      return Response.json({
+        versions: [...versions.keys()]
+          .filter((name) => name.startsWith(`${secretRef}/versions/`))
+          .filter((name) => !url.searchParams.has("filter") || !destroyedVersions.has(name))
+          .map((name) => ({ name, state: destroyedVersions.has(name) ? "DESTROYED" : "ENABLED" })),
+      });
+    }
+    if (url.pathname.endsWith(":destroy")) {
+      if (options.destroyFailure) return new Response(null, { status: 503 });
+      const versionRef = resourceRef.slice(0, -":destroy".length);
+      destroyedVersions.add(versionRef);
+      return Response.json({ name: versionRef, state: "DESTROYED" });
+    }
+    if (versions.has(resourceRef))
+      return Response.json({
+        name: resourceRef,
+        state: destroyedVersions.has(resourceRef) ? "DESTROYED" : "ENABLED",
+      });
+    throw new Error("Unexpected GCP request");
+  };
+  vi.stubGlobal("fetch", fetcher);
+  return { requests, versions };
+}
+
+function firstPersistedGcpVersionRef(gcp: ReturnType<typeof mockGcpRotation>): string {
+  const [versionRef] = gcp.versions.keys();
+  if (!versionRef) throw new Error("No GCP version was written");
+  return versionRef.replace("projects/1234567890/", "projects/sdp-lifecycle-test/");
+}
+
+function deferredVoid() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+async function seedActiveGcpCredential(gcp: ReturnType<typeof mockGcpRotation>) {
+  const module = await import("@/services/credential-secret-store");
+  const parent = module.prepareGcpCredentialSecret(env, CREDENTIAL_ID);
+  const versionRef = `${parent.secretRef?.replace("projects/sdp-lifecycle-test/", "projects/1234567890/")}/versions/1`;
+  gcp.versions.set(
+    versionRef,
+    Buffer.from(JSON.stringify({ appId: APP_ID, appSecret: APP_SECRET })).toString("base64")
+  );
+  await getDb(env).execute(
+    `UPDATE provider_credentials SET storage_backend = 'gcp_secret_manager',
+       secret_ref = ?, secret_version_ref = ?, encrypted_secret_payload = NULL,
+       secret_next_scan_at = clock_timestamp() WHERE id = ?`,
+    [parent.secretRef, versionRef, CREDENTIAL_ID]
+  );
+  return parent.secretRef;
+}
+
+async function activeConnectionCredentialIds() {
+  return getDb(env).queryMany<{ provider_credential_id: string }>(
+    "SELECT provider_credential_id FROM custody_connections WHERE status = 'active' ORDER BY id"
+  );
+}
+
+describe("provider credential lifecycle", () => {
+  beforeEach(async () => {
+    env.CREDENTIAL_SECRET_STORE_BACKEND = "encrypted_db";
+    env.CUSTODY_ENCRYPTION_KEY = Buffer.alloc(32, 19).toString("base64");
+    await seedTestDatabase(env);
+    await seedActor();
+    await seedActiveSharedCredential();
+  });
+
+  afterEach(async () => {
+    env.CREDENTIAL_SECRET_STORE_BACKEND = ORIGINAL_SECRET_BACKEND;
+    env.CUSTODY_ENCRYPTION_KEY = ORIGINAL_ENCRYPTION_KEY;
+    env.GCP_SECRET_MANAGER_PROJECT_ID = ORIGINAL_GCP_PROJECT_ID;
+    env.GCP_SECRET_MANAGER_SECRET_PREFIX = ORIGINAL_GCP_PREFIX;
+    env.GCP_SECRET_MANAGER_API_BASE_URL = ORIGINAL_GCP_API_BASE_URL;
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    await clearKVStores(env);
+  });
+
+  it("rotates a GCP credential into a new exact version of the same container", async () => {
+    const gcp = mockGcpRotation();
+    const parent = await seedActiveGcpCredential(gcp);
+    const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "shared-gcp-parent",
+      body: { fields: { appId: APP_ID, appSecret: "new-gcp-secret" } },
+    });
+    expect(response.status).toBe(200);
+    const rows = await getDb(env).queryMany<{ secret_ref: string; secret_version_ref: string }>(
+      "SELECT secret_ref, secret_version_ref FROM provider_credentials ORDER BY credential_version"
+    );
+    expect(rows.map((row) => row.secret_ref)).toEqual([parent, parent]);
+    expect(new Set(rows.map((row) => row.secret_version_ref)).size).toBe(2);
+    expect(gcp.requests.some(({ url }) => url.includes("?secretId="))).toBe(false);
+  });
+
+  it("persists the first GCP container's scan schedule before the external write completes", async () => {
+    const gcp = mockGcpRotation({
+      beforeAddResponse: async () => {
+        const row = await getDb(env).queryOne<{ scheduled: boolean }>(
+          "SELECT secret_next_scan_at IS NOT NULL AS scheduled FROM provider_credentials WHERE status = 'creating'"
+        );
+        expect(row).toEqual({ scheduled: true });
+      },
+    });
+    const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "first-gcp-owner",
+      body: { fields: { appId: APP_ID, appSecret: "first-owner-secret" } },
+    });
+    expect(response.status).toBe(200);
+    expect(gcp.versions.size).toBe(1);
+  });
+
+  it("keeps scan ownership with each GCP container across backend changes", async () => {
+    const gcp = mockGcpRotation();
+    let current = CREDENTIAL_ID;
+    for (const [index, backend] of (
+      ["gcp_secret_manager", "encrypted_db", "gcp_secret_manager"] as const
+    ).entries()) {
+      env.CREDENTIAL_SECRET_STORE_BACKEND = backend;
+      const response = await lifecycleRequest(`/provider-credentials/${current}/rotate`, {
+        method: "POST",
+        key: `backend-change-${index}`,
+        body: { fields: { appId: APP_ID, appSecret: `backend-change-secret-${index}` } },
+      });
+      expect(response.status).toBe(200);
+      current = credentialResponseSchema.parse(await response.json()).data.providerCredential.id;
+    }
+    const rows = await getDb(env).queryMany<{
+      storage_backend: string;
+      owns_scan: boolean;
+      secret_ref: string | null;
+    }>(
+      "SELECT storage_backend, secret_next_scan_at IS NOT NULL AS owns_scan, secret_ref FROM provider_credentials ORDER BY credential_version"
+    );
+    expect(rows.map((row) => row.storage_backend)).toEqual([
+      "encrypted_db",
+      "gcp_secret_manager",
+      "encrypted_db",
+      "gcp_secret_manager",
+    ]);
+    expect(rows.map((row) => row.owns_scan)).toEqual([false, true, false, true]);
+    expect(rows[1]?.secret_ref).not.toBe(rows[3]?.secret_ref);
+    expect(gcp.versions.size).toBe(2);
+  });
+
+  it.each(["gcp_secret_manager", "encrypted_db"] as const)(
+    "rolls back to the persisted %s backend after changing the write backend",
+    async (previousBackend) => {
+      const gcp = mockGcpRotation();
+      if (previousBackend === "gcp_secret_manager") await seedActiveGcpCredential(gcp);
+      env.CREDENTIAL_SECRET_STORE_BACKEND =
+        previousBackend === "gcp_secret_manager" ? "encrypted_db" : "gcp_secret_manager";
+      const rotated = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+        method: "POST",
+        key: `rollback-backend-${previousBackend}`,
+        body: { fields: { appId: APP_ID, appSecret: "backend-rollback-secret" } },
+      });
+      expect(rotated.status).toBe(200);
+      const current = credentialResponseSchema.parse(await rotated.json()).data.providerCredential
+        .id;
+      const rollback = await lifecycleRequest(`/provider-credentials/${current}/rollback`, {
+        method: "POST",
+      });
+      expect(rollback.status).toBe(200);
+      expect(await activeConnectionCredentialIds()).toEqual([
+        { provider_credential_id: CREDENTIAL_ID },
+        { provider_credential_id: CREDENTIAL_ID },
+      ]);
+    }
+  );
+
+  it("shared-container cleanup preserves a rotation adopted after a lost COMMIT reply", async () => {
+    const db = getDb(env);
+    const runTransaction = db.transaction.bind(db);
+    const gcp = mockGcpRotation({
+      inventory: () =>
+        Response.json({
+          versions: [...gcp.versions.keys()].map((name) => ({ name, state: "ENABLED" })),
+        }),
+      beforeAddResponse: async () => {
+        vi.spyOn(db, "transaction").mockImplementationOnce(async (callback) => {
+          await runTransaction(callback);
+          throw new Error("Lost finalization COMMIT response");
+        });
+      },
+    });
+    await seedActiveGcpCredential(gcp);
+
+    const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "prototype-shared-commit",
+      body: { fields: { appId: APP_ID, appSecret: "prototype-new-secret" } },
+    });
+    expect(response.status).toBe(200);
+    const { data } = credentialResponseSchema.parse(await response.json());
+    expect(await activeConnectionCredentialIds()).toEqual([
+      { provider_credential_id: data.providerCredential.id },
+      { provider_credential_id: data.providerCredential.id },
+    ]);
+    expect(
+      await scanGcpCredentialContainers(env, () =>
+        createCredentialSecretStore(env, "gcp_secret_manager")
+      )
+    ).toMatchObject({ cleaned: 0, failed: [] });
+    expect(gcp.requests.some(({ url }) => url.endsWith(":destroy"))).toBe(false);
+  });
+
+  it("shared-container cleanup fences a cancelled HTTP writer before its late reply", async () => {
+    const started = deferredVoid();
+    const released = deferredVoid();
+    const gcp = mockGcpRotation({
+      inventory: () =>
+        Response.json({
+          versions: [...gcp.versions.keys()].map((name) => ({ name, state: "ENABLED" })),
+        }),
+      beforeAddResponse: async () => {
+        started.resolve();
+        await released.promise;
+      },
+    });
+    await seedActiveGcpCredential(gcp);
+    const rotation = lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "prototype-shared-cancel",
+      body: { fields: { appId: APP_ID, appSecret: "prototype-late-secret" } },
+    });
+    try {
+      await started.promise;
+      expect(
+        (
+          await scanGcpCredentialContainers(env, () =>
+            createCredentialSecretStore(env, "gcp_secret_manager")
+          )
+        ).skipped
+      ).toBeGreaterThan(0);
+      const read = await lifecycleRequest(`/connections/${CONNECTION_A_ID}/provider-credential`);
+      const candidateId = z
+        .object({ data: z.object({ rotationCandidate: z.object({ id: z.string() }) }) })
+        .parse(await read.json()).data.rotationCandidate.id;
+      expect(
+        (
+          await lifecycleRequest(`/provider-credentials/${candidateId}/deactivate`, {
+            method: "POST",
+          })
+        ).status
+      ).toBe(200);
+      const result = await scanGcpCredentialContainers(
+        env,
+        () => createCredentialSecretStore(env, "gcp_secret_manager"),
+        { now: new Date(Date.now() + 6 * 60_000) }
+      );
+      expect(result.cleaned).toBe(1);
+      expect(
+        gcp.requests.some(({ url }) =>
+          url.endsWith(`sdp-provider-credentials-${CREDENTIAL_ID}/versions/7:destroy`)
+        )
+      ).toBe(true);
+    } finally {
+      released.resolve();
+      await rotation;
+    }
+    expect((await rotation).status).toBe(409);
+    expect(await activeConnectionCredentialIds()).toEqual([
+      { provider_credential_id: CREDENTIAL_ID },
+      { provider_credential_id: CREDENTIAL_ID },
+    ]);
+  });
+
+  it.each(["actor", "organization"])(
+    "refuses rotation when the %s quota is exhausted",
+    async (scope) => {
+      vi.spyOn(Date, "now").mockReturnValue(Date.now());
+      await seedRateLimit(
+        env,
+        `metered:credential-rotation:org:${ORGANIZATION_ID}${scope === "actor" ? `:user:${USER_ID}` : ""}`,
+        scope === "actor" ? 5 : 20
+      );
+      const providerFetch = vi.fn().mockResolvedValue(Response.json({ data: [] }));
+      vi.stubGlobal("fetch", providerFetch);
+
+      const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+        method: "POST",
+        key: "rotate-quota-exhausted",
+        body: { fields: { appId: APP_ID, appSecret: "new-secret" } },
+      });
+
+      expect(response.status).toBe(429);
+      expect(response.headers.get("Retry-After")).not.toBeNull();
+      expect(await response.json()).toMatchObject({ error: { code: "RATE_LIMITED" } });
+      expect(providerFetch).not.toHaveBeenCalled();
+      const state = await lifecycleRequest(`/connections/${CONNECTION_A_ID}/provider-credential`);
+      expect(state.status).toBe(200);
+      expect(await state.json()).toMatchObject({
+        data: { providerCredential: { id: CREDENTIAL_ID }, rotationCandidate: null },
+      });
+    }
+  );
+
+  it("refuses rotation before provider calls or secret storage when the quota store is unavailable", async () => {
+    vi.spyOn(RedisKVStore.prototype, "admitSlidingWindow").mockRejectedValue(
+      new Error("KV unavailable")
+    );
+    const providerFetch = vi.fn().mockResolvedValue(Response.json({ data: [] }));
+    vi.stubGlobal("fetch", providerFetch);
+
+    const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-quota-unavailable",
+      body: { fields: { appId: APP_ID, appSecret: "new-secret" } },
+    });
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({ error: { code: "SERVICE_UNAVAILABLE" } });
+    expect(providerFetch).not.toHaveBeenCalled();
+    const state = await lifecycleRequest(`/connections/${CONNECTION_A_ID}/provider-credential`);
+    expect(state.status).toBe(200);
+    expect(await state.json()).toMatchObject({
+      data: { providerCredential: { id: CREDENTIAL_ID }, rotationCandidate: null },
+    });
+  });
+
+  it.each(["complete-rotation", "rollback", "deactivate"])(
+    "refuses %s before provider calls or state changes when its quota is exhausted",
+    async (action) => {
+      vi.spyOn(Date, "now").mockReturnValue(Date.now());
+      const providerFetch = vi
+        .fn()
+        .mockImplementation(() =>
+          Promise.resolve(
+            action === "rollback"
+              ? Response.json({ data: [] })
+              : new Response(null, { status: 503 })
+          )
+        );
+      vi.stubGlobal("fetch", providerFetch);
+      const rotated = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+        method: "POST",
+        key: "rotate-before-quota-test",
+        body: { fields: { appId: APP_ID, appSecret: "new-secret" } },
+      });
+      expect(rotated.status).toBe(200);
+      const { data } = await rotated.json();
+      const statePath = `/connections/${CONNECTION_A_ID}/provider-credential`;
+      const before = await (await lifecycleRequest(statePath)).json();
+      const quota = action === "complete-rotation" ? "credential-rotation" : "credential-recovery";
+      await seedRateLimit(env, `metered:${quota}:org:${ORGANIZATION_ID}`, 20);
+      providerFetch.mockClear();
+
+      const response = await lifecycleRequest(
+        `/provider-credentials/${data.providerCredential.id}/${action}`,
+        { method: "POST" }
+      );
+
+      expect(response.status).toBe(429);
+      expect(await response.json()).toMatchObject({ error: { code: "RATE_LIMITED" } });
+      expect(providerFetch).not.toHaveBeenCalled();
+      const after = await (await lifecycleRequest(statePath)).json();
+      expect(after.data).toEqual(before.data);
+    }
+  );
+
+  it("returns the exact credential and complete authorized impact", async () => {
+    const response = await lifecycleRequest(`/connections/${CONNECTION_A_ID}/provider-credential`);
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { data: Record<string, unknown> };
+    expect(body.data).toMatchObject({
+      providerCredential: { id: CREDENTIAL_ID, status: "active", source: "stored" },
+      rotationCandidate: null,
+      impact: {
+        projects: [
+          { id: PROJECT_A_ID, name: "Lifecycle a" },
+          { id: PROJECT_B_ID, name: "Lifecycle b" },
+        ],
+        connections: [
+          { id: CONNECTION_A_ID, projectId: PROJECT_A_ID },
+          { id: CONNECTION_B_ID, projectId: PROJECT_B_ID },
+        ],
+      },
+      rollback: null,
+    });
+    expect(JSON.stringify(body)).not.toContain(APP_SECRET);
+  });
+
+  it("denies shared impact before disclosure when one project is inaccessible", async () => {
+    await getDb(env)
+      .prepare("DELETE FROM project_members WHERE project_id = ? AND user_id = ?")
+      .bind(PROJECT_B_ID, USER_ID)
+      .run();
+
+    const response = await lifecycleRequest(`/connections/${CONNECTION_A_ID}/provider-credential`);
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: { code: "FORBIDDEN", message: "Requested project is not accessible" },
+    });
+  });
+
+  it("exposes runtime credentials as deployment-managed state and rejects rotation", async () => {
+    await getDb(env)
+      .prepare(
+        `UPDATE provider_credentials
+         SET source = 'runtime', storage_backend = 'runtime_env', encrypted_secret_payload = NULL
+         WHERE id = ?`
+      )
+      .bind(CREDENTIAL_ID)
+      .run();
+
+    const read = await lifecycleRequest(`/connections/${CONNECTION_A_ID}/provider-credential`);
+    expect(read.status).toBe(200);
+    expect(await read.json()).toMatchObject({
+      data: { providerCredential: { id: CREDENTIAL_ID, source: "runtime" } },
+    });
+
+    const providerFetch = vi.fn();
+    vi.stubGlobal("fetch", providerFetch);
+    const rotate = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-runtime-credential",
+      body: { fields: { appId: APP_ID, appSecret: "new-secret" } },
+    });
+    expect(rotate.status).toBe(409);
+    expect(providerFetch).not.toHaveBeenCalled();
+  });
+
+  it("hides a foreign-project credential before inspecting its lifecycle", async () => {
+    const credentialId = "pcred_foreign_project_root";
+    await getDb(env)
+      .prepare(
+        `INSERT INTO provider_credentials (
+           id, organization_id, project_id, provider, label, scope, source,
+           storage_backend, status, credential_version, created_by
+         ) VALUES (?, ?, ?, 'privy', 'Foreign Privy', 'project', 'runtime',
+                   'runtime_env', 'active', 1, ?)`
+      )
+      .bind(credentialId, ORGANIZATION_ID, PROJECT_B_ID, USER_ID)
+      .run();
+    const secretLookup = vi.spyOn(
+      ProviderCredentialStore.prototype,
+      "findLifecycleCredentialWithSecret"
+    );
+    const providerFetch = vi.fn();
+    vi.stubGlobal("fetch", providerFetch);
+
+    const response = await lifecycleRequest(
+      `/provider-credentials/${credentialId}/complete-rotation`,
+      { method: "POST" }
+    );
+
+    expect(response.status).toBe(404);
+    expect(secretLookup).not.toHaveBeenCalled();
+    expect(providerFetch).not.toHaveBeenCalled();
+  });
+
+  it("rotates every referencing connection after one continuity check", async () => {
+    const providerFetch = vi.fn().mockResolvedValue(Response.json({ data: [] }));
+    vi.stubGlobal("fetch", providerFetch);
+
+    const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-shared-credential",
+      body: { fields: { appId: `  ${APP_ID}  `, appSecret: "new-secret" } },
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      data: { providerCredential: { id: string; status: string }; rotation: { status: string } };
+    };
+    expect(body.data).toMatchObject({
+      providerCredential: { status: "active" },
+      rotation: { status: "success" },
+    });
+    expect(body.data.providerCredential.id).not.toBe(CREDENTIAL_ID);
+    expect(providerFetch).toHaveBeenCalledTimes(1);
+
+    const rows = await getDb(env).queryMany<{
+      id: string;
+      status: string;
+      secret_retention_expires_at: string | null;
+    }>(
+      `SELECT id, status, secret_retention_expires_at
+       FROM provider_credentials
+       ORDER BY credential_version, id`
+    );
+    expect(rows).toEqual([
+      expect.objectContaining({
+        id: CREDENTIAL_ID,
+        status: "retired",
+        secret_retention_expires_at: expect.any(String),
+      }),
+      expect.objectContaining({
+        id: body.data.providerCredential.id,
+        status: "active",
+        secret_retention_expires_at: null,
+      }),
+    ]);
+    expect(
+      await getDb(env).queryMany<{ provider_credential_id: string }>(
+        `SELECT provider_credential_id FROM custody_connections ORDER BY id`
+      )
+    ).toEqual([
+      { provider_credential_id: body.data.providerCredential.id },
+      { provider_credential_id: body.data.providerCredential.id },
+    ]);
+  });
+
+  it("rolls back the whole cutover when retiring the predecessor fails", async () => {
+    const logger = getLogger();
+    const errorLog = vi.spyOn(logger, "error").mockImplementation(() => logger);
+    const providerFetch = vi.fn().mockResolvedValue(Response.json({ data: [] }));
+    vi.stubGlobal("fetch", providerFetch);
+    const db = getDb(env);
+    await db.execute(
+      `ALTER TABLE provider_credentials
+       ADD CONSTRAINT sdp_test_fail_provider_credential_retirement
+       CHECK (status <> 'retired') NOT VALID`
+    );
+
+    try {
+      const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+        method: "POST",
+        key: "rotate-retirement-write-failure",
+        body: { fields: { appId: APP_ID, appSecret: "new-secret" } },
+      });
+
+      expect(response.status).toBe(409);
+      expect(errorLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "sdp_api_credential_lifecycle_failure",
+          stage: "rotation_commit",
+          organization_id: ORGANIZATION_ID,
+          request_id: "req_provider_credential_lifecycle",
+          error_code: "23514",
+        }),
+        "sdp_api_credential_lifecycle_failure"
+      );
+      expect(JSON.stringify(errorLog.mock.calls)).not.toContain("new-secret");
+      expect(JSON.stringify(errorLog.mock.calls)).not.toContain(
+        "sdp_test_fail_provider_credential_retirement"
+      );
+      expect(providerFetch).toHaveBeenCalledTimes(1);
+      expect(
+        await db.queryMany<{
+          id: string;
+          status: string;
+          rotated_from_provider_credential_id: string | null;
+        }>(
+          `SELECT id, status, rotated_from_provider_credential_id
+           FROM provider_credentials
+           ORDER BY credential_version, id`
+        )
+      ).toEqual([
+        {
+          id: CREDENTIAL_ID,
+          status: "active",
+          rotated_from_provider_credential_id: null,
+        },
+        expect.objectContaining({
+          status: "pending",
+          rotated_from_provider_credential_id: CREDENTIAL_ID,
+        }),
+      ]);
+      expect(
+        await db.queryMany<{ id: string; provider_credential_id: string }>(
+          `SELECT id, provider_credential_id
+           FROM custody_connections
+           ORDER BY id`
+        )
+      ).toEqual([
+        { id: CONNECTION_A_ID, provider_credential_id: CREDENTIAL_ID },
+        { id: CONNECTION_B_ID, provider_credential_id: CREDENTIAL_ID },
+      ]);
+    } finally {
+      await db.execute(
+        `ALTER TABLE provider_credentials
+         DROP CONSTRAINT sdp_test_fail_provider_credential_retirement`
+      );
+    }
+  });
+
+  it("does not create a GCP secret when reserving the rotation candidate fails", async () => {
+    env.CREDENTIAL_SECRET_STORE_BACKEND = "gcp_secret_manager";
+    env.GCP_SECRET_MANAGER_PROJECT_ID = "sdp-lifecycle-test";
+    env.GCP_SECRET_MANAGER_SECRET_PREFIX = "sdp-provider-credentials";
+    env.GCP_SECRET_MANAGER_API_BASE_URL = "https://gcp-lifecycle.test";
+    const requests: Array<{ url: string; method: string }> = [];
+    let secretRef: string | undefined;
+    let versionRef: string | undefined;
+    const fetcher: typeof fetch = async (input, init) => {
+      const url = new URL(String(input));
+      const method = init?.method ?? "GET";
+      requests.push({ url: url.href, method });
+      if (url.hostname === "metadata.google.internal") {
+        return url.pathname.endsWith("/numeric-project-id")
+          ? new Response("1234567890")
+          : Response.json({ access_token: "gcp-sensitive-token", expires_in: 300 });
+      }
+      if (url.hostname !== "gcp-lifecycle.test") throw new Error("Unexpected provider request");
+      const secretId = url.searchParams.get("secretId");
+      if (secretId) {
+        secretRef = `projects/1234567890/secrets/${secretId}`;
+        return Response.json({ name: secretRef });
+      }
+      if (url.pathname.endsWith(":addVersion")) {
+        if (!secretRef) throw new Error("Version requested before secret creation");
+        versionRef = `${secretRef}/versions/7`;
+        return Response.json({ name: versionRef });
+      }
+      if (url.pathname === `/v1/${versionRef}:destroy`) {
+        return Response.json({ name: versionRef, state: "DESTROYED" });
+      }
+      if (url.pathname === `/v1/${versionRef}` && method === "GET") {
+        return Response.json({ name: versionRef, state: "ENABLED" });
+      }
+      throw new Error("Unexpected GCP request");
+    };
+    vi.stubGlobal("fetch", fetcher);
+    const logger = getLogger();
+    const errorLog = vi.spyOn(logger, "error").mockImplementation(() => logger);
+    const db = getDb(env);
+    const original = await db.queryOne("SELECT * FROM provider_credentials WHERE id = ?", [
+      CREDENTIAL_ID,
+    ]);
+    await db.execute(
+      `ALTER TABLE provider_credentials ADD CONSTRAINT sdp_test_fail_gcp_rotation_insert
+         CHECK (credential_version = 1) NOT VALID`
+    );
+    try {
+      await expect(
+        lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+          method: "POST",
+          key: "rotate-gcp-insert-rollback",
+          body: { fields: { appId: APP_ID, appSecret: "new-gcp-secret" } },
+        })
+      ).rejects.toMatchObject({ code: "23514" });
+      expect(versionRef).toBeUndefined();
+      expect(requests.filter((request) => request.method === "POST")).toEqual([]);
+      expect(await db.queryMany("SELECT * FROM provider_credentials")).toEqual([original]);
+      expect(
+        await db.queryMany<{ provider_credential_id: string }>(
+          "SELECT provider_credential_id FROM custody_connections ORDER BY id"
+        )
+      ).toEqual([
+        { provider_credential_id: CREDENTIAL_ID },
+        { provider_credential_id: CREDENTIAL_ID },
+      ]);
+      const orphanLogs = errorLog.mock.calls.filter(
+        (call) => call[1] === "provider_credential_orphan_risk"
+      );
+      expect(orphanLogs).toHaveLength(0);
+      const logs = JSON.stringify(errorLog.mock.calls);
+      for (const sensitive of [
+        "new-gcp-secret",
+        "gcp-sensitive-token",
+        "sensitive-upstream-cleanup-detail",
+        "projects/1234567890/secrets/",
+      ]) {
+        expect(logs).not.toContain(sensitive);
+      }
+    } finally {
+      await db.execute(
+        "ALTER TABLE provider_credentials DROP CONSTRAINT sdp_test_fail_gcp_rotation_insert"
+      );
+    }
+  });
+
+  it("exposes an in-flight GCP candidate without permitting a second writer or completion", async () => {
+    const started = deferredVoid();
+    const released = deferredVoid();
+    const gcp = mockGcpRotation({
+      beforeAddResponse: async () => {
+        started.resolve();
+        await released.promise;
+      },
+    });
+    const request = {
+      method: "POST" as const,
+      key: "rotate-gcp-in-flight",
+      body: { fields: { appId: APP_ID, appSecret: "in-flight-secret" } },
+    };
+    const rotation = lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, request);
+    try {
+      await started.promise;
+      const read = await lifecycleRequest(`/connections/${CONNECTION_A_ID}/provider-credential`);
+      expect(read.status).toBe(200);
+      const body = z
+        .object({
+          data: z.object({
+            rotationCandidate: z.object({ id: z.string(), status: z.literal("creating") }),
+          }),
+        })
+        .parse(await read.json());
+      const candidateId = body.data.rotationCandidate.id;
+      expect(
+        (await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, request)).status
+      ).toBe(503);
+      expect(
+        (
+          await lifecycleRequest(`/provider-credentials/${candidateId}/complete-rotation`, {
+            method: "POST",
+          })
+        ).status
+      ).toBe(503);
+      expect(
+        (
+          await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+            ...request,
+            key: "rotate-gcp-other-key",
+          })
+        ).status
+      ).toBe(409);
+      expect(gcp.requests.filter(({ url }) => url.endsWith(":addVersion"))).toHaveLength(1);
+      expect(await activeConnectionCredentialIds()).toEqual([
+        { provider_credential_id: CREDENTIAL_ID },
+        { provider_credential_id: CREDENTIAL_ID },
+      ]);
+    } finally {
+      released.resolve();
+      await rotation;
+    }
+    expect((await rotation).status).toBe(200);
+  });
+
+  it.each(["create", "lost_response"] as const)(
+    "retains cleanup work when GCP fails at %s",
+    async (writeFailure) => {
+      const gcp = mockGcpRotation({ writeFailure });
+      const request = {
+        method: "POST" as const,
+        key: `rotate-gcp-${writeFailure}`,
+        body: { fields: { appId: APP_ID, appSecret: "failed-gcp-write-secret" } },
+      };
+      const response = await lifecycleRequest(
+        `/provider-credentials/${CREDENTIAL_ID}/rotate`,
+        request
+      );
+      expect(response.status).toBe(503);
+      const rows = await getDb(env).queryMany<{
+        id: string;
+        status: string;
+        last_failure_code: string | null;
+        secret_ref: string | null;
+        secret_version_ref: string | null;
+        secret_retention_expires_at: string | null;
+      }>(
+        "SELECT id, status, last_failure_code, secret_ref, secret_version_ref, secret_retention_expires_at FROM provider_credentials ORDER BY credential_version"
+      );
+      expect(rows).toEqual([
+        expect.objectContaining({
+          id: CREDENTIAL_ID,
+          status: "active",
+          secret_retention_expires_at: null,
+        }),
+        expect.objectContaining({
+          status: "deactivated",
+          last_failure_code: "secret_creation_abandoned",
+          secret_ref: expect.stringContaining("/secrets/sdp-provider-credentials-"),
+          secret_version_ref: null,
+          secret_retention_expires_at: expect.any(String),
+        }),
+      ]);
+      expect(gcp.versions.size).toBe(writeFailure === "lost_response" ? 1 : 0);
+      expect(await activeConnectionCredentialIds()).toEqual([
+        { provider_credential_id: CREDENTIAL_ID },
+        { provider_credential_id: CREDENTIAL_ID },
+      ]);
+      const writesBeforeReplay = gcp.requests.filter(({ method }) => method === "POST");
+      expect(
+        (await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, request)).status
+      ).toBe(409);
+      expect(gcp.requests.filter(({ method }) => method === "POST")).toEqual(writesBeforeReplay);
+      expect(gcp.requests.some(({ url }) => url.endsWith(":destroy"))).toBe(false);
+    }
+  );
+
+  it("retains and destroys the acknowledged rotation version after SQL rejects finalization", async () => {
+    const gcp = mockGcpRotation();
+    const db = getDb(env);
+    await db.execute(
+      `ALTER TABLE provider_credentials ADD CONSTRAINT sdp_test_fail_gcp_finalization
+       CHECK (credential_version = 1 OR status IN ('creating', 'deactivated')) NOT VALID`
+    );
+    try {
+      await expect(
+        lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+          method: "POST",
+          key: "rotate-gcp-finalization-sql-failure",
+          body: { fields: { appId: APP_ID, appSecret: "sql-rejected-gcp-secret" } },
+        })
+      ).rejects.toMatchObject({ code: "23514" });
+      expect(gcp.versions.size).toBe(1);
+      expect(
+        await db.queryOne(
+          "SELECT status, last_failure_code, secret_version_ref, secret_retention_expires_at FROM provider_credentials WHERE rotated_from_provider_credential_id = ?",
+          [CREDENTIAL_ID]
+        )
+      ).toEqual({
+        status: "deactivated",
+        last_failure_code: "secret_creation_abandoned",
+        secret_version_ref: firstPersistedGcpVersionRef(gcp),
+        secret_retention_expires_at: expect.any(String),
+      });
+      expect(await activeConnectionCredentialIds()).toEqual([
+        { provider_credential_id: CREDENTIAL_ID },
+        { provider_credential_id: CREDENTIAL_ID },
+      ]);
+      expect(gcp.requests.some(({ url }) => url.endsWith(":destroy"))).toBe(false);
+      await expect(cleanupRetiredProviderCredentialSecrets(env)).resolves.toMatchObject({
+        cleaned: 1,
+        failed: 0,
+      });
+      expect(gcp.requests.filter(({ url }) => url.endsWith(":destroy"))).toEqual([
+        {
+          url: `https://gcp-lifecycle.test/v1/${firstPersistedGcpVersionRef(gcp)}:destroy`,
+          method: "POST",
+        },
+      ]);
+    } finally {
+      await db.execute(
+        "ALTER TABLE provider_credentials DROP CONSTRAINT sdp_test_fail_gcp_finalization"
+      );
+    }
+  });
+
+  it("keeps a GCP candidate cancelled when its late write response arrives", async () => {
+    const started = deferredVoid();
+    const released = deferredVoid();
+    const gcp = mockGcpRotation({
+      beforeAddResponse: async () => {
+        started.resolve();
+        await released.promise;
+      },
+    });
+    const request = {
+      method: "POST" as const,
+      key: "rotate-gcp-cancel-creating",
+      body: { fields: { appId: APP_ID, appSecret: "late-gcp-write-secret" } },
+    };
+    const rotation = lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, request);
+    let candidateId: string | undefined;
+    try {
+      await started.promise;
+      const read = await lifecycleRequest(`/connections/${CONNECTION_A_ID}/provider-credential`);
+      candidateId = z
+        .object({ data: z.object({ rotationCandidate: z.object({ id: z.string() }) }) })
+        .parse(await read.json()).data.rotationCandidate.id;
+      const cancelled = await lifecycleRequest(`/provider-credentials/${candidateId}/deactivate`, {
+        method: "POST",
+      });
+      expect(cancelled.status).toBe(200);
+      expect(await cancelled.json()).toMatchObject({
+        data: { providerCredential: { id: candidateId, status: "deactivated" } },
+      });
+    } finally {
+      released.resolve();
+      await rotation;
+    }
+    expect((await rotation).status).toBe(409);
+    expect(
+      await getDb(env).queryOne(
+        "SELECT status, last_failure_code, secret_version_ref, secret_retention_expires_at FROM provider_credentials WHERE id = ?",
+        [candidateId]
+      )
+    ).toEqual({
+      status: "deactivated",
+      last_failure_code: "secret_creation_abandoned",
+      secret_version_ref: firstPersistedGcpVersionRef(gcp),
+      secret_retention_expires_at: expect.any(String),
+    });
+    expect(await activeConnectionCredentialIds()).toEqual([
+      { provider_credential_id: CREDENTIAL_ID },
+      { provider_credential_id: CREDENTIAL_ID },
+    ]);
+    expect(gcp.requests.some(({ url }) => new URL(url).hostname === "api.privy.io")).toBe(false);
+    expect(
+      (await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, request)).status
+    ).toBe(409);
+    expect(gcp.requests.filter(({ url }) => url.endsWith(":addVersion"))).toHaveLength(1);
+  });
+
+  it("reopens legacy absence metadata when a cancelled writer acknowledges its version", async () => {
+    const db = getDb(env);
+    let candidateId = "";
+    const gcp = mockGcpRotation({
+      beforeAddResponse: async () => {
+        const candidate = await db.queryOne<{ id: string }>(
+          "SELECT id FROM provider_credentials WHERE status = 'creating'"
+        );
+        if (!candidate) throw new Error("Missing creating candidate");
+        candidateId = candidate.id;
+        await new ProviderCredentialStore(db).abandonCredentialCreation({
+          organizationId: ORGANIZATION_ID,
+          credentialId: candidateId,
+        });
+        await db.execute(
+          `UPDATE provider_credentials SET secret_retention_expires_at = NULL,
+        secret_cleanup_outcome = 'assumed_absent', secret_cleanup_absent_since = '2000-01-01T00:00:00.000Z'
+        WHERE id = ?`,
+          [candidateId]
+        );
+      },
+    });
+    const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "legacy-absence-ack",
+      body: { fields: { appId: APP_ID, appSecret: "late-known-secret" } },
+    });
+    expect(response.status).toBe(409);
+    expect(
+      await db.queryOne(
+        "SELECT secret_version_ref, secret_cleanup_outcome, secret_cleanup_absent_since FROM provider_credentials WHERE id = ?",
+        [candidateId]
+      )
+    ).toEqual({
+      secret_version_ref: firstPersistedGcpVersionRef(gcp),
+      secret_cleanup_outcome: null,
+      secret_cleanup_absent_since: null,
+    });
+    await expect(cleanupRetiredProviderCredentialSecrets(env)).resolves.toMatchObject({
+      cleaned: 1,
+      failed: 0,
+    });
+    expect(
+      await db.queryOne(
+        "SELECT secret_retention_expires_at FROM provider_credentials WHERE id = ?",
+        [candidateId]
+      )
+    ).toEqual({ secret_retention_expires_at: null });
+  });
+
+  it.each([
+    { privyStatus: 200, status: "active" },
+    { privyStatus: 503, status: "pending" },
+  ])(
+    "preserves an adopted GCP candidate after a lost finalization COMMIT ($status)",
+    async ({ privyStatus, status }) => {
+      const db = getDb(env);
+      const runTransaction = db.transaction.bind(db);
+      const gcp = mockGcpRotation({
+        privyStatus,
+        beforeAddResponse: async () => {
+          vi.spyOn(db, "transaction").mockImplementationOnce(async (callback) => {
+            await runTransaction(callback);
+            throw new Error("Lost finalization COMMIT response");
+          });
+        },
+      });
+      const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+        method: "POST",
+        key: `rotate-gcp-adopted-${status}`,
+        body: { fields: { appId: APP_ID, appSecret: "adopted-gcp-secret" } },
+      });
+      expect(response.status).toBe(200);
+      const { data } = credentialResponseSchema.parse(await response.json());
+      expect(
+        await db.queryOne(
+          "SELECT status, secret_version_ref, secret_retention_expires_at FROM provider_credentials WHERE id = ?",
+          [data.providerCredential.id]
+        )
+      ).toEqual({
+        status,
+        secret_version_ref: firstPersistedGcpVersionRef(gcp),
+        secret_retention_expires_at: null,
+      });
+      const currentId = status === "active" ? data.providerCredential.id : CREDENTIAL_ID;
+      expect(await activeConnectionCredentialIds()).toEqual([
+        { provider_credential_id: currentId },
+        { provider_credential_id: currentId },
+      ]);
+      expect(gcp.requests.some(({ url }) => url.endsWith(":destroy"))).toBe(false);
+      expect(gcp.requests.filter(({ url }) => url.endsWith(":addVersion"))).toHaveLength(1);
+    }
+  );
+
+  it.each([true, false])(
+    "retains GCP ownership when finalization reconciliation is unavailable (committed: %s)",
+    async (committed) => {
+      const db = getDb(env);
+      const runTransaction = db.transaction.bind(db);
+      const lostCommit = new Error("Lost finalization COMMIT response");
+      const gcp = mockGcpRotation({
+        beforeAddResponse: async () => {
+          vi.spyOn(db, "transaction")
+            .mockImplementationOnce(async (callback) => {
+              if (committed) await runTransaction(callback);
+              else
+                await expect(
+                  runTransaction(async (tx) => {
+                    await callback(tx);
+                    throw lostCommit;
+                  })
+                ).rejects.toBe(lostCommit);
+              throw lostCommit;
+            })
+            .mockRejectedValueOnce(new Error("Reconciliation database unavailable"));
+        },
+      });
+      const request = {
+        method: "POST" as const,
+        key: `rotate-gcp-unknown-${committed}`,
+        body: { fields: { appId: APP_ID, appSecret: "uncertain-gcp-secret" } },
+      };
+      expect(
+        (await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, request)).status
+      ).toBe(503);
+      expect(
+        await db.queryOne(
+          "SELECT status, secret_version_ref, last_failure_code FROM provider_credentials WHERE rotated_from_provider_credential_id = ?",
+          [CREDENTIAL_ID]
+        )
+      ).toEqual({
+        status: committed ? "pending" : "creating",
+        secret_version_ref: committed ? firstPersistedGcpVersionRef(gcp) : null,
+        last_failure_code: null,
+      });
+      expect(await activeConnectionCredentialIds()).toEqual([
+        { provider_credential_id: CREDENTIAL_ID },
+        { provider_credential_id: CREDENTIAL_ID },
+      ]);
+      expect(gcp.requests.some(({ url }) => url.endsWith(":destroy"))).toBe(false);
+      const replay = await lifecycleRequest(
+        `/provider-credentials/${CREDENTIAL_ID}/rotate`,
+        request
+      );
+      expect(replay.status).toBe(committed ? 200 : 503);
+      expect(gcp.requests.filter(({ url }) => url.endsWith(":addVersion"))).toHaveLength(1);
+    }
+  );
+
+  it("never writes GCP after losing the reservation COMMIT acknowledgement", async () => {
+    const gcp = mockGcpRotation();
+    const db = getDb(env);
+    const runTransaction = db.transaction.bind(db);
+    vi.spyOn(db, "transaction").mockImplementationOnce(async (callback) => {
+      await runTransaction(callback);
+      throw new Error("Lost reservation COMMIT response");
+    });
+    const request = {
+      method: "POST" as const,
+      key: "rotate-gcp-unknown-reservation",
+      body: { fields: { appId: APP_ID, appSecret: "unwritten-gcp-secret" } },
+    };
+    expect(
+      (await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, request)).status
+    ).toBe(503);
+    expect(
+      await db.queryOne(
+        "SELECT status, secret_version_ref FROM provider_credentials WHERE rotated_from_provider_credential_id = ?",
+        [CREDENTIAL_ID]
+      )
+    ).toEqual({ status: "creating", secret_version_ref: null });
+    expect(
+      (await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, request)).status
+    ).toBe(503);
+    expect(gcp.requests.filter(({ method }) => method === "POST")).toEqual([]);
+    expect(gcp.versions.size).toBe(0);
+    expect(await activeConnectionCredentialIds()).toEqual([
+      { provider_credential_id: CREDENTIAL_ID },
+      { provider_credential_id: CREDENTIAL_ID },
+    ]);
+  });
+
+  it("fails closed when credential references change during provider validation", async () => {
+    const projectCId = "prj_provider_credential_lifecycle_c";
+    const connectionCId = "cconn_provider_credential_lifecycle_c";
+    await seedProject(projectCId, "c");
+
+    let markProviderCheckStarted: () => void = () => undefined;
+    let releaseProviderCheck: () => void = () => undefined;
+    const providerCheckStarted = new Promise<void>((resolve) => {
+      markProviderCheckStarted = resolve;
+    });
+    const providerCheckReleased = new Promise<void>((resolve) => {
+      releaseProviderCheck = resolve;
+    });
+    const providerFetch = vi.fn().mockImplementation(async () => {
+      markProviderCheckStarted();
+      await providerCheckReleased;
+      return Response.json({ data: [] });
+    });
+    vi.stubGlobal("fetch", providerFetch);
+
+    const rotation = lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-reference-race",
+      body: { fields: { appId: APP_ID, appSecret: "new-secret" } },
+    });
+    await providerCheckStarted;
+    try {
+      await getDb(env)
+        .prepare(
+          `INSERT INTO custody_connections (
+             id, organization_id, project_id, provider, scope, provider_credential_id,
+             provider_credential_scope_key, provider_account_fingerprint, status, created_by
+           ) VALUES (?, ?, ?, 'privy', 'project', ?, '__organization__', ?, 'pending', ?)`
+        )
+        .bind(
+          connectionCId,
+          ORGANIZATION_ID,
+          projectCId,
+          CREDENTIAL_ID,
+          await getPrivyProviderAccountFingerprint(APP_ID),
+          USER_ID
+        )
+        .run();
+    } finally {
+      releaseProviderCheck();
+    }
+
+    expect((await rotation).status).toBe(409);
+    expect(providerFetch).toHaveBeenCalledTimes(1);
+    expect(
+      await getDb(env).queryMany<{ id: string; status: string }>(
+        "SELECT id, status FROM provider_credentials ORDER BY credential_version, id"
+      )
+    ).toEqual([
+      { id: CREDENTIAL_ID, status: "active" },
+      expect.objectContaining({ status: "pending" }),
+    ]);
+    expect(
+      await getDb(env).queryMany<{ provider_credential_id: string }>(
+        "SELECT provider_credential_id FROM custody_connections ORDER BY id"
+      )
+    ).toEqual([
+      { provider_credential_id: CREDENTIAL_ID },
+      { provider_credential_id: CREDENTIAL_ID },
+      { provider_credential_id: CREDENTIAL_ID },
+    ]);
+  });
+
+  it("rejects only the candidate when Privy rejects the new credentials", async () => {
+    const providerFetch = vi.fn().mockResolvedValue(new Response(null, { status: 401 }));
+    vi.stubGlobal("fetch", providerFetch);
+
+    const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-invalid-credential",
+      body: { fields: { appId: APP_ID, appSecret: "invalid-secret" } },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      data: {
+        providerCredential: { status: "failed_validation" },
+        rotation: { status: "failed", code: "invalid_credentials" },
+      },
+    });
+    expect(
+      await getDb(env).queryMany<{ id: string; status: string }>(
+        "SELECT id, status FROM provider_credentials ORDER BY credential_version, id"
+      )
+    ).toEqual([
+      { id: CREDENTIAL_ID, status: "active" },
+      expect.objectContaining({ status: "failed_validation" }),
+    ]);
+    expect(
+      await getDb(env).queryMany<{ provider_credential_id: string }>(
+        "SELECT provider_credential_id FROM custody_connections ORDER BY id"
+      )
+    ).toEqual([
+      { provider_credential_id: CREDENTIAL_ID },
+      { provider_credential_id: CREDENTIAL_ID },
+    ]);
+  });
+
+  it("audits a rejected rotation once across replays", async () => {
+    const providerFetch = vi.fn().mockResolvedValue(new Response(null, { status: 401 }));
+    vi.stubGlobal("fetch", providerFetch);
+    const request = {
+      method: "POST" as const,
+      key: "rotate-rejected-audit",
+      body: { fields: { appId: APP_ID, appSecret: "invalid-secret" } },
+    };
+    const response = await lifecycleRequest(
+      `/provider-credentials/${CREDENTIAL_ID}/rotate`,
+      request
+    );
+    expect(response.status).toBe(200);
+    const events = await rotationFailureEvents();
+    expect(events).toEqual([
+      { resource_id: expect.any(String), status: "failure", failure_code: "invalid_credentials" },
+    ]);
+
+    const replay = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, request);
+    expect(replay.status).toBe(200);
+    expect(await rotationFailureEvents()).toEqual(events);
+    expect(providerFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a valid credential for a different Privy account without changing the current credential", async () => {
+    const providerFetch = vi.fn().mockResolvedValue(Response.json({ data: [] }));
+    vi.stubGlobal("fetch", providerFetch);
+    const db = getDb(env);
+    const original = await db.queryOne("SELECT * FROM provider_credentials WHERE id = ?", [
+      CREDENTIAL_ID,
+    ]);
+
+    const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-different-privy-account",
+      body: { fields: { appId: "different-privy-app", appSecret: "valid-other-secret" } },
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      data: { providerCredential: { id: string } };
+    };
+    expect(body).toMatchObject({
+      data: {
+        providerCredential: { status: "failed_validation" },
+        rotation: { status: "failed", code: "provider_account_mismatch" },
+      },
+    });
+    expect(body.data.providerCredential.id).not.toBe(CREDENTIAL_ID);
+    expect(providerFetch).toHaveBeenCalledTimes(1);
+    expect(
+      await db.queryOne("SELECT * FROM provider_credentials WHERE id = ?", [CREDENTIAL_ID])
+    ).toEqual(original);
+    expect(
+      await db.queryMany<{ id: string; provider_credential_id: string }>(
+        "SELECT id, provider_credential_id FROM custody_connections ORDER BY id"
+      )
+    ).toEqual([
+      { id: CONNECTION_A_ID, provider_credential_id: CREDENTIAL_ID },
+      { id: CONNECTION_B_ID, provider_credential_id: CREDENTIAL_ID },
+    ]);
+    expect(
+      await db.queryOne<{
+        status: string;
+        last_failure_code: string | null;
+        rotated_from_provider_credential_id: string | null;
+        encrypted_secret_payload: string | null;
+      }>(
+        `SELECT status, last_failure_code, rotated_from_provider_credential_id,
+                encrypted_secret_payload
+         FROM provider_credentials WHERE id = ?`,
+        [body.data.providerCredential.id]
+      )
+    ).toEqual({
+      status: "failed_validation",
+      last_failure_code: "provider_account_mismatch",
+      rotated_from_provider_credential_id: CREDENTIAL_ID,
+      encrypted_secret_payload: null,
+    });
+    expect(await rotationFailureEvents()).toEqual([
+      {
+        resource_id: body.data.providerCredential.id,
+        status: "failure",
+        failure_code: "provider_account_mismatch",
+      },
+    ]);
+  });
+
+  it("emits one rejection outcome when two completions reject the same candidate", async () => {
+    const providerFetch = vi.fn().mockResolvedValue(new Response(null, { status: 503 }));
+    vi.stubGlobal("fetch", providerFetch);
+    const pending = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-concurrent-rejection",
+      body: { fields: { appId: APP_ID, appSecret: "rejected-secret" } },
+    });
+    const { data } = credentialResponseSchema.parse(await pending.json());
+    const candidateId = data.providerCredential.id;
+    let checksStarted = 0;
+    let releaseChecks = () => {};
+    const bothChecking = new Promise<void>((resolve) => {
+      releaseChecks = resolve;
+    });
+    providerFetch.mockImplementation(async () => {
+      if (++checksStarted === 2) releaseChecks();
+      await bothChecking;
+      return new Response(null, { status: 401 });
+    });
+
+    const results = await Promise.all([
+      lifecycleRequest(`/provider-credentials/${candidateId}/complete-rotation`, {
+        method: "POST",
+      }),
+      lifecycleRequest(`/provider-credentials/${candidateId}/complete-rotation`, {
+        method: "POST",
+      }),
+    ]);
+    for (const response of results) {
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        data: { rotation: { status: "failed", code: "invalid_credentials" } },
+      });
+    }
+    expect(await rotationFailureEvents()).toEqual([
+      { resource_id: candidateId, status: "failure", failure_code: "invalid_credentials" },
+    ]);
+    expect(
+      await getDb(env).queryOne<{ count: number }>(
+        `SELECT count(*) AS count FROM audit_logs
+         WHERE action = 'maintenance'
+           AND metadata::jsonb ->> 'event' = 'provider_credential_rotation_rejection_not_committed'`
+      )
+    ).toEqual({ count: 1 });
+  });
+
+  it("keeps a rejection intent unresolved when the COMMIT response is lost", async () => {
+    const logger = getLogger();
+    const warning = vi.spyOn(logger, "warn").mockImplementation(() => logger);
+    const providerFetch = vi.fn().mockResolvedValue(new Response(null, { status: 503 }));
+    vi.stubGlobal("fetch", providerFetch);
+    const pending = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-rejection-commit-unknown",
+      body: { fields: { appId: APP_ID, appSecret: "rejected-secret" } },
+    });
+    const { data } = credentialResponseSchema.parse(await pending.json());
+    const candidateId = data.providerCredential.id;
+    providerFetch.mockResolvedValue(new Response(null, { status: 401 }));
+    const db = getDb(env);
+    const runTransaction = db.transaction.bind(db);
+    vi.spyOn(db, "transaction").mockImplementationOnce(async (callback) => {
+      await runTransaction(callback);
+      throw new Error("Lost COMMIT response");
+    });
+
+    const response = await lifecycleRequest(
+      `/provider-credentials/${candidateId}/complete-rotation`,
+      {
+        method: "POST",
+      }
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      data: { rotation: { status: "failed", code: "invalid_credentials" } },
+    });
+    expect(await rotationFailureEvents()).toEqual([]);
+    expect(
+      await db.queryOne<{ count: number }>(
+        `SELECT count(*) AS count FROM audit_logs intent
+       WHERE intent.metadata::jsonb ->> 'auditPhase' = 'intent'
+         AND intent.metadata::jsonb -> 'target' ->> 'resourceId' = ?
+         AND NOT EXISTS (
+           SELECT 1 FROM audit_logs outcome
+           WHERE outcome.metadata::jsonb ->> 'auditIntentId' = intent.resource_id
+         )`,
+        [candidateId]
+      )
+    ).toEqual({ count: 1 });
+    const intent = await db.queryOne<{ resource_id: string }>(
+      `SELECT resource_id FROM audit_logs
+       WHERE metadata::jsonb ->> 'auditPhase' = 'intent'
+         AND metadata::jsonb -> 'target' ->> 'resourceId' = ?`,
+      [candidateId]
+    );
+    expect(warning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "sdp_api_credential_lifecycle_audit_unresolved",
+        provider_credential_id: candidateId,
+        audit_intent_id: intent?.resource_id,
+        reason: "commit_outcome_unknown",
+      }),
+      "sdp_api_credential_lifecycle_audit_unresolved"
+    );
+  });
+
+  describe.each([
+    {
+      operation: "rotation",
+      command: "complete-rotation",
+      event: "provider_credential_rotated",
+      action: "rotate",
+    },
+    {
+      operation: "rollback",
+      command: "rollback",
+      event: "provider_credential_rolled_back",
+      action: "rollback",
+    },
+    {
+      operation: "cancellation",
+      command: "deactivate",
+      event: "provider_credential_rotation_canceled",
+      action: "deactivate",
+    },
+  ])("$operation COMMIT recovery", ({ operation, command, event, action }) => {
+    it.each([false, true])(
+      "keeps the ambiguous intent unresolved (transaction committed: %s)",
+      async (committed) => {
+        const secret = "commit-recovery-secret";
+        const providerFetch = vi
+          .fn()
+          .mockResolvedValue(
+            operation === "rollback"
+              ? Response.json({ data: [] })
+              : new Response(null, { status: 503 })
+          );
+        vi.stubGlobal("fetch", providerFetch);
+        const initial = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+          method: "POST",
+          key: "rotate-before-commit-recovery",
+          body: { fields: { appId: APP_ID, appSecret: secret } },
+        });
+        expect(initial.status).toBe(200);
+        const { data } = credentialResponseSchema.parse(await initial.json());
+        const candidateId = data.providerCredential.id;
+        const targetId = operation === "rollback" ? CREDENTIAL_ID : candidateId;
+        const path = `/provider-credentials/${candidateId}/${command}`;
+        providerFetch.mockImplementation(async () => Response.json({ data: [] }));
+
+        const logger = getLogger();
+        const warning = vi.spyOn(logger, "warn").mockImplementation(() => logger);
+        const db = getDb(env);
+        const runTransaction = db.transaction.bind(db);
+        const lostCommit = new Error(`Lost COMMIT response with sensitive detail: ${secret}`);
+        vi.spyOn(db, "transaction").mockImplementationOnce(async (callback) => {
+          if (committed) {
+            await runTransaction(callback);
+          } else {
+            // The callback completes, but its writes roll back before another
+            // request wins. The loser then observes the winner's committed state.
+            await expect(
+              runTransaction(async (tx) => {
+                await callback(tx);
+                throw lostCommit;
+              })
+            ).rejects.toBe(lostCommit);
+            const winner = await lifecycleRequest(path, { method: "POST" });
+            expect(winner.status).toBe(200);
+          }
+          throw lostCommit;
+        });
+
+        const response = await lifecycleRequest(path, { method: "POST" });
+        expect(response.status).toBe(200);
+        expect(
+          credentialResponseSchema.parse(await response.json()).data.providerCredential.id
+        ).toBe(targetId);
+        const outcomes = await db.queryMany<{ id: string }>(
+          `SELECT id FROM audit_logs
+           WHERE organization_id = ? AND status = 'success'
+             AND metadata::jsonb ->> 'event' = ?`,
+          [ORGANIZATION_ID, event]
+        );
+        expect(outcomes).toHaveLength(committed ? 0 : 1);
+        const unresolved = await db.queryMany<{ resource_id: string }>(
+          `SELECT intent.resource_id FROM audit_logs intent
+           WHERE intent.organization_id = ?
+             AND intent.metadata::jsonb ->> 'auditPhase' = 'intent'
+             AND intent.metadata::jsonb -> 'target' ->> 'resourceId' = ?
+             AND intent.metadata::jsonb -> 'target' ->> 'action' = ?
+             AND NOT EXISTS (
+               SELECT 1 FROM audit_logs outcome
+               WHERE outcome.organization_id = intent.organization_id
+                 AND outcome.metadata::jsonb ->> 'auditIntentId' = intent.resource_id
+             )`,
+          [ORGANIZATION_ID, targetId, action]
+        );
+        expect(unresolved).toHaveLength(1);
+        const intent = unresolved[0];
+        if (!intent) throw new Error("Expected the unresolved lifecycle intent");
+        expect(warning).toHaveBeenCalledExactlyOnceWith(
+          {
+            event: "sdp_api_credential_lifecycle_audit_unresolved",
+            organization_id: ORGANIZATION_ID,
+            project_id: PROJECT_A_ID,
+            provider: "privy",
+            provider_credential_id: targetId,
+            audit_intent_id: intent.resource_id,
+            request_id: "req_provider_credential_lifecycle",
+            operation: action,
+            reason: "commit_outcome_unknown",
+          },
+          "sdp_api_credential_lifecycle_audit_unresolved"
+        );
+        expect(JSON.stringify(warning.mock.calls)).not.toContain(secret);
+      }
+    );
+  });
+
+  it("keeps rejected credentials pending when their audit intent cannot be persisted", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 401 })));
+    const db = getDb(env);
+    await db.execute(
+      `ALTER TABLE audit_logs ADD CONSTRAINT sdp_test_fail_rotation_audit
+       CHECK (action <> 'maintenance') NOT VALID`
+    );
+    try {
+      await expect(
+        lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+          method: "POST",
+          key: "rotate-audit-unavailable",
+          body: { fields: { appId: APP_ID, appSecret: "rejected-secret" } },
+        })
+      ).rejects.toThrow("Required audit record could not be persisted");
+      expect(
+        await db.queryOne<{ status: string; has_secret: boolean }>(
+          `SELECT status, encrypted_secret_payload IS NOT NULL AS has_secret
+           FROM provider_credentials WHERE idempotency_key = 'rotate-audit-unavailable'`
+        )
+      ).toEqual({ status: "pending", has_secret: true });
+      expect(await rotationFailureEvents()).toEqual([]);
+    } finally {
+      await db.execute("ALTER TABLE audit_logs DROP CONSTRAINT sdp_test_fail_rotation_audit");
+    }
+  });
+
+  it("logs an unreadable candidate secret without exposing its stored contents", async () => {
+    const providerFetch = vi.fn().mockResolvedValue(new Response(null, { status: 503 }));
+    vi.stubGlobal("fetch", providerFetch);
+    const pending = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-unreadable-secret",
+      body: { fields: { appId: APP_ID, appSecret: "new-secret" } },
+    });
+    const { data } = credentialResponseSchema.parse(await pending.json());
+    const candidateId = data.providerCredential.id;
+    await getDb(env).execute(
+      "UPDATE provider_credentials SET encrypted_secret_payload = ? WHERE id = ?",
+      ["invalid-secret-ciphertext", candidateId]
+    );
+    const logger = getLogger();
+    const errorLog = vi.spyOn(logger, "error").mockImplementation(() => logger);
+
+    const response = await lifecycleRequest(
+      `/provider-credentials/${candidateId}/complete-rotation`,
+      {
+        method: "POST",
+      }
+    );
+    expect(response.status).toBe(500);
+    expect(errorLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "sdp_api_credential_lifecycle_failure",
+        stage: "secret_read",
+        provider_credential_id: candidateId,
+        error_name: "CredentialSecretStoreError",
+        error_code: "MISSING_SECRET",
+      }),
+      "sdp_api_credential_lifecycle_failure"
+    );
+    expect(JSON.stringify(errorLog.mock.calls)).not.toContain("invalid-secret-ciphertext");
+    expect(JSON.stringify(errorLog.mock.calls)).not.toContain("new-secret");
+    expect(providerFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists an uncertain candidate and resumes it without another secret submission", async () => {
+    const providerFetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(Response.json({ data: [] }));
+    vi.stubGlobal("fetch", providerFetch);
+
+    const first = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-retry-unknown",
+      body: { fields: { appId: APP_ID, appSecret: "new-secret" } },
+    });
+    expect(first.status).toBe(200);
+    const firstBody = (await first.json()) as {
+      data: { providerCredential: { id: string; status: string }; rotation: { status: string } };
+    };
+    expect(firstBody.data).toMatchObject({
+      providerCredential: { status: "pending" },
+      rotation: { status: "retry_unknown", code: "provider_response_unknown" },
+    });
+
+    const completed = await lifecycleRequest(
+      `/provider-credentials/${firstBody.data.providerCredential.id}/complete-rotation`,
+      { method: "POST" }
+    );
+    expect(completed.status).toBe(200);
+    expect(await completed.json()).toMatchObject({
+      data: {
+        providerCredential: { id: firstBody.data.providerCredential.id, status: "active" },
+        rotation: { status: "success" },
+      },
+    });
+    expect(providerFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns a conflict when cancellation wins before candidate secret access", async () => {
+    const providerFetch = vi.fn().mockResolvedValue(new Response(null, { status: 503 }));
+    vi.stubGlobal("fetch", providerFetch);
+    const rotated = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-before-secret-access-cancel",
+      body: { fields: { appId: APP_ID, appSecret: "new-secret" } },
+    });
+    const rotatedBody = (await rotated.json()) as {
+      data: { providerCredential: { id: string } };
+    };
+    const candidateId = rotatedBody.data.providerCredential.id;
+    const findWithSecret = ProviderCredentialStore.prototype.findLifecycleCredentialWithSecret;
+    let releaseSecretLookup: () => void = () => undefined;
+    let markSecretLookupStarted: () => void = () => undefined;
+    const secretLookupStarted = new Promise<void>((resolve) => {
+      markSecretLookupStarted = resolve;
+    });
+    const secretLookupReleased = new Promise<void>((resolve) => {
+      releaseSecretLookup = resolve;
+    });
+    let blocked = false;
+    vi.spyOn(
+      ProviderCredentialStore.prototype,
+      "findLifecycleCredentialWithSecret"
+    ).mockImplementation(async function (this: ProviderCredentialStore, organizationId, id) {
+      if (!blocked && id === candidateId) {
+        blocked = true;
+        markSecretLookupStarted();
+        await secretLookupReleased;
+      }
+      return findWithSecret.call(this, organizationId, id);
+    });
+
+    const completion = lifecycleRequest(`/provider-credentials/${candidateId}/complete-rotation`, {
+      method: "POST",
+    });
+    await secretLookupStarted;
+    const cancellation = await lifecycleRequest(`/provider-credentials/${candidateId}/deactivate`, {
+      method: "POST",
+    });
+    releaseSecretLookup();
+
+    expect(cancellation.status).toBe(200);
+    expect((await completion).status).toBe(409);
+    expect(providerFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("replays a completed rotation by idempotency key without another provider call", async () => {
+    const providerFetch = vi.fn().mockResolvedValue(Response.json({ data: [] }));
+    vi.stubGlobal("fetch", providerFetch);
+    const request = {
+      method: "POST" as const,
+      key: "rotate-replay",
+      body: { fields: { appId: APP_ID, appSecret: "new-secret" } },
+    };
+
+    const first = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, request);
+    const firstBody = (await first.json()) as {
+      data: { providerCredential: { id: string }; rotation: { status: string } };
+    };
+    const replay = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, request);
+
+    expect(replay.status).toBe(200);
+    expect(await replay.json()).toMatchObject({
+      data: {
+        providerCredential: { id: firstBody.data.providerCredential.id, status: "active" },
+        rotation: { status: "success" },
+      },
+    });
+    expect(providerFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("replays the exact successful rotation after a later rotation", async () => {
+    const providerFetch = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve(Response.json({ data: [] })));
+    vi.stubGlobal("fetch", providerFetch);
+    const firstRequest = {
+      method: "POST" as const,
+      key: "rotate-historical-replay",
+      body: { fields: { appId: APP_ID, appSecret: "first-new-secret" } },
+    };
+    const first = await lifecycleRequest(
+      `/provider-credentials/${CREDENTIAL_ID}/rotate`,
+      firstRequest
+    );
+    const firstBody = (await first.json()) as {
+      data: { providerCredential: { id: string } };
+    };
+    const firstCandidateId = firstBody.data.providerCredential.id;
+
+    const second = await lifecycleRequest(`/provider-credentials/${firstCandidateId}/rotate`, {
+      method: "POST",
+      key: "rotate-after-historical-replay",
+      body: { fields: { appId: APP_ID, appSecret: "second-new-secret" } },
+    });
+    expect(second.status).toBe(200);
+    expect(await second.json()).toMatchObject({
+      data: { providerCredential: { status: "active" }, rotation: { status: "success" } },
+    });
+
+    const replay = await lifecycleRequest(
+      `/provider-credentials/${CREDENTIAL_ID}/rotate`,
+      firstRequest
+    );
+
+    expect(replay.status).toBe(200);
+    expect(await replay.json()).toMatchObject({
+      data: {
+        providerCredential: { id: firstCandidateId, status: "retired" },
+        rotation: { status: "success" },
+      },
+    });
+    expect(providerFetch).toHaveBeenCalledTimes(2);
+    expect(
+      await getDb(env).queryOne<{ count: number }>(
+        "SELECT COUNT(*) AS count FROM provider_credentials"
+      )
+    ).toEqual({ count: 3 });
+  });
+
+  it("reauthorizes the active result before reporting an idempotency mismatch", async () => {
+    const providerFetch = vi.fn().mockResolvedValue(Response.json({ data: [] }));
+    vi.stubGlobal("fetch", providerFetch);
+    await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-before-membership-loss",
+      body: { fields: { appId: APP_ID, appSecret: "new-secret" } },
+    });
+    await getDb(env)
+      .prepare("DELETE FROM project_members WHERE project_id = ? AND user_id = ?")
+      .bind(PROJECT_B_ID, USER_ID)
+      .run();
+
+    const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-before-membership-loss",
+      body: { fields: { appId: APP_ID, appSecret: "different-secret" } },
+    });
+
+    expect(response.status).toBe(403);
+    expect(providerFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("rolls every connection back even when the rotation quota is exhausted", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.now());
+    const providerFetch = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve(Response.json({ data: [] })));
+    vi.stubGlobal("fetch", providerFetch);
+    const rotated = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-before-rollback",
+      body: { fields: { appId: APP_ID, appSecret: "new-secret" } },
+    });
+    const rotatedBody = (await rotated.json()) as {
+      data: { providerCredential: { id: string } };
+    };
+
+    await seedRateLimit(
+      env,
+      `metered:credential-rotation:org:${ORGANIZATION_ID}:user:${USER_ID}`,
+      5
+    );
+    await seedRateLimit(env, `metered:credential-rotation:org:${ORGANIZATION_ID}`, 20);
+
+    const rollback = await lifecycleRequest(
+      `/provider-credentials/${rotatedBody.data.providerCredential.id}/rollback`,
+      { method: "POST" }
+    );
+
+    expect(rollback.status).toBe(200);
+    expect(await rollback.json()).toMatchObject({
+      data: { providerCredential: { id: CREDENTIAL_ID, status: "active" } },
+    });
+    expect(
+      await getDb(env).queryMany<{ provider_credential_id: string }>(
+        "SELECT provider_credential_id FROM custody_connections ORDER BY id"
+      )
+    ).toEqual([
+      { provider_credential_id: CREDENTIAL_ID },
+      { provider_credential_id: CREDENTIAL_ID },
+    ]);
+    const rolledBackFrom = await getDb(env).queryOne<{
+      status: string;
+      secret_retention_expires_at: string | null;
+    }>(`SELECT status, secret_retention_expires_at FROM provider_credentials WHERE id = ?`, [
+      rotatedBody.data.providerCredential.id,
+    ]);
+    expect(rolledBackFrom).toMatchObject({
+      status: "retired",
+      secret_retention_expires_at: expect.any(String),
+    });
+    expect(providerFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("allocates beyond failed versions when retrying with a new rotation intent", async () => {
+    const providerFetch = vi.fn().mockResolvedValue(new Response(null, { status: 401 }));
+    vi.stubGlobal("fetch", providerFetch);
+    const rejected = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "lineage-version-rejected",
+      body: { fields: { appId: APP_ID, appSecret: "rejected-secret" } },
+    });
+    expect(rejected.status).toBe(200);
+    expect(await rejected.json()).toMatchObject({
+      data: { providerCredential: { status: "failed_validation" } },
+    });
+    providerFetch.mockResolvedValue(Response.json({ data: [] }));
+    expect(
+      await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+        method: "POST",
+        key: "lineage-version-after-rejection",
+        body: { fields: { appId: APP_ID, appSecret: "replacement-secret" } },
+      })
+    ).toMatchObject({ status: 200 });
+    expect(
+      await getDb(env).queryMany<{ credential_version: number }>(
+        `SELECT credential_version FROM provider_credentials
+         WHERE organization_id = ? ORDER BY credential_version`,
+        [ORGANIZATION_ID]
+      )
+    ).toEqual([{ credential_version: 1 }, { credential_version: 2 }, { credential_version: 3 }]);
+  });
+
+  it("allocates beyond a rolled-back descendant without reusing its version", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(async () => Response.json({ data: [] }))
+    );
+    const secondResponse = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "lineage-version-two",
+      body: { fields: { appId: APP_ID, appSecret: "second-secret" } },
+    });
+    expect(secondResponse.status).toBe(200);
+    const second = credentialResponseSchema.parse(await secondResponse.json()).data
+      .providerCredential;
+    const thirdResponse = await lifecycleRequest(`/provider-credentials/${second.id}/rotate`, {
+      method: "POST",
+      key: "lineage-version-three",
+      body: { fields: { appId: APP_ID, appSecret: "third-secret" } },
+    });
+    expect(thirdResponse.status).toBe(200);
+    const third = credentialResponseSchema.parse(await thirdResponse.json()).data
+      .providerCredential;
+    expect(
+      await lifecycleRequest(`/provider-credentials/${third.id}/rollback`, { method: "POST" })
+    ).toMatchObject({ status: 200 });
+    expect(
+      await lifecycleRequest(`/provider-credentials/${second.id}/rotate`, {
+        method: "POST",
+        key: "lineage-version-four",
+        body: { fields: { appId: APP_ID, appSecret: "fourth-secret" } },
+      })
+    ).toMatchObject({ status: 200 });
+    expect(
+      await getDb(env).queryMany<{ credential_version: number }>(
+        `SELECT credential_version FROM provider_credentials
+         WHERE organization_id = ? ORDER BY credential_version`,
+        [ORGANIZATION_ID]
+      )
+    ).toEqual([
+      { credential_version: 1 },
+      { credential_version: 2 },
+      { credential_version: 3 },
+      { credential_version: 4 },
+    ]);
+  });
+
+  it("returns a conflict when retention cleanup wins before rollback secret access", async () => {
+    const providerFetch = vi.fn().mockResolvedValue(Response.json({ data: [] }));
+    vi.stubGlobal("fetch", providerFetch);
+    const rotated = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-before-rollback-cleanup",
+      body: { fields: { appId: APP_ID, appSecret: "new-secret" } },
+    });
+    const rotatedBody = (await rotated.json()) as {
+      data: { providerCredential: { id: string } };
+    };
+    const findWithSecret = ProviderCredentialStore.prototype.findLifecycleCredentialWithSecret;
+    let releaseSecretLookup: () => void = () => undefined;
+    let markSecretLookupStarted: () => void = () => undefined;
+    const secretLookupStarted = new Promise<void>((resolve) => {
+      markSecretLookupStarted = resolve;
+    });
+    const secretLookupReleased = new Promise<void>((resolve) => {
+      releaseSecretLookup = resolve;
+    });
+    let blocked = false;
+    vi.spyOn(
+      ProviderCredentialStore.prototype,
+      "findLifecycleCredentialWithSecret"
+    ).mockImplementation(async function (this: ProviderCredentialStore, organizationId, id) {
+      if (!blocked && id === CREDENTIAL_ID) {
+        blocked = true;
+        markSecretLookupStarted();
+        await secretLookupReleased;
+      }
+      return findWithSecret.call(this, organizationId, id);
+    });
+
+    const rollback = lifecycleRequest(
+      `/provider-credentials/${rotatedBody.data.providerCredential.id}/rollback`,
+      { method: "POST" }
+    );
+    await secretLookupStarted;
+    await getDb(env)
+      .prepare(
+        `UPDATE provider_credentials
+         SET encrypted_secret_payload = NULL, secret_retention_expires_at = NULL
+         WHERE id = ?`
+      )
+      .bind(CREDENTIAL_ID)
+      .run();
+    releaseSecretLookup();
+
+    expect((await rollback).status).toBe(409);
+    expect(providerFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels an unreferenced pending candidate without a fallible post-commit read", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.now());
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 503 })));
+    const rotated = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-before-cancel",
+      body: { fields: { appId: APP_ID, appSecret: "new-secret" } },
+    });
+    const rotatedBody = (await rotated.json()) as {
+      data: { providerCredential: { id: string } };
+    };
+    const candidateId = rotatedBody.data.providerCredential.id;
+    await seedRateLimit(
+      env,
+      `metered:credential-rotation:org:${ORGANIZATION_ID}:user:${USER_ID}`,
+      5
+    );
+    await seedRateLimit(env, `metered:credential-rotation:org:${ORGANIZATION_ID}`, 20);
+    const findLifecycleCredential = ProviderCredentialStore.prototype.findLifecycleCredential;
+    vi.spyOn(ProviderCredentialStore.prototype, "findLifecycleCredential").mockImplementation(
+      async function (this: ProviderCredentialStore, organizationId, credentialId, options) {
+        const credential = await findLifecycleCredential.call(
+          this,
+          organizationId,
+          credentialId,
+          options
+        );
+        if (credential?.id === candidateId && credential.status === "deactivated") {
+          throw new Error("post-commit reads are unavailable");
+        }
+        return credential;
+      }
+    );
+
+    const canceled = await lifecycleRequest(`/provider-credentials/${candidateId}/deactivate`, {
+      method: "POST",
+    });
+
+    expect(canceled.status).toBe(200);
+    expect(await canceled.json()).toMatchObject({
+      data: {
+        providerCredential: { id: candidateId, status: "deactivated" },
+      },
+    });
+    expect(
+      await getDb(env).queryMany<{ provider_credential_id: string }>(
+        "SELECT provider_credential_id FROM custody_connections ORDER BY id"
+      )
+    ).toEqual([
+      { provider_credential_id: CREDENTIAL_ID },
+      { provider_credential_id: CREDENTIAL_ID },
+    ]);
+    expect(
+      await getDb(env).queryOne<{ encrypted_secret_payload: string | null }>(
+        "SELECT encrypted_secret_payload FROM provider_credentials WHERE id = ?",
+        [candidateId]
+      )
+    ).toEqual({ encrypted_secret_payload: null });
+  });
+
+  it("keeps a committed GCP candidate cancellation successful when cleanup cannot start", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 503 })));
+    const rotated = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-gcp-cancel",
+      body: { fields: { appId: APP_ID, appSecret: "new-secret" } },
+    });
+    const rotatedBody = (await rotated.json()) as {
+      data: { providerCredential: { id: string } };
+    };
+    await getDb(env)
+      .prepare(
+        `UPDATE provider_credentials
+         SET storage_backend = 'gcp_secret_manager', encrypted_secret_payload = NULL,
+             secret_ref = 'projects/123/secrets/sdp-provider-credentials-test',
+             secret_version_ref = 'projects/123/secrets/sdp-provider-credentials-test/versions/1'
+         WHERE id = ?`
+      )
+      .bind(rotatedBody.data.providerCredential.id)
+      .run();
+    env.GCP_SECRET_MANAGER_PROJECT_ID = undefined;
+
+    const canceled = await lifecycleRequest(
+      `/provider-credentials/${rotatedBody.data.providerCredential.id}/deactivate`,
+      { method: "POST" }
+    );
+
+    expect(canceled.status).toBe(200);
+    expect(await canceled.json()).toMatchObject({
+      data: { providerCredential: { status: "deactivated" } },
+    });
+    expect(
+      await getDb(env).queryOne<{ secret_retention_expires_at: string | null }>(
+        "SELECT secret_retention_expires_at FROM provider_credentials WHERE id = ?",
+        [rotatedBody.data.providerCredential.id]
+      )
+    ).toEqual({ secret_retention_expires_at: expect.any(String) });
+  });
+
+  it("reauthorizes a canceled candidate replay against current lineage references", async () => {
+    const providerFetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(Response.json({ data: [] }));
+    vi.stubGlobal("fetch", providerFetch);
+    const first = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-before-canceled-lineage-replay",
+      body: { fields: { appId: APP_ID, appSecret: "candidate-secret" } },
+    });
+    const firstBody = (await first.json()) as {
+      data: { providerCredential: { id: string } };
+    };
+    const canceledCandidateId = firstBody.data.providerCredential.id;
+    expect(
+      await lifecycleRequest(`/provider-credentials/${canceledCandidateId}/deactivate`, {
+        method: "POST",
+      })
+    ).toMatchObject({ status: 200 });
+    expect(
+      await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+        method: "POST",
+        key: "rotate-after-canceled-lineage-replay",
+        body: { fields: { appId: APP_ID, appSecret: "replacement-secret" } },
+      })
+    ).toMatchObject({ status: 200 });
+    expect(
+      await getDb(env).queryMany<{ credential_version: number }>(
+        `SELECT credential_version FROM provider_credentials
+         WHERE organization_id = ? ORDER BY credential_version`,
+        [ORGANIZATION_ID]
+      )
+    ).toEqual([{ credential_version: 1 }, { credential_version: 2 }, { credential_version: 3 }]);
+
+    await getDb(env)
+      .prepare("DELETE FROM project_members WHERE project_id = ? AND user_id = ?")
+      .bind(PROJECT_B_ID, USER_ID)
+      .run();
+    const secretLookup = vi.spyOn(
+      ProviderCredentialStore.prototype,
+      "findLifecycleCredentialWithSecret"
+    );
+    const denied = await lifecycleRequest(
+      `/provider-credentials/${canceledCandidateId}/deactivate`,
+      { method: "POST" }
+    );
+    expect(denied.status).toBe(403);
+    expect(secretLookup).not.toHaveBeenCalled();
+
+    await getDb(env)
+      .prepare(
+        `INSERT INTO project_members (id, project_id, user_id, role)
+         VALUES ('pm_lifecycle_b', ?, ?, 'admin')`
+      )
+      .bind(PROJECT_B_ID, USER_ID)
+      .run();
+    const replay = await lifecycleRequest(
+      `/provider-credentials/${canceledCandidateId}/deactivate`,
+      { method: "POST" }
+    );
+    expect(replay.status).toBe(200);
+    expect(await replay.json()).toMatchObject({
+      data: { providerCredential: { id: canceledCandidateId, status: "deactivated" } },
+    });
+    expect(providerFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("blocks cancellation when an invariant-breach reference owns an active wallet", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 503 })));
+    const rotated = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-before-invariant-breach",
+      body: { fields: { appId: APP_ID, appSecret: "new-secret" } },
+    });
+    const rotatedBody = (await rotated.json()) as {
+      data: { providerCredential: { id: string } };
+    };
+    const candidateId = rotatedBody.data.providerCredential.id;
+    const db = getDb(env);
+    await db.batch([
+      db
+        .prepare(
+          `INSERT INTO custody_connections (
+             id, organization_id, project_id, provider, scope, provider_credential_id,
+             provider_credential_scope_key, status, deactivated_at, created_by
+           ) VALUES (
+             'cconn_candidate_invariant', ?, ?, 'privy', 'project', ?,
+             '__organization__', 'deactivated', sdp_iso_now(), ?
+           )`
+        )
+        .bind(ORGANIZATION_ID, PROJECT_A_ID, candidateId, USER_ID),
+      db.prepare(
+        `INSERT INTO custody_wallets
+           (id, custody_connection_id, wallet_id, public_key, status)
+         VALUES (
+           'cwlt_candidate_invariant', 'cconn_candidate_invariant',
+           'provider-candidate-invariant', 'address-candidate-invariant', 'active'
+         )`
+      ),
+    ]);
+
+    const canceled = await lifecycleRequest(`/provider-credentials/${candidateId}/deactivate`, {
+      method: "POST",
+    });
+
+    expect(canceled.status).toBe(409);
+    expect(
+      await db.queryOne<{ status: string }>(
+        "SELECT status FROM provider_credentials WHERE id = ?",
+        [candidateId]
+      )
+    ).toEqual({ status: "pending" });
+  });
+
+  it("returns 503 when a retryable Provider outcome cannot be persisted", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 503 })));
+    vi.spyOn(ProviderCredentialStore.prototype, "recordRotationRetryUnknown").mockRejectedValueOnce(
+      new Error("database unavailable")
+    );
+
+    const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-unpersisted-outcome",
+      body: { fields: { appId: APP_ID, appSecret: "new-secret" } },
+    });
+
+    expect(response.status).toBe(503);
+  });
+
+  it("validates credentials at the 4096-character input limit", async () => {
+    const appId = "a".repeat(4096);
+    const appSecret = ` ${"s".repeat(4094)} `;
+    const providerFetch = vi.fn().mockResolvedValue(new Response(null, { status: 401 }));
+    vi.stubGlobal("fetch", providerFetch);
+
+    const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-max-length-fields",
+      body: { fields: { appId: ` ${appId} `, appSecret } },
+    });
+
+    expect(response.status).toBe(200);
+    expect(providerFetch).toHaveBeenCalledExactlyOnceWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: `Basic ${Buffer.from(`${appId}:${appSecret}`).toString("base64")}`,
+          "privy-app-id": appId,
+        }),
+      })
+    );
+  });
+
+  it.each(["appId", "appSecret"])("rejects oversized %s before secret-store I/O", async (field) => {
+    env.CREDENTIAL_SECRET_STORE_BACKEND = "gcp_secret_manager";
+    env.GCP_SECRET_MANAGER_PROJECT_ID = "sdp-lifecycle-test";
+    env.GCP_SECRET_MANAGER_SECRET_PREFIX = "sdp-provider-credentials";
+    const providerFetch = vi.fn().mockResolvedValue(new Response(null, { status: 503 }));
+    vi.stubGlobal("fetch", providerFetch);
+
+    const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-oversized-field",
+      body: { fields: { appId: APP_ID, appSecret: "new-secret", [field]: "x".repeat(4097) } },
+    });
+
+    expect(response.status).toBe(400);
+    expect(providerFetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed rotation input before writing a candidate", async () => {
+    const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-unknown-field",
+      body: {
+        fields: { appId: APP_ID, appSecret: "new-secret" },
+        connectionIds: [CONNECTION_A_ID],
+      },
+    });
+
+    expect(response.status).toBe(400);
+    expect(
+      await getDb(env).queryOne<{ count: number }>(
+        "SELECT COUNT(*) AS count FROM provider_credentials"
+      )
+    ).toEqual({ count: 1 });
+  });
+
+  it("rejects rotation before Provider I/O when any affected project is inaccessible", async () => {
+    await getDb(env)
+      .prepare("DELETE FROM project_members WHERE project_id = ? AND user_id = ?")
+      .bind(PROJECT_B_ID, USER_ID)
+      .run();
+    const providerFetch = vi.fn();
+    vi.stubGlobal("fetch", providerFetch);
+
+    const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-inaccessible-impact",
+      body: { fields: { appId: APP_ID, appSecret: "new-secret" } },
+    });
+
+    expect(response.status).toBe(403);
+    expect(providerFetch).not.toHaveBeenCalled();
+    expect(
+      await getDb(env).queryOne<{ count: number }>(
+        "SELECT COUNT(*) AS count FROM provider_credentials"
+      )
+    ).toEqual({ count: 1 });
+  });
+
+  it("rejects an orphan rotation target before Provider I/O", async () => {
+    await getDb(env)
+      .prepare(
+        `UPDATE custody_connections
+         SET status = 'deactivated', deactivated_at = sdp_iso_now()
+         WHERE provider_credential_id = ?`
+      )
+      .bind(CREDENTIAL_ID)
+      .run();
+    const providerFetch = vi.fn();
+    vi.stubGlobal("fetch", providerFetch);
+
+    const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-orphan",
+      body: { fields: { appId: APP_ID, appSecret: "new-secret" } },
+    });
+
+    expect(response.status).toBe(409);
+    expect(providerFetch).not.toHaveBeenCalled();
+  });
+
+  it("blocks rollback while a retryable direct child is pending", async () => {
+    const providerFetch = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ data: [] }))
+      .mockResolvedValue(new Response(null, { status: 503 }));
+    vi.stubGlobal("fetch", providerFetch);
+    const rotated = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-before-pending-child",
+      body: { fields: { appId: APP_ID, appSecret: "new-secret" } },
+    });
+    expect(rotated.status).toBe(200);
+    const rotatedBody = (await rotated.json()) as {
+      data: { providerCredential: { id: string } };
+    };
+    expect(rotatedBody.data).toMatchObject({
+      providerCredential: { status: "active" },
+      rotation: { status: "success" },
+    });
+    const currentId = rotatedBody.data.providerCredential.id;
+
+    const pending = await lifecycleRequest(`/provider-credentials/${currentId}/rotate`, {
+      method: "POST",
+      key: "rotate-pending-before-rollback",
+      body: { fields: { appId: APP_ID, appSecret: "pending-secret" } },
+    });
+    expect(pending.status).toBe(200);
+    const pendingBody = (await pending.json()) as {
+      data: { providerCredential: { id: string } };
+    };
+    expect(pendingBody.data).toMatchObject({
+      providerCredential: { status: "pending" },
+      rotation: { status: "retry_unknown", code: "provider_response_unknown" },
+    });
+    const candidateId = pendingBody.data.providerCredential.id;
+
+    const response = await lifecycleRequest(`/provider-credentials/${currentId}/rollback`, {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(409);
+    expect(providerFetch).toHaveBeenCalledTimes(2);
+    const state = await lifecycleRequest(`/connections/${CONNECTION_A_ID}/provider-credential`);
+    expect(state.status).toBe(200);
+    expect(await state.json()).toMatchObject({
+      data: {
+        providerCredential: { id: currentId, status: "active" },
+        rotationCandidate: { id: candidateId, status: "pending" },
+        rollback: {
+          providerCredential: { id: CREDENTIAL_ID, status: "retired" },
+          expiresAt: expect.any(String),
+        },
+      },
+    });
+    expect(
+      await getDb(env).queryMany<{ provider_credential_id: string }>(
+        "SELECT provider_credential_id FROM custody_connections ORDER BY id"
+      )
+    ).toEqual([{ provider_credential_id: currentId }, { provider_credential_id: currentId }]);
+
+    const canceled = await lifecycleRequest(`/provider-credentials/${candidateId}/deactivate`, {
+      method: "POST",
+    });
+    expect(canceled.status).toBe(200);
+    expect(await canceled.json()).toMatchObject({
+      data: { providerCredential: { id: candidateId, status: "deactivated" } },
+    });
+    expect(
+      await getDb(env).queryOne<{ status: string; encrypted_secret_payload: string | null }>(
+        "SELECT status, encrypted_secret_payload FROM provider_credentials WHERE id = ?",
+        [candidateId]
+      )
+    ).toEqual({ status: "deactivated", encrypted_secret_payload: null });
+    const afterCancellation = await lifecycleRequest(
+      `/connections/${CONNECTION_A_ID}/provider-credential`
+    );
+    expect(afterCancellation.status).toBe(200);
+    expect(await afterCancellation.json()).toMatchObject({
+      data: {
+        providerCredential: { id: currentId, status: "active" },
+        rotationCandidate: null,
+      },
+    });
+    expect(providerFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the active version unchanged when rollback Provider state is uncertain", async () => {
+    const providerFetch = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ data: [] }))
+      .mockResolvedValueOnce(new Response(null, { status: 503 }));
+    vi.stubGlobal("fetch", providerFetch);
+    const rotated = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-before-uncertain-rollback",
+      body: { fields: { appId: APP_ID, appSecret: "new-secret" } },
+    });
+    const rotatedBody = (await rotated.json()) as {
+      data: { providerCredential: { id: string } };
+    };
+
+    const response = await lifecycleRequest(
+      `/provider-credentials/${rotatedBody.data.providerCredential.id}/rollback`,
+      { method: "POST" }
+    );
+
+    expect(response.status).toBe(503);
+    expect(
+      await getDb(env).queryMany<{ provider_credential_id: string }>(
+        "SELECT provider_credential_id FROM custody_connections ORDER BY id"
+      )
+    ).toEqual([
+      { provider_credential_id: rotatedBody.data.providerCredential.id },
+      { provider_credential_id: rotatedBody.data.providerCredential.id },
+    ]);
+  });
+});

--- a/apps/sdp-api/src/services/custody/privy-credential.test.ts
+++ b/apps/sdp-api/src/services/custody/privy-credential.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { checkPrivyCredential } from "@/services/custody/privy-credential";
+
+describe("checkPrivyCredential", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("authenticates one bounded Privy wallet-list request", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse({ data: [] }, 200));
+
+    await expect(
+      checkPrivyCredential(
+        { PRIVY_API_BASE_URL: "https://privy.example.test/v1/" },
+        { appId: "app-123", appSecret: "secret" }
+      )
+    ).resolves.toBe("success");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://privy.example.test/v1/wallets?limit=1&chain_type=solana",
+      {
+        method: "GET",
+        headers: {
+          // Base64 of dummy test credentials "app-123:secret"; fetch is mocked.
+          Authorization: "Basic YXBwLTEyMzpzZWNyZXQ=",
+          "privy-app-id": "app-123",
+        },
+        signal: expect.any(AbortSignal),
+      }
+    );
+  });
+
+  it("classifies a 401 response as a conclusive credential failure", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ error: "unauthorized" }, 401));
+
+    await expect(checkPrivyCredential({}, { appId: "app-123", appSecret: "secret" })).resolves.toBe(
+      "failed"
+    );
+  });
+
+  it.each([
+    ["rate limit", () => jsonResponse({ error: "rate limited" }, 429)],
+    ["provider failure", () => jsonResponse({ error: "unavailable" }, 503)],
+    ["untrusted success body", () => jsonResponse({ data: {} }, 200)],
+  ])("keeps %s retryable", async (_case, response) => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response());
+
+    await expect(checkPrivyCredential({}, { appId: "app-123", appSecret: "secret" })).resolves.toBe(
+      "retry_unknown"
+    );
+  });
+
+  it("keeps a transport failure retryable", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network failure"));
+
+    await expect(checkPrivyCredential({}, { appId: "app-123", appSecret: "secret" })).resolves.toBe(
+      "retry_unknown"
+    );
+  });
+});
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/apps/sdp-api/src/services/custody/privy-credential.ts
+++ b/apps/sdp-api/src/services/custody/privy-credential.ts
@@ -1,6 +1,15 @@
 import { hashString } from "@sdp/payments/hash";
 import type { Env } from "@/types/env";
 
+const PRIVY_CHECK_TIMEOUT_MS = 10_000;
+
+export interface PrivyCredentialAuthentication {
+  appId: string;
+  appSecret: string;
+}
+
+export type PrivyCredentialCheckResult = "success" | "failed" | "retry_unknown";
+
 export const PRIVY_RUNTIME_ENV_FIELDS = {
   appId: "PRIVY_APP_ID",
   appSecret: "PRIVY_APP_SECRET",
@@ -8,4 +17,36 @@ export const PRIVY_RUNTIME_ENV_FIELDS = {
 
 export async function getPrivyProviderAccountFingerprint(appId: string): Promise<string> {
   return `sha256:${await hashString(appId.trim())}`;
+}
+
+export async function checkPrivyCredential(
+  env: Pick<Env, "PRIVY_API_BASE_URL">,
+  credential: PrivyCredentialAuthentication
+): Promise<PrivyCredentialCheckResult> {
+  const baseUrl = (env.PRIVY_API_BASE_URL ?? "https://api.privy.io/v1").replace(/\/+$/, "");
+  try {
+    const response = await fetch(`${baseUrl}/wallets?limit=1&chain_type=solana`, {
+      method: "GET",
+      headers: {
+        Authorization: `Basic ${Buffer.from(`${credential.appId}:${credential.appSecret}`).toString("base64")}`,
+        "privy-app-id": credential.appId,
+      },
+      signal: AbortSignal.timeout(PRIVY_CHECK_TIMEOUT_MS),
+    });
+    if (response.status === 401) return "failed";
+    if (response.status !== 200) return "retry_unknown";
+    const body = await response.json().catch(() => null);
+    return isWalletListResponse(body) ? "success" : "retry_unknown";
+  } catch {
+    return "retry_unknown";
+  }
+}
+
+function isWalletListResponse(value: unknown): value is { data: unknown[] } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "data" in value &&
+    Array.isArray((value as { data?: unknown }).data)
+  );
 }

--- a/apps/sdp-api/src/services/custody/provisioning.ts
+++ b/apps/sdp-api/src/services/custody/provisioning.ts
@@ -25,6 +25,7 @@ import {
   provisionTurnkeyPrivateKey as provisionTurnkeyPrivateKeyInCustody,
   provisionUtilaWallet as provisionUtilaWalletInCustody,
 } from "@sdp/custody/provisioning";
+import type { PrivyCredentialAuthentication } from "@/services/custody/privy-credential";
 import type { Env } from "@/types/env";
 
 // Credential-bearing provider requests must resolve destinations from trusted
@@ -37,12 +38,7 @@ export type ProvisionFireblocksOptions = CustodyProvisionFireblocksOptions & {
 export type { ProvisionFireblocksResult };
 
 export type ProvisionPrivyOptions = CustodyProvisionPrivyOptions;
-export type { ProvisionPrivyResult };
-
-export interface PrivyCredentialAuthentication {
-  appId: string;
-  appSecret: string;
-}
+export type { PrivyCredentialAuthentication, ProvisionPrivyResult };
 
 export type ProvisionCoinbaseCdpOptions = CustodyProvisionCoinbaseCdpOptions & {
   network?: "solana" | "solana-devnet";

--- a/apps/sdp-api/src/services/domain/signing/custody-runtime-target.ts
+++ b/apps/sdp-api/src/services/domain/signing/custody-runtime-target.ts
@@ -221,6 +221,7 @@ interface ConnectionCredentialRow {
 
 interface LockedConnectionWalletCreationRow {
   provider_credential_id: string;
+  provider_credential_scope_key: string;
   status: string;
   last_check_status: string | null;
   provider_account_fingerprint: string | null;
@@ -229,7 +230,6 @@ interface LockedConnectionWalletCreationRow {
 
 interface LockedCredentialWalletCreationRow {
   status: string;
-  credential_version: number;
 }
 
 interface CreatedConnectionWalletRow {
@@ -1015,7 +1015,7 @@ export class CustodyRuntimeTargets {
       }
 
       const connection = await tx.queryOne<LockedConnectionWalletCreationRow>(
-        `SELECT provider_credential_id, status, last_check_status,
+        `SELECT provider_credential_id, provider_credential_scope_key, status, last_check_status,
                 provider_account_fingerprint, default_custody_wallet_id
          FROM custody_connections
          WHERE id = ? AND organization_id = ? AND project_id = ?
@@ -1026,23 +1026,33 @@ export class CustodyRuntimeTargets {
         throw conflict("Custody Connection changed during wallet creation");
       }
 
+      // A Privy wallet belongs to the Provider account, not one Credential
+      // version. Rotation and rollback may change the pointer while the
+      // Provider request is in flight, so re-lock the current scoped
+      // Credential and rely on the unchanged account fingerprint above.
       const currentCredential = await tx.queryOne<LockedCredentialWalletCreationRow>(
-        `SELECT status, credential_version
+        `SELECT status
          FROM provider_credentials
          WHERE id = ?
            AND organization_id = ?
-           AND project_id = ?
+           AND provider = ?
+           AND scope_key = ?
+           AND (project_id IS NULL OR project_id = ?)
          FOR UPDATE`,
-        [credential.provider_credential_id, target.organizationId, target.projectId]
+        [
+          connection.provider_credential_id,
+          target.organizationId,
+          target.provider,
+          connection.provider_credential_scope_key,
+          target.projectId,
+        ]
       );
       if (
         connection.status !== "active" ||
         connection.last_check_status !== "success" ||
         connection.provider_account_fingerprint !== credential.provider_account_fingerprint ||
         connection.default_custody_wallet_id === null ||
-        connection.provider_credential_id !== credential.provider_credential_id ||
-        currentCredential?.status !== "active" ||
-        currentCredential.credential_version !== credential.credential_version
+        currentCredential?.status !== "active"
       ) {
         throw conflict("Custody Connection changed during wallet creation");
       }

--- a/apps/sdp-api/src/services/jobs/cleanup-provider-credential-secrets.test.ts
+++ b/apps/sdp-api/src/services/jobs/cleanup-provider-credential-secrets.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
 import { rootLogger } from "@/runtime/logger";
 import type { CredentialSecretStore } from "@/services/credential-secret-store";
+import { ProviderCredentialStore } from "@/services/stores/provider-credential.store";
+import { ProviderCredentialSecretCleanupStore } from "@/services/stores/provider-credential-secret-cleanup.store";
 import { env } from "@/test/helpers/env";
 import { seedTestDatabase } from "@/test/mocks/db";
 import { cleanupRetiredProviderCredentialSecrets } from "./cleanup-provider-credential-secrets";
@@ -356,6 +358,110 @@ describe("cleanupRetiredProviderCredentialSecrets", () => {
     expect((await credentialState("pcred_expired_gcp")).secret_retention_expires_at).toBeNull();
   });
 
+  it("lets an in-flight rollback win before destroying the predecessor secret", async () => {
+    const predecessorId = "pcred_rollback_wins";
+    const currentId = "pcred_rollback_wins_current";
+    const connectionId = "conn_rollback_wins";
+    const retentionExpiresAt = new Date(Date.now() + 1_500).toISOString();
+    await insertCredential({
+      id: predecessorId,
+      backend: "gcp_secret_manager",
+      retentionExpiresAt,
+    });
+    await insertCredential({ id: currentId, status: "active", rotatedFromId: predecessorId });
+    await insertConnection(connectionId, currentId);
+
+    let releaseRollback: (() => void) | undefined;
+    let markRollbackReady: (() => void) | undefined;
+    const rollbackGate = new Promise<void>((resolve) => {
+      releaseRollback = resolve;
+    });
+    const rollbackReady = new Promise<void>((resolve) => {
+      markRollbackReady = resolve;
+    });
+    const rollback = getDb(env).transaction(async (tx) => {
+      const changed = await new ProviderCredentialStore(tx).rollBackCredential({
+        organizationId: ORGANIZATION_ID,
+        currentId,
+        predecessorId,
+        predecessorScopeKey: "__organization__",
+        expectedConnectionIds: [connectionId],
+      });
+      expect(changed).toBe(true);
+      markRollbackReady?.();
+      await rollbackGate;
+    });
+    await rollbackReady;
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, Math.max(0, Date.parse(retentionExpiresAt) - Date.now() + 50));
+    });
+
+    const cleanupStore = new ProviderCredentialSecretCleanupStore(getDb(env));
+    await expect(
+      cleanupStore.listPendingDestructions(
+        {
+          id: predecessorId,
+          organization_id: ORGANIZATION_ID,
+          secret_ref: `projects/p/secrets/sdp-provider-credentials-${predecessorId}`,
+        },
+        25
+      )
+    ).resolves.toEqual([expect.objectContaining({ id: predecessorId })]);
+    const fenced = cleanupStore.fenceGcpCleanupCandidate({
+      id: predecessorId,
+      expectedSecretVersionRef: `projects/p/secrets/sdp-provider-credentials-${predecessorId}/versions/7`,
+    });
+    await new Promise<void>((resolve) => setTimeout(resolve, 25));
+    expect(destroyVersion).not.toHaveBeenCalled();
+
+    releaseRollback?.();
+    await rollback;
+    await expect(fenced).resolves.toBeNull();
+    expect(destroyVersion).not.toHaveBeenCalled();
+    await expect(credentialState(predecessorId)).resolves.toMatchObject({
+      status: "active",
+      secret_retention_expires_at: null,
+    });
+  });
+
+  it("makes rollback ineligible after cleanup wins", async () => {
+    const predecessorId = "pcred_cleanup_wins";
+    const currentId = "pcred_cleanup_wins_current";
+    const connectionId = "conn_cleanup_wins";
+    await insertCredential({
+      id: predecessorId,
+      backend: "gcp_secret_manager",
+      retentionExpiresAt: "2020-01-01T00:00:00.000Z",
+    });
+    await insertCredential({ id: currentId, status: "active", rotatedFromId: predecessorId });
+    await insertConnection(connectionId, currentId);
+
+    await expect(cleanupRetiredProviderCredentialSecrets(env)).resolves.toEqual({
+      cleaned: 1,
+      skipped: 0,
+      failed: 0,
+    });
+    await expect(
+      getDb(env).transaction(async (tx) => {
+        const changed = await new ProviderCredentialStore(tx).rollBackCredential({
+          organizationId: ORGANIZATION_ID,
+          currentId,
+          predecessorId,
+          predecessorScopeKey: "__organization__",
+          expectedConnectionIds: [connectionId],
+        });
+        if (!changed) throw new Error("Rollback is no longer eligible");
+      })
+    ).rejects.toThrow("Rollback is no longer eligible");
+    expect(destroyVersion).toHaveBeenCalledOnce();
+    expect(
+      await getDb(env).queryOne<{ provider_credential_id: string }>(
+        "SELECT provider_credential_id FROM custody_connections WHERE id = ?",
+        [connectionId]
+      )
+    ).toEqual({ provider_credential_id: currentId });
+  });
+
   it("isolates GCP failures, keeps their marker, and rejects once with redacted telemetry", async () => {
     const rawFailure =
       "raw upstream detail for projects/p/secrets/sdp-provider-credentials-pcred_a_failure/versions/7";
@@ -393,6 +499,59 @@ describe("cleanupRetiredProviderCredentialSecrets", () => {
     expect(JSON.stringify(logError.mock.calls)).not.toContain(rawFailure);
     expect(JSON.stringify(logError.mock.calls)).not.toContain("raw upstream detail");
   });
+
+  it.each(["failed_validation", "deactivated"] as const)(
+    "retries cleanup for a GCP rotation candidate that ends %s without changing its status",
+    async (status) => {
+      const predecessorId = `pcred_${status}_predecessor`;
+      const candidateId = `pcred_${status}_candidate`;
+      await insertCredential({ id: predecessorId, status: "active" });
+      await insertCredential({
+        id: candidateId,
+        status: "pending",
+        backend: "gcp_secret_manager",
+        rotatedFromId: predecessorId,
+      });
+      const credentialStore = new ProviderCredentialStore(getDb(env));
+      const transitioned =
+        status === "failed_validation"
+          ? await credentialStore.recordRotationFailure(candidateId, "invalid_credentials")
+          : await credentialStore.deactivateRotationCandidate({
+              organizationId: ORGANIZATION_ID,
+              candidateId,
+              predecessorId,
+            });
+      expect(transitioned).toBe(true);
+      const retentionExpiresAt = (await credentialState(candidateId)).secret_retention_expires_at;
+      expect(retentionExpiresAt).toEqual(expect.any(String));
+      destroyVersion.mockRejectedValueOnce(new Error("transient GCP failure"));
+
+      await expect(cleanupRetiredProviderCredentialSecrets(env)).rejects.toThrow(
+        "Provider Credential secret cleanup failed for 1 row(s)"
+      );
+      await expect(credentialState(candidateId)).resolves.toMatchObject({
+        status,
+        secret_retention_expires_at: retentionExpiresAt,
+      });
+
+      await makeCleanupDue(candidateId);
+      await expect(cleanupRetiredProviderCredentialSecrets(env)).resolves.toEqual({
+        cleaned: 1,
+        skipped: 0,
+        failed: 0,
+      });
+      expect(destroyVersion).toHaveBeenCalledTimes(2);
+      expect(destroyVersion).toHaveBeenLastCalledWith({
+        secretVersionRef: `projects/p/secrets/sdp-provider-credentials-${candidateId}/versions/7`,
+        signal: expect.any(AbortSignal),
+        requireDestroyed: true,
+      });
+      await expect(credentialState(candidateId)).resolves.toMatchObject({
+        status,
+        secret_retention_expires_at: null,
+      });
+    }
+  );
 
   it("does not clear a GCP marker that changed while the destroy was in flight", async () => {
     await insertCredential({

--- a/apps/sdp-api/src/services/provider-credential-installation.service.ts
+++ b/apps/sdp-api/src/services/provider-credential-installation.service.ts
@@ -22,12 +22,13 @@ import {
   type StoredCredentialSecret,
 } from "@/services/credential-secret-store";
 import {
+  checkPrivyCredential,
   getPrivyProviderAccountFingerprint,
   PRIVY_RUNTIME_ENV_FIELDS,
+  type PrivyCredentialAuthentication,
 } from "@/services/custody/privy-credential";
 import {
   findPrivyWalletByExternalId,
-  type PrivyCredentialAuthentication,
   type ProvisionPrivyResult,
   provisionPrivyWallet,
 } from "@/services/custody/provisioning";
@@ -48,7 +49,6 @@ import {
 import type { Env } from "@/types/env";
 
 const INSTALLATION_UNAVAILABLE_MESSAGE = "Provider credential installation is unavailable";
-const PRIVY_CHECK_TIMEOUT_MS = 10_000;
 
 type CompletionStatus = "running" | "success" | "failed" | "retry_unknown";
 type CompletionFailureCode =
@@ -528,7 +528,7 @@ async function executeCompletionMode(
     return lookupProviderWallet(context.c.env, externalId, credential);
   }
 
-  const validation = await validatePrivyCredential(context.c.env, credential);
+  const validation = await checkPrivyCredential(context.c.env, credential);
   if (validation !== "success") {
     return validation === "failed"
       ? { kind: "failed", code: "invalid_credentials" }
@@ -638,38 +638,6 @@ async function acquireCompletionLease(
     expectedLastCheckStatus: target.last_check_status,
     expectedLastCheckAt: target.last_check_at,
   });
-}
-
-async function validatePrivyCredential(
-  env: Env,
-  credential: PrivyCredentialAuthentication
-): Promise<"success" | "failed" | "retry_unknown"> {
-  const baseUrl = (env.PRIVY_API_BASE_URL ?? "https://api.privy.io/v1").replace(/\/+$/, "");
-  try {
-    const response = await fetch(`${baseUrl}/wallets?limit=1&chain_type=solana`, {
-      method: "GET",
-      headers: {
-        Authorization: `Basic ${Buffer.from(`${credential.appId}:${credential.appSecret}`).toString("base64")}`,
-        "privy-app-id": credential.appId,
-      },
-      signal: AbortSignal.timeout(PRIVY_CHECK_TIMEOUT_MS),
-    });
-    if (response.status === 401) return "failed";
-    if (response.status !== 200) return "retry_unknown";
-    const body = await response.json().catch(() => null);
-    return isWalletListResponse(body) ? "success" : "retry_unknown";
-  } catch {
-    return "retry_unknown";
-  }
-}
-
-function isWalletListResponse(value: unknown): value is { data: unknown[] } {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "data" in value &&
-    Array.isArray((value as { data?: unknown }).data)
-  );
 }
 
 async function persistSuccess(

--- a/apps/sdp-api/src/services/provider-credential-lifecycle.service.ts
+++ b/apps/sdp-api/src/services/provider-credential-lifecycle.service.ts
@@ -1,0 +1,1399 @@
+import { hashString } from "@sdp/payments/hash";
+import type { Context } from "hono";
+import { getDb } from "@/db";
+import { isPostgresUniqueViolation } from "@/db/postgres-utils";
+import { getAuth, requireProjectId } from "@/lib/auth";
+import {
+  AppError,
+  conflict,
+  forbidden,
+  internalError,
+  notFound,
+  providerUnavailable,
+} from "@/lib/errors";
+import { normalizeForFingerprint, resolveIdempotencyReplay } from "@/lib/idempotency";
+import { getLogger } from "@/runtime/logger";
+import { describeError, logEvent } from "@/runtime/money-path-events";
+import { type AuditIntent, AuditService } from "@/services/audit.service";
+import {
+  type CredentialSecretPayload,
+  type CredentialSecretStore,
+  CredentialSecretStoreError,
+  createCredentialSecretStore,
+  prepareGcpCredentialSecret,
+  type StoredCredentialSecret,
+} from "@/services/credential-secret-store";
+import {
+  checkPrivyCredential,
+  getPrivyProviderAccountFingerprint,
+  type PrivyCredentialAuthentication,
+} from "@/services/custody/privy-credential";
+import {
+  assertCredentialCreationSettled,
+  recoverCredentialCreation,
+} from "@/services/provider-credential-creation";
+import {
+  mapProviderCredential,
+  type SafeProviderCredential,
+} from "@/services/provider-credential-submission.service";
+import {
+  type CredentialReferenceRow,
+  type LifecycleCredentialRow,
+  type LifecycleCredentialWithSecretRow,
+  type ProviderCredentialRow,
+  ProviderCredentialStore,
+} from "@/services/stores/provider-credential.store";
+import type { Env } from "@/types/env";
+
+const ROTATION_UNAVAILABLE = "Credential rotation is not available";
+const ROLLBACK_UNAVAILABLE = "Credential rollback is not available";
+const CANDIDATE_UNAVAILABLE = "Credential cannot be deactivated from its current state";
+
+export type RotationFailureCode = "invalid_credentials" | "provider_account_mismatch";
+
+export interface ProviderCredentialLifecycle {
+  providerCredential: LifecycleProviderCredential;
+  rotationCandidate: LifecycleProviderCredential | null;
+  impact: {
+    projects: Array<{ id: string; name: string }>;
+    connections: Array<{ id: string; projectId: string; status: string }>;
+  };
+  rollback: {
+    providerCredential: LifecycleProviderCredential;
+    expiresAt: string;
+  } | null;
+}
+
+export interface LifecycleProviderCredential extends SafeProviderCredential {
+  source: LifecycleCredentialRow["source"];
+}
+
+export interface ProviderCredentialRotationResult {
+  providerCredential: SafeProviderCredential;
+  rotation:
+    | { status: "success" }
+    | { status: "failed"; code: RotationFailureCode }
+    | { status: "retry_unknown"; code: "provider_response_unknown" };
+}
+
+interface LifecycleContext {
+  c: Context<{ Bindings: Env }>;
+  organizationId: string;
+  projectId: string;
+  userId: string;
+  store: ProviderCredentialStore;
+  audit: AuditService;
+}
+
+interface AuthorizedCredential {
+  credential: LifecycleCredentialRow;
+  references: CredentialReferenceRow[];
+}
+
+export async function getProviderCredentialLifecycle(
+  c: Context<{ Bindings: Env }>,
+  connectionId: string
+): Promise<ProviderCredentialLifecycle> {
+  const context = createContext(c);
+  const credentialId = await context.store.findLifecycleConnectionCredentialId(
+    context.organizationId,
+    context.projectId,
+    connectionId
+  );
+  if (!credentialId) throw notFound("Custody Connection");
+
+  const authorized = await loadAuthorizedCredential(context, credentialId);
+  const candidate =
+    authorized.credential.status === "active"
+      ? await context.store.findUnfinishedDirectChild(
+          context.organizationId,
+          authorized.credential.id
+        )
+      : null;
+  const rollback = await loadRollbackTarget(context, authorized.credential);
+
+  return {
+    providerCredential: mapLifecycleCredential(authorized.credential),
+    rotationCandidate: candidate ? mapLifecycleCredential(candidate) : null,
+    impact: projectImpact(authorized.references),
+    rollback: rollback
+      ? {
+          providerCredential: mapLifecycleCredential(rollback),
+          expiresAt: rollback.secret_retention_expires_at as string,
+        }
+      : null,
+  };
+}
+
+export async function rotateProviderCredential(
+  c: Context<{ Bindings: Env }>,
+  currentCredentialId: string,
+  fields: { appId: string; appSecret: string },
+  idempotencyKey: string
+): Promise<ProviderCredentialRotationResult> {
+  const context = createContext(c);
+  const target = await loadAuthorizedCredential(context, currentCredentialId);
+  const fingerprint = await rotationFingerprint(context, currentCredentialId, fields);
+  const existing = await context.store.findReplayByKey(context.organizationId, idempotencyKey);
+  if (existing) {
+    if (existing.rotated_from_provider_credential_id !== target.credential.id) {
+      throw conflict(ROTATION_UNAVAILABLE);
+    }
+    const authorizedReplay = await loadAuthorizedCandidate(context, existing.id, true);
+    const replay = await resolveIdempotencyReplay(() => Promise.resolve(existing), fingerprint);
+    if (replay) return replayRotationCandidate(c, authorizedReplay);
+  }
+  const current = await loadAuthorizedCurrent(context, currentCredentialId, ROTATION_UNAVAILABLE);
+  if (
+    await context.store.findUnfinishedDirectChild(context.organizationId, current.credential.id)
+  ) {
+    throw conflict(ROTATION_UNAVAILABLE);
+  }
+
+  const candidateId = `pcred_${crypto.randomUUID()}`;
+  const secretStore = createStoredSecretStore(c, candidateId);
+  const creating = secretStore.storageBackend === "gcp_secret_manager";
+  const existingSecretRef = creating
+    ? await context.store.findGcpContainerRef(context.organizationId, current.credential.id)
+    : null;
+  const stored = creating
+    ? existingSecretRef
+      ? { storageBackend: "gcp_secret_manager" as const, secretRef: existingSecretRef }
+      : prepareGcpCredentialSecret(c.env, candidateId)
+    : await writeRotationSecret(context, secretStore, candidateId, fields.appId, fields.appSecret);
+
+  let candidate: LifecycleCredentialRow;
+  try {
+    const transaction = await getDb(c.env).transaction(async (tx) => {
+      const store = new ProviderCredentialStore(tx);
+      await lockRotationTarget(context, store, current);
+
+      const concurrentReplay = await resolveIdempotencyReplay(async () => {
+        const row = await store.findReplayByKey(context.organizationId, idempotencyKey);
+        if (row && row.rotated_from_provider_credential_id !== current.credential.id) {
+          throw conflict(ROTATION_UNAVAILABLE);
+        }
+        return row;
+      }, fingerprint);
+      if (concurrentReplay) return { kind: "replay" as const, id: concurrentReplay.id };
+      if (
+        await store.findUnfinishedDirectChild(context.organizationId, current.credential.id, {
+          lock: true,
+        })
+      ) {
+        throw conflict(ROTATION_UNAVAILABLE);
+      }
+
+      const inserted = await store.insertCredential({
+        id: candidateId,
+        organizationId: context.organizationId,
+        projectId: current.credential.project_id,
+        provider: "privy",
+        label: current.credential.label,
+        scope: current.credential.scope,
+        source: "stored",
+        stored,
+        displayMetadata: fields.appId.length > 4 ? { appIdSuffix: fields.appId.slice(-4) } : {},
+        version: await store.nextCredentialVersion(context.organizationId, current.credential.id),
+        rotatedFromId: current.credential.id,
+        idempotencyKey,
+        idempotencyFingerprint: fingerprint,
+        createdBy: context.userId,
+        status: creating ? "creating" : "pending",
+        ownsGcpContainer: creating && !existingSecretRef,
+      });
+      return { kind: "committed" as const, id: inserted.id };
+    });
+    const loaded = await context.store.findLifecycleCredential(
+      context.organizationId,
+      transaction.id
+    );
+    if (!loaded) throw internalError();
+    candidate = loaded;
+    // A replay never owns the external write, even if the winning row is still creating.
+    if (transaction.kind === "replay")
+      return replayRotationCandidate(c, await loadAuthorizedCandidate(context, candidate.id, true));
+  } catch (error) {
+    let recovered: ProviderCredentialRow | null;
+    try {
+      recovered = await context.store.findReplayByKey(context.organizationId, idempotencyKey);
+    } catch (reconciliationError) {
+      logLifecycleFailure(c, "candidate_insert_reconcile", candidateId, reconciliationError);
+      throw error;
+    }
+    if (recovered?.idempotency_fingerprint === fingerprint) {
+      return completeRotationCandidate(c, recovered.id);
+    }
+    if (isPostgresUniqueViolation(error)) throw conflict(ROTATION_UNAVAILABLE);
+    throw error;
+  }
+
+  if (creating)
+    return finishGcpRotationCreation(
+      context,
+      current,
+      candidate,
+      secretStore,
+      fields,
+      existingSecretRef ?? undefined
+    );
+  return completeRotationCandidate(c, candidate.id);
+}
+
+async function finishGcpRotationCreation(
+  context: LifecycleContext,
+  current: AuthorizedCredential,
+  candidate: LifecycleCredentialRow,
+  secretStore: CredentialSecretStore,
+  fields: { appId: string; appSecret: string },
+  existingSecretRef?: string
+): Promise<ProviderCredentialRotationResult> {
+  const c = context.c;
+  const candidateId = candidate.id;
+  if (candidate.status !== "creating") throw conflict(ROTATION_UNAVAILABLE);
+  let written: StoredCredentialSecret | undefined;
+  try {
+    written = await writeRotationSecret(
+      context,
+      secretStore,
+      candidateId,
+      fields.appId,
+      fields.appSecret,
+      existingSecretRef
+    );
+    const { secretRef, secretVersionRef } = written;
+    if (!secretRef || !secretVersionRef) throw internalError();
+    await getDb(c.env).transaction(async (tx) => {
+      const store = new ProviderCredentialStore(tx);
+      await lockRotationTarget(context, store, current);
+      const finalized = await store.finalizeCredentialCreation({
+        organizationId: context.organizationId,
+        credentialId: candidateId,
+        secretRef,
+        secretVersionRef,
+      });
+      if (!finalized) throw conflict(ROTATION_UNAVAILABLE);
+    });
+  } catch (error) {
+    const recovered = await recoverCredentialCreation(
+      c,
+      context.organizationId,
+      candidateId,
+      written
+    );
+    if (recovered.kind === "adopted") return completeRotationCandidate(c, candidateId);
+    if (recovered.kind === "unknown") {
+      throw providerUnavailable("Credential creation outcome is temporarily unknown");
+    }
+    throw error;
+  }
+  return completeRotationCandidate(c, candidate.id);
+}
+
+async function lockRotationTarget(
+  context: LifecycleContext,
+  store: ProviderCredentialStore,
+  current: AuthorizedCredential
+): Promise<void> {
+  await assertLockedAuthorization(context, store, current.references);
+  const references = await store.listCredentialReferences(
+    context.organizationId,
+    current.credential.id,
+    { lock: true }
+  );
+  const credential = await store.findLifecycleCredential(
+    context.organizationId,
+    current.credential.id,
+    { lock: true }
+  );
+  assertCurrentSnapshot(credential, references, current, ROTATION_UNAVAILABLE);
+}
+
+export async function completeRotationCandidate(
+  c: Context<{ Bindings: Env }>,
+  candidateId: string
+): Promise<ProviderCredentialRotationResult> {
+  const context = createContext(c);
+  const loaded = await loadAuthorizedCandidate(context, candidateId);
+  assertCredentialCreationSettled(loaded.candidate);
+  if (loaded.candidate.status === "active") {
+    return rotationResult(loaded.candidate, "success");
+  }
+  if (loaded.candidate.status === "failed_validation") {
+    const code = safeRotationFailureCode(loaded.candidate.last_failure_code);
+    if (!code) throw conflict(ROTATION_UNAVAILABLE);
+    return rotationResult(loaded.candidate, "failed", code);
+  }
+  if (loaded.candidate.status !== "pending") throw conflict(ROTATION_UNAVAILABLE);
+  if (loaded.references.length === 0 || loaded.candidateReferences.length > 0) {
+    throw conflict(ROTATION_UNAVAILABLE);
+  }
+
+  let candidateSecret: LifecycleCredentialWithSecretRow;
+  let authentication: PrivyCredentialAuthentication;
+  try {
+    candidateSecret = await requireLifecycleCredentialSecret(context, loaded.candidate.id);
+    const secretStore = createPersistedSecretStore(c, candidateSecret.storage_backend, candidateId);
+    authentication = await readPrivyCredential(secretStore, context, candidateSecret);
+  } catch (error) {
+    return reconcileCandidateSecretReadFailure(c, context, loaded.candidate.id, error);
+  }
+  const check = await checkPrivyCredential(c.env, authentication);
+  if (check === "retry_unknown") {
+    const race = await settleCandidateOutcome(context, loaded, "retry_unknown");
+    if (race) return race;
+    return rotationResult(loaded.candidate, "retry_unknown", "provider_response_unknown");
+  }
+
+  const accountMatches =
+    check === "success" &&
+    (await continuityFingerprint(authentication.appId)) ===
+      uniqueReferenceFingerprint(loaded.references);
+  if (check === "failed" || !accountMatches) {
+    const code: RotationFailureCode =
+      check === "failed" ? "invalid_credentials" : "provider_account_mismatch";
+    const race = await settleCandidateOutcome(context, loaded, code);
+    if (race?.rotation.status === "success") return race;
+    await cleanupRejectedCandidate(c, candidateSecret);
+    if (race) return race;
+    return rotationResult({ ...loaded.candidate, status: "failed_validation" }, "failed", code);
+  }
+
+  const auditIntent = await context.audit.beginCritical(c, {
+    organizationId: context.organizationId,
+    userId: context.userId,
+    action: "rotate",
+    resourceType: "provider_credential",
+    resourceId: loaded.candidate.id,
+    metadata: { event: "provider_credential_rotation_started", provider: "privy" },
+  });
+  let applied = false;
+  try {
+    await getDb(c.env).transaction(async (tx) => {
+      const store = new ProviderCredentialStore(tx);
+      await assertLockedAuthorization(context, store, loaded.references);
+      const lockedReferences = await store.listCredentialReferences(
+        context.organizationId,
+        loaded.predecessor.id,
+        { lock: true }
+      );
+      const lockedCandidateReferences = await store.listCredentialReferences(
+        context.organizationId,
+        loaded.candidate.id,
+        { lock: true }
+      );
+      const lockedCandidate = await store.findLifecycleCredential(
+        context.organizationId,
+        loaded.candidate.id,
+        { lock: true }
+      );
+      const lockedPredecessor = await store.findLifecycleCredential(
+        context.organizationId,
+        loaded.predecessor.id,
+        { lock: true }
+      );
+      assertCandidateSnapshot(lockedCandidate, lockedPredecessor, lockedReferences, loaded);
+      if (lockedCandidateReferences.length > 0) throw conflict(ROTATION_UNAVAILABLE);
+      const changed = await store.cutOverRotation({
+        organizationId: context.organizationId,
+        predecessorId: loaded.predecessor.id,
+        candidateId: loaded.candidate.id,
+        candidateScopeKey: loaded.candidate.scope_key,
+        expectedConnectionIds: referenceIds(loaded.references),
+      });
+      if (!changed) {
+        throw conflict(ROTATION_UNAVAILABLE);
+      }
+      applied = true;
+    });
+  } catch (error) {
+    logLifecycleFailure(c, "rotation_commit", loaded.candidate.id, error);
+    const visible = await rotationCommitIsVisible(context, loaded);
+    if (visible === true) {
+      if (applied) {
+        logUnresolvedAuditIntent(context, auditIntent, loaded.candidate.id);
+      } else {
+        await closeRejectedIntent(context, auditIntent, "provider_credential_rotation_replayed");
+        await loadAuthorizedCandidate(context, loaded.candidate.id);
+      }
+      return rotationResult({ ...loaded.candidate, status: "active" }, "success");
+    }
+    if (applied || visible === null) {
+      throw providerUnavailable("Credential rotation outcome is temporarily unknown");
+    }
+    await closeRejectedIntent(context, auditIntent, "provider_credential_rotation_not_committed");
+    if (error instanceof AppError) throw error;
+    throw conflict(ROTATION_UNAVAILABLE);
+  }
+  await context.audit.completeCritical(c, auditIntent, {
+    metadata: { event: "provider_credential_rotated", provider: "privy" },
+  });
+  return rotationResult({ ...loaded.candidate, status: "active" }, "success");
+}
+
+export async function rollbackProviderCredential(
+  c: Context<{ Bindings: Env }>,
+  currentCredentialId: string
+): Promise<{ providerCredential: SafeProviderCredential }> {
+  const context = createContext(c);
+  const current = await loadAuthorizedCurrent(context, currentCredentialId, ROLLBACK_UNAVAILABLE);
+  if (
+    await context.store.findUnfinishedDirectChild(context.organizationId, current.credential.id)
+  ) {
+    throw conflict(ROLLBACK_UNAVAILABLE);
+  }
+  const predecessor = await loadRollbackTarget(context, current.credential);
+  if (!predecessor) throw conflict(ROLLBACK_UNAVAILABLE);
+
+  let authentication: PrivyCredentialAuthentication;
+  try {
+    const predecessorSecret = await requireLifecycleCredentialSecret(context, predecessor.id);
+    const secretStore = createPersistedSecretStore(
+      c,
+      predecessorSecret.storage_backend,
+      predecessor.id
+    );
+    authentication = await readPrivyCredential(secretStore, context, predecessorSecret);
+  } catch (error) {
+    const refreshedCurrent = await loadAuthorizedCurrent(
+      context,
+      currentCredentialId,
+      ROLLBACK_UNAVAILABLE
+    );
+    const refreshedPredecessor = await loadRollbackTarget(context, refreshedCurrent.credential);
+    if (
+      refreshedPredecessor?.id !== predecessor.id ||
+      !sameReferences(refreshedCurrent.references, current.references)
+    ) {
+      throw conflict(ROLLBACK_UNAVAILABLE);
+    }
+    throw error;
+  }
+  const check = await checkPrivyCredential(c.env, authentication);
+  if (check === "retry_unknown") {
+    throw providerUnavailable("Credential provider is temporarily unavailable");
+  }
+  if (
+    check === "failed" ||
+    (await continuityFingerprint(authentication.appId)) !==
+      uniqueReferenceFingerprint(current.references)
+  ) {
+    throw conflict(ROLLBACK_UNAVAILABLE);
+  }
+
+  const auditIntent = await context.audit.beginCritical(c, {
+    organizationId: context.organizationId,
+    userId: context.userId,
+    action: "rollback",
+    resourceType: "provider_credential",
+    resourceId: predecessor.id,
+    metadata: { event: "provider_credential_rollback_started", provider: "privy" },
+  });
+  let applied = false;
+  try {
+    await getDb(c.env).transaction(async (tx) => {
+      const store = new ProviderCredentialStore(tx);
+      await assertLockedAuthorization(context, store, current.references);
+      const lockedReferences = await store.listCredentialReferences(
+        context.organizationId,
+        current.credential.id,
+        { lock: true }
+      );
+      const lockedCurrent = await store.findLifecycleCredential(
+        context.organizationId,
+        current.credential.id,
+        { lock: true }
+      );
+      const lockedPredecessor = await store.findLifecycleCredential(
+        context.organizationId,
+        predecessor.id,
+        { lock: true }
+      );
+      assertRollbackSnapshot(lockedCurrent, lockedPredecessor, lockedReferences, current);
+      if (
+        await store.findUnfinishedDirectChild(context.organizationId, current.credential.id, {
+          lock: true,
+        })
+      ) {
+        throw conflict(ROLLBACK_UNAVAILABLE);
+      }
+      const changed = await store.rollBackCredential({
+        organizationId: context.organizationId,
+        currentId: current.credential.id,
+        predecessorId: predecessor.id,
+        predecessorScopeKey: predecessor.scope_key,
+        expectedConnectionIds: referenceIds(current.references),
+      });
+      if (!changed) {
+        throw conflict(ROLLBACK_UNAVAILABLE);
+      }
+      applied = true;
+    });
+  } catch (error) {
+    logLifecycleFailure(c, "rollback_commit", currentCredentialId, error);
+    const visible = await rollbackCommitIsVisible(context, current, predecessor);
+    if (visible === true) {
+      if (applied) {
+        logUnresolvedAuditIntent(context, auditIntent, predecessor.id);
+      } else {
+        await closeRejectedIntent(context, auditIntent, "provider_credential_rollback_replayed");
+        await loadAuthorizedCurrent(context, predecessor.id, ROLLBACK_UNAVAILABLE);
+      }
+      return {
+        providerCredential: mapProviderCredential({ ...predecessor, status: "active" }),
+      };
+    }
+    if (applied || visible === null) {
+      throw providerUnavailable("Credential rollback outcome is temporarily unknown");
+    }
+    await closeRejectedIntent(context, auditIntent, "provider_credential_rollback_not_committed");
+    if (error instanceof AppError) throw error;
+    throw conflict(ROLLBACK_UNAVAILABLE);
+  }
+  await context.audit.completeCritical(c, auditIntent, {
+    metadata: { event: "provider_credential_rolled_back", provider: "privy" },
+  });
+  return {
+    providerCredential: mapProviderCredential({ ...predecessor, status: "active" }),
+  };
+}
+
+export async function deactivateRotationCandidate(
+  c: Context<{ Bindings: Env }>,
+  candidateId: string
+): Promise<{ providerCredential: SafeProviderCredential }> {
+  const context = createContext(c);
+  const loaded = await loadAuthorizedCandidate(context, candidateId, true, CANDIDATE_UNAVAILABLE);
+  if (loaded.candidate.status === "deactivated") {
+    const candidateSecret = await requireLifecycleCredentialSecret(context, candidateId);
+    await cleanupRejectedCandidate(c, candidateSecret);
+    return { providerCredential: mapProviderCredential(loaded.candidate) };
+  }
+  const candidateStatus = loaded.candidate.status;
+  if (
+    (candidateStatus !== "pending" && candidateStatus !== "creating") ||
+    loaded.candidateReferences.length > 0
+  ) {
+    throw conflict(CANDIDATE_UNAVAILABLE);
+  }
+  if (loaded.references.length === 0) throw conflict(CANDIDATE_UNAVAILABLE);
+  const candidateSecret = await requireLifecycleCredentialSecret(context, candidateId);
+
+  const auditIntent = await context.audit.beginCritical(c, {
+    organizationId: context.organizationId,
+    userId: context.userId,
+    action: "deactivate",
+    resourceType: "provider_credential",
+    resourceId: loaded.candidate.id,
+    metadata: { event: "provider_credential_rotation_cancellation_started", provider: "privy" },
+  });
+  let applied = false;
+  try {
+    await getDb(c.env).transaction(async (tx) => {
+      const store = new ProviderCredentialStore(tx);
+      await assertLockedAuthorization(context, store, loaded.references);
+      const lockedReferences = await store.listCredentialReferences(
+        context.organizationId,
+        loaded.predecessor.id,
+        { lock: true }
+      );
+      const lockedCandidateReferences = await store.listCredentialReferences(
+        context.organizationId,
+        loaded.candidate.id,
+        { lock: true }
+      );
+      const lockedCandidate = await store.findLifecycleCredential(
+        context.organizationId,
+        loaded.candidate.id,
+        { lock: true }
+      );
+      const lockedPredecessor = await store.findLifecycleCredential(
+        context.organizationId,
+        loaded.predecessor.id,
+        { lock: true }
+      );
+      assertCandidateSnapshot(
+        lockedCandidate,
+        lockedPredecessor,
+        lockedReferences,
+        loaded,
+        CANDIDATE_UNAVAILABLE,
+        candidateStatus
+      );
+      if (lockedCandidateReferences.length > 0) throw conflict(CANDIDATE_UNAVAILABLE);
+      const changed =
+        candidateStatus === "creating"
+          ? await store.abandonCredentialCreation({
+              organizationId: context.organizationId,
+              credentialId: loaded.candidate.id,
+            })
+          : await store.deactivateRotationCandidate({
+              organizationId: context.organizationId,
+              candidateId: loaded.candidate.id,
+              predecessorId: loaded.predecessor.id,
+            });
+      if (!changed) {
+        throw conflict(CANDIDATE_UNAVAILABLE);
+      }
+      applied = true;
+    });
+  } catch (error) {
+    logLifecycleFailure(c, "cancellation_commit", candidateId, error);
+    const visible = await cancellationCommitIsVisible(context, loaded);
+    if (visible === true) {
+      if (applied) {
+        logUnresolvedAuditIntent(context, auditIntent, candidateId);
+      } else {
+        await closeRejectedIntent(
+          context,
+          auditIntent,
+          "provider_credential_rotation_cancellation_replayed"
+        );
+        await loadAuthorizedCandidate(context, loaded.candidate.id, true, CANDIDATE_UNAVAILABLE);
+      }
+      await cleanupRejectedCandidate(c, candidateSecret);
+      return {
+        providerCredential: mapProviderCredential({ ...loaded.candidate, status: "deactivated" }),
+      };
+    }
+    if (applied || visible === null) {
+      throw providerUnavailable("Credential cancellation outcome is temporarily unknown");
+    }
+    await closeRejectedIntent(
+      context,
+      auditIntent,
+      "provider_credential_rotation_cancellation_not_committed"
+    );
+    if (error instanceof AppError) throw error;
+    throw conflict(CANDIDATE_UNAVAILABLE);
+  }
+  await cleanupRejectedCandidate(c, candidateSecret);
+  await context.audit.completeCritical(c, auditIntent, {
+    metadata: { event: "provider_credential_rotation_canceled", provider: "privy" },
+  });
+  return {
+    providerCredential: mapProviderCredential({ ...loaded.candidate, status: "deactivated" }),
+  };
+}
+
+function createContext(c: Context<{ Bindings: Env }>): LifecycleContext {
+  const auth = getAuth(c);
+  const projectId = requireProjectId(c);
+  if (!auth.userId) throw internalError();
+  const db = getDb(c.env);
+  return {
+    c,
+    organizationId: auth.organizationId,
+    projectId,
+    userId: auth.userId,
+    store: new ProviderCredentialStore(db),
+    audit: new AuditService(db),
+  };
+}
+
+async function loadAuthorizedCredential(
+  context: LifecycleContext,
+  credentialId: string
+): Promise<AuthorizedCredential> {
+  const credential = await requireLifecycleCredential(context, credentialId);
+  if (credential.scope === "project" && credential.project_id !== context.projectId) {
+    throw notFound("Provider Credential");
+  }
+  const references = await context.store.listCredentialReferences(
+    context.organizationId,
+    credential.id
+  );
+  await assertAuthorization(context, references);
+  return { credential, references };
+}
+
+async function loadAuthorizedCurrent(
+  context: LifecycleContext,
+  credentialId: string,
+  unavailableMessage: string
+): Promise<AuthorizedCredential> {
+  const authorized = await loadAuthorizedCredential(context, credentialId);
+  if (
+    authorized.credential.status !== "active" ||
+    authorized.credential.source !== "stored" ||
+    authorized.references.length === 0
+  ) {
+    throw conflict(unavailableMessage);
+  }
+  return authorized;
+}
+
+async function loadAuthorizedCandidate(
+  context: LifecycleContext,
+  candidateId: string,
+  allowHistorical = false,
+  unavailableMessage = ROTATION_UNAVAILABLE
+): Promise<{
+  candidate: LifecycleCredentialRow;
+  predecessor: LifecycleCredentialRow;
+  references: CredentialReferenceRow[];
+  candidateReferences: CredentialReferenceRow[];
+}> {
+  const candidate = await requireLifecycleCredential(context, candidateId);
+  if (candidate.scope === "project" && candidate.project_id !== context.projectId) {
+    throw notFound("Provider Credential");
+  }
+  if (!candidate.rotated_from_provider_credential_id || candidate.source !== "stored") {
+    throw conflict(unavailableMessage);
+  }
+  const predecessor = await requireLifecycleCredential(
+    context,
+    candidate.rotated_from_provider_credential_id
+  );
+  const candidateReferences = await context.store.listCredentialReferences(
+    context.organizationId,
+    candidate.id
+  );
+  const references =
+    candidate.status === "active"
+      ? candidateReferences
+      : predecessor.status === "active"
+        ? await context.store.listCredentialReferences(context.organizationId, predecessor.id)
+        : await context.store.listCredentialLineageReferences(context.organizationId, candidate.id);
+  await assertAuthorization(context, [...references, ...candidateReferences]);
+  if (!allowHistorical && candidate.status !== "active" && predecessor.status !== "active") {
+    throw conflict(unavailableMessage);
+  }
+  return { candidate, predecessor, references, candidateReferences };
+}
+
+async function replayRotationCandidate(
+  c: Context<{ Bindings: Env }>,
+  loaded: Awaited<ReturnType<typeof loadAuthorizedCandidate>>
+): Promise<ProviderCredentialRotationResult> {
+  const candidate = loaded.candidate;
+  assertCredentialCreationSettled(candidate);
+  if (candidate.status === "pending") return completeRotationCandidate(c, candidate.id);
+  if (
+    (candidate.status === "active" || candidate.status === "retired") &&
+    candidate.last_validated_at
+  ) {
+    return rotationResult(candidate, "success");
+  }
+  if (candidate.status === "failed_validation") {
+    const code = safeRotationFailureCode(candidate.last_failure_code);
+    if (code) return rotationResult(candidate, "failed", code);
+  }
+  throw conflict(ROTATION_UNAVAILABLE);
+}
+
+async function reconcileCandidateSecretReadFailure(
+  c: Context<{ Bindings: Env }>,
+  context: LifecycleContext,
+  candidateId: string,
+  error: unknown
+): Promise<ProviderCredentialRotationResult> {
+  const current = await loadAuthorizedCandidate(context, candidateId, true);
+  if (current.candidate.status !== "pending") return replayRotationCandidate(c, current);
+  throw error;
+}
+
+async function requireLifecycleCredential(
+  context: LifecycleContext,
+  credentialId: string
+): Promise<LifecycleCredentialRow> {
+  const row = await context.store.findLifecycleCredential(context.organizationId, credentialId);
+  if (!row) throw notFound("Provider Credential");
+  return row;
+}
+
+async function requireLifecycleCredentialSecret(
+  context: LifecycleContext,
+  credentialId: string
+): Promise<LifecycleCredentialWithSecretRow> {
+  const row = await context.store.findLifecycleCredentialWithSecret(
+    context.organizationId,
+    credentialId
+  );
+  if (!row) throw notFound("Provider Credential");
+  return row;
+}
+
+async function assertAuthorization(
+  context: LifecycleContext,
+  references: readonly CredentialReferenceRow[]
+): Promise<void> {
+  if (
+    !(await context.store.lockAuthorizedProjects(
+      context.organizationId,
+      context.userId,
+      references.map((reference) => reference.project_id)
+    ))
+  ) {
+    throw forbidden("Requested project is not accessible");
+  }
+}
+
+async function assertLockedAuthorization(
+  context: LifecycleContext,
+  store: ProviderCredentialStore,
+  references: readonly CredentialReferenceRow[]
+): Promise<void> {
+  if (
+    references.length === 0 ||
+    !(await store.lockAuthorizedProjects(
+      context.organizationId,
+      context.userId,
+      references.map((reference) => reference.project_id)
+    ))
+  ) {
+    throw forbidden("Requested project is not accessible");
+  }
+}
+
+async function loadRollbackTarget(
+  context: LifecycleContext,
+  current: LifecycleCredentialRow
+): Promise<LifecycleCredentialRow | null> {
+  if (current.status !== "active" || !current.rotated_from_provider_credential_id) return null;
+  const predecessor = await context.store.findLifecycleCredential(
+    context.organizationId,
+    current.rotated_from_provider_credential_id
+  );
+  if (
+    predecessor?.status !== "retired" ||
+    predecessor.source !== "stored" ||
+    !predecessor.secret_retention_expires_at ||
+    Date.parse(predecessor.secret_retention_expires_at) <= (await context.store.getDatabaseNowMs())
+  ) {
+    return null;
+  }
+  return predecessor;
+}
+
+async function settleCandidateOutcome(
+  context: LifecycleContext,
+  expected: Awaited<ReturnType<typeof loadAuthorizedCandidate>>,
+  outcome: "retry_unknown" | RotationFailureCode
+): Promise<ProviderCredentialRotationResult | null> {
+  const auditIntent =
+    outcome === "retry_unknown"
+      ? null
+      : await context.audit.beginCritical(context.c, {
+          organizationId: context.organizationId,
+          userId: context.userId,
+          action: "rotate",
+          resourceType: "provider_credential",
+          resourceId: expected.candidate.id,
+          metadata: { event: "provider_credential_rotation_rejection_started", provider: "privy" },
+        });
+  let applied = false;
+  try {
+    await getDb(context.c.env).transaction(async (tx) => {
+      const store = new ProviderCredentialStore(tx);
+      await assertLockedAuthorization(context, store, expected.references);
+      const lockedReferences = await store.listCredentialReferences(
+        context.organizationId,
+        expected.predecessor.id,
+        { lock: true }
+      );
+      const lockedCandidateReferences = await store.listCredentialReferences(
+        context.organizationId,
+        expected.candidate.id,
+        { lock: true }
+      );
+      const lockedCandidate = await store.findLifecycleCredential(
+        context.organizationId,
+        expected.candidate.id,
+        { lock: true }
+      );
+      const lockedPredecessor = await store.findLifecycleCredential(
+        context.organizationId,
+        expected.predecessor.id,
+        { lock: true }
+      );
+      assertCandidateSnapshot(lockedCandidate, lockedPredecessor, lockedReferences, expected);
+      if (lockedCandidateReferences.length > 0) throw conflict(ROTATION_UNAVAILABLE);
+      const persisted =
+        outcome === "retry_unknown"
+          ? await store.recordRotationRetryUnknown(expected.candidate.id)
+          : await store.recordRotationFailure(expected.candidate.id, outcome);
+      if (!persisted) throw conflict(ROTATION_UNAVAILABLE);
+      applied = true;
+    });
+  } catch (error) {
+    logLifecycleFailure(context.c, "candidate_outcome_write", expected.candidate.id, error);
+    let current: Awaited<ReturnType<typeof loadAuthorizedCandidate>>;
+    try {
+      current = await loadAuthorizedCandidate(context, expected.candidate.id);
+    } catch (reconciliationError) {
+      logLifecycleFailure(
+        context.c,
+        "candidate_outcome_read",
+        expected.candidate.id,
+        reconciliationError
+      );
+      if (reconciliationError instanceof AppError) throw reconciliationError;
+      throw providerUnavailable("Credential rotation outcome is temporarily unknown");
+    }
+    if (
+      auditIntent &&
+      (!applied ||
+        current.candidate.status !== "failed_validation" ||
+        current.candidate.last_failure_code !== outcome)
+    ) {
+      await closeRejectedIntent(
+        context,
+        auditIntent,
+        "provider_credential_rotation_rejection_not_committed"
+      );
+    } else if (auditIntent) {
+      logUnresolvedAuditIntent(context, auditIntent, expected.candidate.id);
+    }
+    // A failed COMMIT followed by the expected state does not prove which
+    // concurrent request wrote it. Keep that intent unresolved, not a duplicate outcome.
+    if (
+      outcome === "retry_unknown" &&
+      current.candidate.status === "pending" &&
+      current.candidate.last_failure_code === "provider_response_unknown"
+    ) {
+      return null;
+    }
+    if (current.candidate.status === "active") {
+      return rotationResult(current.candidate, "success");
+    }
+    if (current.candidate.status === "failed_validation") {
+      const code = safeRotationFailureCode(current.candidate.last_failure_code);
+      if (code) return rotationResult(current.candidate, "failed", code);
+    }
+    if (error instanceof AppError) throw error;
+    throw providerUnavailable("Credential rotation outcome is temporarily unknown");
+  }
+  if (auditIntent) {
+    await context.audit.completeCritical(context.c, auditIntent, {
+      status: "failure",
+      metadata: {
+        event: "provider_credential_rotation_rejected",
+        provider: "privy",
+        failureCode: outcome,
+      },
+    });
+  }
+  return null;
+}
+
+function projectImpact(
+  references: readonly CredentialReferenceRow[]
+): ProviderCredentialLifecycle["impact"] {
+  return {
+    projects: [
+      ...new Map(
+        references.map((row) => [row.project_id, { id: row.project_id, name: row.project_name }])
+      ).values(),
+    ],
+    connections: references.map((row) => ({
+      id: row.id,
+      projectId: row.project_id,
+      status: row.status,
+    })),
+  };
+}
+
+function referenceIds(references: readonly CredentialReferenceRow[]): string[] {
+  return references.map((reference) => reference.id).sort();
+}
+
+function sameReferences(
+  left: readonly CredentialReferenceRow[],
+  right: readonly CredentialReferenceRow[]
+): boolean {
+  return (
+    JSON.stringify(
+      left.map((row) => [row.id, row.project_id, row.status, row.provider_account_fingerprint])
+    ) ===
+    JSON.stringify(
+      right.map((row) => [row.id, row.project_id, row.status, row.provider_account_fingerprint])
+    )
+  );
+}
+
+function assertCurrentSnapshot(
+  lockedCredential: LifecycleCredentialRow | null,
+  lockedReferences: CredentialReferenceRow[],
+  expected: AuthorizedCredential,
+  message: string
+): asserts lockedCredential is LifecycleCredentialRow {
+  if (
+    lockedCredential?.status !== "active" ||
+    lockedCredential.id !== expected.credential.id ||
+    !sameReferences(lockedReferences, expected.references)
+  ) {
+    throw conflict(message);
+  }
+}
+
+function assertCandidateSnapshot(
+  candidate: LifecycleCredentialRow | null,
+  predecessor: LifecycleCredentialRow | null,
+  references: CredentialReferenceRow[],
+  expected: {
+    candidate: LifecycleCredentialRow;
+    predecessor: LifecycleCredentialRow;
+    references: CredentialReferenceRow[];
+  },
+  unavailableMessage = ROTATION_UNAVAILABLE,
+  expectedStatus: "pending" | "creating" = "pending"
+): void {
+  if (
+    !candidate ||
+    !predecessor ||
+    candidate.status !== expectedStatus ||
+    predecessor.status !== "active" ||
+    candidate.rotated_from_provider_credential_id !== predecessor.id ||
+    !sameReferences(references, expected.references)
+  ) {
+    throw conflict(unavailableMessage);
+  }
+}
+
+function assertRollbackSnapshot(
+  current: LifecycleCredentialRow | null,
+  predecessor: LifecycleCredentialRow | null,
+  references: CredentialReferenceRow[],
+  expected: AuthorizedCredential
+): void {
+  if (
+    !current ||
+    !predecessor ||
+    current.status !== "active" ||
+    current.rotated_from_provider_credential_id !== predecessor.id ||
+    predecessor.status !== "retired" ||
+    !predecessor.secret_retention_expires_at ||
+    !sameReferences(references, expected.references)
+  ) {
+    throw conflict(ROLLBACK_UNAVAILABLE);
+  }
+}
+
+async function rotationCommitIsVisible(
+  context: LifecycleContext,
+  expected: Awaited<ReturnType<typeof loadAuthorizedCandidate>>
+): Promise<boolean | null> {
+  try {
+    const [candidate, predecessor, candidateReferences, predecessorReferences] = await Promise.all([
+      context.store.findLifecycleCredential(context.organizationId, expected.candidate.id),
+      context.store.findLifecycleCredential(context.organizationId, expected.predecessor.id),
+      context.store.listCredentialReferences(context.organizationId, expected.candidate.id),
+      context.store.listCredentialReferences(context.organizationId, expected.predecessor.id),
+    ]);
+    return (
+      candidate?.status === "active" &&
+      predecessor?.status === "retired" &&
+      predecessorReferences.length === 0 &&
+      JSON.stringify(referenceIds(candidateReferences)) ===
+        JSON.stringify(referenceIds(expected.references))
+    );
+  } catch (error) {
+    logLifecycleFailure(context.c, "rotation_outcome_read", expected.candidate.id, error);
+    return null;
+  }
+}
+
+async function rollbackCommitIsVisible(
+  context: LifecycleContext,
+  expected: AuthorizedCredential,
+  predecessor: LifecycleCredentialRow
+): Promise<boolean | null> {
+  try {
+    const [current, restored, currentReferences, restoredReferences] = await Promise.all([
+      context.store.findLifecycleCredential(context.organizationId, expected.credential.id),
+      context.store.findLifecycleCredential(context.organizationId, predecessor.id),
+      context.store.listCredentialReferences(context.organizationId, expected.credential.id),
+      context.store.listCredentialReferences(context.organizationId, predecessor.id),
+    ]);
+    return (
+      current?.status === "retired" &&
+      restored?.status === "active" &&
+      currentReferences.length === 0 &&
+      JSON.stringify(referenceIds(restoredReferences)) ===
+        JSON.stringify(referenceIds(expected.references))
+    );
+  } catch (error) {
+    logLifecycleFailure(context.c, "rollback_outcome_read", expected.credential.id, error);
+    return null;
+  }
+}
+
+async function cancellationCommitIsVisible(
+  context: LifecycleContext,
+  expected: Awaited<ReturnType<typeof loadAuthorizedCandidate>>
+): Promise<boolean | null> {
+  try {
+    const [candidate, predecessor, candidateReferences, predecessorReferences] = await Promise.all([
+      context.store.findLifecycleCredential(context.organizationId, expected.candidate.id),
+      context.store.findLifecycleCredential(context.organizationId, expected.predecessor.id),
+      context.store.listCredentialReferences(context.organizationId, expected.candidate.id),
+      context.store.listCredentialReferences(context.organizationId, expected.predecessor.id),
+    ]);
+    return (
+      candidate?.status === "deactivated" &&
+      predecessor?.status === "active" &&
+      candidateReferences.length === 0 &&
+      sameReferences(predecessorReferences, expected.references)
+    );
+  } catch (error) {
+    logLifecycleFailure(context.c, "cancellation_outcome_read", expected.candidate.id, error);
+    return null;
+  }
+}
+
+function uniqueReferenceFingerprint(references: readonly CredentialReferenceRow[]): string | null {
+  const fingerprints = new Set(
+    references.map((reference) => reference.provider_account_fingerprint)
+  );
+  if (fingerprints.size !== 1) return null;
+  return fingerprints.values().next().value ?? null;
+}
+
+async function continuityFingerprint(appId: string): Promise<string> {
+  return getPrivyProviderAccountFingerprint(appId);
+}
+
+function rotationResult(
+  credential: LifecycleCredentialRow,
+  status: "success"
+): ProviderCredentialRotationResult;
+function rotationResult(
+  credential: LifecycleCredentialRow,
+  status: "failed",
+  code: RotationFailureCode
+): ProviderCredentialRotationResult;
+function rotationResult(
+  credential: LifecycleCredentialRow,
+  status: "retry_unknown",
+  code: "provider_response_unknown"
+): ProviderCredentialRotationResult;
+function rotationResult(
+  credential: LifecycleCredentialRow,
+  status: "success" | "failed" | "retry_unknown",
+  code?: RotationFailureCode | "provider_response_unknown"
+): ProviderCredentialRotationResult {
+  const providerCredential = mapProviderCredential(credential);
+  if (status === "success") return { providerCredential, rotation: { status } };
+  if (status === "retry_unknown") {
+    return { providerCredential, rotation: { status, code: "provider_response_unknown" } };
+  }
+  return { providerCredential, rotation: { status, code: code as RotationFailureCode } };
+}
+
+function safeRotationFailureCode(value: string | null): RotationFailureCode | null {
+  return value === "invalid_credentials" || value === "provider_account_mismatch" ? value : null;
+}
+
+async function rotationFingerprint(
+  context: LifecycleContext,
+  credentialId: string,
+  fields: { appId: string; appSecret: string }
+): Promise<string> {
+  const pepper = context.c.env.CREDENTIAL_FINGERPRINT_PEPPER;
+  if (!pepper) throw internalError();
+  return hashString(
+    JSON.stringify(
+      normalizeForFingerprint({
+        version: 1,
+        operation: "provider_credential_rotation",
+        target: { organizationId: context.organizationId, credentialId },
+        fields,
+      })
+    ),
+    pepper
+  );
+}
+
+function createStoredSecretStore(
+  c: Context<{ Bindings: Env }>,
+  credentialId: string
+): CredentialSecretStore {
+  try {
+    const store = createCredentialSecretStore(c.env);
+    if (store.storageBackend === "runtime_env") throw internalError();
+    return store;
+  } catch (error) {
+    logLifecycleFailure(c, "secret_store_create", credentialId, error);
+    if (error instanceof AppError) throw error;
+    throw internalError();
+  }
+}
+
+function createPersistedSecretStore(
+  c: Context<{ Bindings: Env }>,
+  backend: LifecycleCredentialRow["storage_backend"],
+  credentialId: string
+): CredentialSecretStore {
+  if (backend === "runtime_env") throw conflict(ROTATION_UNAVAILABLE);
+  try {
+    return createCredentialSecretStore(c.env, backend);
+  } catch (error) {
+    logLifecycleFailure(c, "secret_store_create", credentialId, error);
+    throw internalError();
+  }
+}
+
+async function writeRotationSecret(
+  context: LifecycleContext,
+  store: CredentialSecretStore,
+  candidateId: string,
+  appId: string,
+  appSecret: string,
+  existingSecretRef?: string
+): Promise<StoredCredentialSecret> {
+  try {
+    return await store.write({
+      orgId: context.organizationId,
+      provider: "privy",
+      providerCredentialId: candidateId,
+      payload: { appId, appSecret },
+      existingSecretRef,
+    });
+  } catch (error) {
+    logLifecycleFailure(context.c, "secret_write", candidateId, error);
+    if (error instanceof CredentialSecretStoreError && error.code === "UPSTREAM_ERROR") {
+      if (store.storageBackend === "gcp_secret_manager") {
+        logSecretWriteOutcomeUnknown(context.c, candidateId, store.storageBackend);
+      }
+      throw providerUnavailable("Credential storage is temporarily unavailable");
+    }
+    throw internalError();
+  }
+}
+
+async function readPrivyCredential(
+  store: CredentialSecretStore,
+  context: LifecycleContext,
+  row: LifecycleCredentialWithSecretRow
+): Promise<PrivyCredentialAuthentication> {
+  let payload: CredentialSecretPayload;
+  try {
+    payload = await store.read({ orgId: context.organizationId, stored: storedSecret(row) });
+  } catch (error) {
+    logLifecycleFailure(context.c, "secret_read", row.id, error);
+    if (error instanceof CredentialSecretStoreError && error.code === "UPSTREAM_ERROR") {
+      throw providerUnavailable("Credential storage is temporarily unavailable");
+    }
+    throw internalError();
+  }
+  const appId = typeof payload.appId === "string" ? payload.appId.trim() : "";
+  const appSecret = typeof payload.appSecret === "string" ? payload.appSecret : "";
+  if (!appId || !appSecret) throw internalError();
+  return { appId, appSecret };
+}
+
+function storedSecret(row: LifecycleCredentialWithSecretRow): StoredCredentialSecret {
+  return {
+    storageBackend: row.storage_backend,
+    secretRef: row.secret_ref ?? undefined,
+    secretVersionRef: row.secret_version_ref ?? undefined,
+    encryptedSecretPayload: row.encrypted_secret_payload ?? undefined,
+  };
+}
+
+async function cleanupRejectedCandidate(
+  c: Context<{ Bindings: Env }>,
+  candidate: LifecycleCredentialWithSecretRow
+): Promise<void> {
+  if (candidate.storage_backend !== "gcp_secret_manager" || !candidate.secret_version_ref) return;
+  try {
+    const store = createPersistedSecretStore(c, candidate.storage_backend, candidate.id);
+    await store.destroyVersion({ secretVersionRef: candidate.secret_version_ref });
+  } catch {
+    logCleanupFailure(c, candidate.id, candidate.storage_backend);
+  }
+}
+
+function mapLifecycleCredential(row: LifecycleCredentialRow): LifecycleProviderCredential {
+  return { ...mapProviderCredential(row), source: row.source };
+}
+
+function logUnresolvedAuditIntent(
+  context: LifecycleContext,
+  intent: AuditIntent,
+  credentialId: string
+): void {
+  // A visible transition after a failed COMMIT may belong to another request.
+  // Keep this intent unresolved until its own transaction outcome is proven.
+  logEvent("warn", {
+    event: "sdp_api_credential_lifecycle_audit_unresolved",
+    organization_id: context.organizationId,
+    project_id: context.projectId,
+    provider: "privy",
+    provider_credential_id: credentialId,
+    audit_intent_id: intent.id,
+    request_id: context.c.get("requestId"),
+    operation: intent.entry.action,
+    reason: "commit_outcome_unknown",
+  });
+}
+
+function logLifecycleFailure(
+  c: Context<{ Bindings: Env }>,
+  stage: string,
+  credentialId: string,
+  cause: unknown
+): void {
+  if (cause instanceof AppError) return;
+  const auth = getAuth(c);
+  logEvent("error", {
+    event: "sdp_api_credential_lifecycle_failure",
+    stage,
+    organization_id: auth.organizationId,
+    project_id: auth.projectId,
+    provider: "privy",
+    provider_credential_id: credentialId,
+    request_id: c.get("requestId"),
+    ...describeError(cause),
+  });
+}
+
+function logCleanupFailure(
+  c: Context<{ Bindings: Env }>,
+  credentialId: string,
+  storageBackend: "gcp_secret_manager"
+): void {
+  getLogger().error(
+    {
+      providerCredentialId: credentialId,
+      provider: "privy",
+      storageBackend,
+      requestId: c.get("requestId"),
+      reason: "secret_cleanup_failed",
+    },
+    "provider_credential_orphan_risk"
+  );
+}
+
+function logSecretWriteOutcomeUnknown(
+  c: Context<{ Bindings: Env }>,
+  credentialId: string,
+  storageBackend: StoredCredentialSecret["storageBackend"]
+): void {
+  if (storageBackend !== "gcp_secret_manager") return;
+  getLogger().error(
+    {
+      providerCredentialId: credentialId,
+      provider: "privy",
+      storageBackend,
+      requestId: c.get("requestId"),
+      reason: "secret_write_outcome_unknown",
+    },
+    "provider_credential_orphan_risk"
+  );
+}
+
+async function closeRejectedIntent(
+  context: LifecycleContext,
+  intent: AuditIntent,
+  event: string
+): Promise<void> {
+  await context.audit.completeCritical(context.c, intent, {
+    action: "maintenance",
+    resourceType: "audit_ledger",
+    resourceId: intent.id,
+    status: "failure",
+    metadata: { event },
+  });
+}

--- a/apps/sdp-api/src/services/stores/provider-credential.store.ts
+++ b/apps/sdp-api/src/services/stores/provider-credential.store.ts
@@ -41,6 +41,20 @@ export interface LifecycleCredentialRow extends ProviderCredentialRow {
   secret_retention_expires_at: string | null;
 }
 
+export interface LifecycleCredentialWithSecretRow extends LifecycleCredentialRow {
+  secret_ref: string | null;
+  secret_version_ref: string | null;
+  encrypted_secret_payload: string | null;
+}
+
+export interface CredentialReferenceRow {
+  id: string;
+  project_id: string;
+  project_name: string;
+  status: CustodyConnectionStatus;
+  provider_account_fingerprint: string | null;
+}
+
 export interface CustodyConnectionRow {
   id: string;
   organization_id: string;
@@ -226,6 +240,23 @@ export class ProviderCredentialStore {
     );
   }
 
+  async findLifecycleCredentialWithSecret(
+    organizationId: string,
+    id: string
+  ): Promise<LifecycleCredentialWithSecretRow | null> {
+    return this.db.queryOne<LifecycleCredentialWithSecretRow>(
+      `SELECT id, organization_id, project_id, provider, label, scope, scope_key,
+              source, storage_backend, secret_ref, secret_version_ref,
+              encrypted_secret_payload, display_metadata, status, credential_version,
+              rotated_from_provider_credential_id, idempotency_key,
+              idempotency_fingerprint, deactivated_at, last_validated_at,
+              last_failed_at, last_failure_code, secret_retention_expires_at, created_at
+       FROM provider_credentials
+       WHERE id = ? AND organization_id = ? AND provider = 'privy'`,
+      [id, organizationId]
+    );
+  }
+
   async findGcpContainerRef(organizationId: string, credentialId: string): Promise<string | null> {
     const row = await this.db.queryOne<{ secret_ref: string }>(
       `SELECT secret_ref FROM provider_credentials
@@ -237,6 +268,80 @@ export class ProviderCredentialStore {
     return row?.secret_ref ?? null;
   }
 
+  async findLifecycleConnectionCredentialId(
+    organizationId: string,
+    projectId: string,
+    connectionId: string
+  ): Promise<string | null> {
+    const row = await this.db.queryOne<{ provider_credential_id: string }>(
+      `SELECT provider_credential_id
+       FROM custody_connections
+       WHERE id = ? AND organization_id = ? AND project_id = ? AND provider = 'privy'`,
+      [connectionId, organizationId, projectId]
+    );
+    return row?.provider_credential_id ?? null;
+  }
+
+  async listCredentialReferences(
+    organizationId: string,
+    providerCredentialId: string,
+    options: { lock?: boolean } = {}
+  ): Promise<CredentialReferenceRow[]> {
+    return this.db.queryMany<CredentialReferenceRow>(
+      `SELECT c.id, c.project_id, p.name AS project_name, c.status,
+              c.provider_account_fingerprint
+       FROM custody_connections c
+       JOIN projects p ON p.id = c.project_id
+       WHERE c.organization_id = ?
+         AND c.provider = 'privy'
+         AND c.provider_credential_id = ?
+         AND c.status <> 'deactivated'
+       ORDER BY c.project_id, c.id
+       ${options.lock ? "FOR UPDATE OF c" : ""}`,
+      [organizationId, providerCredentialId]
+    );
+  }
+
+  async listCredentialLineageReferences(
+    organizationId: string,
+    providerCredentialId: string
+  ): Promise<CredentialReferenceRow[]> {
+    return this.db.queryMany<CredentialReferenceRow>(
+      `${CREDENTIAL_LINEAGE_SQL}
+       SELECT c.id, c.project_id, p.name AS project_name, c.status,
+              c.provider_account_fingerprint
+       FROM custody_connections c
+       JOIN credential_lineage lineage ON lineage.id = c.provider_credential_id
+       JOIN projects p ON p.id = c.project_id
+       WHERE c.organization_id = ?
+         AND c.provider = 'privy'
+         AND c.status <> 'deactivated'
+       ORDER BY c.project_id, c.id`,
+      [providerCredentialId, organizationId, organizationId, organizationId]
+    );
+  }
+
+  async lockAuthorizedProjects(
+    organizationId: string,
+    userId: string,
+    projectIds: readonly string[]
+  ): Promise<boolean> {
+    const uniqueIds = [...new Set(projectIds)].sort();
+    if (uniqueIds.length === 0) return true;
+    const rows = await this.db.queryMany<{ id: string }>(
+      `SELECT p.id
+       FROM projects p
+       JOIN project_members pm ON pm.project_id = p.id AND pm.user_id = ?
+       WHERE p.organization_id = ?
+         AND p.status = 'active'
+         AND p.id IN (SELECT jsonb_array_elements_text(?::jsonb))
+       ORDER BY p.id
+       FOR UPDATE OF p, pm`,
+      [userId, organizationId, JSON.stringify(uniqueIds)]
+    );
+    return rows.length === uniqueIds.length;
+  }
+
   /** The caller holds the existing Project/current-Credential admission locks. */
   async nextCredentialVersion(organizationId: string, predecessorId: string): Promise<number> {
     const row = await this.db.queryOne<{ next_version: number | null }>(
@@ -246,6 +351,198 @@ export class ProviderCredentialStore {
     );
     if (!row || row.next_version === null) throw new Error("Credential lineage was not found");
     return row.next_version;
+  }
+
+  async findUnfinishedDirectChild(
+    organizationId: string,
+    providerCredentialId: string,
+    options: { lock?: boolean } = {}
+  ): Promise<LifecycleCredentialRow | null> {
+    return this.db.queryOne<LifecycleCredentialRow>(
+      `SELECT id, organization_id, project_id, provider, label, scope, scope_key,
+              source, storage_backend, display_metadata, status, credential_version,
+              rotated_from_provider_credential_id, idempotency_key,
+              idempotency_fingerprint, deactivated_at, last_validated_at,
+              last_failed_at, last_failure_code, secret_retention_expires_at, created_at
+       FROM provider_credentials
+       WHERE organization_id = ?
+         AND provider = 'privy'
+         AND rotated_from_provider_credential_id = ?
+         AND status IN ('creating', 'pending')
+       ORDER BY created_at, id
+       LIMIT 1
+       ${options.lock ? "FOR UPDATE" : ""}`,
+      [organizationId, providerCredentialId]
+    );
+  }
+
+  async recordRotationRetryUnknown(candidateId: string): Promise<boolean> {
+    return (
+      (await this.db.execute(
+        `UPDATE provider_credentials
+         SET last_failed_at = sdp_iso_now(),
+             last_failure_code = 'provider_response_unknown',
+             updated_at = sdp_iso_now()
+         WHERE id = ? AND status = 'pending' AND rotated_from_provider_credential_id IS NOT NULL`,
+        [candidateId]
+      )) === 1
+    );
+  }
+
+  async recordRotationFailure(
+    candidateId: string,
+    failureCode: "invalid_credentials" | "provider_account_mismatch"
+  ): Promise<boolean> {
+    return (
+      (await this.db.execute(
+        `UPDATE provider_credentials
+         SET status = 'failed_validation',
+             encrypted_secret_payload =
+               CASE WHEN storage_backend = 'encrypted_db' THEN NULL
+                    ELSE encrypted_secret_payload END,
+             secret_retention_expires_at =
+               CASE WHEN storage_backend = 'gcp_secret_manager' THEN sdp_iso_now()
+                    ELSE secret_retention_expires_at END,
+             last_failed_at = sdp_iso_now(),
+             last_failure_code = ?,
+             updated_at = sdp_iso_now()
+         WHERE id = ? AND status = 'pending' AND rotated_from_provider_credential_id IS NOT NULL`,
+        [failureCode, candidateId]
+      )) === 1
+    );
+  }
+
+  async cutOverRotation(params: {
+    organizationId: string;
+    predecessorId: string;
+    candidateId: string;
+    candidateScopeKey: string;
+    expectedConnectionIds: readonly string[];
+  }): Promise<boolean> {
+    const moved = await this.db.execute(
+      `UPDATE custody_connections
+       SET provider_credential_id = ?, provider_credential_scope_key = ?, updated_at = sdp_iso_now()
+       WHERE organization_id = ?
+         AND provider = 'privy'
+         AND provider_credential_id = ?
+         AND status <> 'deactivated'`,
+      [params.candidateId, params.candidateScopeKey, params.organizationId, params.predecessorId]
+    );
+    if (moved !== params.expectedConnectionIds.length) return false;
+
+    const activated = await this.db.execute(
+      `UPDATE provider_credentials
+       SET status = 'active', last_validated_at = sdp_iso_now(), last_failed_at = NULL,
+           last_failure_code = NULL, updated_at = sdp_iso_now()
+       WHERE id = ? AND organization_id = ? AND status = 'pending'
+         AND rotated_from_provider_credential_id = ?`,
+      [params.candidateId, params.organizationId, params.predecessorId]
+    );
+    const retired = await this.db.execute(
+      `UPDATE provider_credentials
+       SET status = 'retired',
+           secret_retention_expires_at = to_char(
+             timezone('UTC', clock_timestamp() + interval '24 hours'),
+             'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+           ),
+           updated_at = sdp_iso_now()
+       WHERE id = ? AND organization_id = ? AND status = 'active'`,
+      [params.predecessorId, params.organizationId]
+    );
+    if (activated !== 1 || retired !== 1) return false;
+
+    await this.db.execute(
+      `WITH RECURSIVE ancestors(id) AS (
+         SELECT rotated_from_provider_credential_id
+         FROM provider_credentials
+         WHERE id = ?
+         UNION ALL
+         SELECT pc.rotated_from_provider_credential_id
+         FROM provider_credentials pc
+         JOIN ancestors a ON pc.id = a.id
+         WHERE a.id IS NOT NULL
+       )
+       UPDATE provider_credentials
+       SET secret_retention_expires_at = sdp_iso_now(), updated_at = sdp_iso_now()
+       WHERE id IN (SELECT id FROM ancestors WHERE id IS NOT NULL)
+         AND status = 'retired'
+         AND secret_retention_expires_at IS NOT NULL`,
+      [params.predecessorId]
+    );
+    return true;
+  }
+
+  async rollBackCredential(params: {
+    organizationId: string;
+    currentId: string;
+    predecessorId: string;
+    predecessorScopeKey: string;
+    expectedConnectionIds: readonly string[];
+  }): Promise<boolean> {
+    const moved = await this.db.execute(
+      `UPDATE custody_connections
+       SET provider_credential_id = ?, provider_credential_scope_key = ?, updated_at = sdp_iso_now()
+       WHERE organization_id = ?
+         AND provider = 'privy'
+         AND provider_credential_id = ?
+         AND status <> 'deactivated'`,
+      [params.predecessorId, params.predecessorScopeKey, params.organizationId, params.currentId]
+    );
+    if (moved !== params.expectedConnectionIds.length) return false;
+    const restored = await this.db.execute(
+      `UPDATE provider_credentials
+       SET status = 'active', secret_retention_expires_at = NULL,
+           last_validated_at = sdp_iso_now(), last_failed_at = NULL,
+           last_failure_code = NULL, updated_at = sdp_iso_now()
+       WHERE id = ? AND organization_id = ? AND status = 'retired'
+         AND secret_retention_expires_at::timestamptz > clock_timestamp()`,
+      [params.predecessorId, params.organizationId]
+    );
+    const retired = await this.db.execute(
+      `UPDATE provider_credentials
+       SET status = 'retired', secret_retention_expires_at = sdp_iso_now(),
+           updated_at = sdp_iso_now()
+       WHERE id = ? AND organization_id = ? AND status = 'active'
+         AND rotated_from_provider_credential_id = ?`,
+      [params.currentId, params.organizationId, params.predecessorId]
+    );
+    return restored === 1 && retired === 1;
+  }
+
+  async deactivateRotationCandidate(params: {
+    organizationId: string;
+    candidateId: string;
+    predecessorId: string;
+  }): Promise<boolean> {
+    return (
+      (await this.db.execute(
+        `UPDATE provider_credentials candidate
+         SET status = 'deactivated',
+             encrypted_secret_payload =
+               CASE WHEN storage_backend = 'encrypted_db' THEN NULL
+                    ELSE encrypted_secret_payload END,
+             secret_retention_expires_at =
+               CASE WHEN storage_backend = 'gcp_secret_manager' THEN sdp_iso_now()
+                    ELSE secret_retention_expires_at END,
+             deactivated_at = sdp_iso_now(), updated_at = sdp_iso_now()
+         WHERE candidate.id = ?
+           AND candidate.organization_id = ?
+           AND candidate.status = 'pending'
+           AND candidate.rotated_from_provider_credential_id = ?
+           AND NOT EXISTS (
+             SELECT 1 FROM custody_connections c
+             WHERE c.provider_credential_id = candidate.id AND c.status <> 'deactivated'
+           )
+           AND NOT EXISTS (
+             SELECT 1
+             FROM custody_connections c
+             JOIN custody_wallets w
+               ON w.custody_connection_id = c.id AND w.status = 'active'
+             WHERE c.provider_credential_id = candidate.id
+           )`,
+        [params.candidateId, params.organizationId, params.predecessorId]
+      )) === 1
+    );
   }
 
   /**

--- a/docs/ops/audit-ledger.md
+++ b/docs/ops/audit-ledger.md
@@ -74,6 +74,15 @@ On a verification failure:
 
 If Redis contains a pending witness after a failed commit or promotion, preserve it with the database snapshot and verifier output. A writer automatically finalizes only an exact pending `next` match to the valid committed head; every other pending state requires comparing both `previous` and `next` with the transaction outcome and independently retained operations record before approved recovery. If Redis is missing—even when PostgreSQL contains only sequence one—the state is ambiguous and requires the incident procedure above. Never rewind or reseed a checkpoint from PostgreSQL alone.
 
-If `unresolvedCriticalIntents` is nonzero, first reconcile the target transaction from the intent's nested `target` metadata against the issuance transaction record and Solana signature state. Append the missing outcome only after the result is proven. Do not repeat an irreversible operation merely because its outcome record is missing.
+For unresolved issuance intents reported in `unresolvedCriticalIntents`, first reconcile the target transaction from the intent's nested `target` metadata against the issuance transaction record and Solana signature state. Append the missing outcome only after the result is proven. Do not repeat an irreversible operation merely because its outcome record is missing.
 
 Do not repair hashes in place. Recomputing them would destroy the evidence this control exists to preserve.
+
+### Credential lifecycle intents after an unknown COMMIT
+
+For credential rotation, rollback, and cancellation, HTTP `200` reports the observed state, not who committed the transition. If the transaction callback completed but COMMIT confirmation failed, and the intended state is visible, the request leaves its durable intent unresolved instead of recording an attributed success. An ordinary replay that did not apply the transition closes its intent as before. The verifier reports unresolved critical intents after 15 minutes.
+
+1. Find the `sdp_api_credential_lifecycle_audit_unresolved` warning with `reason: commit_outcome_unknown`. Locate the intent using `organization_id` and `audit_intent_id`; correlate `request_id`, `project_id`, `operation`, and `provider_credential_id` with its nested `target`. For rollback, the credential ID identifies the restored version.
+2. Compare request logs, database transaction evidence, and other audit outcomes for the same transition. The current credential status alone cannot prove which request committed it.
+3. Preserve the evidence in the incident record. Append an outcome only after both the transaction result and its attribution are proven; otherwise leave the intent unresolved and escalate to the security/on-call team.
+4. Do not repeat a credential transition just to close its audit intent. Do not rewrite append-only audit rows or PostgreSQL/Redis checkpoints.


### PR DESCRIPTION
**What changed**

- Add an internal lifecycle read showing the current Credential, unfinished rotation candidate, affected projects/Connections, and eligible rollback target.
- Add `rotate`, `complete-rotation`, `rollback`, and candidate `deactivate` commands under `/internal/dashboard/custody`.
- Validate replacement credentials with one bounded, read-only Privy request per validation attempt and require the same Privy account before switching Connections.
- Atomically move all affected Connections, retain the immediate predecessor for a 24-hour rollback window, and audit successful and rejected transitions.
- Add separate rotation/recovery quotas and preserve wallet creation when concurrent rotation changes the Credential but not the provider account.

**Why**

Stored Privy credentials need to be replaceable without recreating Connections or wallets. An uncertain validation response must leave the current Credential in place and provide a retry or cancellation path.

**Impact**

Lifecycle commands apply to stored Privy credentials. Runtime-environment credentials remain deployment-managed and cannot be rotated through this API.

Commands require human `custody:admin` authorization. Shared-credential operations require access to every affected project, checked before disclosure/provider access and again under transaction locks.

Rotation requires an `Idempotency-Key`. `complete-rotation` resumes an existing candidate without resubmitting or rewriting its secret.

Rotation and recovery use separate quota pools, each allowing 5 requests per actor and 20 per organization per minute. Rotation retries do not consume the rollback/cancellation quota.

No new migration is added; this PR uses the preceding persistence and cleanup changes.

**Pre/post release actions**

1. Deploy after the secret-persistence/cleanup PR and its migrations.
2. Before rollout, exercise rotation, retry, rollback, cancellation, and cross-tenant rejection through the running API.
3. After rollout, monitor lifecycle failures, rejected validations, and `sdp_api_credential_lifecycle_audit_unresolved`. Follow `docs/ops/audit-ledger.md` when an audit outcome requires investigation.

**Result Validation**

- `pnpm --filter @sdp/api typecheck` and `pnpm --filter @sdp/api build` — passed.
- 135 targeted tests — passed, including account continuity, authorization, idempotency, transaction rollback, lost responses, cleanup races, and concurrent wallet creation.
- `pnpm --filter @sdp/api test --coverage.thresholds.autoUpdate=false --exclude src/runtime/kv-redis.node.test.ts --exclude src/runtime/sponsorship-budget-redis.node.test.ts` — 4,654 passed, 14 skipped; coverage thresholds passed.
- `pnpm -C apps/sdp-api exec vitest run --no-file-parallelism src/runtime/kv-redis.node.test.ts src/runtime/sponsorship-budget-redis.node.test.ts` — 54 passed. Together, both runs cover all 341 test files.
- Live running-API/provider checks, including unauthenticated and cross-tenant probes for the new endpoints — not run.

**Does it affect current flows & behavior and how**

**Before:** an installed Credential had no rotation, bounded rollback, or rotation-candidate cancellation flow.

**After:**

1. Create a new Credential candidate while Connections continue referencing the current Credential.
2. Validate the candidate and confirm the same Privy account.
3. On success, switch all affected Connections atomically and retire the predecessor.
4. On invalid credentials or account mismatch, reject only the candidate. On an uncertain validation response, keep it pending for `complete-rotation` or cancellation.

Callers must inspect `rotation.status`: HTTP `200` can contain `success`, `failed`, or `retry_unknown`.

Rollback revalidates the retained immediate predecessor and restores all affected Connections only while its 24-hour window remains valid. A subsequent successful rotation expires older rollback retention.

Cancellation leaves the current Credential and its Connections unchanged. Cleanup handles rejected or canceled secret versions.

Connection IDs, wallet ownership, and selected defaults are preserved. No Config fallback is introduced. Maintenance commands remain available independently of custody runtime enablement and provider entitlement, subject to their authorization and state checks.

**Known gaps**

- These are internal backend endpoints; dashboard UI is not included.
- SDP accepts replacement Privy credentials; it does not generate or rotate the app secret inside Privy.
- A lost database commit acknowledgement can leave an audit intent unresolved. This requires investigation, not automatic repetition of the transition.
- Live API/provider evidence remains outstanding.

**Notes**

Part 3 of 4, based on secret persistence and cleanup.

The `deactivate` command in this PR cancels an unused rotation candidate. General Credential and Connection deactivation is added by the next PR.
This rollout assumes no pre-existing `custody_connections` in staging or production. New custody connections require a fingerprint before activation; rotation rejects connections without it, and automatic backfill is not included.
