### PR TITLE
feat(custody): add Privy credential and connection deactivation

### DIFF
--- a/apps/sdp-api/src/db/migrations/0080_provider_credential_secret_retention.migration.test.ts
+++ b/apps/sdp-api/src/db/migrations/0080_provider_credential_secret_retention.migration.test.ts
@@ -128,7 +128,7 @@ describe("0080 provider Credential secret retention", () => {
   });
 
   it.each(["failed_validation", "deactivated"] as const)(
-    "permits an immediate cleanup marker only for a GCP rotation candidate that ends %s",
+    "permits terminal GCP rotation cleanup and preserves the latest root policy for %s",
     async (status) => {
       const predecessorId = `pcred_${status}_predecessor`;
       await insertCredential({
@@ -156,14 +156,18 @@ describe("0080 provider Credential secret retention", () => {
         })
       ).rejects.toThrow(/provider_credentials_secret_retention_check/);
 
-      await expect(
-        insertCredential({
-          id: `pcred_unrotated_gcp_${status}`,
-          status,
-          backend: "gcp_secret_manager",
-          retentionExpiresAt: "2026-09-04T10:00:00.000Z",
-        })
-      ).rejects.toThrow(/provider_credentials_secret_retention_check/);
+      const root = insertCredential({
+        id: `pcred_unrotated_gcp_${status}`,
+        status,
+        backend: "gcp_secret_manager",
+        retentionExpiresAt: "2026-09-04T10:00:00.000Z",
+      });
+      // The test database includes 0085's explicit root deactivation expansion.
+      if (status === "deactivated") {
+        await expect(root).resolves.toBeUndefined();
+      } else {
+        await expect(root).rejects.toThrow(/provider_credentials_secret_retention_check/);
+      }
     }
   );
 });

--- a/apps/sdp-api/src/db/migrations/0082_provider_credential_creation.migration.test.ts
+++ b/apps/sdp-api/src/db/migrations/0082_provider_credential_creation.migration.test.ts
@@ -34,7 +34,7 @@ describe("0082 Provider Credential creation", () => {
     ).resolves.toBe(1);
   });
 
-  it("does not permit cleanup markers on unrelated deactivated GCP roots", async () => {
+  it("permits deactivated GCP root cleanup after the 0085 expansion", async () => {
     await expect(
       getDb(env).execute(
         `INSERT INTO provider_credentials (
@@ -46,7 +46,7 @@ describe("0082 Provider Credential creation", () => {
            'deactivated', sdp_iso_now(), sdp_iso_now()
          )`
       )
-    ).rejects.toThrow(/provider_credentials_secret_retention_check/);
+    ).resolves.toBe(1);
   });
 
   it.each([

--- a/apps/sdp-api/src/db/migrations/0085_provider_credential_deactivation_cleanup.migration.test.ts
+++ b/apps/sdp-api/src/db/migrations/0085_provider_credential_deactivation_cleanup.migration.test.ts
@@ -1,0 +1,171 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "pg";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { adminDatabaseUrl as databaseUrl, env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import {
+  runPostgresMigrations,
+  splitSqlStatements,
+} from "../../../scripts/lib/run-postgres-migrations.mjs";
+
+const migrationsDir = path.join(path.dirname(fileURLToPath(import.meta.url)), "postgres");
+const migrationFile = "0085_provider_credential_deactivation_cleanup.sql";
+const previousRetentionCheck = splitSqlStatements(
+  readFileSync(path.join(migrationsDir, "0082_provider_credential_creation.sql"), "utf8")
+).find((statement: string) =>
+  statement.includes("ADD CONSTRAINT provider_credentials_secret_retention_check")
+);
+const retentionExpiresAt = "2026-09-05T10:00:00.000Z";
+let client: Client;
+
+async function insertCredential(params: {
+  id: string;
+  status: "creating" | "pending" | "active" | "failed_validation" | "retired" | "deactivated";
+  backend?: "encrypted_db" | "gcp_secret_manager" | "runtime_env";
+  retained?: boolean;
+  predecessor?: string;
+  abandoned?: boolean;
+}): Promise<void> {
+  const backend = params.backend ?? "gcp_secret_manager";
+  const gcp = backend === "gcp_secret_manager";
+  await client.query(
+    `INSERT INTO provider_credentials (
+       id, organization_id, provider, label, scope, source, storage_backend,
+       secret_ref, secret_version_ref, encrypted_secret_payload, status,
+       deactivated_at, secret_retention_expires_at, rotated_from_provider_credential_id,
+       last_failure_code, created_by
+     ) VALUES ($1, 'org_cleanup_0085', 'privy', 'Privy', 'organization', $2, $3,
+       $4, $5, $6, $7, $8, $9, $10, $11, 'usr_cleanup_0085')`,
+    [
+      params.id,
+      backend === "runtime_env" ? "runtime" : "stored",
+      backend,
+      gcp ? `projects/p/secrets/${params.id}` : null,
+      gcp && params.status !== "creating" && !params.abandoned
+        ? `projects/p/secrets/${params.id}/versions/7`
+        : null,
+      backend === "encrypted_db" ? "v2.ciphertext" : null,
+      params.status,
+      params.status === "deactivated" ? retentionExpiresAt : null,
+      params.retained ? retentionExpiresAt : null,
+      params.predecessor ?? null,
+      params.abandoned ? "secret_creation_abandoned" : null,
+    ]
+  );
+}
+
+describe("0085 provider Credential deactivation cleanup", () => {
+  beforeAll(async () => {
+    client = new Client({ connectionString: databaseUrl });
+    await client.connect();
+  });
+
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    await client.query(
+      "INSERT INTO organizations (id, name, slug) VALUES ('org_cleanup_0085', 'Cleanup', 'cleanup-0085')"
+    );
+    await client.query(
+      "INSERT INTO users (id, email) VALUES ('usr_cleanup_0085', 'cleanup-0085@example.test')"
+    );
+  });
+
+  afterEach(async () => {
+    await runPostgresMigrations({ databaseUrl, migrationsDir });
+  });
+
+  afterAll(async () => {
+    await client.end();
+  });
+
+  it("preserves A's rows without backfill and admits an explicitly deactivated root marker", async () => {
+    if (!previousRetentionCheck) throw new Error("Missing 0082 retention constraint");
+    await client.query(
+      `ALTER TABLE provider_credentials DROP CONSTRAINT provider_credentials_secret_retention_check; ${previousRetentionCheck}`
+    );
+    await client.query("DELETE FROM schema_migrations WHERE version = $1", [migrationFile]);
+    await insertCredential({ id: "pcred_predecessor_0085", status: "active" });
+    for (const status of ["failed_validation", "deactivated"] as const) {
+      await insertCredential({ id: `pcred_root_${status}_0085`, status });
+      await insertCredential({
+        id: `pcred_candidate_${status}_0085`,
+        status,
+        retained: true,
+        predecessor: "pcred_predecessor_0085",
+      });
+    }
+    for (const backend of ["encrypted_db", "gcp_secret_manager"] as const) {
+      await insertCredential({
+        id: `pcred_retired_${backend}_0085`,
+        status: "retired",
+        backend,
+        retained: true,
+      });
+    }
+    await insertCredential({ id: "pcred_creating_0085", status: "creating" });
+    await insertCredential({
+      id: "pcred_abandoned_root_0085",
+      status: "deactivated",
+      retained: true,
+      abandoned: true,
+    });
+    await client.query(
+      `UPDATE provider_credentials
+       SET secret_cleanup_attempt_count = 2, secret_cleanup_next_attempt_at = $1,
+           secret_cleanup_absent_since = $1, secret_next_scan_at = $1::text::timestamptz
+       WHERE id = 'pcred_abandoned_root_0085'`,
+      [retentionExpiresAt]
+    );
+    const before = await client.query("SELECT * FROM provider_credentials ORDER BY id");
+    await expect(
+      client.query(
+        "UPDATE provider_credentials SET secret_retention_expires_at = $1 WHERE id = 'pcred_root_deactivated_0085'",
+        [retentionExpiresAt]
+      )
+    ).rejects.toMatchObject({ constraint: "provider_credentials_secret_retention_check" });
+
+    await runPostgresMigrations({ databaseUrl, migrationsDir });
+
+    expect((await client.query("SELECT * FROM provider_credentials ORDER BY id")).rows).toEqual(
+      before.rows
+    );
+    await expect(
+      client.query(
+        "UPDATE provider_credentials SET secret_retention_expires_at = $1 WHERE id = 'pcred_root_deactivated_0085'",
+        [retentionExpiresAt]
+      )
+    ).resolves.toMatchObject({ rowCount: 1 });
+    await runPostgresMigrations({ databaseUrl, migrationsDir });
+    expect(
+      (
+        await client.query(
+          "SELECT status, secret_retention_expires_at FROM provider_credentials WHERE id = 'pcred_root_deactivated_0085'"
+        )
+      ).rows
+    ).toEqual([{ status: "deactivated", secret_retention_expires_at: retentionExpiresAt }]);
+  });
+
+  it("admits a deactivated GCP root marker on the freshly migrated schema", async () => {
+    await expect(
+      insertCredential({ id: "pcred_deactivated_root_0085", status: "deactivated", retained: true })
+    ).resolves.toBeUndefined();
+  });
+
+  it.each([
+    { status: "failed_validation", backend: "gcp_secret_manager" },
+    { status: "creating", backend: "gcp_secret_manager" },
+    { status: "pending", backend: "gcp_secret_manager" },
+    { status: "active", backend: "gcp_secret_manager" },
+    { status: "deactivated", backend: "encrypted_db" },
+    { status: "deactivated", backend: "runtime_env" },
+  ] as const)(
+    "rejects a root cleanup marker for $status / $backend",
+    async ({ status, backend }) => {
+      await expect(
+        insertCredential({ id: "pcred_rejected_0085", status, backend, retained: true })
+      ).rejects.toMatchObject({ constraint: "provider_credentials_secret_retention_check" });
+    }
+  );
+});

--- a/apps/sdp-api/src/db/migrations/postgres/0085_provider_credential_deactivation_cleanup.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0085_provider_credential_deactivation_cleanup.sql
@@ -1,0 +1,26 @@
+-- Explicit GCP Credential deactivation also retains cleanup retries for roots.
+-- Preserve 0082's abandoned roots and all existing creation/retry/scan constraints.
+-- Existing terminal history without a marker remains unchanged.
+
+ALTER TABLE provider_credentials
+    DROP CONSTRAINT provider_credentials_secret_retention_check,
+    ADD CONSTRAINT provider_credentials_secret_retention_check
+        CHECK (
+            secret_retention_expires_at IS NULL
+            OR (
+                source = 'stored'
+                AND (
+                    status = 'retired'
+                    OR (
+                        storage_backend = 'gcp_secret_manager'
+                        AND (
+                            status = 'deactivated'
+                            OR (
+                                status = 'failed_validation'
+                                AND rotated_from_provider_credential_id IS NOT NULL
+                            )
+                        )
+                    )
+                )
+            )
+        );

--- a/apps/sdp-api/src/routes/internal-custody/custody-connection-deactivation.test.ts
+++ b/apps/sdp-api/src/routes/internal-custody/custody-connection-deactivation.test.ts
@@ -1,0 +1,459 @@
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getDb } from "@/db";
+import { AppError } from "@/lib/errors";
+import { databaseIdentityBoundary } from "@/middleware/database-identity";
+import { kvStoreMiddleware } from "@/middleware/kv-store";
+import { setupTestAuth } from "@/test/helpers/auth";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import { clearKVStores } from "@/test/mocks/kv";
+import type { Env } from "@/types/env";
+import internalCustody from "./index";
+
+const ORG = "org_connection_deactivation";
+const USER = "usr_connection_deactivation";
+const PROJECT = "prj_connection_deactivation";
+const CONNECTION = "cconn_connection_deactivation";
+const CREDENTIAL = "pcred_connection_deactivation";
+const SESSION = "ses_connection_deactivation";
+const ORIGINAL_PRIVY_BYOK_ENABLED = env.PRIVY_BYOK_ENABLED;
+
+const app = new Hono<{ Bindings: Env }>();
+app.use("*", databaseIdentityBoundary());
+app.use("*", kvStoreMiddleware());
+app.use("*", async (c, next) => {
+  c.set("requestId", "req_connection_deactivation");
+  await next();
+});
+app.route("/internal/dashboard/custody", internalCustody);
+app.onError((error, c) => {
+  if (error instanceof AppError) return c.json(error.toResponse(), error.statusCode as 400);
+  throw error;
+});
+
+function request(
+  path = `/connections/${CONNECTION}/deactivate`,
+  options: { method?: "GET" | "POST"; projectId?: string; authenticated?: boolean } = {}
+) {
+  return app.request(
+    `/internal/dashboard/custody${path}`,
+    {
+      method: options.method ?? "POST",
+      headers: {
+        ...(options.authenticated === false ? {} : { Cookie: `sdp_session=${SESSION}` }),
+        "X-Project-ID": options.projectId ?? PROJECT,
+      },
+    },
+    env
+  );
+}
+
+async function seedConnection(status: "pending" | "checking" | "failed" = "pending") {
+  const db = getDb(env);
+  await db.execute(
+    `INSERT INTO provider_credentials
+       (id, organization_id, project_id, provider, label, scope, source,
+        storage_backend, encrypted_secret_payload, status)
+     VALUES (?, ?, ?, 'privy', 'Deactivation test', 'project', 'stored',
+             'encrypted_db', 'retained-ciphertext', ?)`,
+    [CREDENTIAL, ORG, PROJECT, status === "failed" ? "failed_validation" : "pending"]
+  );
+  await db.execute(
+    `INSERT INTO custody_connections
+       (id, organization_id, project_id, provider, scope, provider_credential_id,
+        provider_credential_scope_key, status, last_check_status, last_check_at)
+     VALUES (?, ?, ?, 'privy', 'project', ?, ?, ?, ?, ?)`,
+    [
+      CONNECTION,
+      ORG,
+      PROJECT,
+      CREDENTIAL,
+      PROJECT,
+      status,
+      status === "checking" ? "running" : status === "failed" ? "failed" : null,
+      status === "pending" ? null : "2026-01-01T00:00:00.000Z",
+    ]
+  );
+}
+
+async function lifecycleAudits() {
+  return getDb(env).queryMany(
+    `SELECT action, status, metadata FROM audit_logs
+     WHERE organization_id = ? AND resource_type = 'custody_connection' AND resource_id = ?`,
+    [ORG, CONNECTION]
+  );
+}
+
+async function seedActiveConnection(walletStatus: "active" | "inactive") {
+  await seedConnection();
+  const db = getDb(env);
+  await db.execute("UPDATE provider_credentials SET status = 'active' WHERE id = ?", [CREDENTIAL]);
+  await db.execute(
+    `INSERT INTO custody_wallets (id, custody_connection_id, wallet_id, public_key, status)
+     VALUES ('cwlt_connection_deactivation', ?, 'provider-wallet-deactivation', 'address-deactivation', ?)`,
+    [CONNECTION, walletStatus]
+  );
+  await db.execute(
+    `UPDATE custody_connections
+     SET status = 'active', last_check_status = 'success', last_check_at = sdp_iso_now(),
+         activated_at = sdp_iso_now(), provider_account_fingerprint = 'retained-fingerprint',
+         default_custody_wallet_id = 'cwlt_connection_deactivation'
+     WHERE id = ?`,
+    [CONNECTION]
+  );
+  await db.execute(
+    `INSERT INTO custody_scope_defaults
+       (id, organization_id, project_id, default_custody_connection_id)
+     VALUES ('csd_connection_deactivation', ?, ?, ?)`,
+    [ORG, PROJECT, CONNECTION]
+  );
+}
+
+async function persistedState() {
+  const db = getDb(env);
+  return {
+    connection: await db.queryOne("SELECT * FROM custody_connections WHERE id = ?", [CONNECTION]),
+    credential: await db.queryOne("SELECT * FROM provider_credentials WHERE id = ?", [CREDENTIAL]),
+    wallets: await db.queryMany("SELECT * FROM custody_wallets WHERE custody_connection_id = ?", [
+      CONNECTION,
+    ]),
+    selection: await db.queryOne("SELECT * FROM custody_scope_defaults WHERE project_id = ?", [
+      PROJECT,
+    ]),
+  };
+}
+
+describe("custody Connection deactivation", () => {
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    const db = getDb(env);
+    await db.execute(
+      `INSERT INTO organizations (id, name, slug, tier, status)
+      VALUES (?, 'Deactivation', 'connection-deactivation', 'enterprise', 'active')`,
+      [ORG]
+    );
+    await db.execute(
+      `INSERT INTO users (id, email, email_verified, status)
+      VALUES (?, 'connection-deactivation@example.com', 1, 'active')`,
+      [USER]
+    );
+    await db.execute(
+      `INSERT INTO organization_members (id, organization_id, user_id, role, status)
+      VALUES ('mem_connection_deactivation', ?, ?, 'admin', 'active')`,
+      [ORG, USER]
+    );
+    await db.execute(
+      `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+      VALUES (?, ?, 'Deactivation', 'connection-deactivation', 'sandbox', 'active', ?)`,
+      [PROJECT, ORG, USER]
+    );
+    await db.execute(
+      `INSERT INTO project_members (id, project_id, user_id, role)
+      VALUES ('pm_connection_deactivation', ?, ?, 'admin')`,
+      [PROJECT, USER]
+    );
+    await db.execute(
+      `INSERT INTO sessions (id, user_id, organization_id, auth_method, expires_at)
+      VALUES (?, ?, ?, 'session', '2999-01-01T00:00:00.000Z')`,
+      [SESSION, USER, ORG]
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => {
+        throw new Error("Unexpected Provider I/O");
+      })
+    );
+  });
+
+  afterEach(async () => {
+    env.PRIVY_BYOK_ENABLED = ORIGINAL_PRIVY_BYOK_ENABLED;
+    vi.unstubAllGlobals();
+    await clearKVStores(env);
+  });
+
+  it.each(["pending", "checking"] as const)(
+    "rejects unfinished %s installation without cancellation",
+    async (status) => {
+      await seedConnection(status);
+      const persisted = await persistedState();
+      const before = await (await request(`/connections/${CONNECTION}`, { method: "GET" })).json();
+      const result = await request();
+      expect(result.status).toBe(409);
+      expect(await result.json()).toMatchObject({ error: { code: "CONFLICT" } });
+      const after = await (await request(`/connections/${CONNECTION}`, { method: "GET" })).json();
+      expect(after.data).toEqual(before.data);
+      expect(await persistedState()).toEqual(persisted);
+      expect(await lifecycleAudits()).toEqual([]);
+      expect(fetch).not.toHaveBeenCalled();
+    }
+  );
+
+  it("rejects a fingerprint-pinned current completion lease without delegating", async () => {
+    await seedConnection("checking");
+    await getDb(env).execute(
+      "UPDATE custody_connections SET provider_account_fingerprint = 'pinned-account', last_check_at = sdp_iso_now() WHERE id = ?",
+      [CONNECTION]
+    );
+    const before = await persistedState();
+    const result = await request();
+    expect(result.status).toBe(409);
+    expect((await result.json()).error).toEqual({
+      code: "CONFLICT",
+      message: "Provider credential installation is unavailable",
+    });
+    expect(await persistedState()).toEqual(before);
+    expect(await lifecycleAudits()).toEqual([]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("deactivates a failed Connection and replays its current safe projection once", async () => {
+    await seedConnection("failed");
+    const result = await request();
+    expect(result.status).toBe(200);
+    const body = await result.json();
+    expect(body.data).toEqual({
+      custodyConnection: {
+        id: CONNECTION,
+        provider: "privy",
+        label: "Deactivation test",
+        status: "deactivated",
+        completion: null,
+        isDefault: false,
+        canComplete: false,
+        canReplaceCredentials: false,
+        canCancel: false,
+      },
+    });
+    const replay = await request();
+    expect(replay.status).toBe(200);
+    expect((await replay.json()).data).toEqual(body.data);
+    const read = await request(`/connections/${CONNECTION}`, { method: "GET" });
+    expect((await read.json()).data.connection).toEqual(body.data.custodyConnection);
+    expect(await lifecycleAudits()).toMatchObject([{ action: "deactivate", status: "success" }]);
+    expect(
+      await getDb(env).queryOne(
+        "SELECT status, encrypted_secret_payload FROM provider_credentials WHERE id = ?",
+        [CREDENTIAL]
+      )
+    ).toEqual({ status: "failed_validation", encrypted_secret_payload: "retained-ciphertext" });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("blocks active owned wallets without changing the Connection, Credential, wallets, or default", async () => {
+    await seedActiveConnection("active");
+    const before = await persistedState();
+    const result = await request();
+    expect(result.status).toBe(409);
+    expect((await result.json()).error).toEqual({
+      code: "CONFLICT",
+      message: "Connection cannot be deactivated while it has active wallets",
+    });
+    expect(await persistedState()).toEqual(before);
+    expect(await lifecycleAudits()).toEqual([]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("preserves inactive wallets, the current Credential, and the selected default while runtime is off", async () => {
+    await seedActiveConnection("inactive");
+    env.PRIVY_BYOK_ENABLED = "false";
+    await getDb(env).execute("UPDATE organizations SET settings = ?::jsonb WHERE id = ?", [
+      JSON.stringify({ providerOverrides: { custody: { privy: false } } }),
+      ORG,
+    ]);
+    const before = await persistedState();
+    const result = await request();
+    expect(result.status).toBe(200);
+    expect((await result.json()).data.custodyConnection).toMatchObject({
+      id: CONNECTION,
+      status: "deactivated",
+      canComplete: false,
+      canCancel: false,
+      canReplaceCredentials: false,
+    });
+    const after = await persistedState();
+    expect(after.credential).toEqual(before.credential);
+    expect(after.wallets).toEqual(before.wallets);
+    expect(after.selection).toEqual(before.selection);
+    expect(after.connection).toMatchObject({
+      ...before.connection,
+      status: "deactivated",
+      deactivated_at: expect.any(String),
+      updated_at: expect.any(String),
+    });
+    expect(await lifecycleAudits()).toMatchObject([{ action: "deactivate", status: "success" }]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("serializes simultaneous requests to one transition and one lifecycle audit", async () => {
+    await seedConnection("failed");
+    const responses = await Promise.all([request(), request()]);
+    expect(responses.map((response) => response.status)).toEqual([200, 200]);
+    const bodies = await Promise.all(responses.map((response) => response.json()));
+    expect(bodies[0].data).toEqual(bodies[1].data);
+    expect(await lifecycleAudits()).toMatchObject([{ action: "deactivate", status: "success" }]);
+  });
+
+  it("restores the Connection and preserves related state when its deactivation transaction fails", async () => {
+    await seedActiveConnection("inactive");
+    const persisted = await persistedState();
+    const before = await request(`/connections/${CONNECTION}`, { method: "GET" });
+    expect(before.status).toBe(200);
+    const beforeBody = await before.json();
+    const db = getDb(env);
+    const runTransaction = db.transaction.bind(db);
+    let updatedConnection: unknown;
+    const transaction = vi.spyOn(db, "transaction").mockImplementationOnce((callback) =>
+      runTransaction(async (tx) => {
+        await callback(tx);
+        updatedConnection = await tx.queryOne(
+          "SELECT status, deactivated_at FROM custody_connections WHERE id = ?",
+          [CONNECTION]
+        );
+        await tx.execute("SELECT 1 / 0");
+      })
+    );
+    try {
+      const response = await request();
+      expect(response.status).toBe(503);
+      expect((await response.json()).error).toEqual({
+        code: "PROVIDER_UNAVAILABLE",
+        message: "Connection deactivation outcome is temporarily unknown",
+      });
+      expect(updatedConnection).toEqual({
+        status: "deactivated",
+        deactivated_at: expect.any(String),
+      });
+    } finally {
+      transaction.mockRestore();
+    }
+    const after = await request(`/connections/${CONNECTION}`, { method: "GET" });
+    expect(after.status).toBe(200);
+    expect((await after.json()).data).toEqual(beforeBody.data);
+    expect(await persistedState()).toEqual(persisted);
+    expect(await lifecycleAudits()).toEqual([]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("rechecks an active wallet persisted after the initial walletless check", async () => {
+    await seedActiveConnection("inactive");
+    let signalLocked: () => void = () => undefined;
+    let releaseWalletCreation: () => void = () => undefined;
+    const locked = new Promise<void>((resolve) => {
+      signalLocked = resolve;
+    });
+    const released = new Promise<void>((resolve) => {
+      releaseWalletCreation = resolve;
+    });
+    const walletCreation = getDb(env).transaction(async (tx) => {
+      await tx.queryOne("SELECT id FROM projects WHERE id = ? FOR UPDATE", [PROJECT]);
+      signalLocked();
+      await released;
+      await tx.execute(
+        `INSERT INTO custody_wallets (id, custody_connection_id, wallet_id, public_key, status)
+         VALUES ('cwlt_racing_creation', ?, 'racing-provider-wallet', 'racing-address', 'active')`,
+        [CONNECTION]
+      );
+    });
+    await locked;
+    const response = request();
+    try {
+      await vi.waitFor(
+        async () => {
+          expect(
+            await getDb(env).queryOne(
+              `SELECT id FROM audit_logs WHERE organization_id = ?
+           AND metadata::jsonb -> 'target' ->> 'resourceId' = ?`,
+              [ORG, CONNECTION]
+            )
+          ).not.toBeNull();
+        },
+        { timeout: 5000 }
+      );
+    } finally {
+      releaseWalletCreation();
+      await walletCreation;
+    }
+    const result = await response;
+    expect(result.status).toBe(409);
+    expect((await result.json()).error).toEqual({
+      code: "CONFLICT",
+      message: "Connection cannot be deactivated while it has active wallets",
+    });
+    expect((await persistedState()).connection).toMatchObject({
+      status: "active",
+      deactivated_at: null,
+    });
+    expect(await lifecycleAudits()).toEqual([]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["unauthenticated", { authenticated: false }, 401],
+    ["missing Project", { projectId: "" }, 400],
+    ["inaccessible Project", { projectId: "prj_foreign" }, 403],
+  ] as const)("rejects %s requests before target mutation", async (_name, options, status) => {
+    await seedConnection("failed");
+    const before = await persistedState();
+    expect((await request(undefined, options)).status).toBe(status);
+    expect(await persistedState()).toEqual(before);
+    expect(await lifecycleAudits()).toEqual([]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("requires custody administration even for a completed replay", async () => {
+    await seedConnection("failed");
+    await getDb(env).execute(
+      "UPDATE custody_connections SET status = 'deactivated', deactivated_at = sdp_iso_now() WHERE id = ?",
+      [CONNECTION]
+    );
+    await getDb(env).execute("UPDATE organization_members SET role = 'member' WHERE user_id = ?", [
+      USER,
+    ]);
+    const before = await persistedState();
+    expect((await request()).status).toBe(403);
+    expect(await persistedState()).toEqual(before);
+    expect(await lifecycleAudits()).toEqual([]);
+  });
+
+  it("rejects API keys before resource mutation", async () => {
+    await seedConnection("failed");
+    const before = await persistedState();
+    const { header } = await setupTestAuth(env);
+    const response = await app.request(
+      `/internal/dashboard/custody/connections/${CONNECTION}/deactivate`,
+      { method: "POST", headers: { Authorization: header, "X-Project-ID": PROJECT } },
+      env
+    );
+    expect(response.status).toBe(403);
+    expect(await persistedState()).toEqual(before);
+    expect(await lifecycleAudits()).toEqual([]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("hides a Connection outside the authorized Project just like an unknown target", async () => {
+    await seedConnection("failed");
+    const db = getDb(env);
+    await db.execute(
+      `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+      VALUES ('prj_other_deactivation', ?, 'Other', 'other', 'sandbox', 'active', ?)`,
+      [ORG, USER]
+    );
+    await db.execute(
+      `INSERT INTO project_members (id, project_id, user_id, role)
+      VALUES ('pm_other_deactivation', 'prj_other_deactivation', ?, 'admin')`,
+      [USER]
+    );
+    const before = await persistedState();
+    const foreign = await request(undefined, { projectId: "prj_other_deactivation" });
+    const unknown = await request("/connections/cconn_unknown/deactivate", {
+      projectId: "prj_other_deactivation",
+    });
+    expect(foreign.status).toBe(404);
+    expect(unknown.status).toBe(404);
+    expect((await foreign.json()).error).toEqual((await unknown.json()).error);
+    expect(await persistedState()).toEqual(before);
+    expect(await lifecycleAudits()).toEqual([]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/sdp-api/src/routes/internal-custody/index.ts
+++ b/apps/sdp-api/src/routes/internal-custody/index.ts
@@ -16,10 +16,13 @@ import {
   getProviderAvailability,
   isCustodyProviderEntitled,
 } from "@/services/provider-availability.service";
-import { getProviderCredentialInstallation } from "@/services/provider-credential-installation.service";
+import {
+  deactivateCustodyConnection,
+  getProviderCredentialInstallation,
+} from "@/services/provider-credential-installation.service";
 import {
   completeRotationCandidate,
-  deactivateRotationCandidate,
+  deactivateProviderCredential,
   getProviderCredentialLifecycle,
   rollbackProviderCredential,
   rotateProviderCredential,
@@ -185,6 +188,15 @@ internalCustody.get("/connections/:connectionId/provider-credential", async (c) 
   return success(c, await getProviderCredentialLifecycle(c, params.data.connectionId));
 });
 
+internalCustody.post("/connections/:connectionId/deactivate", async (c) => {
+  const params = connectionParamsSchema.safeParse(c.req.param());
+  if (!params.success) {
+    throw badRequestParams({ errors: z.flattenError(params.error).fieldErrors });
+  }
+  await enforceMeteredQuota(c, recoveryQuota);
+  return success(c, await deactivateCustodyConnection(c, params.data.connectionId));
+});
+
 internalCustody.post("/provider-credentials/:credentialId/rotate", async (c) => {
   const params = credentialParamsSchema.safeParse(c.req.param());
   if (!params.success) {
@@ -229,7 +241,7 @@ internalCustody.post("/provider-credentials/:credentialId/deactivate", async (c)
     throw badRequestParams({ errors: z.flattenError(params.error).fieldErrors });
   }
   await enforceMeteredQuota(c, recoveryQuota);
-  return success(c, await deactivateRotationCandidate(c, params.data.credentialId));
+  return success(c, await deactivateProviderCredential(c, params.data.credentialId));
 });
 
 internalCustody.post("/connections/:connectionId/complete", async (c) => {

--- a/apps/sdp-api/src/routes/internal-custody/provider-credential-lifecycle.test.ts
+++ b/apps/sdp-api/src/routes/internal-custody/provider-credential-lifecycle.test.ts
@@ -571,6 +571,476 @@ describe("provider credential lifecycle", () => {
     ]);
   });
 
+  it("deactivates an unused setup Credential and replays without another lifecycle audit", async () => {
+    const credentialId = "pcred_unused_setup";
+    const stored = await createCredentialSecretStore(env).write({
+      orgId: ORGANIZATION_ID,
+      provider: "privy",
+      providerCredentialId: credentialId,
+      payload: { appId: APP_ID, appSecret: APP_SECRET },
+    });
+    await new ProviderCredentialStore(getDb(env)).insertCredential({
+      id: credentialId,
+      organizationId: ORGANIZATION_ID,
+      projectId: PROJECT_A_ID,
+      provider: "privy",
+      label: "Unused setup",
+      scope: "project",
+      source: "stored",
+      stored,
+      displayMetadata: {},
+      version: 1,
+      rotatedFromId: null,
+      idempotencyKey: "unused-setup",
+      idempotencyFingerprint: "unused-setup-fingerprint",
+      createdBy: USER_ID,
+    });
+    const providerFetch = vi.fn();
+    vi.stubGlobal("fetch", providerFetch);
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const response = await lifecycleRequest(`/provider-credentials/${credentialId}/deactivate`, {
+        method: "POST",
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        data: { providerCredential: { id: credentialId, status: "deactivated" } },
+      });
+    }
+
+    expect(
+      await getDb(env).queryOne(
+        "SELECT status, encrypted_secret_payload FROM provider_credentials WHERE id = ?",
+        [credentialId]
+      )
+    ).toEqual({ status: "deactivated", encrypted_secret_payload: null });
+    expect(
+      await getDb(env).queryOne(
+        "SELECT COUNT(*) AS count FROM audit_logs WHERE resource_id = ? AND action = 'deactivate'",
+        [credentialId]
+      )
+    ).toEqual({ count: 1 });
+    expect(providerFetch).not.toHaveBeenCalled();
+  });
+
+  it.each(["pending", "checking", "failed", "active"])(
+    "blocks Credential deactivation while a %s Connection references it, even without active wallets",
+    async (status) => {
+      const db = getDb(env);
+      await db.execute("UPDATE custody_wallets SET status = 'deactivated'");
+      await db.execute(
+        `UPDATE custody_connections SET status = ?, deactivated_at = NULL,
+           last_check_status = CASE ? WHEN 'checking' THEN 'running' WHEN 'failed' THEN 'failed' ELSE 'success' END,
+           activated_at = CASE WHEN ? = 'active' THEN activated_at ELSE NULL END WHERE id = ?`,
+        [status, status, status, CONNECTION_A_ID]
+      );
+      await db.execute(
+        "UPDATE custody_connections SET status = 'deactivated', deactivated_at = sdp_iso_now() WHERE id = ?",
+        [CONNECTION_B_ID]
+      );
+      const original = await db.queryOne("SELECT * FROM provider_credentials WHERE id = ?", [
+        CREDENTIAL_ID,
+      ]);
+      const providerFetch = vi.fn();
+      vi.stubGlobal("fetch", providerFetch);
+
+      const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/deactivate`, {
+        method: "POST",
+      });
+
+      expect(response.status).toBe(409);
+      expect((await response.json()).error).toEqual({
+        code: "CONFLICT",
+        message: "Credential cannot be deactivated while it is in use",
+      });
+      expect(
+        await db.queryOne("SELECT * FROM provider_credentials WHERE id = ?", [CREDENTIAL_ID])
+      ).toEqual(original);
+      expect(await db.queryMany("SELECT id FROM audit_logs WHERE action = 'deactivate'")).toEqual(
+        []
+      );
+      expect(providerFetch).not.toHaveBeenCalled();
+    }
+  );
+
+  it("keeps a pending child visible and cancelable after its eligible parent is deactivated", async () => {
+    const providerFetch = vi.fn().mockResolvedValue(new Response(null, { status: 503 }));
+    vi.stubGlobal("fetch", providerFetch);
+    const pending = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-before-parent-deactivation",
+      body: { fields: { appId: APP_ID, appSecret: "pending-secret" } },
+    });
+    expect(pending.status).toBe(200);
+    const { data } = credentialResponseSchema.parse(await pending.json());
+    const childId = data.providerCredential.id;
+    // Prospective walletless history, prepared only in this test fixture.
+    const db = getDb(env);
+    await db.execute("UPDATE custody_wallets SET status = 'deactivated'");
+    await db.execute(
+      "UPDATE custody_connections SET status = 'deactivated', deactivated_at = sdp_iso_now()"
+    );
+    providerFetch.mockClear();
+
+    const parent = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/deactivate`, {
+      method: "POST",
+    });
+    expect(parent.status).toBe(200);
+    expect(await parent.json()).toMatchObject({
+      data: { providerCredential: { id: CREDENTIAL_ID, status: "deactivated" } },
+    });
+    const state = await lifecycleRequest(`/connections/${CONNECTION_A_ID}/provider-credential`);
+    expect(state.status).toBe(200);
+    expect(await state.json()).toMatchObject({
+      data: {
+        providerCredential: { id: CREDENTIAL_ID, status: "deactivated" },
+        rotationCandidate: { id: childId, status: "pending" },
+        rollback: null,
+      },
+    });
+    const child = await lifecycleRequest(`/provider-credentials/${childId}/deactivate`, {
+      method: "POST",
+    });
+    expect(child.status).toBe(200);
+    expect(await child.json()).toMatchObject({
+      data: { providerCredential: { id: childId, status: "deactivated" } },
+    });
+    expect(
+      await (await lifecycleRequest(`/connections/${CONNECTION_A_ID}/provider-credential`)).json()
+    ).toMatchObject({
+      data: {
+        providerCredential: { id: CREDENTIAL_ID, status: "deactivated" },
+        rotationCandidate: null,
+      },
+    });
+    expect(
+      await db.queryMany(
+        "SELECT resource_id FROM audit_logs WHERE action = 'deactivate' ORDER BY resource_id"
+      )
+    ).toEqual([CREDENTIAL_ID, childId].sort().map((resource_id) => ({ resource_id })));
+    expect(providerFetch).not.toHaveBeenCalled();
+  });
+
+  describe("unreferenced current Credential deactivation", () => {
+    beforeEach(async () => {
+      // Prospective walletless history; Privy has no supported wallet deactivation command.
+      await getDb(env).execute("UPDATE custody_wallets SET status = 'deactivated'");
+      await getDb(env).execute(
+        "UPDATE custody_connections SET status = 'deactivated', deactivated_at = sdp_iso_now()"
+      );
+    });
+
+    it("refuses deactivation of an initial GCP Credential while its secret is creating", async () => {
+      const gcp = mockGcpRotation();
+      await seedActiveGcpCredential(gcp);
+      const db = getDb(env);
+      await db.execute(
+        "UPDATE provider_credentials SET status = 'creating', secret_version_ref = NULL WHERE id = ?",
+        [CREDENTIAL_ID]
+      );
+      const original = await db.queryOne("SELECT * FROM provider_credentials WHERE id = ?", [
+        CREDENTIAL_ID,
+      ]);
+
+      const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/deactivate`, {
+        method: "POST",
+      });
+
+      expect(response.status).toBe(409);
+      expect(
+        await db.queryOne("SELECT * FROM provider_credentials WHERE id = ?", [CREDENTIAL_ID])
+      ).toEqual(original);
+      expect(await db.queryMany("SELECT id FROM audit_logs WHERE action = 'deactivate'")).toEqual(
+        []
+      );
+      expect(gcp.requests).toEqual([]);
+    });
+
+    it.each(["encrypted_db", "runtime_env"])(
+      "deactivates the active %s Credential without changing deployment secrets or Connection history",
+      async (backend) => {
+        const db = getDb(env);
+        if (backend === "runtime_env") {
+          await db.execute(
+            `UPDATE provider_credentials SET source = 'runtime', storage_backend = 'runtime_env',
+               encrypted_secret_payload = NULL WHERE id = ?`,
+            [CREDENTIAL_ID]
+          );
+        }
+        const deployment = { ...env };
+        const connections = await db.queryMany("SELECT * FROM custody_connections ORDER BY id");
+        const providerFetch = vi.fn();
+        vi.stubGlobal("fetch", providerFetch);
+
+        const response = await lifecycleRequest(
+          `/provider-credentials/${CREDENTIAL_ID}/deactivate`,
+          {
+            method: "POST",
+          }
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toMatchObject({
+          data: { providerCredential: { id: CREDENTIAL_ID, status: "deactivated" } },
+        });
+        expect(
+          await db.queryOne(
+            "SELECT status, encrypted_secret_payload FROM provider_credentials WHERE id = ?",
+            [CREDENTIAL_ID]
+          )
+        ).toEqual({ status: "deactivated", encrypted_secret_payload: null });
+        expect(await db.queryMany("SELECT * FROM custody_connections ORDER BY id")).toEqual(
+          connections
+        );
+        expect(
+          await db.queryOne(
+            "SELECT COUNT(*) AS count FROM audit_logs WHERE resource_id = ? AND action = 'deactivate'",
+            [CREDENTIAL_ID]
+          )
+        ).toEqual({ count: 1 });
+        expect(env).toEqual(deployment);
+        expect(providerFetch).not.toHaveBeenCalled();
+      }
+    );
+
+    it.each(["failed_validation", "retired"])("preserves %s history", async (status) => {
+      const db = getDb(env);
+      await db.execute("UPDATE provider_credentials SET status = ? WHERE id = ?", [
+        status,
+        CREDENTIAL_ID,
+      ]);
+      const original = await db.queryOne("SELECT * FROM provider_credentials WHERE id = ?", [
+        CREDENTIAL_ID,
+      ]);
+      const providerFetch = vi.fn();
+      vi.stubGlobal("fetch", providerFetch);
+
+      const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/deactivate`, {
+        method: "POST",
+      });
+
+      expect(response.status).toBe(409);
+      expect((await response.json()).error).toEqual({
+        code: "CONFLICT",
+        message: "Credential cannot be deactivated from its current state",
+      });
+      expect(
+        await db.queryOne("SELECT * FROM provider_credentials WHERE id = ?", [CREDENTIAL_ID])
+      ).toEqual(original);
+      expect(await db.queryMany("SELECT id FROM audit_logs WHERE action = 'deactivate'")).toEqual(
+        []
+      );
+      expect(providerFetch).not.toHaveBeenCalled();
+    });
+
+    it("returns success with one audit when two deactivations pass preflight together", async () => {
+      let started = 0;
+      let release = () => {};
+      const bothStarted = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const findSecret = ProviderCredentialStore.prototype.findLifecycleCredentialWithSecret;
+      vi.spyOn(
+        ProviderCredentialStore.prototype,
+        "findLifecycleCredentialWithSecret"
+      ).mockImplementation(async function (this: ProviderCredentialStore, ...args) {
+        const row = await findSecret.apply(this, args);
+        if (++started === 2) release();
+        await bothStarted;
+        return row;
+      });
+      const providerFetch = vi.fn();
+      vi.stubGlobal("fetch", providerFetch);
+
+      const responses = await Promise.all(
+        [0, 1].map(() =>
+          lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/deactivate`, { method: "POST" })
+        )
+      );
+
+      for (const response of responses) {
+        expect(response.status).toBe(200);
+        expect(await response.json()).toMatchObject({
+          data: { providerCredential: { id: CREDENTIAL_ID, status: "deactivated" } },
+        });
+      }
+      expect(
+        await getDb(env).queryOne(
+          "SELECT COUNT(*) AS count FROM audit_logs WHERE resource_id = ? AND action = 'deactivate'",
+          [CREDENTIAL_ID]
+        )
+      ).toEqual({ count: 1 });
+      expect(providerFetch).not.toHaveBeenCalled();
+    });
+
+    it("preserves a fresh authorization refusal when a concurrent deactivation has committed", async () => {
+      const db = getDb(env);
+      const transaction = db.transaction.bind(db);
+      const providerFetch = vi.fn();
+      vi.stubGlobal("fetch", providerFetch);
+      vi.spyOn(db, "transaction").mockImplementationOnce(async (callback) => {
+        // The first request has passed preflight; another authorized request wins.
+        const winner = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/deactivate`, {
+          method: "POST",
+        });
+        expect(winner.status).toBe(200);
+        await db.execute("DELETE FROM project_members WHERE project_id = ? AND user_id = ?", [
+          PROJECT_A_ID,
+          USER_ID,
+        ]);
+        return transaction(callback);
+      });
+
+      const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/deactivate`, {
+        method: "POST",
+      });
+
+      expect(response.status).toBe(403);
+      expect(await response.json()).toMatchObject({
+        error: { code: "FORBIDDEN", message: "Requested project is not accessible" },
+      });
+      expect(
+        await db.queryOne("SELECT status FROM provider_credentials WHERE id = ?", [CREDENTIAL_ID])
+      ).toEqual({ status: "deactivated" });
+      expect(
+        await db.queryOne(
+          "SELECT COUNT(*) AS count FROM audit_logs WHERE resource_id = ? AND action = 'deactivate'",
+          [CREDENTIAL_ID]
+        )
+      ).toEqual({ count: 1 });
+      expect(providerFetch).not.toHaveBeenCalled();
+    });
+
+    it.each(["database failure", "membership loss"])(
+      "preserves Credential and secret when %s occurs after preflight",
+      async (fault) => {
+        const db = getDb(env);
+        const original = await db.queryOne("SELECT * FROM provider_credentials WHERE id = ?", [
+          CREDENTIAL_ID,
+        ]);
+        if (fault === "database failure") {
+          const transaction = db.transaction.bind(db);
+          vi.spyOn(db, "transaction").mockImplementationOnce((callback) =>
+            transaction(async (tx) => {
+              await callback(tx);
+              await tx.execute("SELECT 1 / 0");
+            })
+          );
+        } else {
+          const lockProjects = ProviderCredentialStore.prototype.lockAuthorizedProjects;
+          vi.spyOn(
+            ProviderCredentialStore.prototype,
+            "lockAuthorizedProjects"
+          ).mockImplementationOnce(async function (this: ProviderCredentialStore, ...args) {
+            await db.execute("DELETE FROM project_members WHERE project_id = ? AND user_id = ?", [
+              PROJECT_A_ID,
+              USER_ID,
+            ]);
+            return lockProjects.apply(this, args);
+          });
+        }
+        const providerFetch = vi.fn();
+        vi.stubGlobal("fetch", providerFetch);
+
+        const response = await lifecycleRequest(
+          `/provider-credentials/${CREDENTIAL_ID}/deactivate`,
+          { method: "POST" }
+        );
+
+        expect(response.status).toBe(fault === "database failure" ? 503 : 403);
+        expect(
+          await db.queryOne("SELECT * FROM provider_credentials WHERE id = ?", [CREDENTIAL_ID])
+        ).toEqual(original);
+        expect(await db.queryMany("SELECT id FROM audit_logs WHERE action = 'deactivate'")).toEqual(
+          []
+        );
+        expect(providerFetch).not.toHaveBeenCalled();
+      }
+    );
+  });
+
+  it("retries failed GCP root destruction at its container scan and preserves its live child", async () => {
+    const options = { privyStatus: 503, destroyFailure: true };
+    const gcp = mockGcpRotation(options);
+    const secretRef = z.string().parse(await seedActiveGcpCredential(gcp));
+    const canonicalRef = secretRef.replace("projects/sdp-lifecycle-test/", "projects/1234567890/");
+    const rotation = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/rotate`, {
+      method: "POST",
+      key: "rotate-before-gcp-root-deactivation",
+      body: { fields: { appId: APP_ID, appSecret: "live-child-secret" } },
+    });
+    expect(rotation.status).toBe(200);
+    const childId = credentialResponseSchema.parse(await rotation.json()).data.providerCredential
+      .id;
+    const secrets = () => createCredentialSecretStore(env, "gcp_secret_manager");
+    expect(await scanGcpCredentialContainers(env, secrets)).toMatchObject({
+      scanned: [secretRef],
+      cleaned: 0,
+      failed: [],
+    });
+    // Prospective walletless history, prepared only in this test fixture.
+    const db = getDb(env);
+    await db.execute("UPDATE custody_wallets SET status = 'deactivated'");
+    await db.execute(
+      "UPDATE custody_connections SET status = 'deactivated', deactivated_at = sdp_iso_now()"
+    );
+
+    const response = await lifecycleRequest(`/provider-credentials/${CREDENTIAL_ID}/deactivate`, {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      data: { providerCredential: { id: CREDENTIAL_ID, status: "deactivated" } },
+    });
+    expect(JSON.stringify(body)).not.toContain(secretRef);
+    expect(
+      await db.queryOne(
+        `SELECT status, secret_retention_expires_at::timestamptz <= clock_timestamp() AS due,
+           secret_next_scan_at > clock_timestamp() AS scheduled
+         FROM provider_credentials WHERE id = ?`,
+        [CREDENTIAL_ID]
+      )
+    ).toEqual({ status: "deactivated", due: true, scheduled: true });
+    expect(await cleanupRetiredProviderCredentialSecrets(env)).toEqual({
+      cleaned: 0,
+      skipped: 0,
+      failed: 0,
+    });
+    const destruction = {
+      url: `https://gcp-lifecycle.test/v1/${canonicalRef}/versions/1:destroy`,
+      method: "POST",
+    };
+    expect(gcp.requests.filter(({ url }) => url.endsWith(":destroy"))).toEqual([destruction]);
+
+    options.destroyFailure = false;
+    expect(
+      await scanGcpCredentialContainers(env, secrets, { now: new Date(Date.now() + 6 * 60_000) })
+    ).toMatchObject({ scanned: [secretRef], cleaned: 1, failed: [] });
+    expect(gcp.requests.filter(({ url }) => url.endsWith(":destroy"))).toEqual([
+      destruction,
+      destruction,
+    ]);
+    expect(await secrets().listVersions?.({ secretRef, liveOnly: true })).toMatchObject({
+      versions: [{ secretVersionRef: `${canonicalRef}/versions/7`, state: "ENABLED" }],
+    });
+    expect(
+      await db.queryOne(
+        "SELECT status, secret_retention_expires_at FROM provider_credentials WHERE id = ?",
+        [CREDENTIAL_ID]
+      )
+    ).toEqual({ status: "deactivated", secret_retention_expires_at: null });
+    expect(
+      await (await lifecycleRequest(`/connections/${CONNECTION_A_ID}/provider-credential`)).json()
+    ).toMatchObject({
+      data: {
+        providerCredential: { id: CREDENTIAL_ID, status: "deactivated" },
+        rotationCandidate: { id: childId, status: "pending" },
+      },
+    });
+  });
+
   it.each(["actor", "organization"])(
     "refuses rotation when the %s quota is exhausted",
     async (scope) => {
@@ -2407,6 +2877,10 @@ describe("provider credential lifecycle", () => {
     });
 
     expect(canceled.status).toBe(409);
+    expect((await canceled.json()).error).toEqual({
+      code: "CONFLICT",
+      message: "Credential cannot be deactivated while it is in use",
+    });
     expect(
       await db.queryOne<{ status: string }>(
         "SELECT status FROM provider_credentials WHERE id = ?",

--- a/apps/sdp-api/src/services/jobs/cleanup-provider-credential-secrets.test.ts
+++ b/apps/sdp-api/src/services/jobs/cleanup-provider-credential-secrets.test.ts
@@ -500,6 +500,43 @@ describe("cleanupRetiredProviderCredentialSecrets", () => {
     expect(JSON.stringify(logError.mock.calls)).not.toContain("raw upstream detail");
   });
 
+  it("retries exact-version cleanup for a deactivated GCP root on its next container scan", async () => {
+    const id = "pcred_deactivated_root";
+    const retentionExpiresAt = "2020-01-01T00:00:00.000Z";
+    await insertCredential({
+      id,
+      status: "deactivated",
+      backend: "gcp_secret_manager",
+      retentionExpiresAt,
+    });
+    destroyVersion.mockRejectedValueOnce(new Error("transient GCP failure"));
+
+    await expect(cleanupRetiredProviderCredentialSecrets(env)).rejects.toThrow(
+      "Provider Credential secret cleanup failed for 1 row(s)"
+    );
+    await expect(credentialState(id)).resolves.toMatchObject({
+      status: "deactivated",
+      secret_retention_expires_at: retentionExpiresAt,
+    });
+
+    await makeCleanupDue(id);
+    await expect(cleanupRetiredProviderCredentialSecrets(env)).resolves.toEqual({
+      cleaned: 1,
+      skipped: 0,
+      failed: 0,
+    });
+    expect(destroyVersion).toHaveBeenCalledTimes(2);
+    expect(destroyVersion).toHaveBeenLastCalledWith({
+      secretVersionRef: `projects/p/secrets/sdp-provider-credentials-${id}/versions/7`,
+      signal: expect.any(AbortSignal),
+      requireDestroyed: true,
+    });
+    await expect(credentialState(id)).resolves.toMatchObject({
+      status: "deactivated",
+      secret_retention_expires_at: null,
+    });
+  });
+
   it.each(["failed_validation", "deactivated"] as const)(
     "retries cleanup for a GCP rotation candidate that ends %s without changing its status",
     async (status) => {
@@ -516,9 +553,10 @@ describe("cleanupRetiredProviderCredentialSecrets", () => {
       const transitioned =
         status === "failed_validation"
           ? await credentialStore.recordRotationFailure(candidateId, "invalid_credentials")
-          : await credentialStore.deactivateRotationCandidate({
+          : await credentialStore.deactivateCredential({
               organizationId: ORGANIZATION_ID,
-              candidateId,
+              credentialId: candidateId,
+              expectedStatus: "pending",
               predecessorId,
             });
       expect(transitioned).toBe(true);
@@ -552,6 +590,56 @@ describe("cleanupRetiredProviderCredentialSecrets", () => {
       });
     }
   );
+
+  it("preserves a deactivated GCP root marker while a live Connection references it", async () => {
+    const id = "pcred_referenced_deactivated_root";
+    const retentionExpiresAt = "2020-01-01T00:00:00.000Z";
+    await insertCredential({
+      id,
+      status: "deactivated",
+      backend: "gcp_secret_manager",
+      retentionExpiresAt,
+    });
+    await insertConnection("conn_referenced_deactivated_root", id);
+
+    await expect(cleanupRetiredProviderCredentialSecrets(env)).resolves.toEqual({
+      cleaned: 0,
+      skipped: 0,
+      failed: 0,
+    });
+    expect(destroyVersion).not.toHaveBeenCalled();
+    await expect(credentialState(id)).resolves.toMatchObject({
+      status: "deactivated",
+      secret_retention_expires_at: retentionExpiresAt,
+    });
+  });
+
+  it("preserves a deactivated GCP root marker if its exact reference changes during destruction", async () => {
+    const id = "pcred_deactivated_ref_cas";
+    const retentionExpiresAt = "2020-01-01T00:00:00.000Z";
+    await insertCredential({
+      id,
+      status: "deactivated",
+      backend: "gcp_secret_manager",
+      retentionExpiresAt,
+    });
+    destroyVersion.mockImplementationOnce(async () => {
+      await getDb(env).execute(
+        "UPDATE provider_credentials SET secret_version_ref = ? WHERE id = ?",
+        [`projects/p/secrets/sdp-provider-credentials-${id}/versions/8`, id]
+      );
+    });
+
+    await expect(cleanupRetiredProviderCredentialSecrets(env)).resolves.toEqual({
+      cleaned: 0,
+      skipped: 1,
+      failed: 0,
+    });
+    await expect(credentialState(id)).resolves.toMatchObject({
+      status: "deactivated",
+      secret_retention_expires_at: retentionExpiresAt,
+    });
+  });
 
   it("does not clear a GCP marker that changed while the destroy was in flight", async () => {
     await insertCredential({

--- a/apps/sdp-api/src/services/provider-credential-installation.service.ts
+++ b/apps/sdp-api/src/services/provider-credential-installation.service.ts
@@ -115,6 +115,115 @@ export async function getProviderCredentialInstallation(
   return { connection: projectConnection(c.env, loaded) };
 }
 
+export async function deactivateCustodyConnection(
+  c: Context<{ Bindings: Env }>,
+  connectionId: string
+): Promise<{ custodyConnection: SafeInstallationConnection }> {
+  const context = createInstallationContext(c);
+  const loaded = await loadInstallation(context, connectionId);
+  if (loaded.target.status === "deactivated") {
+    return { custodyConnection: projectConnection(c.env, loaded) };
+  }
+  if (loaded.target.status !== "failed" && loaded.target.status !== "active") {
+    throw conflict(INSTALLATION_UNAVAILABLE_MESSAGE);
+  }
+  if (
+    await context.store.hasActiveInstallationWallet(
+      context.organizationId,
+      context.projectId,
+      connectionId
+    )
+  ) {
+    throw conflict("Connection cannot be deactivated while it has active wallets");
+  }
+  const intent = await context.audit.beginCritical(c, {
+    organizationId: context.organizationId,
+    userId: context.userId,
+    action: "deactivate",
+    resourceType: "custody_connection",
+    resourceId: connectionId,
+    metadata: { event: "custody_connection_deactivation_started", provider: "privy" },
+  });
+  let changed = false;
+  let result: SafeInstallationConnection;
+  try {
+    result = await context.db.transaction(async (tx) => {
+      const store = new ProviderCredentialStore(tx);
+      if (
+        !(await store.lockAuthorizedProjects(context.organizationId, context.userId, [
+          context.projectId,
+        ]))
+      ) {
+        throw forbidden("Requested project is not accessible");
+      }
+      const target = await store.findInstallationConnection(
+        context.organizationId,
+        context.projectId,
+        connectionId,
+        { lock: true }
+      );
+      if (!target) throw notFound("Custody Connection");
+      if (target.status !== "deactivated") {
+        if (target.status !== "failed" && target.status !== "active") {
+          throw conflict(INSTALLATION_UNAVAILABLE_MESSAGE);
+        }
+        if (
+          await store.hasActiveInstallationWallet(
+            context.organizationId,
+            context.projectId,
+            connectionId
+          )
+        ) {
+          throw conflict("Connection cannot be deactivated while it has active wallets");
+        }
+        if (
+          !(await store.deactivateInstallationConnection({
+            organizationId: context.organizationId,
+            projectId: context.projectId,
+            connectionId,
+            credentialId: target.provider_credential_id,
+            credentialStatus: target.credential_status,
+            observedStatus: target.status,
+          }))
+        ) {
+          throw conflict(INSTALLATION_UNAVAILABLE_MESSAGE);
+        }
+        changed = true;
+      }
+      const deactivated = { ...target, status: "deactivated" as const };
+      return projectConnection(c.env, {
+        target: deactivated,
+        decisions: decideInstallation(
+          installationFactsFromConnection(deactivated, await store.getDatabaseNowMs(), false)
+        ),
+      });
+    });
+  } catch (error) {
+    if (changed) {
+      // Preserve the durable intent when the commit outcome cannot be established.
+      throw providerUnavailable("Connection deactivation outcome is temporarily unknown");
+    }
+    await completeInstallationCriticalNoop(
+      context,
+      intent,
+      "custody_connection_deactivation_not_committed"
+    );
+    throw error;
+  }
+  if (changed) {
+    await context.audit.completeCritical(c, intent, {
+      metadata: { event: "custody_connection_deactivated", provider: "privy" },
+    });
+  } else {
+    await completeInstallationCriticalNoop(
+      context,
+      intent,
+      "custody_connection_deactivation_replayed"
+    );
+  }
+  return { custodyConnection: result };
+}
+
 export async function completeProviderCredentialInstallation(
   c: Context<{ Bindings: Env }>,
   connectionId: string

--- a/apps/sdp-api/src/services/provider-credential-lifecycle.service.ts
+++ b/apps/sdp-api/src/services/provider-credential-lifecycle.service.ts
@@ -47,7 +47,9 @@ import type { Env } from "@/types/env";
 
 const ROTATION_UNAVAILABLE = "Credential rotation is not available";
 const ROLLBACK_UNAVAILABLE = "Credential rollback is not available";
-const CANDIDATE_UNAVAILABLE = "Credential cannot be deactivated from its current state";
+const CREDENTIAL_DEACTIVATION_UNAVAILABLE =
+  "Credential cannot be deactivated from its current state";
+const CREDENTIAL_IN_USE = "Credential cannot be deactivated while it is in use";
 
 export type RotationFailureCode = "invalid_credentials" | "provider_account_mismatch";
 
@@ -90,6 +92,11 @@ interface AuthorizedCredential {
   references: CredentialReferenceRow[];
 }
 
+interface DeactivationTarget extends AuthorizedCredential {
+  authorizationReferences: CredentialReferenceRow[];
+  predecessor: LifecycleCredentialRow | null;
+}
+
 export async function getProviderCredentialLifecycle(
   c: Context<{ Bindings: Env }>,
   connectionId: string
@@ -104,7 +111,7 @@ export async function getProviderCredentialLifecycle(
 
   const authorized = await loadAuthorizedCredential(context, credentialId);
   const candidate =
-    authorized.credential.status === "active"
+    authorized.credential.status === "active" || authorized.credential.status === "deactivated"
       ? await context.store.findUnfinishedDirectChild(
           context.organizationId,
           authorized.credential.id
@@ -354,7 +361,7 @@ export async function completeRotationCandidate(
       check === "failed" ? "invalid_credentials" : "provider_account_mismatch";
     const race = await settleCandidateOutcome(context, loaded, code);
     if (race?.rotation.status === "success") return race;
-    await cleanupRejectedCandidate(c, candidateSecret);
+    await cleanupTerminalCredential(c, candidateSecret);
     if (race) return race;
     return rotationResult({ ...loaded.candidate, status: "failed_validation" }, "failed", code);
   }
@@ -558,122 +565,200 @@ export async function rollbackProviderCredential(
   };
 }
 
-export async function deactivateRotationCandidate(
+export async function deactivateProviderCredential(
   c: Context<{ Bindings: Env }>,
-  candidateId: string
+  credentialId: string
 ): Promise<{ providerCredential: SafeProviderCredential }> {
   const context = createContext(c);
-  const loaded = await loadAuthorizedCandidate(context, candidateId, true, CANDIDATE_UNAVAILABLE);
-  if (loaded.candidate.status === "deactivated") {
-    const candidateSecret = await requireLifecycleCredentialSecret(context, candidateId);
-    await cleanupRejectedCandidate(c, candidateSecret);
-    return { providerCredential: mapProviderCredential(loaded.candidate) };
+  const loaded = await loadDeactivationTarget(context, credentialId);
+  if (loaded.credential.status === "deactivated") {
+    const secret = await requireLifecycleCredentialSecret(context, credentialId);
+    await cleanupTerminalCredential(c, secret);
+    return { providerCredential: mapProviderCredential(loaded.credential) };
   }
-  const candidateStatus = loaded.candidate.status;
+  const expectedStatus = loaded.credential.status;
   if (
-    (candidateStatus !== "pending" && candidateStatus !== "creating") ||
-    loaded.candidateReferences.length > 0
+    expectedStatus !== "pending" &&
+    expectedStatus !== "active" &&
+    expectedStatus !== "creating"
   ) {
-    throw conflict(CANDIDATE_UNAVAILABLE);
+    throw conflict(CREDENTIAL_DEACTIVATION_UNAVAILABLE);
   }
-  if (loaded.references.length === 0) throw conflict(CANDIDATE_UNAVAILABLE);
-  const candidateSecret = await requireLifecycleCredentialSecret(context, candidateId);
+  // Keep A's cancellation path for an in-flight rotation, not unfinished initial setup.
+  if (
+    expectedStatus === "creating" &&
+    (loaded.predecessor?.status !== "active" || loaded.authorizationReferences.length === 0)
+  ) {
+    throw conflict(CREDENTIAL_DEACTIVATION_UNAVAILABLE);
+  }
+  if (
+    loaded.references.length > 0 ||
+    (await context.store.hasActiveCredentialWallet(context.organizationId, credentialId))
+  ) {
+    throw conflict(CREDENTIAL_IN_USE);
+  }
+  const secret = await requireLifecycleCredentialSecret(context, credentialId);
+  const rotationCancellation =
+    expectedStatus !== "active" &&
+    loaded.predecessor !== null &&
+    loaded.predecessor.status !== "failed_validation";
+  const completedEvent = rotationCancellation
+    ? "provider_credential_rotation_canceled"
+    : "provider_credential_deactivated";
 
   const auditIntent = await context.audit.beginCritical(c, {
     organizationId: context.organizationId,
     userId: context.userId,
     action: "deactivate",
     resourceType: "provider_credential",
-    resourceId: loaded.candidate.id,
-    metadata: { event: "provider_credential_rotation_cancellation_started", provider: "privy" },
+    resourceId: credentialId,
+    metadata: {
+      event: rotationCancellation
+        ? "provider_credential_rotation_cancellation_started"
+        : "provider_credential_deactivation_started",
+      provider: "privy",
+    },
   });
   let applied = false;
   try {
     await getDb(c.env).transaction(async (tx) => {
       const store = new ProviderCredentialStore(tx);
-      await assertLockedAuthorization(context, store, loaded.references);
-      const lockedReferences = await store.listCredentialReferences(
+      if (
+        !(await store.lockAuthorizedProjects(context.organizationId, context.userId, [
+          context.projectId,
+          ...loaded.authorizationReferences.map((reference) => reference.project_id),
+        ]))
+      ) {
+        throw forbidden("Requested project is not accessible");
+      }
+      await store.lockCredentialReferenceRows(
         context.organizationId,
-        loaded.predecessor.id,
+        loaded.authorizationReferences.map((reference) => reference.id)
+      );
+      const lockedCredential = await store.findLifecycleCredential(
+        context.organizationId,
+        credentialId,
         { lock: true }
       );
-      const lockedCandidateReferences = await store.listCredentialReferences(
-        context.organizationId,
-        loaded.candidate.id,
-        { lock: true }
-      );
-      const lockedCandidate = await store.findLifecycleCredential(
-        context.organizationId,
-        loaded.candidate.id,
-        { lock: true }
-      );
-      const lockedPredecessor = await store.findLifecycleCredential(
-        context.organizationId,
-        loaded.predecessor.id,
-        { lock: true }
-      );
-      assertCandidateSnapshot(
-        lockedCandidate,
-        lockedPredecessor,
-        lockedReferences,
-        loaded,
-        CANDIDATE_UNAVAILABLE,
-        candidateStatus
-      );
-      if (lockedCandidateReferences.length > 0) throw conflict(CANDIDATE_UNAVAILABLE);
+      if (
+        !lockedCredential ||
+        lockedCredential.status !== expectedStatus ||
+        lockedCredential.rotated_from_provider_credential_id !==
+          loaded.credential.rotated_from_provider_credential_id
+      ) {
+        throw conflict(CREDENTIAL_DEACTIVATION_UNAVAILABLE);
+      }
+      const lockedPredecessor = loaded.predecessor
+        ? await store.findLifecycleCredential(context.organizationId, loaded.predecessor.id, {
+            lock: true,
+          })
+        : null;
+      const references = await store.listCredentialReferences(context.organizationId, credentialId);
+      const authorizationReferences = loaded.predecessor
+        ? [
+            ...(lockedPredecessor?.status === "active"
+              ? await store.listCredentialReferences(context.organizationId, loaded.predecessor.id)
+              : await store.listCredentialLineageReferences(context.organizationId, credentialId)),
+            ...references,
+          ]
+        : references;
+      if (
+        !sameReferences(authorizationReferences, loaded.authorizationReferences) ||
+        !sameReferences(references, loaded.references) ||
+        (expectedStatus === "creating" &&
+          (lockedPredecessor?.status !== "active" || authorizationReferences.length === 0))
+      ) {
+        throw conflict(CREDENTIAL_DEACTIVATION_UNAVAILABLE);
+      }
       const changed =
-        candidateStatus === "creating"
+        expectedStatus === "creating"
           ? await store.abandonCredentialCreation({
               organizationId: context.organizationId,
-              credentialId: loaded.candidate.id,
+              credentialId,
             })
-          : await store.deactivateRotationCandidate({
+          : await store.deactivateCredential({
               organizationId: context.organizationId,
-              candidateId: loaded.candidate.id,
-              predecessorId: loaded.predecessor.id,
+              credentialId,
+              expectedStatus,
+              predecessorId: loaded.credential.rotated_from_provider_credential_id,
             });
-      if (!changed) {
-        throw conflict(CANDIDATE_UNAVAILABLE);
-      }
+      if (!changed) throw conflict(CREDENTIAL_IN_USE);
       applied = true;
     });
   } catch (error) {
-    logLifecycleFailure(c, "cancellation_commit", candidateId, error);
-    const visible = await cancellationCommitIsVisible(context, loaded);
+    logLifecycleFailure(c, "deactivation_commit", credentialId, error);
+    // Another request's completed transition cannot override this request's access denial.
+    if (error instanceof AppError && error.code === "FORBIDDEN") {
+      await closeRejectedIntent(
+        context,
+        auditIntent,
+        "provider_credential_deactivation_not_committed"
+      );
+      throw error;
+    }
+    const visible = await deactivationCommitIsVisible(context, loaded);
     if (visible === true) {
+      await loadDeactivationTarget(context, credentialId);
+      // A lost COMMIT reply does not prove which concurrent request won. Keep
+      // an applied-but-uncertain intent open instead of duplicating its outcome.
       if (applied) {
-        logUnresolvedAuditIntent(context, auditIntent, candidateId);
+        logUnresolvedAuditIntent(context, auditIntent, credentialId);
       } else {
         await closeRejectedIntent(
           context,
           auditIntent,
-          "provider_credential_rotation_cancellation_replayed"
+          "provider_credential_deactivation_replayed"
         );
-        await loadAuthorizedCandidate(context, loaded.candidate.id, true, CANDIDATE_UNAVAILABLE);
       }
-      await cleanupRejectedCandidate(c, candidateSecret);
+      await cleanupTerminalCredential(c, secret);
       return {
-        providerCredential: mapProviderCredential({ ...loaded.candidate, status: "deactivated" }),
+        providerCredential: mapProviderCredential({ ...loaded.credential, status: "deactivated" }),
       };
     }
     if (applied || visible === null) {
-      throw providerUnavailable("Credential cancellation outcome is temporarily unknown");
+      throw providerUnavailable("Credential deactivation outcome is temporarily unknown");
     }
     await closeRejectedIntent(
       context,
       auditIntent,
-      "provider_credential_rotation_cancellation_not_committed"
+      "provider_credential_deactivation_not_committed"
     );
     if (error instanceof AppError) throw error;
-    throw conflict(CANDIDATE_UNAVAILABLE);
+    throw providerUnavailable("Credential deactivation is temporarily unavailable");
   }
-  await cleanupRejectedCandidate(c, candidateSecret);
+  await cleanupTerminalCredential(c, secret);
   await context.audit.completeCritical(c, auditIntent, {
-    metadata: { event: "provider_credential_rotation_canceled", provider: "privy" },
+    metadata: { event: completedEvent, provider: "privy" },
   });
   return {
-    providerCredential: mapProviderCredential({ ...loaded.candidate, status: "deactivated" }),
+    providerCredential: mapProviderCredential({ ...loaded.credential, status: "deactivated" }),
   };
+}
+
+async function loadDeactivationTarget(
+  context: LifecycleContext,
+  credentialId: string
+): Promise<DeactivationTarget> {
+  const authorized = await loadAuthorizedCredential(context, credentialId);
+  if (
+    authorized.credential.source === "stored" &&
+    authorized.credential.rotated_from_provider_credential_id &&
+    authorized.credential.status !== "active"
+  ) {
+    const candidate = await loadAuthorizedCandidate(
+      context,
+      credentialId,
+      true,
+      CREDENTIAL_DEACTIVATION_UNAVAILABLE
+    );
+    return {
+      credential: candidate.candidate,
+      references: candidate.candidateReferences,
+      authorizationReferences: [...candidate.references, ...candidate.candidateReferences],
+      predecessor: candidate.predecessor,
+    };
+  }
+  return { ...authorized, authorizationReferences: authorized.references, predecessor: null };
 }
 
 function createContext(c: Context<{ Bindings: Env }>): LifecycleContext {
@@ -1119,25 +1204,22 @@ async function rollbackCommitIsVisible(
   }
 }
 
-async function cancellationCommitIsVisible(
+async function deactivationCommitIsVisible(
   context: LifecycleContext,
-  expected: Awaited<ReturnType<typeof loadAuthorizedCandidate>>
+  expected: DeactivationTarget
 ): Promise<boolean | null> {
   try {
-    const [candidate, predecessor, candidateReferences, predecessorReferences] = await Promise.all([
-      context.store.findLifecycleCredential(context.organizationId, expected.candidate.id),
-      context.store.findLifecycleCredential(context.organizationId, expected.predecessor.id),
-      context.store.listCredentialReferences(context.organizationId, expected.candidate.id),
-      context.store.listCredentialReferences(context.organizationId, expected.predecessor.id),
-    ]);
+    const credential = await context.store.findLifecycleCredential(
+      context.organizationId,
+      expected.credential.id
+    );
     return (
-      candidate?.status === "deactivated" &&
-      predecessor?.status === "active" &&
-      candidateReferences.length === 0 &&
-      sameReferences(predecessorReferences, expected.references)
+      credential?.status === "deactivated" &&
+      credential.rotated_from_provider_credential_id ===
+        expected.credential.rotated_from_provider_credential_id
     );
   } catch (error) {
-    logLifecycleFailure(context.c, "cancellation_outcome_read", expected.candidate.id, error);
+    logLifecycleFailure(context.c, "deactivation_outcome_read", expected.credential.id, error);
     return null;
   }
 }
@@ -1292,16 +1374,16 @@ function storedSecret(row: LifecycleCredentialWithSecretRow): StoredCredentialSe
   };
 }
 
-async function cleanupRejectedCandidate(
+async function cleanupTerminalCredential(
   c: Context<{ Bindings: Env }>,
-  candidate: LifecycleCredentialWithSecretRow
+  credential: LifecycleCredentialWithSecretRow
 ): Promise<void> {
-  if (candidate.storage_backend !== "gcp_secret_manager" || !candidate.secret_version_ref) return;
+  if (credential.storage_backend !== "gcp_secret_manager" || !credential.secret_version_ref) return;
   try {
-    const store = createPersistedSecretStore(c, candidate.storage_backend, candidate.id);
-    await store.destroyVersion({ secretVersionRef: candidate.secret_version_ref });
+    const store = createPersistedSecretStore(c, credential.storage_backend, credential.id);
+    await store.destroyVersion({ secretVersionRef: credential.secret_version_ref });
   } catch {
-    logCleanupFailure(c, candidate.id, candidate.storage_backend);
+    logCleanupFailure(c, credential.id, credential.storage_backend);
   }
 }
 

--- a/apps/sdp-api/src/services/stores/provider-credential.store.ts
+++ b/apps/sdp-api/src/services/stores/provider-credential.store.ts
@@ -509,10 +509,37 @@ export class ProviderCredentialStore {
     return restored === 1 && retired === 1;
   }
 
-  async deactivateRotationCandidate(params: {
+  async lockCredentialReferenceRows(
+    organizationId: string,
+    connectionIds: readonly string[]
+  ): Promise<void> {
+    if (connectionIds.length === 0) return;
+    await this.db.queryMany<{ id: string }>(
+      `SELECT id FROM custody_connections
+       WHERE organization_id = ? AND provider = 'privy'
+         AND id IN (SELECT jsonb_array_elements_text(?::jsonb))
+       ORDER BY project_id, id FOR UPDATE`,
+      [organizationId, JSON.stringify(connectionIds)]
+    );
+  }
+
+  async hasActiveCredentialWallet(organizationId: string, credentialId: string): Promise<boolean> {
+    const row = await this.db.queryOne<{ id: string }>(
+      `SELECT w.id FROM custody_connections c
+       JOIN custody_wallets w ON w.custody_connection_id = c.id
+       WHERE c.organization_id = ? AND c.provider = 'privy'
+         AND c.provider_credential_id = ? AND w.status = 'active'
+       LIMIT 1`,
+      [organizationId, credentialId]
+    );
+    return row !== null;
+  }
+
+  async deactivateCredential(params: {
     organizationId: string;
-    candidateId: string;
-    predecessorId: string;
+    credentialId: string;
+    expectedStatus: "pending" | "active";
+    predecessorId: string | null;
   }): Promise<boolean> {
     return (
       (await this.db.execute(
@@ -527,8 +554,9 @@ export class ProviderCredentialStore {
              deactivated_at = sdp_iso_now(), updated_at = sdp_iso_now()
          WHERE candidate.id = ?
            AND candidate.organization_id = ?
-           AND candidate.status = 'pending'
-           AND candidate.rotated_from_provider_credential_id = ?
+           AND candidate.provider = 'privy'
+           AND candidate.status = ?
+           AND candidate.rotated_from_provider_credential_id IS NOT DISTINCT FROM ?
            AND NOT EXISTS (
              SELECT 1 FROM custody_connections c
              WHERE c.provider_credential_id = candidate.id AND c.status <> 'deactivated'
@@ -540,7 +568,7 @@ export class ProviderCredentialStore {
                ON w.custody_connection_id = c.id AND w.status = 'active'
              WHERE c.provider_credential_id = candidate.id
            )`,
-        [params.candidateId, params.organizationId, params.predecessorId]
+        [params.credentialId, params.organizationId, params.expectedStatus, params.predecessorId]
       )) === 1
     );
   }
@@ -641,6 +669,59 @@ export class ProviderCredentialStore {
       ]
     );
     return rows.map((row) => row.id);
+  }
+
+  async hasActiveInstallationWallet(
+    organizationId: string,
+    projectId: string,
+    connectionId: string
+  ): Promise<boolean> {
+    return !!(await this.db.queryOne<{ id: string }>(
+      `SELECT w.id FROM custody_wallets w
+       JOIN custody_connections c ON c.id = w.custody_connection_id
+       WHERE c.id = ? AND c.organization_id = ? AND c.project_id = ?
+         AND c.provider = 'privy' AND w.status = 'active'
+       LIMIT 1`,
+      [connectionId, organizationId, projectId]
+    ));
+  }
+
+  async deactivateInstallationConnection(params: {
+    organizationId: string;
+    projectId: string;
+    connectionId: string;
+    credentialId: string;
+    credentialStatus: ProviderCredentialStatus;
+    observedStatus: "failed" | "active";
+  }): Promise<boolean> {
+    return (
+      (await this.db.execute(
+        `UPDATE custody_connections c
+         SET status = 'deactivated', deactivated_at = sdp_iso_now(), updated_at = sdp_iso_now()
+         WHERE c.id = ? AND c.organization_id = ? AND c.project_id = ?
+           AND c.provider = 'privy' AND c.provider_credential_id = ?
+           AND c.status = ? AND c.status IN ('failed', 'active')
+           AND EXISTS (
+             SELECT 1 FROM provider_credentials pc
+             WHERE pc.id = c.provider_credential_id AND pc.organization_id = c.organization_id
+               AND pc.provider = c.provider AND pc.scope_key = c.provider_credential_scope_key
+               AND (pc.scope = 'organization' OR pc.project_id = c.project_id)
+               AND pc.status = ?
+           )
+           AND NOT EXISTS (
+             SELECT 1 FROM custody_wallets w
+             WHERE w.custody_connection_id = c.id AND w.status = 'active'
+           )`,
+        [
+          params.connectionId,
+          params.organizationId,
+          params.projectId,
+          params.credentialId,
+          params.observedStatus,
+          params.credentialStatus,
+        ]
+      )) === 1
+    );
   }
 
   async findInstallationConnection(


### PR DESCRIPTION
**What changed**

- Extend Credential deactivation beyond rotation candidates to eligible unused pending or active Privy credentials.
- Add `POST /internal/dashboard/custody/connections/:connectionId/deactivate` for failed or active Connections without active owned wallets.
- Recheck authorization, references, and state under transaction locks; preserve replay behavior and lifecycle audit records.
- Add migration `0085` so explicitly deactivated GCP root credentials can retain cleanup markers.
- Keep pending rotation candidates visible and cancelable after eligible parent deactivation.

**Why**

Canceling a rotation candidate does not cover retiring an unused installed Credential or Connection. These operations need explicit guards so deactivation cannot silently cascade into wallets or disable credentials still referenced elsewhere.

**Impact**

Credential and Connection deactivation are separate operations.

A Credential cannot be deactivated while a non-deactivated Connection references it or an associated wallet is active. A Connection cannot be deactivated while it owns active wallets.

The existing cancellation path for an in-flight rotation remains available. Canceling a `creating` rotation still requires an active predecessor; this is not extended to initial setup in `creating`.

Pending/checking Connections and retired/failed-validation Credential history are not included in general deactivation.

**Pre/post release actions**

1. Apply migration `0085` before deploying the expanded deactivation handler.
2. Before rollout, exercise eligible deactivation, in-use rejection, replay, and cross-tenant rejection through the running API.
3. After rollout, monitor deactivation audit outcomes and GCP cleanup retries. A successful SDP deactivation does not itself confirm GCP payload destruction or provider-side credential revocation.

**Result Validation**

- `pnpm --filter @sdp/api typecheck` and `pnpm --filter @sdp/api build` — passed.
- 136 targeted tests — passed, covering deactivation guards, concurrent requests, authorization changes, transaction failures, migrations, and GCP root cleanup.
- `pnpm --filter @sdp/api test --coverage.thresholds.autoUpdate=false --exclude src/runtime/kv-redis.node.test.ts --exclude src/runtime/sponsorship-budget-redis.node.test.ts` — 4,696 passed, 14 skipped; coverage thresholds passed.
- `pnpm -C apps/sdp-api exec vitest run --no-file-parallelism src/runtime/kv-redis.node.test.ts src/runtime/sponsorship-budget-redis.node.test.ts` — 54 passed. Together, both runs cover all 343 test files.
- Live API/GCP checks, unauthenticated/cross-tenant endpoint probes, and standalone `psql` schema snapshots — not captured. Migration tests ran against test PostgreSQL.

**Does it affect current flows & behavior and how**

**Before:** Credential deactivation was limited to rotation-candidate cancellation; there was no general Connection deactivation endpoint.

**After:**

1. Authorize the operation and inspect current references and wallets.
2. Lock and recheck the relevant state.
3. Mark only the eligible target `deactivated`.
4. Record the lifecycle outcome and clean up the Credential's stored secret where applicable.

Connection deactivation does not deactivate its Credential, delete wallets, rewrite the selected default, or select a fallback. If the deactivated Connection was selected, that retained selection becomes unavailable for runtime use.

Credential deactivation clears encrypted-database payloads transactionally. For GCP, it attempts immediate destruction when the exact version is known and retains a marker for confirmed cleanup. Unknown versions are handled through recurring container inventory.

For `runtime_env` credentials, deactivation changes the SDP record; it does not modify deployment environment variables.

Repeated requests return the current deactivated state without applying the transition again. Lost commit acknowledgements do not fabricate an attributed audit success.

These maintenance commands remain available when custody runtime is disabled, subject to authorization and state checks.

**Known gaps**

- No cascading deactivation, reactivation flow, or dashboard UI is added.
- SDP deactivation and GCP payload destruction do not revoke the app secret in Privy.
- Live API/provider evidence remains outstanding.

**Notes**

Part 4 of 4, based on rotation and rollback.

Migration `0085` expands the retention constraint without backfilling terminal history.