### PR TITLE
ci: packages leg on hosted runners; superseded PR runs auto-cancel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CI_IS_FORK_PULL_REQUEST: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
 
@@ -261,7 +265,7 @@ jobs:
 
   test_packages:
     name: Unit Tests (packages)
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJson('["self-hosted", "sdp-ci"]') }}
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read


### PR DESCRIPTION
Two queue-relief changes for the single-runner bottleneck Andrey flagged (four runs stuck queued 09:09–09:24 with zero execution time):

- **`Unit Tests (packages)` moves back to `ubuntu-latest`** — the original #1575 design; it's the light leg (~2 min, plain pnpm + vitest, no heavy caching need), so it gains nothing from the VM and halves the demand on the `sdp-ci` pool. The heavy api leg stays self-hosted where the persistent turbo cache (#1689) lives.
- **CI gets a concurrency group** (`ci-<ref>`, `cancel-in-progress` for PRs only): a new push supersedes the previous run instead of queueing behind it. Today's queue held two superseded duplicates doing nothing but occupying slots. Pushes to main are never cancelled.

Real capacity (N concurrent runners, each on its own VM with its own ports) is the merged sdp-infra#136 pool — blocked only on the org-admin GitHub App creation. This PR is the relief we can ship today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)