### PR TITLE
ci: skip the pnpm-store cache restore on the warm runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          cache: pnpm
+          cache: ${{ runner.environment == 'github-hosted' && 'pnpm' || '' }}
 
       - name: Install
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Last trim for the sub-minute unit-test goal. The `test` job's `setup-node` restores the pnpm store from the GitHub cache service on every run — useful on ephemeral hosted runners, pure overhead (~15–20s of tarball download/extract) on the warm `sdp-ci` VM whose pnpm store already persists on disk. The cache input now applies only when `runner.environment == 'github-hosted'` (i.e. fork PRs), so hosted behavior is unchanged.

Stack context: with #1689 (persistent turbo cache), #1690 (dead service containers removed), #1693 (packages leg hosted + superseded-run cancellation) all merged, a PR that doesn't touch `@sdp/api`'s graph should now cost: checkout+pnpm(~20s) + turbo FULL TURBO replay(~10s) ≈ **under a minute**. This PR's own run is the measurement — **merge only if the observed `Unit Tests` job lands < 1 min**; if it doesn't, the run's timings will show which step still bleeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)