### PR TITLE
fix(smoke): assert ticket sign-in completes; activate session and org together

### DIFF
--- a/apps/sdp-web/playwright/tests/auth.global.setup.ts
+++ b/apps/sdp-web/playwright/tests/auth.global.setup.ts
@@ -41,25 +41,42 @@ setup("authenticate admin test user and save auth state", async ({ page, browser
       undefined,
       { timeout: 120_000 }
     );
-    await target.evaluate(async (ticket) => {
-      const clerkClient = (
-        window as unknown as {
-          Clerk?: {
-            client: {
-              signIn: {
-                create: (p: Record<string, string>) => Promise<{ createdSessionId: string }>;
+    await target.evaluate(
+      async ({ ticket, organizationId }) => {
+        const clerkClient = (
+          window as unknown as {
+            Clerk?: {
+              client: {
+                signIn: {
+                  create: (p: Record<string, string>) => Promise<{
+                    status: string;
+                    createdSessionId: string | null;
+                  }>;
+                };
               };
+              setActive: (p: { session: string; organization?: string }) => Promise<void>;
             };
-            setActive: (p: { session: string }) => Promise<void>;
-          };
+          }
+        ).Clerk;
+        if (!clerkClient) {
+          throw new Error("Clerk failed to load in Playwright global setup");
         }
-      ).Clerk;
-      if (!clerkClient) {
-        throw new Error("Clerk failed to load in Playwright global setup");
-      }
-      const signIn = await clerkClient.client.signIn.create({ strategy: "ticket", ticket });
-      await clerkClient.setActive({ session: signIn.createdSessionId });
-    }, token);
+        const signIn = await clerkClient.client.signIn.create({ strategy: "ticket", ticket });
+        if (signIn.status !== "complete" || !signIn.createdSessionId) {
+          throw new Error(`ticket sign-in did not complete: status=${signIn.status}`);
+        }
+        await clerkClient.setActive({
+          session: signIn.createdSessionId,
+          organization: organizationId,
+        });
+      },
+      { ticket: token, organizationId: identity.organizationId }
+    );
+    await target.waitForFunction(
+      () => Boolean((window as unknown as { Clerk?: { session?: unknown } }).Clerk?.session),
+      undefined,
+      { timeout: 30_000 }
+    );
   } else {
     await clerkSetup({
       publishableKey: env.clerkPublishableKey,


### PR DESCRIPTION
PRO-1856's proving run got past Clerk boot (localhost is now in prod allowed_origins) but saved a **signed-out** page: `signIn.create` resolved with a non-complete status, `createdSessionId` was null, and `setActive({session: null})` no-opped silently — the failure only surfaced three steps later as `Clerk.organization === undefined` with a sign-in form in the snapshot.

- Non-complete ticket sign-in now **throws with the actual status**, so the next proving run names its real cause at the right step.
- `setActive` activates session **and** organization in one call, followed by an explicit `Clerk.session` wait before the shared org-verification tail.

**Verification**: tsc/biome clean; the dispatched proving run after merge is the live check — if the status assertion fires, its message tells us what Clerk needs next (that's the point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)