### PR TITLE
fix(smoke): consume the ticket via URL in the untraced context

### DIFF
--- a/apps/sdp-web/playwright/tests/auth.global.setup.ts
+++ b/apps/sdp-web/playwright/tests/auth.global.setup.ts
@@ -35,47 +35,15 @@ setup("authenticate admin test user and save auth state", async ({ page, browser
       }
       return (await response.json()) as { token: string };
     });
-    await target.goto("/sign-in", { waitUntil: "domcontentloaded" });
-    await target.waitForFunction(
-      () => Boolean((window as unknown as { Clerk?: { client?: unknown } }).Clerk?.client),
-      undefined,
-      { timeout: 120_000 }
-    );
-    await target.evaluate(
-      async ({ ticket, organizationId }) => {
-        const clerkClient = (
-          window as unknown as {
-            Clerk?: {
-              client: {
-                signIn: {
-                  create: (p: Record<string, string>) => Promise<{
-                    status: string;
-                    createdSessionId: string | null;
-                  }>;
-                };
-              };
-              setActive: (p: { session: string; organization?: string }) => Promise<void>;
-            };
-          }
-        ).Clerk;
-        if (!clerkClient) {
-          throw new Error("Clerk failed to load in Playwright global setup");
-        }
-        const signIn = await clerkClient.client.signIn.create({ strategy: "ticket", ticket });
-        if (signIn.status !== "complete" || !signIn.createdSessionId) {
-          throw new Error(`ticket sign-in did not complete: status=${signIn.status}`);
-        }
-        await clerkClient.setActive({
-          session: signIn.createdSessionId,
-          organization: organizationId,
-        });
-      },
-      { ticket: token, organizationId: identity.organizationId }
-    );
+    // Proven flow (matches the prod canary): let Clerk consume the ticket from
+    // the URL, which establishes an org-capable session that setActive can
+    // switch. This runs on the untraced context above, so the token never
+    // enters a retained trace artifact.
+    await target.goto(`/sign-in?__clerk_ticket=${token}`, { waitUntil: "domcontentloaded" });
     await target.waitForFunction(
       () => Boolean((window as unknown as { Clerk?: { session?: unknown } }).Clerk?.session),
       undefined,
-      { timeout: 30_000 }
+      { timeout: 120_000 }
     );
   } else {
     await clerkSetup({

--- a/apps/sdp-web/playwright/tests/auth.global.setup.ts
+++ b/apps/sdp-web/playwright/tests/auth.global.setup.ts
@@ -11,9 +11,6 @@ setup("authenticate admin test user and save auth state", async ({ page, browser
   const env = getE2EEnv();
   const identity = await resolveClerkTestIdentity();
 
-  // The ticket flow runs in a manually created context: Playwright tracing only
-  // instruments fixture contexts, so the live sign-in token never enters the
-  // retain-on-failure trace that gets uploaded as a workflow artifact.
   const ticketContext = env.ticketAuth ? await browser.newContext({ baseURL: env.baseURL }) : null;
   const target = ticketContext ? await ticketContext.newPage() : page;
 
@@ -35,10 +32,6 @@ setup("authenticate admin test user and save auth state", async ({ page, browser
       }
       return (await response.json()) as { token: string };
     });
-    // Proven flow (matches the prod canary): let Clerk consume the ticket from
-    // the URL, which establishes an org-capable session that setActive can
-    // switch. This runs on the untraced context above, so the token never
-    // enters a retained trace artifact.
     await target.goto(`/sign-in?__clerk_ticket=${token}`, { waitUntil: "domcontentloaded" });
     await target.waitForFunction(
       () => Boolean((window as unknown as { Clerk?: { session?: unknown } }).Clerk?.session),

--- a/apps/sdp-web/playwright/tests/auth.global.setup.ts
+++ b/apps/sdp-web/playwright/tests/auth.global.setup.ts
@@ -32,11 +32,19 @@ setup("authenticate admin test user and save auth state", async ({ page, browser
       }
       return (await response.json()) as { token: string };
     });
-    await target.goto(`/sign-in?__clerk_ticket=${token}`, { waitUntil: "domcontentloaded" });
-    await target.waitForFunction(
-      () => Boolean((window as unknown as { Clerk?: { session?: unknown } }).Clerk?.session),
-      undefined,
-      { timeout: 120_000 }
+    const redactTicket = <T>(action: Promise<T>): Promise<T> =>
+      action.catch((error: unknown) => {
+        throw new Error(String(error).replaceAll(token, "[redacted-clerk-ticket]"));
+      });
+    await redactTicket(
+      target.goto(`/sign-in?__clerk_ticket=${token}`, { waitUntil: "domcontentloaded" })
+    );
+    await redactTicket(
+      target.waitForFunction(
+        () => Boolean((window as unknown as { Clerk?: { session?: unknown } }).Clerk?.session),
+        undefined,
+        { timeout: 120_000 }
+      )
     );
   } else {
     await clerkSetup({


### PR DESCRIPTION
The stage smoke has failed every proving run at org activation: `Clerk.organization` stays `undefined` after `setActive`.

**Root cause**: #1676's in-page `signIn.create({strategy:"ticket"})` (adopted for the trace-leak fix) creates a session that activates but is **not org-capable** — `setActive({organization})` silently no-ops on it. The prod canary (`sdp-infra observability/canary/tests/prod-authed.spec.ts`, green every 5 min) instead lets Clerk consume the ticket from the **URL**, which builds the fully-populated session `setActive` can switch.

**Fix**: revert to the URL-ticket flow — but run it on the **untraced context** that #1676 already introduced. Playwright traces only fixture contexts, so a token in that context's URL never reaches a retained artifact. Both concerns satisfied: proven org-capable session **and** no trace leak.

**Verification**: tsc/biome clean; the proving run after merge is the live check — this is the exact sequence the prod canary has run continuously since Aug 28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)