### PR TITLE
fix(web): use the canonical dashboard header on Markets pages

### DIFF
--- a/apps/sdp-web/src/app/dashboard/markets/earn/embedded-yield-dashboard.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/embedded-yield-dashboard.tsx
@@ -411,7 +411,7 @@ export function EmbeddedYieldDashboard({ configureHref }: { configureHref: strin
   if (isInitialLoading) return <EmbeddedYieldPortfolioSkeleton />;
 
   return (
-    <DashboardWorkspaceOverviewPanel className="px-4 pt-6 pb-8 md:px-8 xl:px-16">
+    <DashboardWorkspaceOverviewPanel>
       <div className="mx-auto flex w-full max-w-[63rem] flex-col gap-4 pt-3">
         <div className="flex items-center justify-between gap-4">
           <h2 className="flex items-center gap-2 text-[19px] leading-6 font-medium text-primary">

--- a/apps/sdp-web/src/app/dashboard/markets/markets-route-skeletons.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/markets-route-skeletons.tsx
@@ -27,7 +27,7 @@ export function MarketsLandingSkeleton() {
 
 export function TreasurySolutionsSkeleton() {
   return (
-    <DashboardWorkspaceOverviewPanel aria-busy="true" className="px-4 pt-8 pb-12 md:px-8 xl:px-9">
+    <DashboardWorkspaceOverviewPanel aria-busy="true">
       <div className="mx-auto flex w-full max-w-[90rem] flex-col gap-16">
         <div className="grid gap-2 sm:grid-cols-3">
           {BALANCE_SKELETON_IDS.map((id) => (
@@ -62,7 +62,7 @@ export function TreasurySolutionsSkeleton() {
 
 export function EmbeddedYieldPortfolioSkeleton() {
   return (
-    <DashboardWorkspaceOverviewPanel aria-busy="true" className="px-4 pt-6 pb-8 md:px-8 xl:px-16">
+    <DashboardWorkspaceOverviewPanel aria-busy="true">
       <div
         className="mx-auto flex w-full max-w-[63rem] flex-col gap-4 pt-3"
         data-embedded-yield-loading="portfolio"

--- a/apps/sdp-web/src/app/dashboard/markets/treasury-solutions/treasury-solutions-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/treasury-solutions/treasury-solutions-workspace.tsx
@@ -1347,7 +1347,7 @@ export function TreasurySolutionsWorkspace({
       : estimatedTreasuryApy({ positions, strategies });
 
   return (
-    <DashboardWorkspaceOverviewPanel className="px-4 pt-8 pb-12 md:px-8 xl:px-9">
+    <DashboardWorkspaceOverviewPanel>
       <div className="mx-auto flex w-full max-w-[90rem] flex-col gap-16">
         {/* Errors pass undefined so a stale SWR success never renders as a
          * live figure: unavailable must read as unavailable, not as the last

--- a/apps/sdp-web/src/components/dashboard-earn-header.unit.test.tsx
+++ b/apps/sdp-web/src/components/dashboard-earn-header.unit.test.tsx
@@ -21,10 +21,11 @@ describe("Markets dashboard headers", () => {
 
     expect(config).toMatchObject({
       title: "Shared.dashboardShell.markets",
-      titlePosition: "left",
-      headerVariant: "markets",
       contentWidthClass: "max-w-none",
     });
+    // The canonical header: no title-position or variant overrides, so the
+    // shell renders Markets exactly like every other tabbed module.
+    expect(config.titlePosition).toBeUndefined();
     expect(config.headerTabs).toBeUndefined();
     expect(config.routeTabs?.tabs).toEqual([
       {
@@ -43,10 +44,9 @@ describe("Markets dashboard headers", () => {
 
     expect(config).toMatchObject({
       title: "Shared.dashboardShell.markets",
-      titlePosition: "left",
-      headerVariant: "markets",
       contentWidthClass: "max-w-none",
     });
+    expect(config.titlePosition).toBeUndefined();
     expect(config.headerTabs).toBeUndefined();
     expect(config.routeTabs?.tabs).toHaveLength(2);
   });

--- a/apps/sdp-web/src/components/dashboard-header.tsx
+++ b/apps/sdp-web/src/components/dashboard-header.tsx
@@ -23,7 +23,6 @@ type DashboardPageConfig = {
   titlePosition?: "left" | "center";
   headerTabs?: DashboardHeaderTabsConfig;
   routeTabs?: DashboardRouteTabsConfig;
-  headerVariant?: "default" | "markets";
   topBarLeadingContent?: ReactNode;
   contentWidthClass?: string;
   hideTitle?: boolean;
@@ -413,8 +412,6 @@ function getMarketsRoutePageConfig(
   ) {
     return {
       title: t("Shared.dashboardShell.markets"),
-      titlePosition: "left",
-      headerVariant: "markets",
       routeTabs: {
         ariaLabel: t("Shared.dashboardShell.markets"),
         tabs: [

--- a/apps/sdp-web/src/components/dashboard-route-tabs.tsx
+++ b/apps/sdp-web/src/components/dashboard-route-tabs.tsx
@@ -15,7 +15,12 @@ function normalizePathname(pathname: string): string {
   return pathname === "/" ? pathname : pathname.replace(/\/+$/, "");
 }
 
-/** Primary sibling-route navigation. Query-param workspace tabs remain separate. */
+/**
+ * Primary sibling-route navigation. Query-param workspace tabs remain separate.
+ * Links, so the design-system Tabs (value-driven buttons) don't fit, but styled
+ * with the same md-size tab tokens so a route tab is indistinguishable from a
+ * header tab.
+ */
 export function DashboardRouteTabs({
   ariaLabel,
   pathname,
@@ -24,16 +29,21 @@ export function DashboardRouteTabs({
   const currentPathname = normalizePathname(pathname);
 
   return (
-    <nav aria-label={ariaLabel} className="flex min-w-0 items-end gap-8">
+    <nav aria-label={ariaLabel} className="flex min-w-0 flex-row">
       {tabs.map((tab) => {
         const isActive = currentPathname === normalizePathname(tab.href);
         return (
           <Link
             aria-current={isActive ? "page" : undefined}
             className={cn(
-              "relative inline-flex h-14 items-center text-base leading-4 font-semibold text-tertiary transition-colors hover:text-primary",
+              "relative inline-flex items-center justify-center leading-none tracking-wide",
+              "px-[var(--tab-padding-x-md)] py-[var(--tab-padding-y-md)] text-[length:var(--text-button-md)]",
+              "font-[number:var(--tab-weight-idle)] text-[var(--tab-text-idle)]",
+              "transition-[color,font-weight] duration-150 ease-out motion-reduce:transition-none",
+              "hover:text-[var(--tab-text-hover)]",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--button-focus-ring)]",
               isActive &&
-                "text-primary after:absolute after:inset-x-0 after:bottom-0 after:h-[1.5px] after:bg-primary"
+                "font-[number:var(--tab-weight-active)] text-[var(--tab-text-active)] after:absolute after:inset-x-[var(--tab-padding-x-md)] after:bottom-0 after:h-[var(--tab-indicator-height)] after:bg-[var(--tab-indicator-color)]"
             )}
             href={tab.href}
             key={tab.href}

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -579,7 +579,6 @@ export function DashboardShell({
   const headerTabs = pageConfig.headerTabs;
   const routeTabs = pageConfig.routeTabs;
   const hasHeaderTabs = Boolean(headerTabs || routeTabs);
-  const isMarketsHeader = pageConfig.headerVariant === "markets";
   const showBackInTopBar = Boolean(backAction) && !hasHeaderTabs;
   const topBarLeadingContent = showBackInTopBar ? backAction : pageConfig.topBarLeadingContent;
   const shouldRenderTopBarBorder =
@@ -832,14 +831,12 @@ export function DashboardShell({
               shouldLockViewportScroll ? "flex min-h-0 flex-1 flex-col" : "space-y-6",
             ].join(" ")}
           >
-            <div className={cn("shrink-0", !isMarketsHeader && "space-y-4")}>
+            <div className="shrink-0 space-y-4">
               <div
                 className={cn(
                   shouldRenderTopBarBorder && "border-b border-border-default pb-5 md:pb-6",
                   shouldLockViewportScroll
-                    ? isMarketsHeader
-                      ? "px-4 pt-8 md:px-8 md:pt-10 xl:px-16 xl:pt-11"
-                      : "px-3 pt-5 md:px-6 md:pt-6"
+                    ? "px-3 pt-5 md:px-6 md:pt-6"
                     : shouldRenderTopBarBorder && "-mx-3 px-3 md:-mx-6 md:px-6"
                 )}
               >
@@ -851,7 +848,6 @@ export function DashboardShell({
                   titlePosition={pageConfig.titlePosition}
                   topBarLeadingContent={topBarLeadingContent}
                   hasHeaderTabs={hasHeaderTabs}
-                  alignTitleWithTabs={hasHeaderTabs && !isMarketsHeader}
                   showNotifications={assetProfilesEnabled && issuanceEnabled}
                 />
               </div>
@@ -870,8 +866,15 @@ export function DashboardShell({
               ) : null}
 
               {routeTabs ? (
-                <div className="mt-6 border-b border-border-default px-4 md:px-8 xl:px-16">
-                  <DashboardRouteTabs {...routeTabs} pathname={pathname} />
+                <div
+                  className={cn(
+                    "border-b border-border-default",
+                    !shouldLockViewportScroll && "-mx-3 md:-mx-6"
+                  )}
+                >
+                  <div className="flex items-end px-3 md:px-6">
+                    <DashboardRouteTabs {...routeTabs} pathname={pathname} />
+                  </div>
                 </div>
               ) : null}
             </div>


### PR DESCRIPTION
Markets pages carried a one-off header treatment (`headerVariant: "markets"`, from #1553): roughly double the padding around the title (44px top / 64px left at desktop vs the standard 24px / 24px), a wider title-to-tabs gap, and a taller, bolder tab strip. This deletes the variant so Markets renders the exact same header as every other module. The h1 font was already identical (36px); only spacing and tab chrome changed.

**What changed**

- `dashboard-shell.tsx`: removed the `isMarketsHeader` padding, spacing, and title-alignment branches; the route-tabs row now uses the same wrapper as header tabs (`border-b` + `px-3 md:px-6`)
- `dashboard-header.tsx`: dropped `headerVariant` from `DashboardPageConfig` and from the Markets route config
- `dashboard-route-tabs.tsx`: route tabs stay links but are restyled with the design-system md tab tokens (14px text, `--tab-padding-*`, 2px inset indicator) so they render like `DashboardHeaderTabs`
- Treasury and Embedded Yield workspaces plus their skeletons: dropped the widened gutter overrides (`xl:px-16` / `xl:px-9`, which also disagreed with each other) back to the shared panel default so content lines up with the header again

**before** — `/dashboard/markets/treasury-solutions` and `/embedded-yield`: title at 44px/64px offsets, 24px gap to a 56px bold tab strip, content gutters 64px on one tab and 36px on the other.

**after** — title, tab strip, and gutters are pixel-identical to Counterparty / Issuance / Payments; the shell has no Markets-specific branch left.

**Reviewer notes**

- `DashboardRouteTabs` can't reuse the design-system `Tabs` component (it is value/button driven, route tabs are links), so parity is via the same CSS tokens. If the DS tab tokens change, both strips move together.

**Verification**

- `vitest run src/app/dashboard/markets src/components` — 247 + 130 pass; `tsc --noEmit` and `biome check` on touched files clean (repo eslint crashes on every file, pre-existing plugin/ESLint-10 incompatibility)
- local app on this branch: walked Treasury, Embedded Yield, and Counterparty side by side; headers match (screenshot upload from the browser extension failed, so no images attached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
