### PR TITLE
fix(earn): enforce exit slippage floor (PRO-1861) + cross-tenant/authz test evidence (PRO-1860)

### DIFF
--- a/apps/sdp-api/src/routes/earn.external-wallet-positions.test.ts
+++ b/apps/sdp-api/src/routes/earn.external-wallet-positions.test.ts
@@ -272,6 +272,53 @@ describe("external-wallet position reads", () => {
     expect(summary.data.summary.totalsByToken[0]).not.toHaveProperty("tokenValue");
   });
 
+  it("summary excludes a sibling project's positions and never leaks their owner addresses (EARN-028)", async () => {
+    // The summary is project-wide, and totalsByStrategy.ownerAddresses returns
+    // raw end-user addresses to any earn:read key in the project. Its only
+    // tenant boundary is the project_id predicate, so a same-org SIBLING
+    // project's owners must never appear in this key's summary.
+    const siblingProject = "prj_external_position_sibling";
+    await getDb(env)
+      .prepare(
+        `INSERT INTO projects
+           (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, 'Sibling', 'external-positions-sibling', 'sandbox', 'active', ?)`
+      )
+      .bind(siblingProject, ORG, USER)
+      .run();
+
+    await seedPosition({
+      ownerAddress: OWNER_A,
+      vaultAddress: "vault-usdc",
+      tokenMint: USDC,
+      label: "USDC vault",
+    });
+    // OWNER_B holds a position only in the sibling project.
+    await seedPosition({
+      ownerAddress: OWNER_B,
+      vaultAddress: "vault-usdc",
+      tokenMint: USDC,
+      label: "USDC vault",
+      projectId: siblingProject,
+    });
+
+    const body = (await (await get("/v1/earn/external-wallet/positions/summary")).json()) as {
+      data: {
+        summary: {
+          walletCount: number;
+          positionCount: number;
+          totalsByStrategy: Array<{ ownerAddresses: string[] }>;
+        };
+      };
+    };
+
+    expect(body.data.summary.walletCount).toBe(1);
+    expect(body.data.summary.positionCount).toBe(1);
+    const allOwners = body.data.summary.totalsByStrategy.flatMap((s) => s.ownerAddresses);
+    expect(allOwners).toContain(OWNER_A);
+    expect(allOwners).not.toContain(OWNER_B);
+  });
+
   it("404s an owner whose claim belongs to another organization", async () => {
     const foreignOrg = "org_external_position_foreign";
     const foreignProject = "prj_external_position_foreign";

--- a/apps/sdp-api/src/routes/earn.external-wallet.test.ts
+++ b/apps/sdp-api/src/routes/earn.external-wallet.test.ts
@@ -193,6 +193,7 @@ async function seedExternalWalletPosition(
     projectId: string | null;
     ownerAddress: string;
     environment: string;
+    provider: string;
   }> = {}
 ): Promise<string> {
   const id = generateEarnPositionId();
@@ -201,13 +202,14 @@ async function seedExternalWalletPosition(
       `INSERT INTO earn_positions (
          id, organization_id, project_id, environment, provider, kind,
          owner_address, vault_address, share_mint, token_mint, label, activated_at
-       ) VALUES (?, ?, ?, ?, 'kamino', 'vault_direct', ?, ?, ?, ?, 'Exit Vault', sdp_iso_now())`
+       ) VALUES (?, ?, ?, ?, ?, 'vault_direct', ?, ?, ?, ?, 'Exit Vault', sdp_iso_now())`
     )
     .bind(
       id,
       TEST_ORG.id,
       overrides.projectId === undefined ? TEST_PROJECT.id : overrides.projectId,
       overrides.environment ?? "sandbox",
+      overrides.provider ?? "kamino",
       overrides.ownerAddress ?? OWNER,
       VAULT,
       SHARE_MINT,
@@ -971,6 +973,37 @@ describe("POST /v1/earn/external-wallet/withdrawal-transactions — scoping", ()
         minAmountOut: "9.5",
       })
     );
+  });
+
+  // The provider-policy exit floor (EARN-003 / PRO-1861), the external mirror
+  // of the custody rule: a non-null `withdrawalSlippage` refuses a floor-less
+  // build with a 400; kamino's null policy keeps the floor-less builds above
+  // valid.
+  it("refuses a floor-less build for a provider with a withdrawal slippage policy", async () => {
+    await seedAuth();
+    const positionId = await seedExternalWalletPosition({ provider: "jupiter_lend" });
+
+    const res = await post("withdrawal-transactions", { positionId, shares: "10" });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toContain("minAmountOut");
+    expect(body.error.message).toContain("jupiter_lend");
+    expect(buildExternalWalletWithdrawalTransaction).not.toHaveBeenCalled();
+  });
+
+  it("builds the same exit once the caller supplies the policy floor", async () => {
+    await seedAuth();
+    const positionId = await seedExternalWalletPosition({ provider: "jupiter_lend" });
+
+    const res = await post("withdrawal-transactions", {
+      positionId,
+      shares: "10",
+      minAmountOut: "9.5",
+    });
+
+    expect(res.status).toBe(200);
+    expect(buildExternalWalletWithdrawalTransaction).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/sdp-api/src/routes/earn.movements.test.ts
+++ b/apps/sdp-api/src/routes/earn.movements.test.ts
@@ -493,6 +493,61 @@ describe("GET /v1/earn/movements", () => {
       expect((await movementsJson()).movements.map((m) => m.id)).toContain(withdrawal.id);
     });
 
+    it("structurally excludes external-wallet movements (owner-signed, no custody-wallet match)", async () => {
+      // EARN-016: an owner-signed vault row carries owner_address and NULL
+      // custody_wallet_id, so the feed's vault arm (which requires a
+      // custody-wallet match) can never grant it. It is served only by the
+      // per-owner reads. Seed one beside a custody deposit and assert the feed
+      // shows the custody row and never the owner row, whatever wallet scope.
+      const mine = await seedVaultDeposit();
+      const ownerMovementId = `earn_vault_movement_${crypto.randomUUID()}`;
+      const ownerPositionId = `earn_position_${crypto.randomUUID()}`;
+      await getDb(env).batch([
+        getDb(env)
+          .prepare(
+            `INSERT INTO earn_positions
+               (id, organization_id, project_id, environment, provider, kind,
+                owner_address, vault_address, share_mint, token_mint, label, activated_at)
+             VALUES (?, ?, ?, 'sandbox', 'kamino', 'vault_direct', ?, ?, ?, ?, 'Owner vault', sdp_iso_now())`
+          )
+          .bind(
+            ownerPositionId,
+            ORG,
+            PROJECT_A,
+            "OwnerFeed11111111111111111111111111111111111",
+            "VaultFeedOwner11111111111111111111111111111",
+            SHARE_MINT,
+            TOKEN_MINT
+          ),
+        getDb(env)
+          .prepare(
+            `INSERT INTO earn_movements
+               (id, organization_id, project_id, environment, provider, execution_model,
+                direction, position_id, status, denomination, amount_requested,
+                owner_address, vault_address, signature, signed_transaction,
+                last_valid_block_height, request_id, idempotency_fingerprint)
+             VALUES (?, ?, ?, 'sandbox', 'kamino', 'vault_direct', 'deposit', ?, 'requested',
+                     ?, '10', ?, ?, ?, 'AQ==', '12345', ?, ?)`
+          )
+          .bind(
+            ownerMovementId,
+            ORG,
+            PROJECT_A,
+            ownerPositionId,
+            TOKEN_MINT,
+            "OwnerFeed11111111111111111111111111111111111",
+            "VaultFeedOwner11111111111111111111111111111",
+            `sig_${crypto.randomUUID()}`,
+            crypto.randomUUID(),
+            `fp_${crypto.randomUUID()}`
+          ),
+      ]);
+
+      const ids = (await movementsJson()).movements.map((m) => m.id);
+      expect(ids).toContain(mine.movement.id);
+      expect(ids).not.toContain(ownerMovementId);
+    });
+
     it("excludes vault movements when the key has no in-scope signing wallet, and still shows custodial ones", async () => {
       const { withdrawal } = await seedProgramWithdrawal();
       const deposit = await seedVaultDeposit({ walletId: WALLET_A });
@@ -509,6 +564,20 @@ describe("GET /v1/earn/movements", () => {
       expect(body.movements.map((m) => m.id)).toEqual([withdrawal.id]);
       expect(body.movements.map((m) => m.id)).not.toContain(deposit.movement.id);
     });
+  });
+
+  it("has no :id detail route — the feed is collection-only (EARN-016)", async () => {
+    // Per-movement detail lives on the family reads (/vault-deposits/:id,
+    // /vault-withdrawals/:id, /external-wallet/movements/:id), never here. A
+    // guessed id must fall through to a Hono no-match 404, not resolve against
+    // the feed handler.
+    const mine = await seedVaultDeposit();
+    const res = await app.request(
+      `/v1/earn/movements/${mine.movement.id}`,
+      { headers: { Authorization: `Bearer ${API_KEY.raw}` } },
+      env
+    );
+    expect(res.status).toBe(404);
   });
 
   it("serves the feed with no provider credentials configured (ADR 0002 exit safety)", async () => {

--- a/apps/sdp-api/src/routes/earn.route-authz-matrix.test.ts
+++ b/apps/sdp-api/src/routes/earn.route-authz-matrix.test.ts
@@ -1,5 +1,6 @@
 import type { Permission } from "@sdp/types";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db/client";
 import app from "@/index";
 import earnRoutes from "@/routes/earn";
 import { type EarnAuthzTenant, seedEarnApiKey, seedEarnAuthzTenant } from "@/test/helpers/earn";
@@ -261,7 +262,7 @@ describe("scope conformance: a key missing exactly one declared scope is refused
 });
 
 describe("x-project-id is inert for API-key callers, per route (EARN-027)", () => {
-  it("a sibling-project header changes nothing", async () => {
+  it("a sibling-project header changes nothing (per-route status ratchet)", async () => {
     const raw = rawKeyBySet.get(permissionSetId(ALL_EARN_SCOPES));
     if (!raw) throw new Error("missing key");
 
@@ -272,6 +273,59 @@ describe("x-project-id is inert for API-key callers, per route (EARN-027)", () =
       });
       expect(withHeader.status, route).toBe(withoutHeader.status);
     }
+  });
+
+  it("the key still sees its PINNED project's data when the header names a sibling", async () => {
+    // The status ratchet above is coarse: unseeded GETs answer 200 for either
+    // project and POSTs 400 before their handler, so it would pass even if the
+    // key started honoring the header. This asserts the tenant boundary with
+    // project-distinct data: an owner is claimed only in the pinned project, so
+    // GET /external-wallet/movements answers 200 iff the key resolved the
+    // pinned project. Were the sibling header honored, the owner has no claim
+    // there and it would 404.
+    const raw = rawKeyBySet.get(permissionSetId(["earn:read"]));
+    if (!raw) throw new Error("missing key");
+    const owner = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+    const positionId = `earn_position_${crypto.randomUUID()}`;
+    const db = getDb(env);
+    await db.batch([
+      db
+        .prepare(
+          `INSERT INTO earn_positions
+             (id, organization_id, project_id, environment, provider, kind,
+              owner_address, vault_address, share_mint, token_mint, label, activated_at)
+           VALUES (?, ?, ?, 'sandbox', 'kamino', 'vault_direct', ?, 'vault-xpid', 'share-xpid', 'token-xpid', 'X-Project vault', sdp_iso_now())`
+        )
+        .bind(positionId, tenant.org.id, tenant.project.id, owner),
+      db
+        .prepare(
+          `INSERT INTO earn_movements
+             (id, organization_id, project_id, environment, provider, execution_model,
+              direction, position_id, status, denomination, amount_requested,
+              owner_address, vault_address, signature, signed_transaction,
+              last_valid_block_height, request_id, idempotency_fingerprint)
+           VALUES (?, ?, ?, 'sandbox', 'kamino', 'vault_direct', 'deposit', ?, 'requested',
+                   'token-xpid', '10', ?, 'vault-xpid', ?, 'AQ==', '12345', ?, ?)`
+        )
+        .bind(
+          `earn_vault_movement_${crypto.randomUUID()}`,
+          tenant.org.id,
+          tenant.project.id,
+          positionId,
+          owner,
+          `sig_${crypto.randomUUID()}`,
+          crypto.randomUUID(),
+          `fp_${crypto.randomUUID()}`
+        ),
+    ]);
+
+    const res = await requestAsKey(`GET /external-wallet/movements?ownerAddress=${owner}`, raw, {
+      "x-project-id": tenant.siblingProject.id,
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { movements: Array<{ id: string }> } };
+    expect(body.data.movements).toHaveLength(1);
   });
 });
 

--- a/apps/sdp-api/src/routes/earn.route-authz-matrix.test.ts
+++ b/apps/sdp-api/src/routes/earn.route-authz-matrix.test.ts
@@ -1,0 +1,312 @@
+import type { Permission } from "@sdp/types";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import app from "@/index";
+import earnRoutes from "@/routes/earn";
+import { type EarnAuthzTenant, seedEarnApiKey, seedEarnAuthzTenant } from "@/test/helpers/earn";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import { clearKVStores } from "@/test/mocks/kv";
+
+/**
+ * The earn authz matrix (PRO-1860, threat model EARN-019/027).
+ *
+ * Three ratchets over the LIVE route inventory, so a new `/v1/earn` route
+ * fails here until its author declares it:
+ *
+ * 1. **Scope conformance.** Every route's `requirePermissions` list is
+ *    declared in `EARN_ROUTE_SCOPES`, and a key missing exactly one declared
+ *    scope answers 403 `INSUFFICIENT_PERMISSIONS` — including the money-route
+ *    guarantee that an `earn:read`-only key can never reach a write handler.
+ *    Scope checks run before body validation, so the cells need no seeds.
+ * 2. **`x-project-id` is inert for API-key callers**, per route: a header
+ *    naming a sibling project changes nothing (the key pins project and
+ *    environment; `middleware/project-context.ts`).
+ * 3. **Session callers are membership-checked**, per route: a non-member
+ *    project header is refused before any handler runs; a member project
+ *    header is honored (whatever the route then answers, it is never the
+ *    membership 403).
+ *
+ * Wallet BINDING enforcement (selected-scope keys) is deliberately not here:
+ * bindings gate specific wallets, not routes, and live with the suites that
+ * seed custody (`earn.vault.test.ts`, `earn.movements.test.ts`).
+ */
+
+const EARN_ROUTE_SCOPES: Record<string, readonly Permission[]> = {
+  // Catalogue
+  "GET /strategies": ["earn:read"],
+  "GET /strategies/:strategyId": ["earn:read"],
+  // External-wallet per-owner reads (no wallets:read: end-user wallets carry
+  // no custody bindings — see the router comment)
+  "GET /external-wallet/positions/summary": ["earn:read"],
+  "GET /external-wallet/positions": ["earn:read"],
+  "GET /external-wallet/movements": ["earn:read"],
+  "GET /external-wallet/movements/:movementId": ["earn:read"],
+  "GET /external-wallet/earnings": ["earn:read"],
+  // Custody vault money + reads
+  "POST /vault-deposits": ["earn:write", "wallets:read"],
+  "POST /vault-deposit-previews": ["earn:read"],
+  "GET /vault-deposits": ["earn:read", "wallets:read"],
+  "GET /vault-deposits/:movementId": ["earn:read", "wallets:read"],
+  "POST /vault-withdrawals": ["earn:write", "wallets:read"],
+  "POST /vault-withdrawal-previews": ["earn:read", "wallets:read"],
+  "GET /vault-withdrawals": ["earn:read", "wallets:read"],
+  "GET /vault-withdrawals/:movementId": ["earn:read", "wallets:read"],
+  "GET /vault-positions": ["earn:read", "wallets:read"],
+  "GET /vault-share-reconciliation": ["earn:read", "wallets:read"],
+  // External-wallet money (customer signs; the owner's signature is the final
+  // authorization, so no wallets:read and no policy gate — router comment)
+  "POST /external-wallet/deposit-transactions": ["earn:write"],
+  "POST /external-wallet/deposits": ["earn:write"],
+  "POST /external-wallet/withdrawal-previews": ["earn:read"],
+  "POST /external-wallet/withdrawal-transactions": ["earn:write"],
+  "POST /external-wallet/withdrawals": ["earn:write"],
+  // Unified feed
+  "GET /movements": ["earn:read", "wallets:read"],
+  // Managed programs
+  "GET /programs": ["earn:read"],
+  "POST /programs": ["earn:write"],
+  "GET /programs/:programId": ["earn:read"],
+  "PUT /programs/:programId": ["earn:write"],
+  "GET /programs/:programId/deposits": ["earn:read"],
+  "POST /programs/:programId/withdrawal-preview": ["earn:read"],
+  "POST /programs/:programId/withdrawals": ["earn:write"],
+  "GET /programs/:programId/withdrawals": ["earn:read"],
+  "GET /programs/:programId/withdrawals/:withdrawalRef": ["earn:read"],
+};
+
+const ALL_EARN_SCOPES = ["earn:read", "earn:write", "wallets:read"] as const satisfies Permission[];
+
+interface ErrorBody {
+  error: { code: string; message: string };
+}
+
+/**
+ * A distinct client IP per request. The matrix fires far more than the
+ * anonymous per-IP ceiling (`ANONYMOUS_MAX_REQUESTS`) within one rate-limit
+ * window, and session-cookie requests present no `sk_` credential so they meet
+ * that ceiling — a 429 would mask the authz answer under test. A unique
+ * `x-forwarded-for` keys each request to its own counter; rate limiting is not
+ * what these cells verify.
+ */
+let ipCounter = 0;
+function uniqueClientIp(): string {
+  ipCounter += 1;
+  return `10.0.${Math.floor(ipCounter / 256) % 256}.${ipCounter % 256}`;
+}
+
+function extractRoutes(router: unknown): string[] {
+  const routes = ((router as { routes?: Array<{ method: string; path: string }> }).routes ?? [])
+    .map((route) => `${route.method.toUpperCase()} ${route.path}`)
+    .filter((route) => !route.startsWith("ALL "));
+  return Array.from(new Set(routes)).sort();
+}
+
+/** "GET /programs/:programId" → a requestable path with placeholder ids. */
+function requestPath(route: string): { method: string; path: string } {
+  const [method, path] = route.split(" ") as [string, string];
+  return {
+    method,
+    path: `/v1/earn${path.replace(/:[A-Za-z]+/g, "id-probe")}`,
+  };
+}
+
+function requestAsKey(route: string, rawKey: string, extraHeaders: Record<string, string> = {}) {
+  const { method, path } = requestPath(route);
+  return app.request(
+    path,
+    {
+      method,
+      headers: {
+        Authorization: `Bearer ${rawKey}`,
+        "x-forwarded-for": uniqueClientIp(),
+        ...(method === "GET" ? {} : { "Content-Type": "application/json" }),
+        ...extraHeaders,
+      },
+      ...(method === "GET" ? {} : { body: "{}" }),
+    },
+    env
+  );
+}
+
+function requestAsSession(route: string, sessionId: string, projectId: string) {
+  const { method, path } = requestPath(route);
+  return app.request(
+    path,
+    {
+      method,
+      headers: {
+        Cookie: `sdp_session=${sessionId}`,
+        "x-project-id": projectId,
+        "x-forwarded-for": uniqueClientIp(),
+        ...(method === "GET" ? {} : { "Content-Type": "application/json" }),
+      },
+      ...(method === "GET" ? {} : { body: "{}" }),
+    },
+    env
+  );
+}
+
+const ROUTES = Object.keys(EARN_ROUTE_SCOPES).sort();
+
+/** The declared scopes for a route in the table (routes come from its keys). */
+function scopesFor(route: string): readonly Permission[] {
+  const scopes = EARN_ROUTE_SCOPES[route];
+  if (!scopes) throw new Error(`no scopes declared for ${route}`);
+  return scopes;
+}
+
+/** One key per distinct permission set the matrix exercises. */
+function permissionSetId(permissions: readonly Permission[]): string {
+  return permissions.length === 0
+    ? "none"
+    : permissions
+        .map((scope) => scope.replace(":", "_"))
+        .sort()
+        .join("__");
+}
+
+const PERMISSION_SETS = new Map<string, readonly Permission[]>();
+PERMISSION_SETS.set(permissionSetId(ALL_EARN_SCOPES), ALL_EARN_SCOPES);
+for (const scopes of Object.values(EARN_ROUTE_SCOPES)) {
+  PERMISSION_SETS.set(permissionSetId(scopes), scopes);
+  for (const dropped of scopes) {
+    const subset = scopes.filter((scope) => scope !== dropped);
+    PERMISSION_SETS.set(permissionSetId(subset), subset);
+  }
+}
+
+let tenant: EarnAuthzTenant;
+const rawKeyBySet = new Map<string, string>();
+
+let originalMarketsEnabled: string | undefined;
+let originalEarnEnabled: string | undefined;
+
+beforeEach(async () => {
+  originalMarketsEnabled = env.MARKETS_ENABLED;
+  originalEarnEnabled = env.EARN_ENABLED;
+  env.MARKETS_ENABLED = "true";
+  env.EARN_ENABLED = "true";
+  await seedTestDatabase(env);
+  await clearKVStores(env);
+  tenant = await seedEarnAuthzTenant(env, "matrix");
+  rawKeyBySet.clear();
+  for (const [setId, permissions] of PERMISSION_SETS) {
+    const key = await seedEarnApiKey(env, tenant, {
+      id: `key_matrix_${setId}`,
+      permissions: [...permissions],
+    });
+    rawKeyBySet.set(setId, key.raw);
+  }
+});
+
+afterEach(() => {
+  env.MARKETS_ENABLED = originalMarketsEnabled;
+  env.EARN_ENABLED = originalEarnEnabled;
+});
+
+describe("earn route inventory", () => {
+  it("declares every live route in the scope table (a new route fails until added)", () => {
+    expect(extractRoutes(earnRoutes)).toEqual(ROUTES);
+  });
+});
+
+describe("scope conformance: a key missing exactly one declared scope is refused", () => {
+  const cells = ROUTES.flatMap((route) =>
+    scopesFor(route).map((dropped) => ({
+      route,
+      dropped,
+      granted: scopesFor(route).filter((scope) => scope !== dropped),
+    }))
+  );
+
+  it.each(cells)("$route answers 403 without $dropped", async ({ route, granted }) => {
+    const raw = rawKeyBySet.get(permissionSetId(granted));
+    if (!raw) throw new Error(`no key seeded for permission set [${granted.join(", ")}]`);
+
+    const res = await requestAsKey(route, raw);
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as ErrorBody;
+    expect(body.error.code).toBe("INSUFFICIENT_PERMISSIONS");
+  });
+
+  it.each(ROUTES.map((route) => ({ route })))(
+    "$route accepts its declared scopes (the table is exact, not merely sufficient)",
+    async ({ route }) => {
+      const raw = rawKeyBySet.get(permissionSetId(scopesFor(route)));
+      if (!raw) throw new Error("missing key");
+
+      const res = await requestAsKey(route, raw);
+
+      // Whatever the empty-bodied, unseeded request earns (400/404/200/501…),
+      // it must get PAST authorization: a 403 here means the declared list is
+      // missing a scope the route actually demands.
+      expect(res.status, `${route} still refused with its declared scopes`).not.toBe(403);
+    }
+  );
+
+  it("an earn:read-only key cannot reach any money route", async () => {
+    const raw = rawKeyBySet.get(permissionSetId(["earn:read"]));
+    if (!raw) throw new Error("missing key");
+    const moneyRoutes = ROUTES.filter((route) => scopesFor(route).includes("earn:write"));
+    expect(moneyRoutes.length).toBeGreaterThan(0);
+
+    for (const route of moneyRoutes) {
+      const res = await requestAsKey(route, raw);
+      expect(res.status, route).toBe(403);
+      const body = (await res.json()) as ErrorBody;
+      expect(body.error.code, route).toBe("INSUFFICIENT_PERMISSIONS");
+    }
+  });
+});
+
+describe("x-project-id is inert for API-key callers, per route (EARN-027)", () => {
+  it("a sibling-project header changes nothing", async () => {
+    const raw = rawKeyBySet.get(permissionSetId(ALL_EARN_SCOPES));
+    if (!raw) throw new Error("missing key");
+
+    for (const route of ROUTES) {
+      const withoutHeader = await requestAsKey(route, raw);
+      const withHeader = await requestAsKey(route, raw, {
+        "x-project-id": tenant.siblingProject.id,
+      });
+      expect(withHeader.status, route).toBe(withoutHeader.status);
+    }
+  });
+});
+
+describe("session callers are membership-checked, per route (EARN-027)", () => {
+  it("a non-member project header is refused before any handler runs", async () => {
+    for (const route of ROUTES) {
+      const res = await requestAsSession(route, tenant.sessionId, tenant.nonMemberProject.id);
+      expect(res.status, route).toBe(403);
+      const body = (await res.json()) as ErrorBody;
+      expect(body.error.message, route).toContain("not accessible");
+    }
+  });
+
+  it("a member project header is honored (never the membership 403)", async () => {
+    for (const route of ROUTES) {
+      const res = await requestAsSession(route, tenant.sessionId, tenant.project.id);
+      if (res.status !== 403) continue;
+      const body = (await res.json()) as ErrorBody;
+      expect(
+        body.error.message,
+        `${route} answered the membership 403 for a project the user belongs to`
+      ).not.toContain("not accessible");
+    }
+  });
+});
+
+describe("feature gate", () => {
+  it("EARN_ENABLED off darkens every route with 403", async () => {
+    env.EARN_ENABLED = "false";
+    const raw = rawKeyBySet.get(permissionSetId(ALL_EARN_SCOPES));
+    if (!raw) throw new Error("missing key");
+
+    for (const route of ROUTES) {
+      const res = await requestAsKey(route, raw);
+      expect(res.status, route).toBe(403);
+    }
+  });
+});

--- a/apps/sdp-api/src/routes/earn.vault-withdrawals.test.ts
+++ b/apps/sdp-api/src/routes/earn.vault-withdrawals.test.ts
@@ -762,6 +762,34 @@ describe("POST /v1/earn/vault-withdrawals — the exit slippage floor", () => {
       requestId,
     });
   });
+
+  // The policy half of the wire contract (EARN-003 / PRO-1861): a provider
+  // whose `withdrawalSlippage` policy is non-null refuses a floor-less exit
+  // with a 400, while a null-policy provider stays floor-less. Both read the
+  // REAL policy table — the provider-access mock above overrides surfacing
+  // only.
+  it("refuses a floor-less exit for a provider with a withdrawal slippage policy", async () => {
+    await seedAuth();
+    const positionId = await seedPosition({ provider: "jupiter_lend" });
+
+    const res = await postVaultWithdrawal({ positionId, shares: "5" });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toContain("minAmountOut");
+    expect(body.error.message).toContain("jupiter_lend");
+    expect(withdrawFromVault).not.toHaveBeenCalled();
+  });
+
+  it("keeps a null-policy provider's exit floor-less (kamino)", async () => {
+    await seedAuth();
+    const positionId = await seedPosition();
+
+    const res = await postVaultWithdrawal({ positionId, shares: "5" });
+
+    expect(res.status).toBe(200);
+    expect(withdrawFromVault).toHaveBeenCalledTimes(1);
+  });
 });
 
 /**

--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -779,7 +779,12 @@ Never rebuild a transaction during recovery.
     and both mints, so the exit has NO catalogue dependency — a delisted vault
     stays exitable. `expectedAssetIdentity` is the position's stored mints.
   - **Gates: 404 position scoping (org+environment+kind), wallet binding with
-    `earn:write`, wallet policy — and nothing else.** No surfacing, no
+    `earn:write`, wallet policy — and nothing else.** One caller-fixable 400
+    sits beside them without being a gate: a provider whose
+    `withdrawalSlippage` policy is non-null refuses a floor-less
+    `minAmountOut` (PRO-1861 — the wire contract the strategy row documents;
+    the floor comes from the exit preview, so it can never strand a
+    position). No surfacing, no
     entitlement, no availability, no admission, no environment capability
     (`isVaultDirectDepositEnabled` deliberately not consulted: an exit works in
     production today, where deposits are closed). The only provider-shaped

--- a/apps/sdp-api/src/routes/earn/handlers/external-wallet.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/external-wallet.ts
@@ -23,7 +23,11 @@ import type {
   EarnExternalWalletWithdrawalTransactionResponse,
   EarnVaultDirectMovementStatus,
 } from "@sdp/types";
-import { earnDepositStyle, isVaultDirectDepositEnabled } from "@sdp/types/provider-access";
+import {
+  earnDepositStyle,
+  earnWithdrawSlippageFloor,
+  isVaultDirectDepositEnabled,
+} from "@sdp/types/provider-access";
 import type { z } from "zod";
 import { getDb } from "@/db";
 import type { EarnExternalWalletTransactionRow } from "@/db/repositories/earn-external-wallet-transactions.repository";
@@ -704,6 +708,15 @@ export async function createEarnExternalWalletWithdrawalTransaction(
   const position = toExternalWalletHolding(positionRow, projectId);
   if (!position) {
     throw notFound("Earn external-wallet position");
+  }
+
+  // Same provider-policy exit floor as the custody withdrawal: a non-null
+  // `withdrawalSlippage` refuses a floor-less build (caller-fixable 400,
+  // derived from the withdrawal preview — never an admission gate).
+  if (body.minAmountOut === undefined && earnWithdrawSlippageFloor(position.provider) !== null) {
+    throw badRequest(
+      `minAmountOut is required for this withdrawal because ${position.provider} declares a withdrawal slippage policy.`
+    );
   }
 
   // Same owner-is-the-default normalization as the deposit build.

--- a/apps/sdp-api/src/routes/earn/handlers/vault.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/vault.ts
@@ -1119,18 +1119,6 @@ export async function extractEarnVaultWithdrawalPolicyCandidate(
   }
   const position = toVaultHolding(positionRow);
 
-  // The exit twin of the deposit's share floor, keyed on the provider's
-  // declared policy rather than the environment: a non-null
-  // `withdrawalSlippage` answers a floor-less body with a 400 (the wire
-  // contract the strategy row and the OpenAPI description already state).
-  // Not an admission gate — a caller-fixable 400, derived from the exit
-  // preview, so it can never trap a position.
-  if (body.minAmountOut === undefined && earnWithdrawSlippageFloor(position.provider) !== null) {
-    throw badRequest(
-      `minAmountOut is required for this vault withdrawal because ${position.provider} declares a withdrawal slippage policy.`
-    );
-  }
-
   // The signing wallet comes from the POSITION, never the body: a withdrawal
   // returns shares to tokens in the wallet that holds them, and letting a
   // caller name a different wallet would be a transfer wearing an exit's
@@ -1200,6 +1188,33 @@ export async function extractEarnVaultWithdrawalPolicyCandidate(
     },
     idempotencyKey: requestId,
   };
+}
+
+/**
+ * The exit twin of the deposit's share floor, keyed on the provider's declared
+ * policy rather than the environment: a non-null `withdrawalSlippage` answers a
+ * floor-less body with a 400 (the wire contract the strategy row and the
+ * OpenAPI description already state). Not an admission gate — a caller-fixable
+ * 400, derived from the exit preview, so it can never trap a position.
+ *
+ * Runs as a `beforeEnforce` hook, NOT in the extractor: the gate resolves a
+ * completed idempotency replay before this, so an exact retry of a recorded
+ * floor-less withdrawal returns its recorded outcome even if the provider's
+ * floor policy later flipped to non-null. The check only ever admits genuinely
+ * new work.
+ */
+export async function assertEarnVaultWithdrawalFloor(
+  _c: AppContext,
+  extraction: PolicyGateExtraction
+): Promise<void> {
+  // SAFETY: wired only beside extractEarnVaultWithdrawalPolicyCandidate in index.ts.
+  const { position } = extraction.resolved as EarnVaultWithdrawalResolved;
+  const body = extraction.body as EarnVaultWithdrawalBody;
+  if (body.minAmountOut === undefined && earnWithdrawSlippageFloor(position.provider) !== null) {
+    throw badRequest(
+      `minAmountOut is required for this vault withdrawal because ${position.provider} declares a withdrawal slippage policy.`
+    );
+  }
 }
 
 /** Resolve both durable withdrawal-group replays and pre-execution policy replays. */

--- a/apps/sdp-api/src/routes/earn/handlers/vault.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/vault.ts
@@ -14,6 +14,7 @@ import type {
 import {
   type EarnProviderId,
   earnDepositStyle,
+  earnWithdrawSlippageFloor,
   isVaultDirectDepositEnabled,
 } from "@sdp/types/provider-access";
 import { z } from "zod";
@@ -1117,6 +1118,18 @@ export async function extractEarnVaultWithdrawalPolicyCandidate(
     throw notFound("Earn vault position");
   }
   const position = toVaultHolding(positionRow);
+
+  // The exit twin of the deposit's share floor, keyed on the provider's
+  // declared policy rather than the environment: a non-null
+  // `withdrawalSlippage` answers a floor-less body with a 400 (the wire
+  // contract the strategy row and the OpenAPI description already state).
+  // Not an admission gate — a caller-fixable 400, derived from the exit
+  // preview, so it can never trap a position.
+  if (body.minAmountOut === undefined && earnWithdrawSlippageFloor(position.provider) !== null) {
+    throw badRequest(
+      `minAmountOut is required for this vault withdrawal because ${position.provider} declares a withdrawal slippage policy.`
+    );
+  }
 
   // The signing wallet comes from the POSITION, never the body: a withdrawal
   // returns shares to tokens in the wallet that holds them, and letting a

--- a/apps/sdp-api/src/routes/earn/index.ts
+++ b/apps/sdp-api/src/routes/earn/index.ts
@@ -35,6 +35,7 @@ import {
 } from "./handlers/program";
 import { getEarnStrategy, listEarnStrategies } from "./handlers/strategies";
 import {
+  assertEarnVaultWithdrawalFloor,
   createEarnVaultDeposit,
   createEarnVaultDepositPreview,
   createEarnVaultWithdrawal,
@@ -214,6 +215,9 @@ earn.post(
   policyGate({
     extract: extractEarnVaultWithdrawalPolicyCandidate,
     findIdempotentKeyReplay: findEarnVaultWithdrawalIdempotentKeyReplay,
+    // Floor policy runs AFTER the completed-replay exit so a recorded
+    // floor-less withdrawal stays replayable if the provider's policy flips.
+    beforeEnforce: assertEarnVaultWithdrawalFloor,
   }),
   createEarnVaultWithdrawal
 );

--- a/apps/sdp-api/src/test/helpers/earn.ts
+++ b/apps/sdp-api/src/test/helpers/earn.ts
@@ -1,0 +1,173 @@
+/**
+ * Earn authz/tenancy test fixture (PRO-1860).
+ *
+ * The earn route suites each hand-roll their own seeds; the authz matrix and
+ * the cross-tenant cells need the same shapes with the sharp edges handled
+ * once:
+ *
+ * - **API keys must be double-written** — the KV cache (what auth resolves,
+ *   including `walletScope`/bindings) AND an `api_keys` row (the DB resolution
+ *   path, FKs, RLS) — or a test proves nothing (see
+ *   `earn.movements.test.ts`'s header comment).
+ * - **Sessions are three rows and a cookie**: `organization_members`,
+ *   `project_members`, `sessions`, then `Cookie: sdp_session=<id>` plus the
+ *   `x-project-id` header (dashboard callers select their project per
+ *   request).
+ *
+ * Deliberately NOT here: strategy/position/movement seeds. Those stay next to
+ * the suites that own their semantics; this helper owns identity and scoping
+ * only.
+ */
+
+import { hashString } from "@sdp/payments/hash";
+import type { CachedApiKey, Permission } from "@sdp/types";
+import { getDb } from "@/db/client";
+import { seedCachedApiKey } from "@/test/mocks/kv";
+import type { Env } from "@/types/env";
+
+export interface EarnTestApiKey {
+  id: string;
+  raw: string;
+  prefix: string;
+  permissions: Permission[];
+}
+
+export interface EarnAuthzTenant {
+  org: { id: string; name: string; slug: string };
+  user: { id: string; email: string };
+  /** The key's pinned project (sandbox). */
+  project: { id: string; slug: string };
+  /** A sibling sandbox project in the same org, no key pinned to it. */
+  siblingProject: { id: string; slug: string };
+  /** A same-org project the session user is NOT a member of. */
+  nonMemberProject: { id: string; slug: string };
+  /** Session for `user`: org member, project-member of `project` only. */
+  sessionId: string;
+}
+
+/**
+ * Seed one org with the three projects and the session the authz matrix
+ * exercises. Call after `seedTestDatabase(env)`.
+ */
+export async function seedEarnAuthzTenant(
+  env: Env,
+  tag: string,
+  options: { environment?: string } = {}
+): Promise<EarnAuthzTenant> {
+  const environment = options.environment ?? "sandbox";
+  const tenant: EarnAuthzTenant = {
+    org: { id: `org_${tag}`, name: `Earn Authz ${tag}`, slug: `earn-authz-${tag}` },
+    user: { id: `usr_${tag}`, email: `${tag}@earn-authz.example.com` },
+    project: { id: `prj_${tag}_pinned`, slug: `earn-authz-${tag}-pinned` },
+    siblingProject: { id: `prj_${tag}_sibling`, slug: `earn-authz-${tag}-sibling` },
+    nonMemberProject: { id: `prj_${tag}_nonmember`, slug: `earn-authz-${tag}-nonmember` },
+    sessionId: `sess_${tag}`,
+  };
+
+  const db = getDb(env);
+  const projectInsert = `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+     VALUES (?, ?, ?, ?, ?, 'active', ?)`;
+  await db.batch([
+    db
+      .prepare(
+        "INSERT INTO organizations (id, name, slug, tier, status, settings) VALUES (?, ?, ?, 'enterprise', 'active', '{}')"
+      )
+      .bind(tenant.org.id, tenant.org.name, tenant.org.slug),
+    db
+      .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')")
+      .bind(tenant.user.id, tenant.user.email),
+    db
+      .prepare(projectInsert)
+      .bind(
+        tenant.project.id,
+        tenant.org.id,
+        "Pinned",
+        tenant.project.slug,
+        environment,
+        tenant.user.id
+      ),
+    db
+      .prepare(projectInsert)
+      .bind(
+        tenant.siblingProject.id,
+        tenant.org.id,
+        "Sibling",
+        tenant.siblingProject.slug,
+        environment,
+        tenant.user.id
+      ),
+    db
+      .prepare(projectInsert)
+      .bind(
+        tenant.nonMemberProject.id,
+        tenant.org.id,
+        "NonMember",
+        tenant.nonMemberProject.slug,
+        environment,
+        tenant.user.id
+      ),
+    db
+      .prepare(
+        `INSERT INTO organization_members (id, organization_id, user_id, role, status)
+         VALUES (?, ?, ?, 'admin', 'active')`
+      )
+      .bind(`om_${tag}`, tenant.org.id, tenant.user.id),
+    db
+      .prepare(
+        `INSERT INTO project_members (id, project_id, user_id, role) VALUES (?, ?, ?, 'admin')`
+      )
+      .bind(`pm_${tag}_pinned`, tenant.project.id, tenant.user.id),
+    db
+      .prepare(
+        `INSERT INTO sessions (id, user_id, organization_id, auth_method, expires_at)
+         VALUES (?, ?, ?, 'session', '2099-01-01T00:00:00.000Z')`
+      )
+      .bind(tenant.sessionId, tenant.user.id, tenant.org.id),
+  ]);
+
+  return tenant;
+}
+
+/**
+ * Seed one API key (KV cache + `api_keys` row) pinned to `tenant.project`,
+ * carrying exactly `permissions`. Returns the raw bearer value.
+ */
+export async function seedEarnApiKey(
+  env: Env,
+  tenant: EarnAuthzTenant,
+  key: { id: string; permissions: Permission[]; environment?: string }
+): Promise<EarnTestApiKey> {
+  const raw = `sk_test_${key.id}`;
+  const cached: CachedApiKey = {
+    id: key.id,
+    organizationId: tenant.org.id,
+    projectId: tenant.project.id,
+    role: "api_admin",
+    permissions: key.permissions,
+    environment: (key.environment ?? "sandbox") as CachedApiKey["environment"],
+    rateLimitTier: "standard",
+    allowedIps: null,
+    signingWalletId: null,
+    status: "active",
+    expiresAt: null,
+  };
+  await seedCachedApiKey(env, await hashString(raw, env.API_KEY_PEPPER), cached);
+  await getDb(env)
+    .prepare(
+      `INSERT INTO api_keys
+         (id, organization_id, project_id, created_by, name, key_prefix, key_hash, role, permissions, status)
+       VALUES (?, ?, ?, ?, ?, ?, ?, 'api_admin', ?, 'active')`
+    )
+    .bind(
+      key.id,
+      tenant.org.id,
+      tenant.project.id,
+      tenant.user.id,
+      `Earn authz ${key.id}`,
+      raw.slice(0, 11),
+      await hashString(raw, env.API_KEY_PEPPER),
+      JSON.stringify(key.permissions)
+    )
+    .run();
+  return { id: key.id, raw, prefix: raw.slice(0, 11), permissions: key.permissions };
+}


### PR DESCRIPTION
Two Earn threat-model remediations, split into two commits. They share no files; happy to split into separate PRs if preferred.

## PRO-1861 - exit slippage floor (code + tests)

The wire contract documents a typed 400 when a provider with a non-null `withdrawalSlippage` policy is sent a floor-less exit, but nothing implemented it: routes, the withdraw service, and the provider clients all treated `minAmountOut` as optional. Latent while Kamino (null policy) was the only shelf; **live now that `jupiter_lend` ships a non-null exit floor in production.**

Both custody (`POST /vault-withdrawals`) and external-wallet (`POST /external-wallet/withdrawal-transactions`) builds now refuse a missing `minAmountOut` with a caller-fixable 400 when `earnWithdrawSlippageFloor(provider)` is non-null. Derived from the exit preview, so it never traps a position (ADR 0002).

## PRO-1860 - cross-tenant / authz evidence (tests only)

The threat model's "do first" isolation gap. Most earn route tests ran with `permissions: ["*"]`, so nothing proved a read-only key is refused on a money route.

- **Route-inventory ratchet**: a new `/v1/earn` route fails until it declares its scopes, plus per-route scope conformance, the earn:read-only-cannot-reach-money guarantee, two-sided `x-project-id` (key inert / session membership-checked), and the feature gate.
- New shared fixture `test/helpers/earn.ts` (KV + `api_keys` double-write, session rows + cookie).
- Movements: external-wallet structural exclusion + `/movements/:id` no-match 404.
- Positions: sibling-project summary exclusion + `ownerAddresses` containment.

## Reviewer notes

- **PRO-1861 changes real behavior**: a floor-less production `jupiter_lend` exit now 400s where it used to build. Kamino (null policy) is unaffected. Verify that matches the intended contract.
- The matrix's `EARN_ROUTE_SCOPES` table is the source of truth the ratchet enforces; a new route must be added there.

## Verification

164 tests pass across the 5 touched suites; typecheck and lint clean. Base is current `main` (`84caa068a`).