### PR TITLE
fix(api, web): PRO-1865 harden the earn browser boundary

### DIFF
--- a/apps/sdp-api/src/middleware/cors.test.ts
+++ b/apps/sdp-api/src/middleware/cors.test.ts
@@ -60,9 +60,51 @@ describe("corsMiddleware", () => {
     expect(res.headers.get("access-control-allow-origin")).toBeNull();
   });
 
-  it("allows any origin in development", async () => {
+  it("allows a localhost dev origin in development", async () => {
+    const app = buildApp("development");
+    const res = await app.request("/x", { headers: { Origin: "http://localhost:3000" } });
+    expect(res.headers.get("access-control-allow-origin")).toBe("http://localhost:3000");
+  });
+
+  it("allows a vercel preview origin in development", async () => {
+    const app = buildApp("development");
+    const res = await app.request("/x", {
+      headers: { Origin: "https://sdp-web-smoky.vercel.app" },
+    });
+    expect(res.headers.get("access-control-allow-origin")).toBe("https://sdp-web-smoky.vercel.app");
+  });
+
+  it("rejects an unlisted origin in development instead of reflecting it", async () => {
     const app = buildApp("development");
     const res = await app.request("/x", { headers: { Origin: "https://anything.example" } });
-    expect(res.headers.get("access-control-allow-origin")).toBe("https://anything.example");
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  it("refuses a cross-origin credentialed preflight to a money route in development", async () => {
+    const app = buildApp("development");
+    const res = await app.request("/v1/earn/vault-withdrawals", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://attacker.example",
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "content-type",
+      },
+    });
+    // Without Access-Control-Allow-Origin the browser fails the preflight, so
+    // the credentialed cross-origin POST never leaves the preflight stage.
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  it("passes a credentialed preflight from an allowed origin in development", async () => {
+    const app = buildApp("development");
+    const res = await app.request("/v1/earn/vault-withdrawals", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "http://localhost:3000",
+        "Access-Control-Request-Method": "POST",
+      },
+    });
+    expect(res.headers.get("access-control-allow-origin")).toBe("http://localhost:3000");
+    expect(res.headers.get("access-control-allow-credentials")).toBe("true");
   });
 });

--- a/apps/sdp-api/src/middleware/cors.ts
+++ b/apps/sdp-api/src/middleware/cors.ts
@@ -40,10 +40,11 @@ export function corsMiddleware(env: Env["ENVIRONMENT"]) {
 
   return cors({
     origin: (origin) => {
+      // Never reflect an unlisted origin: this middleware runs with
+      // `credentials: true` on the app mounting the earn money routes, and
+      // non-production deployments hold real devnet funds (PRO-1865).
       if (!origin) return null;
-      if (isAllowedOrigin(origin)) return origin;
-      if (!isProduction) return origin;
-      return null;
+      return isAllowedOrigin(origin) ? origin : null;
     },
     allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allowHeaders: ["Content-Type", "Authorization", "X-Request-ID", "Idempotency-Key"],

--- a/apps/sdp-web/src/lib/sdp-api.ts
+++ b/apps/sdp-web/src/lib/sdp-api.ts
@@ -318,6 +318,7 @@ export function proxyFailure(
     {
       status,
       headers: {
+        "Cache-Control": "private, no-store",
         "X-SDP-Trace-ID": trace.traceId,
         "Server-Timing": trace.serverTiming(),
       },
@@ -377,6 +378,8 @@ export async function proxyToSdpApi({
       status: response.status,
       headers: {
         "Content-Type": response.headers.get("Content-Type") ?? "application/json",
+        // Per-org financial state: never storable by browsers or intermediaries.
+        "Cache-Control": "private, no-store",
         "X-SDP-Trace-ID": trace.traceId,
         "Server-Timing": trace.serverTiming(),
       },

--- a/apps/sdp-web/src/lib/sdp-api.unit.test.ts
+++ b/apps/sdp-web/src/lib/sdp-api.unit.test.ts
@@ -185,6 +185,7 @@ describe("createRequestScopedSdpApiClients", () => {
     });
 
     expect(response.status).toBe(204);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [, options] = fetchMock.mock.calls[0] ?? [];
     const headers = new Headers(options?.headers);
@@ -193,5 +194,22 @@ describe("createRequestScopedSdpApiClients", () => {
     expect(headers.get("Authorization")).toBe("Bearer token_test");
     expect(headers.get("x-project-id")).toBe("project_test");
     expect(options?.body).toBe(JSON.stringify({ amount: "1" }));
+  });
+
+  it("marks proxy failure responses uncacheable too", async () => {
+    mocks.cookies.mockResolvedValue({ get: () => undefined });
+    mocks.auth.mockResolvedValue({ userId: null, orgId: null, getToken: vi.fn() });
+
+    const response = await proxyToSdpApi({
+      request: new Request("https://dashboard.example.test/api/anything", {
+        method: "POST",
+        body: "{}",
+      }),
+      traceSource: "test.proxy.cache",
+      path: "/v1/earn/vault-deposits",
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
   });
 });

--- a/apps/sdp-web/src/proxy.ts
+++ b/apps/sdp-web/src/proxy.ts
@@ -30,6 +30,36 @@ const needsSelectedProject = createRouteMatcher([
   "/api/playground(.*)",
 ]);
 
+const isBrowserWriteGated = createRouteMatcher(["/api/dashboard(.*)", "/api/playground(.*)"]);
+
+const WRITE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+/**
+ * CSRF backstop for the BFF write routes (threat model EARN-021, PRO-1865).
+ * The only ambient credential on these routes is the Clerk session cookie, so
+ * a write arriving with a cross-origin `Origin` (including the sandboxed
+ * literal "null") is never legitimate. A write without an `Origin` header
+ * passes unless `Sec-Fetch-Site` positively marks it cross-site: origin-less
+ * callers are non-browser clients, which carry no ambient credentials for
+ * CSRF to ride on.
+ */
+export function rejectCrossSiteWrite(req: NextRequest): NextResponse | null {
+  if (!WRITE_METHODS.has(req.method) || !isBrowserWriteGated(req)) {
+    return null;
+  }
+
+  const origin = req.headers.get("origin");
+  const crossSite =
+    origin !== null
+      ? origin !== req.nextUrl.origin
+      : ["cross-site", "same-site"].includes(req.headers.get("sec-fetch-site") ?? "");
+
+  if (!crossSite) {
+    return null;
+  }
+  return NextResponse.json({ error: { message: "Cross-origin request refused" } }, { status: 403 });
+}
+
 function getUnauthenticatedUrl(req: NextRequest): string {
   const authEntryUrl = new URL(AUTH_ENTRY_PATH, req.url);
   authEntryUrl.searchParams.set("redirect_url", `${req.nextUrl.pathname}${req.nextUrl.search}`);
@@ -70,6 +100,11 @@ async function resolveDefaultProjectId(
 }
 
 export const proxy = clerkMiddleware(async (auth, req) => {
+  const crossSiteWrite = rejectCrossSiteWrite(req);
+  if (crossSiteWrite) {
+    return crossSiteWrite;
+  }
+
   if (!isPublicRoute(req)) {
     await auth.protect({
       unauthenticatedUrl: getUnauthenticatedUrl(req),

--- a/apps/sdp-web/src/proxy.unit.test.ts
+++ b/apps/sdp-web/src/proxy.unit.test.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { describe, expect, it } from "vitest";
-import { isPublicRoute } from "./proxy";
+import { isPublicRoute, rejectCrossSiteWrite } from "./proxy";
 
 describe("public web routes", () => {
   it("keeps the workspace loading transition available during bootstrap", () => {
@@ -41,5 +41,76 @@ describe("public web routes", () => {
         new NextRequest("https://dashboard.example.com/dashboard/markets/embedded-yield")
       )
     ).toBe(false);
+  });
+});
+
+describe("rejectCrossSiteWrite", () => {
+  function write(path: string, headers: Record<string, string> = {}, method = "POST") {
+    return new NextRequest(`https://dashboard.example.com${path}`, { method, headers });
+  }
+
+  it("refuses a cross-origin write to a BFF money route", async () => {
+    const response = rejectCrossSiteWrite(
+      write("/api/dashboard/markets/earn/vault-withdrawals", {
+        origin: "https://attacker.example",
+      })
+    );
+
+    expect(response?.status).toBe(403);
+    expect(await response?.json()).toEqual({
+      error: { message: "Cross-origin request refused" },
+    });
+  });
+
+  it("refuses a write from the sandboxed null origin", () => {
+    const response = rejectCrossSiteWrite(
+      write("/api/dashboard/payments/transfers", { origin: "null" })
+    );
+    expect(response?.status).toBe(403);
+  });
+
+  it("allows a same-origin write", () => {
+    expect(
+      rejectCrossSiteWrite(
+        write("/api/dashboard/markets/earn/vault-withdrawals", {
+          origin: "https://dashboard.example.com",
+        })
+      )
+    ).toBeNull();
+  });
+
+  it("allows an origin-less write unless Sec-Fetch-Site marks it cross-site", () => {
+    expect(rejectCrossSiteWrite(write("/api/dashboard/payments/transfers"))).toBeNull();
+    expect(
+      rejectCrossSiteWrite(
+        write("/api/dashboard/payments/transfers", { "sec-fetch-site": "same-origin" })
+      )
+    ).toBeNull();
+    expect(
+      rejectCrossSiteWrite(
+        write("/api/dashboard/payments/transfers", { "sec-fetch-site": "cross-site" })
+      )?.status
+    ).toBe(403);
+  });
+
+  it("leaves reads to the same-origin policy", () => {
+    expect(
+      rejectCrossSiteWrite(
+        write("/api/dashboard/markets/earn/movements", { origin: "https://attacker.example" }, "GET")
+      )
+    ).toBeNull();
+  });
+
+  it("gates playground writes but not routes outside the BFF", () => {
+    expect(
+      rejectCrossSiteWrite(
+        write("/api/playground/execute", { origin: "https://attacker.example" })
+      )?.status
+    ).toBe(403);
+    expect(
+      rejectCrossSiteWrite(
+        write("/api/vendor/moneygram/sdk/v1", { origin: "https://attacker.example" })
+      )
+    ).toBeNull();
   });
 });

--- a/apps/sdp-web/src/proxy.unit.test.ts
+++ b/apps/sdp-web/src/proxy.unit.test.ts
@@ -96,16 +96,19 @@ describe("rejectCrossSiteWrite", () => {
   it("leaves reads to the same-origin policy", () => {
     expect(
       rejectCrossSiteWrite(
-        write("/api/dashboard/markets/earn/movements", { origin: "https://attacker.example" }, "GET")
+        write(
+          "/api/dashboard/markets/earn/movements",
+          { origin: "https://attacker.example" },
+          "GET"
+        )
       )
     ).toBeNull();
   });
 
   it("gates playground writes but not routes outside the BFF", () => {
     expect(
-      rejectCrossSiteWrite(
-        write("/api/playground/execute", { origin: "https://attacker.example" })
-      )?.status
+      rejectCrossSiteWrite(write("/api/playground/execute", { origin: "https://attacker.example" }))
+        ?.status
     ).toBe(403);
     expect(
       rejectCrossSiteWrite(


### PR DESCRIPTION
Closes the earn browser boundary items from threat model EARN-021 ([PRO-1865](https://linear.app/solana-fndn/issue/PRO-1865/threat-model-harden-the-earn-browser-boundary-cors-cache-control)): non-prod CORS reflection, uncacheable per-org responses, and no cross-site check on BFF writes.

**What changed**

- `corsMiddleware` no longer reflects unlisted origins outside production: non-prod serves only localhost 3000/3001/5173 and `https://*.vercel.app`; production is unchanged.
- Every `proxyToSdpApi` response and `proxyFailure` error now carries `Cache-Control: private, no-store`; the shared helper covers all ~80 dashboard BFF routes.
- New `rejectCrossSiteWrite` gate in the Next proxy 403s POST/PUT/PATCH/DELETE to `/api/dashboard(.*)` and `/api/playground(.*)` when `Origin` mismatches the request origin (including literal `null`), or when `Origin` is absent and `Sec-Fetch-Site` says cross-site. Origin-less non-browser callers (curl, server-to-server) pass; reads are untouched.
- Live `__session` attributes are recorded on the ticket: host-only, `SameSite=Lax`, `Secure`. Lax already keeps the cookie off cross-site POSTs; the gate makes that posture two-layer and tested in-repo.

**before** — credentialed preflight on the deployed dev API (runs `main`):

1. `OPTIONS /v1/earn/vault-withdrawals` with `Origin: https://attacker.example`, `Access-Control-Request-Method: POST`
2. `204` with `access-control-allow-origin: https://attacker.example` and `access-control-allow-credentials: true` (any origin reflected)
3. A hostile page can drive credentialed browser requests at the app mounting the withdrawal routes on dev/staging, which hold real devnet funds

**after** — same preflights against this branch booted locally:

1. Attacker origin: `204` with no `access-control-allow-origin`, so the browser fails the preflight and the POST never leaves it
2. `Origin: http://localhost:3000`: allow-origin echoed with credentials, legitimate clients unaffected
3. Cross-site browser write to the BFF: `403 Cross-origin request refused` from the proxy before Clerk auth runs

**Reviewer notes**

- hono's `cors` emits `access-control-allow-credentials: true` even for refused origins; inert without a matching allow-origin, left as-is.
- The gate compares against `req.nextUrl.origin` (derived from the deployment host), so preview URLs and custom domains need no origin list.
- `Sec-Fetch-Site` only decides origin-less writes, which browsers do not produce for POSTs; it is belt over the CORS braces.

**Verification**

- sdp-api `vitest run src/middleware/cors.test.ts` — 14/14, incl. refused attacker preflight and allowed localhost preflight on `/v1/earn/vault-withdrawals`
- sdp-web `vitest run` — 1790 passed; the 1 failure is a pre-existing timezone-dependent issuance test that fails identically on clean `main` (flagged separately)
- `tsc --noEmit` clean in both apps; `biome check` clean on touched sdp-api files
- local app: booted this branch's API against local Postgres/Redis and captured the after preflights above; the deployed dev API provided the before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
