### PR TITLE
test(web): make asset-profile deploy-date assertion timezone-independent

### DIFF
--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/asset-profile/asset-profile-header.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/asset-profile/asset-profile-header.unit.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { getMessages } from "@/i18n/messages";
 import { I18nProvider } from "@/i18n/provider";
 import { shortenAddress, shortenPrefixedId } from "../../wallet-identity";
+import { formatDate } from "../token-management-workspace.utils";
 import { AssetProfileHeader } from "./asset-profile-header";
 
 const token = {
@@ -123,7 +124,8 @@ describe("asset profile header", () => {
     const markup = render(deployed);
     expect(markup).toContain("Tokenized Security");
     expect(markup).toContain("Active");
-    expect(markup).toContain("Deployed Jul 22, 2026");
+    // Same formatter as the component, so the assertion holds in any timezone.
+    expect(markup).toContain(`Deployed ${formatDate(deployed.deployedAt, "en")}`);
 
     // A draft has no deploy date to speak of, but still says what it is.
     const draft = render(token);


### PR DESCRIPTION
Fixes a timezone-dependent assertion in the asset-profile header unit test: it hardcoded the UTC rendering of the deploy date, so the file failed locally on machines west of UTC while passing in CI.

**before**: the assertion pinned one timezone's rendering:

1. `formatDate` renders `deployedAt` via `toLocaleString` in the machine's local timezone
2. the test asserts the literal `"Deployed Jul 22, 2026"`, the UTC rendering of `2026-07-22T00:00:00.000Z`
3. UTC runners pass; America/Chicago renders `Jul 21, 2026` and fails

**after**: the expected string comes from the component's own formatter:

1. the test imports `formatDate` from `token-management-workspace.utils`, the same module the component calls
2. it asserts `Deployed ${formatDate(deployed.deployedAt, "en")}`, keeping the `Deployed {date}` message-shape check
3. holds in any timezone, and matches the file's existing convention of asserting against production helpers (`shortenPrefixedId`, `shortenAddress`)

No runtime code changed: rendering in the viewer's local timezone is `formatDate`'s intended behavior and is shared by other callers, so the component is untouched.

**Verification**

- `TZ=America/Chicago npx vitest run` on the file: 7/7 pass (failed before the fix)
- `TZ=UTC` same run: 7/7 pass
- `pnpm --filter sdp-web typecheck`: no source errors (only pre-existing stale `.next` generated-type errors local to this worktree)
- eslint not run: the repo's eslint-plugin-react currently crashes under ESLint 10 on any React file, unrelated to this change
