### PR TITLE
feat(projects): metadata-based production project enablement

### DIFF
--- a/apps/sdp-api/src/routes/custody-self-hosted.test.ts
+++ b/apps/sdp-api/src/routes/custody-self-hosted.test.ts
@@ -148,6 +148,10 @@ describe("Custody routes — self-hosted deployment mode", () => {
 
   it("GET /v1/wallets/switch-options returns only the configured local provider", async () => {
     await seedAuth("individual");
+    await getDb(env)
+      .prepare("UPDATE organizations SET settings = ? WHERE id = ?")
+      .bind(JSON.stringify({ providerOverrides: { custody: { local: true } } }), TEST_ORG.id)
+      .run();
 
     const res = await app.request(
       "/v1/wallets/switch-options",

--- a/apps/sdp-api/src/routes/projects.test.ts
+++ b/apps/sdp-api/src/routes/projects.test.ts
@@ -183,6 +183,83 @@ describe("Projects Routes", () => {
       ]);
     });
 
+    it("excludes production projects when the org has no enableProductionProject setting", async () => {
+      await getDb(env)
+        .prepare("UPDATE organizations SET settings = NULL WHERE id = ?")
+        .bind(TEST_ORG.id)
+        .run();
+      await seedProject("prj_production_disabled", "Production", "production-disabled");
+      await getDb(env)
+        .prepare(
+          `UPDATE projects SET environment = 'production' WHERE id = 'prj_production_disabled'`
+        )
+        .run();
+
+      const res = await app.request(
+        "/v1/projects",
+        {
+          headers: { Cookie: `sdp_session=${TEST_SESSION_ID}` },
+        },
+        env
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      const ids = body.data.projects.map((project: { id: string }) => project.id);
+      expect(ids).toContain(TEST_PROJECT.id);
+      expect(ids).not.toContain("prj_production_disabled");
+    });
+
+    it("includes production projects when the org settings have enableProductionProject", async () => {
+      await getDb(env)
+        .prepare("UPDATE organizations SET settings = ? WHERE id = ?")
+        .bind(JSON.stringify({ enableProductionProject: true }), TEST_ORG.id)
+        .run();
+      await seedProject("prj_production_enabled", "Production", "production-enabled");
+      await getDb(env)
+        .prepare(
+          `UPDATE projects SET environment = 'production' WHERE id = 'prj_production_enabled'`
+        )
+        .run();
+
+      const res = await app.request(
+        "/v1/projects",
+        {
+          headers: { Cookie: `sdp_session=${TEST_SESSION_ID}` },
+        },
+        env
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      const ids = body.data.projects.map((project: { id: string }) => project.id);
+      expect(ids).toContain(TEST_PROJECT.id);
+      expect(ids).toContain("prj_production_enabled");
+    });
+
+    it("filters out the API key's own production project when the org is not enabled", async () => {
+      await getDb(env)
+        .prepare("UPDATE organizations SET settings = NULL WHERE id = ?")
+        .bind(TEST_ORG.id)
+        .run();
+      await getDb(env)
+        .prepare(`UPDATE projects SET environment = 'production' WHERE id = ?`)
+        .bind(TEST_PROJECT.id)
+        .run();
+
+      const res = await app.request(
+        "/v1/projects",
+        {
+          headers: { Authorization: `Bearer ${TEST_API_KEY.raw}` },
+        },
+        env
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.projects).toEqual([]);
+    });
+
     it("excludes archived projects by default", async () => {
       const db = getDb(env);
 

--- a/apps/sdp-api/src/routes/projects/handlers/projects.ts
+++ b/apps/sdp-api/src/routes/projects/handlers/projects.ts
@@ -7,6 +7,7 @@ import { noContent, success } from "@/lib/response";
 import type { ValidatedBodyContext } from "@/middleware/validate";
 import { AuditService } from "@/services/audit.service";
 import { ProjectService } from "@/services/project.service";
+import { getOrganizationTierState } from "@/services/provider-availability.service";
 import type { Env } from "@/types/env";
 import type { updateProjectSchema } from "../schemas";
 
@@ -14,9 +15,10 @@ type AppContext = Context<{ Bindings: Env }>;
 
 export const listProjects = async (c: AppContext) => {
   const auth = getAuth(c);
+  const db = getDb(c.env);
   const includeArchived = c.req.query("includeArchived") === "true";
 
-  const projectService = new ProjectService(getDb(c.env));
+  const projectService = new ProjectService(db);
   let projectList: ListProjectsResponse["projects"];
 
   if (auth.authType === "api_key") {
@@ -34,7 +36,13 @@ export const listProjects = async (c: AppContext) => {
     projectList = await projectService.listProjects(auth.organizationId, { includeArchived });
   }
 
-  const response: ListProjectsResponse = { projects: projectList };
+  const orgState = await getOrganizationTierState(db, auth.organizationId);
+  const productionEnabled = orgState.settings?.enableProductionProject === true;
+  const projects = productionEnabled
+    ? projectList
+    : projectList.filter((project) => project.environment !== "production");
+
+  const response: ListProjectsResponse = { projects };
   return success(c, response);
 };
 

--- a/apps/sdp-api/src/services/clerk-organization-provisioning.service.ts
+++ b/apps/sdp-api/src/services/clerk-organization-provisioning.service.ts
@@ -1,6 +1,5 @@
 import type { OrganizationSettings } from "@sdp/types";
 import { isPostgresUniqueViolation } from "@/db/postgres-utils";
-import { isSelfHostedDeployment } from "@/lib/runtime-env";
 import type { Env } from "@/types/env";
 import type { ClerkOrganization } from "./clerk-organizations.service";
 import {
@@ -83,9 +82,7 @@ export async function ensureClerkOrganizationMapping(params: {
     params.organization.name?.trim() || params.organization.slug?.trim() || "Organization";
   const slug = await ensureUniqueSlug(params.db, params.organization.slug || name);
   const organizationId = `org_${crypto.randomUUID()}`;
-  const providerState = isSelfHostedDeployment(params.env)
-    ? { tier: "enterprise" as const, providerOverrides: undefined, enableProductionProject: false }
-    : parseClerkOrganizationTierMetadata(params.organization);
+  const providerState = parseClerkOrganizationTierMetadata(params.organization);
 
   const initialSettings: OrganizationSettings = {
     ...(providerState.providerOverrides
@@ -155,12 +152,10 @@ export async function syncClerkOrganization(params: {
       .bind(name, slug, mapping.organizationId),
   ]);
 
-  if (!isSelfHostedDeployment(params.env)) {
-    await syncProviderAccessFromClerk(params.db, {
-      organizationId: mapping.organizationId,
-      clerkOrganization: params.organization,
-    });
-  }
+  await syncProviderAccessFromClerk(params.db, {
+    organizationId: mapping.organizationId,
+    clerkOrganization: params.organization,
+  });
 
   return { organizationId: mapping.organizationId, slug };
 }

--- a/apps/sdp-api/src/services/clerk-organization-provisioning.service.ts
+++ b/apps/sdp-api/src/services/clerk-organization-provisioning.service.ts
@@ -1,3 +1,4 @@
+import type { OrganizationSettings } from "@sdp/types";
 import { isPostgresUniqueViolation } from "@/db/postgres-utils";
 import { isSelfHostedDeployment } from "@/lib/runtime-env";
 import type { Env } from "@/types/env";
@@ -83,11 +84,16 @@ export async function ensureClerkOrganizationMapping(params: {
   const slug = await ensureUniqueSlug(params.db, params.organization.slug || name);
   const organizationId = `org_${crypto.randomUUID()}`;
   const providerState = isSelfHostedDeployment(params.env)
-    ? { tier: "enterprise" as const, providerOverrides: undefined }
+    ? { tier: "enterprise" as const, providerOverrides: undefined, enableProductionProject: false }
     : parseClerkOrganizationTierMetadata(params.organization);
-  const settings = providerState.providerOverrides
-    ? JSON.stringify({ providerOverrides: providerState.providerOverrides })
-    : null;
+
+  const initialSettings: OrganizationSettings = {
+    ...(providerState.providerOverrides
+      ? { providerOverrides: providerState.providerOverrides }
+      : {}),
+    ...(providerState.enableProductionProject ? { enableProductionProject: true } : {}),
+  };
+  const settings = Object.keys(initialSettings).length > 0 ? JSON.stringify(initialSettings) : null;
 
   // Persist Clerk-derived access state with the mapping so provisioning cannot
   // commit an organization that depends on a later repair update succeeding.

--- a/apps/sdp-api/src/services/provider-availability.service.test.ts
+++ b/apps/sdp-api/src/services/provider-availability.service.test.ts
@@ -421,7 +421,7 @@ describe("provider-availability.service", () => {
     });
   });
 
-  it("entitles every provider in self-hosted mode regardless of tier", async () => {
+  it("applies general defaults and metadata overrides uniformly to self-hosted orgs", async () => {
     env.SDP_DEPLOYMENT_MODE = "self_hosted";
     env.CUSTODY_PRIVATE_KEY =
       "3QpWV8xk4hs7vmQhSLAQWNi2KskuSVSpmR75QGqSuxaKcdA9XJkq8VBihspJddBWVfEybTWLKqHJ19N64DNuwSNd";
@@ -430,21 +430,21 @@ describe("provider-availability.service", () => {
 
     expect(availability.tier).toBe("individual");
     expect(availability.providers.custody.local).toEqual({
-      entitled: true,
+      entitled: false,
       configured: true,
-      enabled: true,
+      enabled: false,
     });
     expect(availability.providers.custody.dfns).toEqual({
-      entitled: true,
+      entitled: false,
       configured: false,
       enabled: false,
     });
     expect(availability.providers.custody.ibm_haven).toEqual({
-      entitled: true,
+      entitled: false,
       configured: false,
       enabled: false,
     });
-    expect(availability.providers.compliance.range.entitled).toBe(true);
+    expect(availability.providers.compliance.range.entitled).toBe(false);
     expect(availability.providers.ramps.lightspark.entitled).toBe(true);
     expect(availability.providers.ramps.bvnk.entitled).toBe(true);
   });
@@ -507,7 +507,7 @@ describe("provider-availability.service", () => {
     ).resolves.toBe(false);
   });
 
-  it("respects providerOverrides[id] === false in self-hosted mode", async () => {
+  it("honors a custody override disabling local the same way in self-hosted mode", async () => {
     env.SDP_DEPLOYMENT_MODE = "self_hosted";
     env.CUSTODY_PRIVATE_KEY =
       "3QpWV8xk4hs7vmQhSLAQWNi2KskuSVSpmR75QGqSuxaKcdA9XJkq8VBihspJddBWVfEybTWLKqHJ19N64DNuwSNd";
@@ -534,7 +534,7 @@ describe("provider-availability.service", () => {
     expect(availability.providers.custody.privy.entitled).toBe(true);
   });
 
-  it("does not bypass entitlements when SDP_DEPLOYMENT_MODE is unset", async () => {
+  it("applies general defaults when SDP_DEPLOYMENT_MODE is unset", async () => {
     env.SDP_DEPLOYMENT_MODE = undefined;
     env.CUSTODY_PRIVATE_KEY =
       "3QpWV8xk4hs7vmQhSLAQWNi2KskuSVSpmR75QGqSuxaKcdA9XJkq8VBihspJddBWVfEybTWLKqHJ19N64DNuwSNd";

--- a/apps/sdp-api/src/services/provider-availability.service.test.ts
+++ b/apps/sdp-api/src/services/provider-availability.service.test.ts
@@ -8,6 +8,7 @@ import {
   assertProviderAvailable,
   getProviderAvailability,
   isPersistedCustodyCompletionEnabled,
+  parseClerkOrganizationTierMetadata,
   syncProviderAccessFromClerk,
 } from "@/services/provider-availability.service";
 import { env } from "@/test/helpers/env";
@@ -581,6 +582,103 @@ describe("provider-availability.service", () => {
     expect(organization?.tier).toBe("enterprise");
     expect(organization?.settings ? JSON.parse(organization.settings) : null).toEqual({
       rpcProvider: "helius",
+    });
+  });
+
+  it("parseClerkOrganizationTierMetadata returns enableProductionProject true only for boolean true", () => {
+    const cases: Array<{ metadata: unknown; expected: boolean }> = [
+      { metadata: { sdp: { enableProductionProject: true } }, expected: true },
+      { metadata: { sdp: { enableProductionProject: false } }, expected: false },
+      { metadata: { sdp: { enableProductionProject: "true" } }, expected: false },
+      { metadata: { sdp: { enableProductionProject: 1 } }, expected: false },
+      { metadata: { sdp: {} }, expected: false },
+      { metadata: {}, expected: false },
+      { metadata: undefined, expected: false },
+    ];
+
+    for (const { metadata, expected } of cases) {
+      expect(
+        parseClerkOrganizationTierMetadata({
+          id: "org_parse_test",
+          private_metadata: metadata,
+        }).enableProductionProject
+      ).toBe(expected);
+    }
+  });
+
+  it("syncs enableProductionProject into settings when true and strips it when absent, preserving unrelated keys", async () => {
+    await getDb(env)
+      .prepare("UPDATE organizations SET settings = ? WHERE id = ?")
+      .bind(
+        JSON.stringify({
+          rpcProvider: "helius",
+          enableProductionProject: true,
+        }),
+        TEST_ORG_ID
+      )
+      .run();
+
+    await syncProviderAccessFromClerk(getDb(env), {
+      organizationId: TEST_ORG_ID,
+      clerkOrganization: {
+        id: "org_clerk_strip_test",
+        private_metadata: {},
+      },
+    });
+
+    const stripped = await getDb(env)
+      .prepare("SELECT settings FROM organizations WHERE id = ?")
+      .bind(TEST_ORG_ID)
+      .first<{ settings: string | null }>();
+    expect(stripped?.settings ? JSON.parse(stripped.settings) : null).toEqual({
+      rpcProvider: "helius",
+    });
+  });
+
+  it("syncs enableProductionProject and collapses settings to null when nothing remains", async () => {
+    await getDb(env)
+      .prepare("UPDATE organizations SET settings = ? WHERE id = ?")
+      .bind(JSON.stringify({ enableProductionProject: true }), TEST_ORG_ID)
+      .run();
+
+    await syncProviderAccessFromClerk(getDb(env), {
+      organizationId: TEST_ORG_ID,
+      clerkOrganization: {
+        id: "org_clerk_collapse_test",
+        private_metadata: {},
+      },
+    });
+
+    const collapsed = await getDb(env)
+      .prepare("SELECT settings FROM organizations WHERE id = ?")
+      .bind(TEST_ORG_ID)
+      .first<{ settings: string | null }>();
+    expect(collapsed?.settings).toBeNull();
+  });
+
+  it("syncs enableProductionProject true alongside provider overrides", async () => {
+    await syncProviderAccessFromClerk(getDb(env), {
+      organizationId: TEST_ORG_ID,
+      clerkOrganization: {
+        id: "org_clerk_combined_test",
+        private_metadata: {
+          sdp: {
+            enableProductionProject: true,
+            providerOverrides: {
+              custody: { local: true },
+            },
+          },
+        },
+      },
+    });
+
+    const combined = await getDb(env)
+      .prepare("SELECT settings FROM organizations WHERE id = ?")
+      .bind(TEST_ORG_ID)
+      .first<{ settings: string | null }>();
+    expect(combined?.settings ? JSON.parse(combined.settings) : null).toEqual({
+      enableProductionProject: true,
+      providerOverrides: { custody: { local: true } },
     });
   });
 

--- a/apps/sdp-api/src/services/provider-availability.service.ts
+++ b/apps/sdp-api/src/services/provider-availability.service.ts
@@ -850,15 +850,6 @@ export async function syncProviderAccessFromClerk(
     ? nextSettings
     : null;
 
-  const wasProductionEnabled = existing.settings?.enableProductionProject === true;
-  if (wasProductionEnabled !== clerkMetadata.enableProductionProject) {
-    logEvent("info", {
-      event: "sdp_api_organization_production_enablement_changed",
-      organization_id: params.organizationId,
-      enable_production_project: clerkMetadata.enableProductionProject,
-    });
-  }
-
   await db
     .prepare(
       `UPDATE organizations
@@ -871,6 +862,15 @@ export async function syncProviderAccessFromClerk(
       params.organizationId
     )
     .run();
+
+  const wasProductionEnabled = existing.settings?.enableProductionProject === true;
+  if (wasProductionEnabled !== clerkMetadata.enableProductionProject) {
+    logEvent("info", {
+      event: "sdp_api_organization_production_enablement_changed",
+      organization_id: params.organizationId,
+      enable_production_project: clerkMetadata.enableProductionProject,
+    });
+  }
 
   return {
     tier: clerkMetadata.tier,

--- a/apps/sdp-api/src/services/provider-availability.service.ts
+++ b/apps/sdp-api/src/services/provider-availability.service.ts
@@ -830,40 +830,50 @@ export async function syncProviderAccessFromClerk(
     clerkOrganization: ClerkOrganizationWithMetadata;
   }
 ): Promise<{ tier: OrganizationTier; settings: OrganizationSettings | null }> {
-  const existing = await getOrganizationTierState(db, params.organizationId);
   const clerkMetadata = parseClerkOrganizationTierMetadata(params.clerkOrganization);
 
-  const {
-    providerOverrides: _staleOverrides,
-    enableProductionProject: _staleEnableProduction,
-    ...retainedSettings
-  } = existing.settings ?? {};
-  const nextSettings: OrganizationSettings = {
-    ...retainedSettings,
-    ...(clerkMetadata.providerOverrides
-      ? { providerOverrides: clerkMetadata.providerOverrides }
-      : {}),
-    ...(clerkMetadata.enableProductionProject ? { enableProductionProject: true } : {}),
-  };
+  // Settings are one JSON column patched by read-merge-write; the row lock keeps
+  // this sync from clobbering a concurrent dashboard settings update (and vice
+  // versa), matching the updateOrganization handler.
+  const { existingSettings, persistedSettings } = await db.transaction(async (tx) => {
+    const row = await tx
+      .prepare("SELECT settings FROM organizations WHERE id = ? FOR UPDATE")
+      .bind(params.organizationId)
+      .first<{ settings: string | null }>();
 
-  const persistedSettings = hasOwnEntries(nextSettings as Record<string, unknown>)
-    ? nextSettings
-    : null;
+    if (!row) {
+      throw new AppError("NOT_FOUND", "Organization not found");
+    }
 
-  await db
-    .prepare(
-      `UPDATE organizations
-       SET tier = ?, settings = ?, updated_at = sdp_datetime_now()
-       WHERE id = ?`
-    )
-    .bind(
-      clerkMetadata.tier,
-      toStoredOrganizationSettings(persistedSettings),
-      params.organizationId
-    )
-    .run();
+    const existing = parseOrganizationSettings(row.settings);
+    const {
+      providerOverrides: _staleOverrides,
+      enableProductionProject: _staleEnableProduction,
+      ...retainedSettings
+    } = existing ?? {};
+    const nextSettings: OrganizationSettings = {
+      ...retainedSettings,
+      ...(clerkMetadata.providerOverrides
+        ? { providerOverrides: clerkMetadata.providerOverrides }
+        : {}),
+      ...(clerkMetadata.enableProductionProject ? { enableProductionProject: true } : {}),
+    };
 
-  const wasProductionEnabled = existing.settings?.enableProductionProject === true;
+    const persisted = hasOwnEntries(nextSettings as Record<string, unknown>) ? nextSettings : null;
+
+    await tx
+      .prepare(
+        `UPDATE organizations
+         SET tier = ?, settings = ?, updated_at = sdp_datetime_now()
+         WHERE id = ?`
+      )
+      .bind(clerkMetadata.tier, toStoredOrganizationSettings(persisted), params.organizationId)
+      .run();
+
+    return { existingSettings: existing, persistedSettings: persisted };
+  });
+
+  const wasProductionEnabled = existingSettings?.enableProductionProject === true;
   if (wasProductionEnabled !== clerkMetadata.enableProductionProject) {
     logEvent("info", {
       event: "sdp_api_organization_production_enablement_changed",

--- a/apps/sdp-api/src/services/provider-availability.service.ts
+++ b/apps/sdp-api/src/services/provider-availability.service.ts
@@ -402,11 +402,6 @@ function toStoredOrganizationSettings(settings: OrganizationSettings | null): st
   return JSON.stringify(settings);
 }
 
-function omitProviderOverrides(settings: OrganizationSettings): OrganizationSettings {
-  const { providerOverrides: _providerOverrides, ...rest } = settings;
-  return rest;
-}
-
 function hasOwnEntries(value: Record<string, unknown>): boolean {
   return Object.keys(value).length > 0;
 }
@@ -475,6 +470,7 @@ export function parseProviderOverridesFromClerkMetadata(
 export function parseClerkOrganizationTierMetadata(organization: ClerkOrganizationWithMetadata): {
   tier: OrganizationTier;
   providerOverrides?: OrganizationProviderOverrides;
+  enableProductionProject: boolean;
 } {
   const privateMetadata = asRecord(organization.private_metadata);
   const sdp = asRecord(privateMetadata?.sdp);
@@ -482,6 +478,7 @@ export function parseClerkOrganizationTierMetadata(organization: ClerkOrganizati
   return {
     tier: normalizeOrganizationTier(typeof sdp?.tier === "string" ? sdp.tier : undefined),
     providerOverrides: parseProviderOverridesFromClerkMetadata(sdp?.providerOverrides),
+    enableProductionProject: sdp?.enableProductionProject === true,
   };
 }
 
@@ -872,16 +869,31 @@ export async function syncProviderAccessFromClerk(
   const existing = await getOrganizationTierState(db, params.organizationId);
   const clerkMetadata = parseClerkOrganizationTierMetadata(params.clerkOrganization);
 
-  const nextSettings: OrganizationSettings = clerkMetadata.providerOverrides
-    ? {
-        ...(existing.settings ?? {}),
-        providerOverrides: clerkMetadata.providerOverrides,
-      }
-    : omitProviderOverrides(existing.settings ?? {});
+  const {
+    providerOverrides: _staleOverrides,
+    enableProductionProject: _staleEnableProduction,
+    ...retainedSettings
+  } = existing.settings ?? {};
+  const nextSettings: OrganizationSettings = {
+    ...retainedSettings,
+    ...(clerkMetadata.providerOverrides
+      ? { providerOverrides: clerkMetadata.providerOverrides }
+      : {}),
+    ...(clerkMetadata.enableProductionProject ? { enableProductionProject: true } : {}),
+  };
 
   const persistedSettings = hasOwnEntries(nextSettings as Record<string, unknown>)
     ? nextSettings
     : null;
+
+  const wasProductionEnabled = existing.settings?.enableProductionProject === true;
+  if (wasProductionEnabled !== clerkMetadata.enableProductionProject) {
+    logEvent("info", {
+      event: "sdp_api_organization_production_enablement_changed",
+      organization_id: params.organizationId,
+      enable_production_project: clerkMetadata.enableProductionProject,
+    });
+  }
 
   await db
     .prepare(

--- a/apps/sdp-api/src/services/provider-availability.service.ts
+++ b/apps/sdp-api/src/services/provider-availability.service.ts
@@ -527,24 +527,6 @@ function getConfiguredProviders(env: Env) {
   };
 }
 
-/**
- * Self-hosted entitlement: every key in `shape` is entitled by default,
- * minus any explicit `false` overrides (disable-only).
- *
- * `shape` is used only as a key set — its values are ignored, since
- * self-hosted bypasses tier-based entitlement.
- */
-function applySelfHostedEntitlements<T extends string>(
-  shape: Record<T, boolean>,
-  overrides?: Partial<Record<T, boolean>>
-): Record<T, boolean> {
-  const next = {} as Record<T, boolean>;
-  for (const key of Object.keys(shape) as T[]) {
-    next[key] = overrides?.[key] !== false;
-  }
-  return next;
-}
-
 function buildAvailabilityEntries<T extends string>(
   entitled: Record<T, boolean>,
   configured: Record<T, boolean>
@@ -586,26 +568,14 @@ export async function getProviderAvailability(
   });
   const configured = getConfiguredProviders(env);
 
-  let entitled = resolved.providers;
-  if (isSelfHostedDeployment(env)) {
-    const overrides = organization.settings?.providerOverrides;
-    entitled = {
-      custody: applySelfHostedEntitlements(entitled.custody, overrides?.custody),
-      rpc: applySelfHostedEntitlements(entitled.rpc, overrides?.rpc),
-      compliance: applySelfHostedEntitlements(entitled.compliance, overrides?.compliance),
-      ramps: applySelfHostedEntitlements(entitled.ramps, overrides?.ramps),
-      earn: applySelfHostedEntitlements(entitled.earn, overrides?.earn),
-    };
-  }
-
   return {
     tier: resolved.tier,
     providers: {
-      custody: buildAvailabilityEntries(entitled.custody, configured.custody),
-      rpc: buildAvailabilityEntries(entitled.rpc, configured.rpc),
-      compliance: buildAvailabilityEntries(entitled.compliance, configured.compliance),
-      ramps: buildAvailabilityEntries(entitled.ramps, configured.ramps),
-      earn: buildAvailabilityEntries(entitled.earn, configured.earn),
+      custody: buildAvailabilityEntries(resolved.providers.custody, configured.custody),
+      rpc: buildAvailabilityEntries(resolved.providers.rpc, configured.rpc),
+      compliance: buildAvailabilityEntries(resolved.providers.compliance, configured.compliance),
+      ramps: buildAvailabilityEntries(resolved.providers.ramps, configured.ramps),
+      earn: buildAvailabilityEntries(resolved.providers.earn, configured.earn),
     },
   };
 }
@@ -640,7 +610,6 @@ export async function assertCustodyProviderEntitled(
     throw new AppError(
       "FORBIDDEN",
       getAvailabilityMessage(
-        env,
         availability.tier,
         "custody",
         provider,
@@ -676,7 +645,6 @@ export async function isPersistedCustodyCompletionEnabled(
 }
 
 function getAvailabilityMessage(
-  env: Env,
   _tier: OrganizationTier,
   family: OrganizationProviderFamily,
   providerId: string,
@@ -685,9 +653,6 @@ function getAvailabilityMessage(
   const label = getProviderLabel(family, providerId);
 
   if (!entry.entitled) {
-    if (isSelfHostedDeployment(env)) {
-      return `${label} is disabled for this organization.`;
-    }
     return `${label} requires manual activation for this organization.`;
   }
 
@@ -752,7 +717,6 @@ export async function assertProviderAvailable(
     throw new AppError(
       "FORBIDDEN",
       getAvailabilityMessage(
-        env,
         access.tier,
         family,
         providerId,

--- a/apps/sdp-api/src/services/rpc-relay.service.test.ts
+++ b/apps/sdp-api/src/services/rpc-relay.service.test.ts
@@ -224,20 +224,21 @@ describe("rpc-relay.service", () => {
     expect(second.selectionMode).toBe("round_robin_default");
   });
 
-  it("rejects invalid deployment mode values", async () => {
+  it("ignores SDP_DEPLOYMENT_MODE and resolves managed providers regardless of its value", async () => {
     rpcEnv.SOLANA_RPC_TRITON_URL = "https://rpc.triton.test";
     rpcEnv.SDP_DEPLOYMENT_MODE = "selfhosted";
 
-    await expect(
-      resolveRpcTarget({
-        env: appEnv,
-        kv,
-        db,
-        organizationId: TEST_ORG_ID,
-        authProjectId: null,
-        requestedProjectId: null,
-      })
-    ).rejects.toThrow('Invalid SDP_DEPLOYMENT_MODE: "selfhosted"');
+    const target = await resolveRpcTarget({
+      env: appEnv,
+      kv,
+      db,
+      organizationId: TEST_ORG_ID,
+      authProjectId: null,
+      requestedProjectId: null,
+    });
+
+    expect(target.providerId).toBe("triton");
+    expect(target.selectionMode).toBe("round_robin_default");
   });
 
   it("resolves validationcloud, substitutes the path-segment key, and redacts it in the label", async () => {

--- a/apps/sdp-web/src/components/workspace-switcher.tsx
+++ b/apps/sdp-web/src/components/workspace-switcher.tsx
@@ -5,7 +5,6 @@ import {
   CheckIcon,
   ChevronsUpDownIcon,
   CopyIcon,
-  LockIcon,
   type LucideIcon,
   Settings2Icon,
 } from "lucide-react";
@@ -183,35 +182,15 @@ export function WorkspaceSwitcher({
               ) : (
                 projects.map((project) => {
                   const isActive = project.id === selectedProjectId;
-                  const isProduction = project.environment === "production";
                   return (
                     <DropdownMenuItem
                       key={project.id}
-                      disabled={isProduction || isOrganizationSwitching || isProjectSwitching}
+                      disabled={isOrganizationSwitching || isProjectSwitching}
                       onSelect={() => selectProject(project.id)}
                       className="gap-2 text-xs"
                     >
                       <span className="min-w-0 flex-1 truncate">{project.name}</span>
-                      {isProduction ? (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span className="pointer-events-auto shrink-0 text-tertiary">
-                              <LockIcon
-                                className="size-3.5"
-                                aria-label={t("Shared.SharedComponents.locked")}
-                              />
-                            </span>
-                          </TooltipTrigger>
-                          <TooltipContent side="top" align="center">
-                            <span className="block">
-                              {t("Shared.SharedComponents.sandboxOnly")}
-                            </span>
-                            <span className="block">
-                              {t("Shared.SharedComponents.mainnetSoon")}
-                            </span>
-                          </TooltipContent>
-                        </Tooltip>
-                      ) : isActive ? (
+                      {isActive ? (
                         <span className="shrink-0 rounded-full bg-fill-subtle px-1.5 py-0.5 text-[10px] font-medium text-secondary">
                           {t("Shared.SharedComponents.current")}
                         </span>

--- a/packages/sdp-rpc/src/relay.ts
+++ b/packages/sdp-rpc/src/relay.ts
@@ -166,10 +166,6 @@ const TRANSACTION_METHOD_NAMES = new Set([SEND_TRANSACTION_METHOD, SEND_RAW_TRAN
 const MANAGED_RPC_PROVIDER_SET = new Set<string>(ORGANIZATION_RPC_PROVIDERS);
 const PROJECT_RPC_PROVIDER_SET = new Set<string>(PROJECT_RPC_PROVIDERS);
 
-type SdpDeploymentMode = "managed" | "self_hosted";
-
-const VALID_DEPLOYMENT_MODES = new Set<string>(["managed", "self_hosted"]);
-
 type OrganizationProviderRow = {
   tier: string;
   settings: unknown | null;
@@ -219,22 +215,6 @@ function parseOrganizationSettings(raw: unknown | null): OrganizationSettings | 
   }
 }
 
-function resolveDeploymentMode(value: string | undefined): SdpDeploymentMode {
-  if (value === undefined) {
-    return "managed";
-  }
-  if (!VALID_DEPLOYMENT_MODES.has(value)) {
-    throw new Error(
-      `Invalid SDP_DEPLOYMENT_MODE: "${value}". Expected "managed" or "self_hosted".`
-    );
-  }
-  return value as SdpDeploymentMode;
-}
-
-function isSelfHostedDeployment(env: Pick<RpcEnv, "SDP_DEPLOYMENT_MODE">): boolean {
-  return resolveDeploymentMode(env.SDP_DEPLOYMENT_MODE) === "self_hosted";
-}
-
 function hasEnv(env: RpcEnv, key: keyof RpcEnv): boolean {
   const value = env[key];
   return typeof value === "string" && value.trim().length > 0;
@@ -247,17 +227,6 @@ function buildConfiguredRpcProviders(env: RpcEnv): Record<OrganizationRpcProvide
       definition.isConfigured(env),
     ])
   ) as Record<OrganizationRpcProvider, boolean>;
-}
-
-function applySelfHostedEntitlements<T extends string>(
-  shape: Record<T, boolean>,
-  overrides?: Partial<Record<T, boolean>>
-): Record<T, boolean> {
-  const next = {} as Record<T, boolean>;
-  for (const key of Object.keys(shape) as T[]) {
-    next[key] = overrides?.[key] !== false;
-  }
-  return next;
 }
 
 function buildAvailabilityEntries<T extends string>(
@@ -510,11 +479,8 @@ async function getRpcProviderAvailability(
     providerOverrides: settings?.providerOverrides,
   });
   const configured = buildConfiguredRpcProviders(env);
-  const entitled = isSelfHostedDeployment(env)
-    ? applySelfHostedEntitlements(resolved.providers.rpc, settings?.providerOverrides?.rpc)
-    : resolved.providers.rpc;
 
-  return buildAvailabilityEntries(entitled, configured);
+  return buildAvailabilityEntries(resolved.providers.rpc, configured);
 }
 
 async function getProjectSettings(

--- a/packages/sdp-types/src/organizations.ts
+++ b/packages/sdp-types/src/organizations.ts
@@ -47,6 +47,12 @@ export interface OrganizationSettings {
    */
   legacyAllowedIpAddresses?: unknown;
   providerOverrides?: OrganizationProviderOverrides;
+  /**
+   * Set from Clerk org `private_metadata.sdp.enableProductionProject` by the
+   * Clerk webhook sync; `true` unlocks selecting production projects in the
+   * dashboard.
+   */
+  enableProductionProject?: boolean;
   customRateLimits?: {
     requestsPerMinute?: number;
     requestsPerDay?: number;


### PR DESCRIPTION
- Production projects are omitted from `GET /v1/projects` unless the organization is enabled for mainnet; enabled orgs see both default projects and can select production in the dashboard switcher.
- Enablement source: Clerk org private metadata `{"sdp": {"enableProductionProject": true}}`, synced into `organizations.settings` by the existing `organization.created/updated` webhook — same pipeline as `tier`/`providerOverrides`. Removing the key strips the setting on the next sync (fail-closed `=== true` parse).
- The switcher's hardcoded production lock (disabled row + LockIcon + "mainnet soon" tooltip) is deleted; any project that reaches the client is selectable.
- Enablement flips are logged (org id + new value) in the webhook sync.
- A later disable self-heals a stale selection: the hidden project drops out of the list and the existing cookie-repair path reselects default-sandbox.

**before** — production always visible, never selectable:

1. `GET /v1/projects` returns sandbox + production for every org
2. switcher renders the production row disabled with a lock tooltip
3. no path to mainnet for anyone

**after** — org-gated visibility:

1. Clerk webhook syncs `sdp.enableProductionProject` → `organizations.settings`
2. `listProjects` filters `environment === "production"` rows unless the org setting is `true` — both auth branches, so a production-scoped API key on a non-enabled org gets an empty list
3. enabled orgs see two selectable projects; everyone else sees sandbox only

**API before/after** — `GET /v1/projects`, org not enabled:

before (reconstructed from the old handler): `projects: [default-sandbox, default-production]`

after (live, dashboard session):
```json
{"data":{"projects":[{"name":"Default Sandbox Project","environment":"sandbox", "...":"..."}]}}
```
Org enabled (live, local): both projects returned. API-key auth (live): 200 with the key's own sandbox project; unauthenticated: 401.

**Self-hosted follows the same strategy** (review feedback):

- Deployment mode no longer determines network access: `SDP_DEPLOYMENT_MODE=self_hosted` previously implied blanket entitlements and skipped the Clerk sync entirely, so a self-hosted deployment was its own authority on what it could reach. That is removed — production/mainnet enablement and provider entitlements are decided by org metadata on every deployment mode.

- Deleted every self-hosted entitlement special case: the metadata-parse bypass and skipped webhook sync in provisioning, the blanket-entitlement overlays in `getProviderAvailability` and the RPC relay, and the self-hosted availability message. Capability config (local signer existence, cipher routing, BYOK flags) is untouched.
- Behavior change for self-hosted deployments: tier/`providerOverrides`/`enableProductionProject` now come from Clerk metadata like hosted; manual providers (compliance, earn) default OFF until overridden. The relay also stops re-validating `SDP_DEPLOYMENT_MODE` (its only entitlement consumer is gone); the API still fail-fast validates it at startup.

**Verification**

- `vitest projects.test.ts + provider-availability.service.test.ts` — 52/52 passed
- typecheck `@sdp/types`, `@sdp/api`, `sdp-web` — clean; Biome — clean
- local app: switcher exercised in a real browser — production row absent for a non-enabled org, sandbox marked current, no console errors; enabled case confirmed manually (two items, production selectable)
- not run locally: full `pnpm check` / `pnpm test:integration` (CI covers them)

**Screenshots**


**Self-hosted migration note**: an existing self-hosted deployment upgrading past this change must set org metadata overrides for providers it used under the old blanket entitlement (`sdp.providerOverrides.custody.local: true`, plus any compliance/earn providers) — until set, those flows report not entitled. This is the intended cost of metadata-only entitlement.

Known gaps
- Enforcement is the list read only: `GET /v1/projects/:projectId` still returns a production project by id and `sk_live` keys remain mintable regardless of the flag (unchanged behavior; follow-ups tracked on the mainnet epic).
- Not all providers support mainnet swapping yet; onchain actions become per-project cluster-aware in the stacked RPC PR — until it lands, onchain cluster selection is deployment-level.

![Projects section of the open workspace switcher for a non-enabled org: sandbox only, no production row](https://github.com/user-attachments/assets/7c4b9d7d-4b8c-496f-8b52-4eea8c15bbc1)

<img width="520" height="322" alt="CleanShot 2026-09-09 at 01 01 25@2x" src="https://github.com/user-attachments/assets/ddcac58e-5b2a-41db-b168-53a5eb511fc6" />




