### PR TITLE
feat(web): Coinbase frame handles the embedded on-ramp flow

### DIFF
--- a/apps/sdp-web/messages/en/dashboard-payments.json
+++ b/apps/sdp-web/messages/en/dashboard-payments.json
@@ -234,6 +234,7 @@
       "sourceWalletNoUsdc": "Source wallet has no USDC balance to send.",
       "coinbaseEventFailed": "Failed to record Coinbase event.",
       "coinbaseOnramp": "Coinbase onramp",
+      "coinbaseSessionError": "Coinbase could not continue this payment: {message} Create a new quote to try again.",
       "status": {
         "waitingForFunding": "Waiting for funding",
         "waitingToSend": "Waiting to send",

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/frame-events.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/frame-events.ts
@@ -40,7 +40,18 @@ const coinbaseFrameEventSchema = z.discriminatedUnion("eventName", [
 ]);
 
 export type CoinbaseFrameEvent = z.infer<typeof coinbaseFrameEventSchema>;
+type CoinbaseFrameError = Extract<CoinbaseFrameEvent, { data: unknown }>["data"];
 type Translate = (key: MessageKey, values?: TranslationValues) => string;
+
+/**
+ * The reason recorded and shown for a Coinbase error event. Coinbase's localized message
+ * when it has one; the error code otherwise, so the ramp-events endpoint (which requires a
+ * non-empty reason) never rejects the report and the operator never sees a blank notice.
+ */
+export function coinbaseErrorReason(data: CoinbaseFrameError): string {
+  const message = data.errorMessage.trim();
+  return message.length > 0 ? message : data.errorCode;
+}
 /** Posts a Coinbase ramp event to the SDP ramp-events endpoint. */
 export type PostCoinbaseRampEvent = typeof postCoinbaseRampEvent;
 
@@ -126,7 +137,11 @@ export function handleCoinbaseFrameEvent(
       break;
     case "onramp_api.commit_error":
     case "onramp_api.session_error":
-      reportRampEvent({ kind: "errored", orderId, reason: event.data.errorMessage }, t, postEvent);
+      reportRampEvent(
+        { kind: "errored", orderId, reason: coinbaseErrorReason(event.data) },
+        t,
+        postEvent
+      );
       break;
     case "onramp_api.load_pending":
     case "onramp_api.load_success":

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/frame-events.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/frame-events.ts
@@ -16,6 +16,11 @@ const coinbaseFrameEventSchema = z.discriminatedUnion("eventName", [
       "onramp_api.cancel",
       "onramp_api.polling_start",
       "onramp_api.polling_success",
+      // Embedded-mode progress events: Coinbase verifies the buyer's phone and email and
+      // runs its limits-upgrade form inside the frame before the payment step.
+      "onramp_api.verification_success",
+      "onramp_api.upgrade_submit_success",
+      "onramp_api.upgrade_approved",
     ]),
   }),
   z.object({
@@ -23,6 +28,9 @@ const coinbaseFrameEventSchema = z.discriminatedUnion("eventName", [
       "onramp_api.load_error",
       "onramp_api.commit_error",
       "onramp_api.polling_error",
+      // Embedded-mode terminal error: verification, limits, or order preparation failed
+      // and the hosted flow cannot continue.
+      "onramp_api.session_error",
     ]),
     data: z.object({
       errorCode: z.string(),
@@ -33,6 +41,13 @@ const coinbaseFrameEventSchema = z.discriminatedUnion("eventName", [
 
 export type CoinbaseFrameEvent = z.infer<typeof coinbaseFrameEventSchema>;
 type Translate = (key: MessageKey, values?: TranslationValues) => string;
+/** Posts a Coinbase ramp event to the SDP ramp-events endpoint. */
+export type PostCoinbaseRampEvent = typeof postCoinbaseRampEvent;
+
+export interface CoinbaseFrameEventOptions {
+  /** Event poster; defaults to the workspace's ramp-events client. Tests inject a spy here. */
+  postEvent?: PostCoinbaseRampEvent;
+}
 
 /**
  * Parses a raw postMessage payload from the Coinbase payment-link iframe.
@@ -56,8 +71,12 @@ function parseCoinbaseFrameEvent(raw: unknown): CoinbaseFrameEvent | null {
   return parsed.success ? parsed.data : null;
 }
 
-function reportRampEvent(event: CoinbaseRampEvent, t: Translate): void {
-  postCoinbaseRampEvent(event, t).catch((error) => {
+function reportRampEvent(
+  event: CoinbaseRampEvent,
+  t: Translate,
+  postEvent: PostCoinbaseRampEvent
+): void {
+  postEvent(event, t).catch((error) => {
     toast.error(t("DashboardPayments.ramps.coinbaseEventFailed"), {
       description:
         error instanceof Error ? error.message : t("DashboardPayments.ramps.eventRequestFailed"),
@@ -69,8 +88,8 @@ function reportRampEvent(event: CoinbaseRampEvent, t: Translate): void {
 /**
  * Handles a raw postMessage payload from the Coinbase payment-link iframe, forwarding
  * provisional transfer transitions to the SDP ramp-events endpoint keyed by the
- * create-order id: commit_success marks the transfer settling, commit_error records the
- * failure with Coinbase's localized error message.
+ * create-order id: commit_success marks the transfer settling, commit_error and the
+ * embedded flow's session_error record the failure with Coinbase's localized error message.
  *
  * polling_success / polling_error are deliberately NOT reported: the iframe's polling is
  * a client-side convenience whose errors can be transient (network) while the charge
@@ -80,20 +99,22 @@ function reportRampEvent(event: CoinbaseRampEvent, t: Translate): void {
  * would permanently block.
  *
  * Load-phase and progress events (load_*, apple_pay_button_pressed, pending_payment_auth,
- * payment_authorized, cancel, polling_start) don't change the transfer's state and are
+ * payment_authorized, cancel, polling_start, and the embedded verification_success,
+ * upgrade_submit_success, upgrade_approved) don't change the transfer's state and are
  * intentionally not reported. In particular load_error can be transient: an
  * ERROR_CODE_GUEST_APPLE_PAY_NOT_SUPPORTED is followed by a successful QR-code fallback
  * render on web.
  *
  * Returns the parsed event (null for foreign messages) so the frame can react to
- * UI-phase transitions like `apple_pay_button_pressed` and `cancel`.
+ * UI-phase transitions like `apple_pay_button_pressed`, `cancel` and `session_error`.
  *
  * @see https://docs.cdp.coinbase.com/onramp/headless-onramp/overview#post-message-events
  */
 export function handleCoinbaseFrameEvent(
   orderId: string,
   raw: unknown,
-  t: Translate
+  t: Translate,
+  { postEvent = postCoinbaseRampEvent }: CoinbaseFrameEventOptions = {}
 ): CoinbaseFrameEvent | null {
   const event = parseCoinbaseFrameEvent(raw);
   if (!event) {
@@ -101,10 +122,11 @@ export function handleCoinbaseFrameEvent(
   }
   switch (event.eventName) {
     case "onramp_api.commit_success":
-      reportRampEvent({ kind: "committed", orderId }, t);
+      reportRampEvent({ kind: "committed", orderId }, t, postEvent);
       break;
     case "onramp_api.commit_error":
-      reportRampEvent({ kind: "errored", orderId, reason: event.data.errorMessage }, t);
+    case "onramp_api.session_error":
+      reportRampEvent({ kind: "errored", orderId, reason: event.data.errorMessage }, t, postEvent);
       break;
     case "onramp_api.load_pending":
     case "onramp_api.load_success":
@@ -116,6 +138,9 @@ export function handleCoinbaseFrameEvent(
     case "onramp_api.polling_start":
     case "onramp_api.polling_success":
     case "onramp_api.polling_error":
+    case "onramp_api.verification_success":
+    case "onramp_api.upgrade_submit_success":
+    case "onramp_api.upgrade_approved":
       break;
     default: {
       const exhaustive: never = event;

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/frame-events.unit.test.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/frame-events.unit.test.ts
@@ -45,6 +45,20 @@ describe("handleCoinbaseFrameEvent", () => {
     );
   });
 
+  it("falls back to the error code when Coinbase sends an empty message", () => {
+    handle(
+      frameMessage("onramp_api.session_error", {
+        errorCode: "ERROR_CODE_SESSION_EXPIRED",
+        errorMessage: "   ",
+      })
+    );
+
+    expect(postEvent).toHaveBeenCalledWith(
+      { kind: "errored", orderId: ORDER_ID, reason: "ERROR_CODE_SESSION_EXPIRED" },
+      t
+    );
+  });
+
   it("rejects a session_error without the error payload", () => {
     expect(handle(frameMessage("onramp_api.session_error"))).toBeNull();
     expect(postEvent).not.toHaveBeenCalled();

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/frame-events.unit.test.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/frame-events.unit.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { handleCoinbaseFrameEvent, type PostCoinbaseRampEvent } from "./frame-events";
+
+const t = (key: string) => key;
+const ORDER_ID = "order_123";
+const postEvent = vi.fn<PostCoinbaseRampEvent>();
+
+function frameMessage(eventName: string, data?: Record<string, string>): string {
+  return JSON.stringify(data ? { eventName, data } : { eventName });
+}
+
+function handle(raw: unknown) {
+  return handleCoinbaseFrameEvent(ORDER_ID, raw, t, { postEvent });
+}
+
+describe("handleCoinbaseFrameEvent", () => {
+  beforeEach(() => {
+    postEvent.mockReset();
+    postEvent.mockResolvedValue(undefined as never);
+  });
+
+  it.each([
+    "onramp_api.verification_success",
+    "onramp_api.upgrade_submit_success",
+    "onramp_api.upgrade_approved",
+  ])("parses the embedded progress event %s without reporting it", (eventName) => {
+    const event = handle(frameMessage(eventName));
+
+    expect(event?.eventName).toBe(eventName);
+    expect(postEvent).not.toHaveBeenCalled();
+  });
+
+  it("reports session_error as an errored transfer with Coinbase's message", () => {
+    const event = handle(
+      frameMessage("onramp_api.session_error", {
+        errorCode: "ERROR_CODE_VERIFICATION_FAILED",
+        errorMessage: "We could not verify your phone number.",
+      })
+    );
+
+    expect(event?.eventName).toBe("onramp_api.session_error");
+    expect(postEvent).toHaveBeenCalledWith(
+      { kind: "errored", orderId: ORDER_ID, reason: "We could not verify your phone number." },
+      t
+    );
+  });
+
+  it("rejects a session_error without the error payload", () => {
+    expect(handle(frameMessage("onramp_api.session_error"))).toBeNull();
+    expect(postEvent).not.toHaveBeenCalled();
+  });
+
+  it("still reports commit_success as committed", () => {
+    handle(frameMessage("onramp_api.commit_success"));
+
+    expect(postEvent).toHaveBeenCalledWith({ kind: "committed", orderId: ORDER_ID }, t);
+  });
+
+  it("returns null for foreign or unknown messages", () => {
+    expect(handle({ eventName: "onramp_api.load_success" })).toBeNull();
+    expect(handle("not json")).toBeNull();
+    expect(handle(frameMessage("onramp_api.future_event"))).toBeNull();
+    expect(postEvent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/ramp-frame.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/ramp-frame.tsx
@@ -6,18 +6,20 @@ import {
   COINBASE_HOSTED_APPROVED_HOSTS,
   isTrustedRampDestination,
 } from "@/lib/trusted-ramp-destinations";
-import { handleCoinbaseFrameEvent } from "./frame-events";
+import { type CoinbaseFrameEventOptions, handleCoinbaseFrameEvent } from "./frame-events";
 
 /**
- * Embeds a Coinbase headless-onramp payment link and forwards its postMessage
- * events (`onramp_api.*`) to the SDP ramp-events endpoint.
+ * Embeds a Coinbase on-ramp payment link and forwards its postMessage events
+ * (`onramp_api.*`) to the SDP ramp-events endpoint.
  *
  * Coinbase-specific by design: the payment link requires the exact
- * `sandbox`/`referrerPolicy` attributes below to render in an iframe. The
- * framed page renders only the Apple Pay button until it is pressed, then
- * expands a payment sheet inside the same frame — so the frame is sized like
- * a button and grows to a panel on `apple_pay_button_pressed`, shrinking back
- * on `cancel`.
+ * `sandbox`/`referrerPolicy` attributes below to render in an iframe. Orders are
+ * created in embedded mode, so the framed page opens on Coinbase's own
+ * verification and limits screens before it reaches the Apple Pay button — the
+ * frame is therefore a full panel from the first render, and only collapses when
+ * the hosted flow ends: `commit_success` hands over to the transfer status, and
+ * `session_error` (a terminal verification, limits or order-preparation failure)
+ * replaces the frame with Coinbase's localized message.
  *
  * The `allow-scripts allow-same-origin` pair is mandated verbatim by Coinbase's
  * embedding docs. The known sandbox escape for that pair (the framed script
@@ -27,11 +29,18 @@ import { handleCoinbaseFrameEvent } from "./frame-events";
  *
  * @see https://docs.cdp.coinbase.com/onramp/headless-onramp/overview#web-app-testing
  */
-type CoinbaseFramePhase = "button" | "sheet" | "processing";
+type CoinbaseFramePhase =
+  | { kind: "panel" }
+  | { kind: "processing" }
+  | { kind: "failed"; message: string };
 
-export function CoinbaseRampFrame({ orderId, src }: { orderId: string; src: string }) {
+export function CoinbaseRampFrame({
+  orderId,
+  src,
+  postEvent,
+}: { orderId: string; src: string } & CoinbaseFrameEventOptions) {
   const t = useTranslations();
-  const [phase, setPhase] = useState<CoinbaseFramePhase>("button");
+  const [phase, setPhase] = useState<CoinbaseFramePhase>({ kind: "panel" });
   // The frame's origin is also what the postMessage listener trusts, so only
   // HTTPS Coinbase payment-link hosts may ever be embedded — fail closed.
   const trustedSrc = isTrustedRampDestination(src, COINBASE_HOSTED_APPROVED_HOSTS);
@@ -44,20 +53,17 @@ export function CoinbaseRampFrame({ orderId, src }: { orderId: string; src: stri
       if (event.origin !== expectedOrigin) {
         return;
       }
-      const frameEvent = handleCoinbaseFrameEvent(orderId, event.data, t);
-      if (frameEvent?.eventName === "onramp_api.apple_pay_button_pressed") {
-        setPhase("sheet");
-      }
-      if (frameEvent?.eventName === "onramp_api.cancel") {
-        setPhase("button");
-      }
+      const frameEvent = handleCoinbaseFrameEvent(orderId, event.data, t, { postEvent });
       if (frameEvent?.eventName === "onramp_api.commit_success") {
-        setPhase("processing");
+        setPhase({ kind: "processing" });
+      }
+      if (frameEvent?.eventName === "onramp_api.session_error") {
+        setPhase({ kind: "failed", message: frameEvent.data.errorMessage });
       }
     };
     window.addEventListener("message", handleMessage);
     return () => window.removeEventListener("message", handleMessage);
-  }, [src, orderId, t, trustedSrc]);
+  }, [src, orderId, t, trustedSrc, postEvent]);
 
   if (!trustedSrc) {
     return (
@@ -67,18 +73,24 @@ export function CoinbaseRampFrame({ orderId, src }: { orderId: string; src: stri
     );
   }
 
-  if (phase === "processing") {
+  if (phase.kind === "processing") {
     return null;
   }
 
+  if (phase.kind === "failed") {
+    return (
+      <div className="rounded-2xl border border-error-border bg-error-bg px-5 py-5 text-sm text-error">
+        {t("DashboardPayments.ramps.coinbaseSessionError", { message: phase.message })}
+      </div>
+    );
+  }
+
   return (
-    <div
-      className={`mx-auto overflow-hidden rounded-lg transition-all duration-300 ${phase === "sheet" ? "max-w-lg" : "max-w-xs"}`}
-    >
+    <div className="mx-auto max-w-lg overflow-hidden rounded-lg">
       <iframe
         title={t("DashboardPayments.ramps.coinbaseOnramp")}
         src={src}
-        className={`w-full border-0 transition-all duration-300 ${phase === "sheet" ? "h-96" : "h-12"}`}
+        className="h-96 w-full border-0"
         allow="payment"
         sandbox="allow-scripts allow-same-origin"
         referrerPolicy="no-referrer"

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/ramp-frame.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/ramp-frame.tsx
@@ -6,7 +6,11 @@ import {
   COINBASE_HOSTED_APPROVED_HOSTS,
   isTrustedRampDestination,
 } from "@/lib/trusted-ramp-destinations";
-import { type CoinbaseFrameEventOptions, handleCoinbaseFrameEvent } from "./frame-events";
+import {
+  type CoinbaseFrameEventOptions,
+  coinbaseErrorReason,
+  handleCoinbaseFrameEvent,
+} from "./frame-events";
 
 /**
  * Embeds a Coinbase on-ramp payment link and forwards its postMessage events
@@ -58,7 +62,7 @@ export function CoinbaseRampFrame({
         setPhase({ kind: "processing" });
       }
       if (frameEvent?.eventName === "onramp_api.session_error") {
-        setPhase({ kind: "failed", message: frameEvent.data.errorMessage });
+        setPhase({ kind: "failed", message: coinbaseErrorReason(frameEvent.data) });
       }
     };
     window.addEventListener("message", handleMessage);

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/ramp-frame.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/ramp-frame.unit.test.tsx
@@ -68,6 +68,17 @@ describe("CoinbaseRampFrame", () => {
     );
   });
 
+  it("shows the error code when Coinbase's message is empty", () => {
+    renderFrame();
+
+    postFrameMessage({
+      eventName: "onramp_api.session_error",
+      data: { errorCode: "ERROR_CODE_SESSION_EXPIRED", errorMessage: "" },
+    });
+
+    expect(screen.getByText(/ERROR_CODE_SESSION_EXPIRED/)).toBeTruthy();
+  });
+
   it("hides the frame once the payment is committed", () => {
     renderFrame();
 

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/ramp-frame.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/ramp-frame.unit.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getMessages } from "@/i18n/messages";
+import { I18nProvider } from "@/i18n/provider";
+import type { PostCoinbaseRampEvent } from "./frame-events";
+import { CoinbaseRampFrame } from "./ramp-frame";
+
+const SRC = "https://pay.coinbase.com/v3/buy/input?sessionToken=abc";
+const postEvent = vi.fn<PostCoinbaseRampEvent>().mockResolvedValue(undefined as never);
+
+function renderFrame() {
+  return render(
+    <I18nProvider locale="en" messages={getMessages("en")}>
+      <CoinbaseRampFrame orderId="order_123" src={SRC} postEvent={postEvent} />
+    </I18nProvider>
+  );
+}
+
+function postFrameMessage(payload: unknown) {
+  act(() => {
+    window.dispatchEvent(
+      new MessageEvent("message", { data: JSON.stringify(payload), origin: new URL(SRC).origin })
+    );
+  });
+}
+
+describe("CoinbaseRampFrame", () => {
+  afterEach(() => {
+    cleanup();
+    postEvent.mockClear();
+  });
+
+  it("renders the hosted flow as a full panel from the first paint", () => {
+    renderFrame();
+
+    const frame = screen.getByTitle("Coinbase onramp");
+    expect(frame.className).toContain("h-96");
+    expect(frame.className).not.toContain("h-12");
+    expect(frame.getAttribute("sandbox")).toBe("allow-scripts allow-same-origin");
+    expect(frame.getAttribute("allow")).toBe("payment");
+  });
+
+  it("keeps the panel through the embedded verification and upgrade steps", () => {
+    renderFrame();
+
+    postFrameMessage({ eventName: "onramp_api.verification_success" });
+    postFrameMessage({ eventName: "onramp_api.upgrade_approved" });
+
+    expect(screen.getByTitle("Coinbase onramp").className).toContain("h-96");
+    expect(postEvent).not.toHaveBeenCalled();
+  });
+
+  it("replaces the frame with Coinbase's message on session_error", () => {
+    renderFrame();
+
+    postFrameMessage({
+      eventName: "onramp_api.session_error",
+      data: { errorCode: "ERROR_CODE_LIMITS", errorMessage: "This purchase exceeds your limit." },
+    });
+
+    expect(screen.queryByTitle("Coinbase onramp")).toBeNull();
+    expect(screen.getByText(/This purchase exceeds your limit\./)).toBeTruthy();
+    expect(postEvent).toHaveBeenCalledWith(
+      { kind: "errored", orderId: "order_123", reason: "This purchase exceeds your limit." },
+      expect.any(Function)
+    );
+  });
+
+  it("hides the frame once the payment is committed", () => {
+    renderFrame();
+
+    postFrameMessage({ eventName: "onramp_api.commit_success" });
+
+    expect(screen.queryByTitle("Coinbase onramp")).toBeNull();
+    expect(postEvent).toHaveBeenCalledWith(
+      { kind: "committed", orderId: "order_123" },
+      expect.any(Function)
+    );
+  });
+});


### PR DESCRIPTION
HOO-1588. First of three slices moving Coinbase on-ramp orders to embedded mode (Coinbase collects phone, email and OTP in its hosted flow); the order switch and the requirements decision follow as separate PRs.

- The Coinbase iframe accepts the four embedded-order events: `verification_success`, `upgrade_submit_success`, `upgrade_approved`, `session_error`.
- `session_error` reports the transfer as errored with Coinbase's localized message and replaces the frame with that message; the three progress events are parsed and ignored like the existing load and polling events.
- The frame is a full panel from the first paint; the button-to-sheet resize keyed on `apple_pay_button_pressed` is gone.
- No behavior change for today's headless orders: the same Apple Pay flow renders in a fixed-size panel. The order switch to embedded mode is the next PR.
- Event posting is injectable (`postEvent` option), so tests inject a spy instead of mocking modules.

**before** — headless order in a button-sized frame:

1. Frame renders at 48px showing only the Apple Pay button.
2. `apple_pay_button_pressed` grows it to a sheet; `cancel` shrinks it back.
3. An embedded order would open on verification screens inside the 48px frame, and its `session_error` would be dropped by the parser as unknown.

**after** — frame ready for embedded orders:

1. Frame renders as a full panel.
2. Verification, upgrade and payment screens run inside it; progress events parse and change nothing.
3. `commit_success` hides the frame and hands over to the transfer status; `session_error` reports `errored` with Coinbase's message and shows it in place of the frame.

**Verification**

- `pnpm --filter sdp-web exec vitest run src/app/dashboard/payments/ramps` — 59 passed
- `pnpm --filter sdp-web test` — 202 files, 1795 passed
- `pnpm typecheck` — 22 of 22 tasks successful
- `biome check` on the changed files — clean
- local app: not exercised, the Coinbase frame needs a sandbox quote and this machine has no Coinbase credentials. Covered by the jsdom tests; end-to-end runs on the dev preview in the order-switch PR.

**Known gaps**
- Other locales for the new string follow through the translation flow.
- React Doctor runs on CI (no local binary).
