### PR TITLE
fix(wallets): route the signer check through the guarded RPC egress

### DIFF
--- a/apps/sdp-api/src/routes/custody/handlers/signer-check.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/signer-check.ts
@@ -93,14 +93,9 @@ export const signerCheck = async (c: ValidatedBodyContext<typeof signerCheckSche
       }),
     ]);
 
-    // Through the guarded transport, not a raw client: `resolveRpcTarget`
-    // returns the project's own `settings.rpcEndpoint` for the `custom`
-    // provider, and that value is only checked for being a URL when it is
-    // written. Dialling it directly made this route an API-key reachable SSRF
-    // into the metadata server and the private network, with error text and
-    // timing as the oracle — the same sink the relay already guards
-    // (HOO-1560). Platform targets keep the ordinary fetch, so local and
-    // Surfpool endpoints are unaffected.
+    // The `custom` provider endpoint is project-supplied and only URL-checked
+    // on write, so it goes through the guarded transport like the relay's
+    // (HOO-1560). Platform targets keep the ordinary fetch.
     const rpc = createRpcFromTransport(createRpcTransportForTarget(rpcTarget));
 
     const { blockhash, lastValidBlockHeight } = await getRecentBlockhash(rpc, "confirmed");

--- a/apps/sdp-api/src/routes/custody/handlers/signer-check.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/signer-check.ts
@@ -1,6 +1,6 @@
 import { SigningError } from "@sdp/custody/signing";
 import { resolveRpcTarget } from "@sdp/rpc/relay";
-import { createRpc, getRecentBlockhash, simulateTransaction } from "@sdp/rpc/solana";
+import { createRpcFromTransport, getRecentBlockhash, simulateTransaction } from "@sdp/rpc/solana";
 import type { Address, SignatureBytes } from "@solana/kit";
 import {
   AccountRole,
@@ -23,6 +23,7 @@ import { success } from "@/lib/response";
 import type { ValidatedBodyContext } from "@/middleware/validate";
 import { resolveApiKeySigningWalletId } from "@/services/api-key-scope.service";
 import { FeePaymentError } from "@/services/ports";
+import { createRpcTransportForTarget } from "@/services/rpc-egress";
 import { createOrgSigner } from "@/services/solana";
 import { createAuthenticatedSponsorshipFeePayment } from "@/services/sponsorship.service";
 import type { SignerCheckResponse, signerCheckSchema } from "../schemas";
@@ -92,10 +93,15 @@ export const signerCheck = async (c: ValidatedBodyContext<typeof signerCheckSche
       }),
     ]);
 
-    const rpc = createRpc(c.env, {
-      rpcUrl: rpcTarget.endpoint,
-      headers: rpcTarget.headers,
-    });
+    // Through the guarded transport, not a raw client: `resolveRpcTarget`
+    // returns the project's own `settings.rpcEndpoint` for the `custom`
+    // provider, and that value is only checked for being a URL when it is
+    // written. Dialling it directly made this route an API-key reachable SSRF
+    // into the metadata server and the private network, with error text and
+    // timing as the oracle — the same sink the relay already guards
+    // (HOO-1560). Platform targets keep the ordinary fetch, so local and
+    // Surfpool endpoints are unaffected.
+    const rpc = createRpcFromTransport(createRpcTransportForTarget(rpcTarget));
 
     const { blockhash, lastValidBlockHeight } = await getRecentBlockhash(rpc, "confirmed");
 

--- a/apps/sdp-api/src/services/rpc-byok-parity.test.ts
+++ b/apps/sdp-api/src/services/rpc-byok-parity.test.ts
@@ -85,6 +85,26 @@ describe("BYOK parity with organization RPC selection", () => {
     expect(files).toContain("routes/rpc/handlers.ts");
   });
 
+  it("dials every resolved target through the guarded transport", () => {
+    // A resolved target can carry the project's own `settings.rpcEndpoint`
+    // (provider `custom`), which is validated as a URL and nothing more. Any
+    // file that resolves a target and then builds a raw client from it is an
+    // SSRF sink reachable by whoever can write that setting — signer-check was
+    // exactly that (HOO-1560). The transport itself is covered behaviourally in
+    // rpc-egress.test.ts; what no runtime test can see is a NEW call site
+    // skipping it, which is what this asserts.
+    const files = readdirSync(apiSrc, { recursive: true, encoding: "utf8" })
+      .filter((entry) => entry.endsWith(".ts") && !entry.includes(".test."))
+      .map((entry) => path.join(apiSrc, entry));
+
+    const unguarded = files.filter((file) => {
+      const source = readFileSync(file, "utf8");
+      return source.includes("resolveRpcTarget(") && source.includes("createRpc(");
+    });
+
+    expect(unguarded.map((file) => path.relative(apiSrc, file))).toEqual([]);
+  });
+
   it("keeps the signer check off the tenant rail", () => {
     // The decision, asserted rather than described: if someone wires the lookup
     // back in, this fails and the exclusion above has to be revisited with it.

--- a/apps/sdp-api/src/services/rpc-byok-parity.test.ts
+++ b/apps/sdp-api/src/services/rpc-byok-parity.test.ts
@@ -99,7 +99,25 @@ describe("BYOK parity with organization RPC selection", () => {
 
     const unguarded = files.filter((file) => {
       const source = readFileSync(file, "utf8");
-      return source.includes("resolveRpcTarget(") && source.includes("createRpc(");
+      if (!source.includes("resolveRpcTarget(")) {
+        return false;
+      }
+      // The binding, not the spelling: an alias or a namespace import is the
+      // same sink under another name.
+      const bindings = [
+        ...source.matchAll(/import\s*{([^}]*)}\s*from\s*"@sdp\/rpc\/solana"/g),
+      ].flatMap((match) =>
+        match[1]
+          .split(",")
+          .map((entry) => entry.trim())
+          .filter((entry) => entry === "createRpc" || entry.startsWith("createRpc as "))
+          .map((entry) => entry.split(" as ").at(-1)?.trim() ?? entry)
+      );
+      const namespaces = [
+        ...source.matchAll(/import\s*\*\s*as\s*(\w+)\s*from\s*"@sdp\/rpc\/solana"/g),
+      ].map((match) => `${match[1]}.createRpc`);
+
+      return [...bindings, ...namespaces].some((binding) => source.includes(`${binding}(`));
     });
 
     expect(unguarded.map((file) => path.relative(apiSrc, file))).toEqual([]);


### PR DESCRIPTION
- `POST /custody/signer-check` resolved the project's RPC target and dialled it with a raw client, so a project whose `settings.rpcEndpoint` pointed at `169.254.169.254` or an internal host had that request made on its behalf, with the error text and response timing as the oracle. The endpoint is only checked for being a well-formed URL when it is written.
- The call now builds its client from the same guarded transport the RPC relay uses, so a customer-supplied target is resolved and checked before connect, on the initial request and on every redirect hop.
- No contract change: request and response schemas, metering, and auth are untouched. Platform providers, local validators, and Surfpool are not customer-supplied, so they keep the ordinary fetch and behave exactly as before.
- Nothing else about the client changes: `createRpc` with an explicit `rpcUrl` already took the single-transport branch with no provider failover, and `createRpcFromTransport` applies the same default request timeout.
- A call-site test asserts the invariant that no runtime test can see — a *new* file that resolves an RPC target and then builds a raw client. It resolves the `createRpc` binding from the import, so an alias or a namespace import is caught too.

**before** — resolved target dialled directly:

1. Handler resolves the project's RPC target (platform provider or the project's own `custom` endpoint).
2. `createRpc(env, { rpcUrl: target.endpoint, headers })` builds a plain HTTP transport over that URL.
3. Blockhash and simulation requests go to whatever that hostname resolves to — link-local, loopback, or RFC1918 included.

**after** — resolved target dialled through the guard:

1. Handler resolves the target as before.
2. `createRpcTransportForTarget(target)` classifies it: `connectionId` present or `providerId === "custom"` → customer-supplied.
3. Customer-supplied targets go through `guardedFetch` — the destination address is checked before connect, redirects are bounded and re-checked per hop, and a blocked destination fails with `EgressBlockedError` instead of a connection.
4. Platform targets take the unguarded path unchanged.

**Verification**

- `vitest run src/services/rpc-egress.test.ts src/services/rpc-byok-parity.test.ts src/routes/custody` — 11 files, 144 tests passed.
- Reverting only the handler change makes the new call-site test fail with `[ "routes/custody/handlers/signer-check.ts" ]`; re-introducing the sink under an aliased import (`createRpc as rawCreateRpc`) fails it too.
- `tsc --noEmit`, `biome check` — clean.
- Local app not exercised: this changes no route contract or UI, and the guarded destination behaviour is covered by the egress suite against a controlled resolver rather than a live endpoint.

Known gaps
- The call-site test is a regression guard over import bindings, not a type-level invariant; a helper in another module that wraps the raw client would still pass it.
