### PR TITLE
feat(earn): PRO-1866 record earn money actions in the audit ledger

### DIFF
--- a/apps/sdp-api/src/db/migrations/postgres/0083_earn_withdraw_audit_uniqueness.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0083_earn_withdraw_audit_uniqueness.sql
@@ -1,0 +1,20 @@
+-- One audit event per earn withdrawal movement (PRO-1866 review follow-up).
+--
+-- The replay backfill in routes/earn/handlers/movement-audit.ts checks for an
+-- existing 'withdraw' event and then appends one. Every audit write serializes
+-- through the ledger's session lock, so two writers cannot interleave, but
+-- both can pass the (unlocked) existence check first and append twice. This
+-- partial unique index makes the INSERT itself the atomic existence check:
+-- the losing writer fails inside the serialized audit transaction, which
+-- rolls back cleanly (the checkpoint witness is restored by the writer's
+-- rollback path), and the caller treats the unique violation as "already
+-- audited" rather than an error.
+--
+-- Scoped to earn withdraw events only: nothing else on audit_logs promises
+-- one-event-per-resource, and deposit events are intent/outcome PAIRS by
+-- design (beginCritical/completeCritical), so they must stay out of it.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_audit_logs_earn_withdraw_movement
+  ON audit_logs (organization_id, resource_id)
+  WHERE action = 'withdraw'
+    AND resource_type = 'earn_movement'
+    AND resource_id IS NOT NULL;

--- a/apps/sdp-api/src/routes/earn-program.test.ts
+++ b/apps/sdp-api/src/routes/earn-program.test.ts
@@ -44,6 +44,7 @@ import { createPostgresEarnMovementsRepository } from "@/db/repositories/earn-mo
 import app from "@/index";
 import { deriveProviderRequestId } from "@/lib/idempotency";
 import { createTenantScope } from "@/lib/tenant-scope";
+import { AuditService } from "@/services/audit.service";
 import { recoverApprovedWalletOperations } from "@/services/policy/approved-operation-replay";
 import { env } from "@/test/helpers/env";
 import { seedTestDatabase } from "@/test/mocks/db";
@@ -2773,5 +2774,57 @@ describe("Earn program — metered quotas", () => {
     });
     expect(withdrawal.status).toBe(201);
     expect(createWithdrawal).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Earn program: withdrawal audit parity (PRO-1866)", () => {
+  it("records the payout with the movement's attribution, and a replay is not re-audited", async () => {
+    await seedAuth();
+    const program = await seedProgramWallet();
+    vi.spyOn(EARN_PROVIDER_CLIENTS.ground, "createPortfolioWithdrawal").mockResolvedValue(
+      WITHDRAWAL
+    );
+    vi.spyOn(EARN_PROVIDER_CLIENTS.ground, "getPortfolioWithdrawal").mockResolvedValue(WITHDRAWAL);
+    const body = {
+      requestId: "8d2e3f4a-5b6c-4d7e-8f9a-0b1c2d3e4f5a",
+      amountUsd: "10.00",
+      token: "usdc",
+      destinationAddress: SOLANA_DESTINATION,
+    };
+
+    const res = await requestEarn("POST", programPath(program.id, "/withdrawals"), body);
+    expect(res.status).toBe(201);
+
+    const movement = await getDb(env)
+      .prepare("SELECT * FROM earn_movements WHERE direction = 'withdrawal'")
+      .first<Record<string, unknown>>();
+    const auditRows = () =>
+      getDb(env)
+        .prepare(
+          "SELECT * FROM audit_logs WHERE action = 'withdraw' AND resource_type = 'earn_movement'"
+        )
+        .all<Record<string, unknown>>()
+        .then(({ results }) => results ?? []);
+
+    // Audit parity: same movement, same actor pair the ledger row carries.
+    const rows = await auditRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      resource_id: movement?.id,
+      organization_id: TEST_ORG.id,
+      user_id: movement?.created_by,
+      api_key_id: movement?.initiated_by_key_id,
+    });
+
+    // The org audit feed can surface it (PRO-1866 "done when").
+    const feed = await new AuditService(getDb(env)).getForOrganization(TEST_ORG.id, {
+      action: "withdraw",
+    });
+    expect(feed.some((entry) => entry.resourceId === movement?.id)).toBe(true);
+
+    // A replay of the accepted payout moves no new money: nothing new to audit.
+    const replay = await requestEarn("POST", programPath(program.id, "/withdrawals"), body);
+    expect(replay.status).toBe(200);
+    await expect(auditRows()).resolves.toHaveLength(1);
   });
 });

--- a/apps/sdp-api/src/routes/earn.external-wallet.test.ts
+++ b/apps/sdp-api/src/routes/earn.external-wallet.test.ts
@@ -1057,3 +1057,79 @@ describe("exit safety (ADR 0002): the exit outlives every money-in gate", () => 
     expect(body.data.withdrawal.denomination).toBe(SHARE_MINT);
   });
 });
+
+describe("external-wallet submits: audit ledger parity (PRO-1866)", () => {
+  function auditRows(action: "deposit" | "withdraw") {
+    return getDb(env)
+      .prepare("SELECT * FROM audit_logs WHERE action = ? AND resource_type = 'earn_movement'")
+      .bind(action)
+      .all<Record<string, unknown>>()
+      .then(({ results }) => results ?? []);
+  }
+
+  it("records the deposit submit, keyed to the movement and the caller's key", async () => {
+    await seedAuth();
+    const result = submitResult();
+    submitExternalWalletDeposit.mockResolvedValue(result);
+
+    const res = await post(
+      "deposits",
+      { transactionId: "earn_ext_tx", signedTransaction: "AQ==" },
+      { idempotencyKey: crypto.randomUUID() }
+    );
+    expect(res.status).toBe(200);
+
+    const rows = await auditRows("deposit");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      resource_id: result.movement.id,
+      organization_id: TEST_ORG.id,
+      api_key_id: TEST_API_KEY.id,
+      user_id: null,
+    });
+  });
+
+  it("records the withdrawal submit with the movement's own attribution", async () => {
+    await seedAuth();
+    const result = submitResult({
+      direction: "withdrawal",
+      denomination: SHARE_MINT,
+      amount_requested: "10",
+      created_by: null,
+      initiated_by_key_id: TEST_API_KEY.id,
+    });
+    submitExternalWalletWithdrawal.mockResolvedValue(result);
+
+    const res = await post(
+      "withdrawals",
+      { transactionId: "earn_ext_tx", signedTransaction: "AQ==" },
+      { idempotencyKey: crypto.randomUUID() }
+    );
+    expect(res.status).toBe(200);
+
+    const rows = await auditRows("withdraw");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      resource_id: result.movement.id,
+      api_key_id: TEST_API_KEY.id,
+      user_id: null,
+    });
+  });
+
+  it("does not audit a replayed withdrawal submit: no new money moved", async () => {
+    await seedAuth();
+    submitExternalWalletWithdrawal.mockResolvedValue({
+      ...submitResult({ direction: "withdrawal", denomination: SHARE_MINT }),
+      replayed: true,
+    });
+
+    const res = await post(
+      "withdrawals",
+      { transactionId: "earn_ext_tx", signedTransaction: "AQ==" },
+      { idempotencyKey: crypto.randomUUID() }
+    );
+    expect(res.status).toBe(200);
+
+    await expect(auditRows("withdraw")).resolves.toHaveLength(0);
+  });
+});

--- a/apps/sdp-api/src/routes/earn.external-wallet.test.ts
+++ b/apps/sdp-api/src/routes/earn.external-wallet.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@/db/repositories";
 import { generateEarnPositionId } from "@/db/repositories/earn-movements.repository";
 import app from "@/index";
+import { badRequest } from "@/lib/errors";
 import { env } from "@/test/helpers/env";
 import { seedTestDatabase } from "@/test/mocks/db";
 import { clearKVStores, seedCachedApiKey } from "@/test/mocks/kv";
@@ -1145,9 +1146,33 @@ describe("external-wallet submits: audit ledger parity (PRO-1866)", () => {
     await expect(auditRows("withdraw")).resolves.toHaveLength(1);
   });
 
-  it("closes the deposit intent as a failure when the submit is refused", async () => {
+  it("closes the deposit intent as a failure when the submit is refused with a 4xx", async () => {
     await seedAuth();
-    submitExternalWalletDeposit.mockRejectedValue(new Error("signature verification failed"));
+    submitExternalWalletDeposit.mockRejectedValue(badRequest("signature verification failed"));
+
+    const res = await post(
+      "deposits",
+      { transactionId: "earn_ext_tx", signedTransaction: "AQ==" },
+      { idempotencyKey: crypto.randomUUID() }
+    );
+    expect(res.status).toBe(400);
+
+    // A 4xx refusal is always pre-broadcast on this path, so the intent
+    // closes as a failure outcome instead of paging verification.
+    const rows = await auditRows("deposit");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ status: "failure" });
+    expect(String(rows[0]?.metadata)).toContain("signature verification failed");
+  });
+
+  it("leaves the deposit intent unresolved on an ambiguous 5xx", async () => {
+    // The submit can throw after a successful send (the post-broadcast ledger
+    // transition failed to verify), so a non-4xx never records a failure
+    // outcome: the unresolved intent is what pages an operator to reconcile.
+    await seedAuth();
+    submitExternalWalletDeposit.mockRejectedValue(
+      new Error("Vault deposit was broadcast but its ledger transition could not be verified")
+    );
 
     const res = await post(
       "deposits",
@@ -1156,11 +1181,6 @@ describe("external-wallet submits: audit ledger parity (PRO-1866)", () => {
     );
     expect(res.status).toBe(500);
 
-    // A refusal is always pre-broadcast on this path, so the intent closes as
-    // a failure outcome instead of paging verification as unresolved.
-    const rows = await auditRows("deposit");
-    expect(rows).toHaveLength(1);
-    expect(rows[0]).toMatchObject({ status: "failure" });
-    expect(String(rows[0]?.metadata)).toContain("signature verification failed");
+    await expect(auditRows("deposit")).resolves.toHaveLength(0);
   });
 });

--- a/apps/sdp-api/src/routes/earn.external-wallet.test.ts
+++ b/apps/sdp-api/src/routes/earn.external-wallet.test.ts
@@ -1116,20 +1116,51 @@ describe("external-wallet submits: audit ledger parity (PRO-1866)", () => {
     });
   });
 
-  it("does not audit a replayed withdrawal submit: no new money moved", async () => {
+  it("backfills a missing audit on a replayed withdrawal submit, exactly once", async () => {
     await seedAuth();
-    submitExternalWalletWithdrawal.mockResolvedValue({
-      ...submitResult({ direction: "withdrawal", denomination: SHARE_MINT }),
-      replayed: true,
+    const result = submitResult({
+      direction: "withdrawal",
+      denomination: SHARE_MINT,
+      initiated_by_key_id: TEST_API_KEY.id,
     });
+    submitExternalWalletWithdrawal.mockResolvedValue({ ...result, replayed: true });
 
-    const res = await post(
+    const first = await post(
       "withdrawals",
       { transactionId: "earn_ext_tx", signedTransaction: "AQ==" },
       { idempotencyKey: crypto.randomUUID() }
     );
-    expect(res.status).toBe(200);
+    expect(first.status).toBe(200);
+    const rows = await auditRows("withdraw");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ resource_id: result.movement.id });
+    expect(String(rows[0]?.metadata)).toContain("backfilledOnReplay");
 
-    await expect(auditRows("withdraw")).resolves.toHaveLength(0);
+    const second = await post(
+      "withdrawals",
+      { transactionId: "earn_ext_tx", signedTransaction: "AQ==" },
+      { idempotencyKey: crypto.randomUUID() }
+    );
+    expect(second.status).toBe(200);
+    await expect(auditRows("withdraw")).resolves.toHaveLength(1);
+  });
+
+  it("closes the deposit intent as a failure when the submit is refused", async () => {
+    await seedAuth();
+    submitExternalWalletDeposit.mockRejectedValue(new Error("signature verification failed"));
+
+    const res = await post(
+      "deposits",
+      { transactionId: "earn_ext_tx", signedTransaction: "AQ==" },
+      { idempotencyKey: crypto.randomUUID() }
+    );
+    expect(res.status).toBe(500);
+
+    // A refusal is always pre-broadcast on this path, so the intent closes as
+    // a failure outcome instead of paging verification as unresolved.
+    const rows = await auditRows("deposit");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ status: "failure" });
+    expect(String(rows[0]?.metadata)).toContain("signature verification failed");
   });
 });

--- a/apps/sdp-api/src/routes/earn.vault-withdrawals.test.ts
+++ b/apps/sdp-api/src/routes/earn.vault-withdrawals.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@/db/repositories/earn-movements.repository";
 import app from "@/index";
 import { buildEarnVaultWithdrawalFingerprint } from "@/lib/idempotency";
+import { AuditService } from "@/services/audit.service";
 import { env } from "@/test/helpers/env";
 import { seedTestDatabase } from "@/test/mocks/db";
 import { clearKVStores, seedCachedApiKey } from "@/test/mocks/kv";
@@ -937,5 +938,72 @@ describe("POST /v1/earn/vault-withdrawal-previews", () => {
     // earn:read-only key from reading any org position's live payout while
     // GET /vault-positions answers the same key 403.
     expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /v1/earn/vault-withdrawals: audit ledger parity (PRO-1866)", () => {
+  function auditRows() {
+    return getDb(env)
+      .prepare(
+        "SELECT * FROM audit_logs WHERE action = 'withdraw' AND resource_type = 'earn_movement'"
+      )
+      .all<Record<string, unknown>>()
+      .then(({ results }) => results ?? []);
+  }
+
+  it("records the exit with the movement's own attribution", async () => {
+    await seedAuth();
+    const positionId = await seedPosition();
+    withdrawFromVault.mockImplementation(async (_env, input) => ({
+      position: { id: input.positionId },
+      movement: movementRow({
+        id: "earn_movement_audit_exit",
+        position_id: input.positionId,
+        request_id: input.requestId,
+        initiated_by_key_id: TEST_API_KEY.id,
+      }),
+      replayed: false,
+    }));
+
+    const res = await postVaultWithdrawal({ positionId, shares: "10" });
+    expect(res.status).toBe(200);
+
+    const rows = await auditRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      resource_id: "earn_movement_audit_exit",
+      organization_id: TEST_ORG.id,
+      api_key_id: TEST_API_KEY.id,
+      user_id: null,
+    });
+  });
+
+  it("never fails the exit when the audit ledger is unavailable (ADR 0002)", async () => {
+    // The audit write is post-effect and best-effort on money OUT: a
+    // fail-closed write here would let an audit-store outage trap funds, the
+    // same shape that keeps metered quotas off every exit route.
+    await seedAuth();
+    const positionId = await seedPosition();
+    vi.spyOn(AuditService.prototype, "log").mockRejectedValue(new Error("audit ledger locked"));
+
+    const res = await postVaultWithdrawal({ positionId, shares: "10" });
+
+    expect(res.status).toBe(200);
+    expect(withdrawFromVault).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not audit a replayed exit: no new money moved", async () => {
+    await seedAuth();
+    const positionId = await seedPosition();
+    withdrawFromVault.mockImplementation(async (_env, input) => ({
+      position: { id: input.positionId },
+      movement: movementRow({ position_id: input.positionId, request_id: input.requestId }),
+      replayed: true,
+    }));
+
+    const res = await postVaultWithdrawal({ positionId, shares: "10" });
+    expect(res.status).toBe(200);
+
+    await expect(auditRows()).resolves.toHaveLength(0);
   });
 });

--- a/apps/sdp-api/src/routes/earn.vault-withdrawals.test.ts
+++ b/apps/sdp-api/src/routes/earn.vault-withdrawals.test.ts
@@ -992,18 +992,35 @@ describe("POST /v1/earn/vault-withdrawals: audit ledger parity (PRO-1866)", () =
     expect(withdrawFromVault).toHaveBeenCalledTimes(1);
   });
 
-  it("does not audit a replayed exit: no new money moved", async () => {
+  it("backfills a missing audit on replay, exactly once", async () => {
+    // The crash-window repair: the movement exists (replay) but the original
+    // attempt died before its audit write. The retry writes the one missing
+    // row; a further retry finds it and writes nothing.
     await seedAuth();
     const positionId = await seedPosition();
     withdrawFromVault.mockImplementation(async (_env, input) => ({
       position: { id: input.positionId },
-      movement: movementRow({ position_id: input.positionId, request_id: input.requestId }),
+      movement: movementRow({
+        id: "earn_movement_audit_backfill",
+        position_id: input.positionId,
+        request_id: input.requestId,
+        initiated_by_key_id: TEST_API_KEY.id,
+      }),
       replayed: true,
     }));
 
-    const res = await postVaultWithdrawal({ positionId, shares: "10" });
-    expect(res.status).toBe(200);
+    const first = await postVaultWithdrawal({ positionId, shares: "10" });
+    expect(first.status).toBe(200);
+    const rows = await auditRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      resource_id: "earn_movement_audit_backfill",
+      api_key_id: TEST_API_KEY.id,
+    });
+    expect(String(rows[0]?.metadata)).toContain("backfilledOnReplay");
 
-    await expect(auditRows()).resolves.toHaveLength(0);
+    const second = await postVaultWithdrawal({ positionId, shares: "10" });
+    expect(second.status).toBe(200);
+    await expect(auditRows()).resolves.toHaveLength(1);
   });
 });

--- a/apps/sdp-api/src/routes/earn.vault-withdrawals.test.ts
+++ b/apps/sdp-api/src/routes/earn.vault-withdrawals.test.ts
@@ -992,6 +992,23 @@ describe("POST /v1/earn/vault-withdrawals: audit ledger parity (PRO-1866)", () =
     expect(withdrawFromVault).toHaveBeenCalledTimes(1);
   });
 
+  it("enforces one withdraw event per movement at the database (migration 0083)", async () => {
+    // The atomic form of the backfill's existence check: two writers that
+    // both pass the SELECT still cannot append twice.
+    await seedAuth();
+    const insert = () =>
+      getDb(env)
+        .prepare(
+          `INSERT INTO audit_logs (id, organization_id, action, resource_type, resource_id, status)
+           VALUES (?, ?, 'withdraw', 'earn_movement', 'earn_movement_uq_test', 'success')`
+        )
+        .bind(`aud_${crypto.randomUUID()}`, TEST_ORG.id)
+        .run();
+
+    await insert();
+    await expect(insert()).rejects.toThrow(/unique|duplicate/i);
+  });
+
   it("backfills a missing audit on replay, exactly once", async () => {
     // The crash-window repair: the movement exists (replay) but the original
     // attempt died before its audit write. The retry writes the one missing

--- a/apps/sdp-api/src/routes/earn.vault.test.ts
+++ b/apps/sdp-api/src/routes/earn.vault.test.ts
@@ -32,6 +32,7 @@ import {
 import { createPostgresEarnMovementsRepository } from "@/db/repositories/earn-movements.repository";
 import { createPostgresPolicyRepository } from "@/db/repositories/policy.repository.postgres";
 import app from "@/index";
+import { badRequest } from "@/lib/errors";
 import { buildEarnVaultDepositFingerprint } from "@/lib/idempotency";
 import { createTenantScope } from "@/lib/tenant-scope";
 import { AuditService } from "@/services/audit.service";
@@ -1182,7 +1183,7 @@ describe("POST /v1/earn/vault-deposits: audit ledger parity (PRO-1866)", () => {
     expect(depositIntoVault).not.toHaveBeenCalled();
   });
 
-  it("closes the intent as a failure when the service refuses the deposit", async () => {
+  it("closes the intent as a failure when the service refuses the deposit with a 4xx", async () => {
     await seedAuth();
     const strategy = await seedStrategy();
     await seedWallet({
@@ -1190,7 +1191,7 @@ describe("POST /v1/earn/vault-deposits: audit ledger parity (PRO-1866)", () => {
       custodyWalletId: "cwlt_earn_vault_audit_fail",
       providerWalletId: "privy_earn_vault_audit_fail",
     });
-    depositIntoVault.mockRejectedValue(new Error("simulation failed"));
+    depositIntoVault.mockRejectedValue(badRequest("simulation failed"));
 
     const res = await postVaultDeposit({
       strategyId: strategy.id,
@@ -1198,9 +1199,9 @@ describe("POST /v1/earn/vault-deposits: audit ledger parity (PRO-1866)", () => {
       amount: "10",
       requestId: crypto.randomUUID(),
     });
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(400);
 
-    // The service throws only pre-broadcast, so the intent closes as a
+    // A 4xx is a definitive pre-broadcast refusal, so the intent closes as a
     // failure outcome instead of paging verification as unresolved.
     const { results } = await getDb(env)
       .prepare(
@@ -1210,5 +1211,37 @@ describe("POST /v1/earn/vault-deposits: audit ledger parity (PRO-1866)", () => {
     expect(results).toHaveLength(1);
     expect(results?.[0]).toMatchObject({ status: "failure" });
     expect(String(results?.[0]?.metadata)).toContain("simulation failed");
+  });
+
+  it("leaves the intent unresolved on an ambiguous 5xx: the send may have landed", async () => {
+    // `broadcastRecordedVaultMovement` can throw AFTER a successful send (the
+    // post-broadcast ledger transition failed to verify), so a non-4xx must
+    // never be recorded as a failure outcome: unresolved is the signal that
+    // sends an operator to the movement ledger.
+    await seedAuth();
+    const strategy = await seedStrategy();
+    await seedWallet({
+      configId: "cfg_earn_vault_audit_ambig",
+      custodyWalletId: "cwlt_earn_vault_audit_ambig",
+      providerWalletId: "privy_earn_vault_audit_ambig",
+    });
+    depositIntoVault.mockRejectedValue(
+      new Error("Vault deposit was broadcast but its ledger transition could not be verified")
+    );
+
+    const res = await postVaultDeposit({
+      strategyId: strategy.id,
+      custodyWalletId: "cwlt_earn_vault_audit_ambig",
+      amount: "10",
+      requestId: crypto.randomUUID(),
+    });
+    expect(res.status).toBe(500);
+
+    const { results } = await getDb(env)
+      .prepare(
+        "SELECT * FROM audit_logs WHERE action = 'deposit' AND resource_type = 'earn_movement'"
+      )
+      .all<Record<string, unknown>>();
+    expect(results ?? []).toHaveLength(0);
   });
 });

--- a/apps/sdp-api/src/routes/earn.vault.test.ts
+++ b/apps/sdp-api/src/routes/earn.vault.test.ts
@@ -1181,4 +1181,34 @@ describe("POST /v1/earn/vault-deposits: audit ledger parity (PRO-1866)", () => {
     expect(res.status).toBe(500);
     expect(depositIntoVault).not.toHaveBeenCalled();
   });
+
+  it("closes the intent as a failure when the service refuses the deposit", async () => {
+    await seedAuth();
+    const strategy = await seedStrategy();
+    await seedWallet({
+      configId: "cfg_earn_vault_audit_fail",
+      custodyWalletId: "cwlt_earn_vault_audit_fail",
+      providerWalletId: "privy_earn_vault_audit_fail",
+    });
+    depositIntoVault.mockRejectedValue(new Error("simulation failed"));
+
+    const res = await postVaultDeposit({
+      strategyId: strategy.id,
+      custodyWalletId: "cwlt_earn_vault_audit_fail",
+      amount: "10",
+      requestId: crypto.randomUUID(),
+    });
+    expect(res.status).toBe(500);
+
+    // The service throws only pre-broadcast, so the intent closes as a
+    // failure outcome instead of paging verification as unresolved.
+    const { results } = await getDb(env)
+      .prepare(
+        "SELECT * FROM audit_logs WHERE action = 'deposit' AND resource_type = 'earn_movement'"
+      )
+      .all<Record<string, unknown>>();
+    expect(results).toHaveLength(1);
+    expect(results?.[0]).toMatchObject({ status: "failure" });
+    expect(String(results?.[0]?.metadata)).toContain("simulation failed");
+  });
 });

--- a/apps/sdp-api/src/routes/earn.vault.test.ts
+++ b/apps/sdp-api/src/routes/earn.vault.test.ts
@@ -34,6 +34,7 @@ import { createPostgresPolicyRepository } from "@/db/repositories/policy.reposit
 import app from "@/index";
 import { buildEarnVaultDepositFingerprint } from "@/lib/idempotency";
 import { createTenantScope } from "@/lib/tenant-scope";
+import { AuditService } from "@/services/audit.service";
 import { env } from "@/test/helpers/env";
 import { seedTestDatabase } from "@/test/mocks/db";
 import { clearKVStores, seedCachedApiKey } from "@/test/mocks/kv";
@@ -1116,5 +1117,68 @@ describe("POST /v1/earn/vault-deposit-previews", () => {
     const res = await postVaultDepositPreview({ strategyId: "earn_strategy_missing", amount: "1" });
 
     expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /v1/earn/vault-deposits: audit ledger parity (PRO-1866)", () => {
+  it("records intent and outcome around the deposit, keyed to the movement", async () => {
+    await seedAuth();
+    const strategy = await seedStrategy();
+    await seedWallet({
+      configId: "cfg_earn_vault_audit",
+      custodyWalletId: "cwlt_earn_vault_audit",
+      providerWalletId: "privy_earn_vault_audit",
+    });
+
+    const res = await postVaultDeposit({
+      strategyId: strategy.id,
+      custodyWalletId: "cwlt_earn_vault_audit",
+      amount: "10",
+      requestId: crypto.randomUUID(),
+    });
+    expect(res.status).toBe(200);
+
+    // The outcome row is the feed-visible event, keyed to the recorded
+    // movement and attributed to the caller's key: the identity the
+    // movement's initiatedByKeyId carries on the wire.
+    const { results } = await getDb(env)
+      .prepare(
+        "SELECT * FROM audit_logs WHERE action = 'deposit' AND resource_type = 'earn_movement'"
+      )
+      .all<Record<string, unknown>>();
+    expect(results).toHaveLength(1);
+    expect(results?.[0]).toMatchObject({
+      resource_id: "earn_vault_movement_test",
+      organization_id: TEST_ORG.id,
+      api_key_id: TEST_API_KEY.id,
+      user_id: null,
+    });
+
+    // The org audit feed can surface it (PRO-1866 "done when").
+    const feed = await new AuditService(getDb(env)).getForOrganization(TEST_ORG.id, {
+      action: "deposit",
+    });
+    expect(feed.some((entry) => entry.resourceId === "earn_vault_movement_test")).toBe(true);
+  });
+
+  it("refuses the deposit when the audit intent cannot persist: money-in fails closed", async () => {
+    await seedAuth();
+    const strategy = await seedStrategy();
+    await seedWallet({
+      configId: "cfg_earn_vault_audit_down",
+      custodyWalletId: "cwlt_earn_vault_audit_down",
+      providerWalletId: "privy_earn_vault_audit_down",
+    });
+    vi.spyOn(AuditService.prototype, "log").mockRejectedValue(new Error("audit ledger locked"));
+
+    const res = await postVaultDeposit({
+      strategyId: strategy.id,
+      custodyWalletId: "cwlt_earn_vault_audit_down",
+      amount: "10",
+      requestId: crypto.randomUUID(),
+    });
+
+    expect(res.status).toBe(500);
+    expect(depositIntoVault).not.toHaveBeenCalled();
   });
 });

--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -1016,13 +1016,20 @@ the two external-wallet submits, and the program withdrawal.
 
 The failure posture follows the metered-quota asymmetry above, on purpose.
 DEPOSITS are admitted through a fail-closed `beginCritical` intent before the
-money effect: an audit outage refuses money IN, and a replay still logs a
-pair whose outcome says `replayed`. WITHDRAWALS log best-effort AFTER the
-effect and never on a replay: the audit persist path fail-closes on its
-external checkpoint store, and a store outage must not 5xx an exit (ADR 0002).
+money effect: an audit outage refuses money IN, a replay still logs a pair
+whose outcome says `replayed`, and a service refusal (always pre-broadcast on
+both deposit paths) closes the intent with a failure outcome so verification
+never pages over money that never moved. Only the approved-operation fence
+leaves an intent unresolved, deliberately: that state needs reconciliation.
+WITHDRAWALS log best-effort AFTER the effect: the audit persist path
+fail-closes on its external checkpoint store, and a store outage must not 5xx
+an exit (ADR 0002). A replayed exit backfills a missing audit row
+(`backfilledOnReplay`) and never duplicates an existing one, so a crash
+between the money effect and the audit write is repaired on the next retry.
 A failed exit audit logs `earn_audit_write_failed` and the movement row stays
 the authoritative money record. Each seam's suite pins its half: parity rows
-in all four route files, fail-closed in `../earn.vault.test.ts`, fail-open in
+in all four route files, fail-closed + failure outcomes in
+`../earn.vault.test.ts`, fail-open + replay backfill in
 `../earn.vault-withdrawals.test.ts`.
 
 ## Gate asymmetry — DO NOT BREAK (ADR 0002 exit-safety)

--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -1005,6 +1005,26 @@ no such rule, which is why the deposit quote is metered and the exit quote is
 not. Pinned by the "metered quotas" describe in `../earn-program.test.ts`,
 whose second test exhausts both counters and asserts the payout still lands.
 
+## Audit-ledger parity (PRO-1866)
+
+Every earn money write also lands a hash-chained `audit_logs` event: action
+`deposit`/`withdraw`, resourceType `earn_movement`, resourceId the movement id,
+actor identical to the movement's `created_by`/`initiated_by_key_id` (passed
+explicitly, so the two records cannot disagree). Helpers live in
+`handlers/movement-audit.ts`; the five seams are the two custody vault routes,
+the two external-wallet submits, and the program withdrawal.
+
+The failure posture follows the metered-quota asymmetry above, on purpose.
+DEPOSITS are admitted through a fail-closed `beginCritical` intent before the
+money effect: an audit outage refuses money IN, and a replay still logs a
+pair whose outcome says `replayed`. WITHDRAWALS log best-effort AFTER the
+effect and never on a replay: the audit persist path fail-closes on its
+external checkpoint store, and a store outage must not 5xx an exit (ADR 0002).
+A failed exit audit logs `earn_audit_write_failed` and the movement row stays
+the authoritative money record. Each seam's suite pins its half: parity rows
+in all four route files, fail-closed in `../earn.vault.test.ts`, fail-open in
+`../earn.vault-withdrawals.test.ts`.
+
 ## Gate asymmetry — DO NOT BREAK (ADR 0002 exit-safety)
 
 - **Money-in** (`POST /programs`, `PUT /programs/:programId`):

--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -1016,21 +1016,25 @@ the two external-wallet submits, and the program withdrawal.
 
 The failure posture follows the metered-quota asymmetry above, on purpose.
 DEPOSITS are admitted through a fail-closed `beginCritical` intent before the
-money effect: an audit outage refuses money IN, a replay still logs a pair
-whose outcome says `replayed`, and a service refusal (always pre-broadcast on
-both deposit paths) closes the intent with a failure outcome so verification
-never pages over money that never moved. Only the approved-operation fence
-leaves an intent unresolved, deliberately: that state needs reconciliation.
+money effect: an audit outage refuses money IN, and a replay still logs a
+pair whose outcome says `replayed`. A thrown deposit concludes by ERROR
+CLASS: a 4xx `AppError` is a definitive pre-broadcast refusal and closes the
+intent with a failure outcome, while anything else stays UNRESOLVED: the
+services can 5xx after a successful send (`broadcastRecordedVaultMovement`'s
+post-broadcast ledger transition), where a failure outcome would be a false
+audit record, and unresolved is what pages an operator to reconcile. The
+approved-operation fence leaves its intent unresolved for the same reason.
 WITHDRAWALS log best-effort AFTER the effect: the audit persist path
 fail-closes on its external checkpoint store, and a store outage must not 5xx
 an exit (ADR 0002). A replayed exit backfills a missing audit row
-(`backfilledOnReplay`) and never duplicates an existing one, so a crash
-between the money effect and the audit write is repaired on the next retry.
-A failed exit audit logs `earn_audit_write_failed` and the movement row stays
-the authoritative money record. Each seam's suite pins its half: parity rows
-in all four route files, fail-closed + failure outcomes in
-`../earn.vault.test.ts`, fail-open + replay backfill in
-`../earn.vault-withdrawals.test.ts`.
+(`backfilledOnReplay`) and never duplicates an existing one; migration 0083's
+partial unique index makes the insert itself the atomic existence check, so
+concurrent replays cannot append twice and the losing writer's unique
+violation reads as "already audited". A failed exit audit logs
+`earn_audit_write_failed` and the movement row stays the authoritative money
+record. Each seam's suite pins its half: parity rows in all four route files,
+fail-closed + 4xx-vs-ambiguous outcomes in `../earn.vault.test.ts`, fail-open
++ replay backfill in `../earn.vault-withdrawals.test.ts`.
 
 ## Gate asymmetry — DO NOT BREAK (ADR 0002 exit-safety)
 

--- a/apps/sdp-api/src/routes/earn/handlers/external-wallet.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/external-wallet.ts
@@ -76,7 +76,7 @@ import { assertStrategyDepositable } from "./admission";
 import {
   beginEarnDepositAudit,
   completeEarnDepositAudit,
-  failEarnDepositAudit,
+  concludeEarnDepositAuditOnError,
   recordEarnWithdrawalAudit,
 } from "./movement-audit";
 import { decodeMovementCursor } from "./movements";
@@ -856,10 +856,11 @@ export async function createEarnExternalWalletDeposit(
       apiKeyId: auth.apiKeyId ?? null,
     });
   } catch (error) {
-    // The submit throws only before any broadcast (verification, build
-    // consumption, recording; a send error returns normally), so this is a
-    // definitive refusal: close the intent instead of paging verification.
-    await failEarnDepositAudit(c, auditIntent, error);
+    // A 4xx is a definitive pre-broadcast refusal (verification, build
+    // consumption, recording): close the intent instead of paging
+    // verification over it. Anything else stays UNRESOLVED (the submit can
+    // 5xx after a successful send; see movement-audit.ts).
+    await concludeEarnDepositAuditOnError(c, auditIntent, error);
     throw error;
   }
 

--- a/apps/sdp-api/src/routes/earn/handlers/external-wallet.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/external-wallet.ts
@@ -73,6 +73,11 @@ import {
   type earnVaultWithdrawalPreviewSchema,
 } from "../schemas";
 import { assertStrategyDepositable } from "./admission";
+import {
+  beginEarnDepositAudit,
+  completeEarnDepositAudit,
+  recordEarnWithdrawalAudit,
+} from "./movement-audit";
 import { decodeMovementCursor } from "./movements";
 import { parseParams, parseQuery, resolveDepositSwapRequest } from "./shared";
 import {
@@ -821,6 +826,22 @@ export async function createEarnExternalWalletDeposit(
   const auth = getAuth(c);
   const projectId = requireProjectId(c);
 
+  // Fail-closed audit admission (PRO-1866): no durable intent, no broadcast.
+  const auditIntent = await beginEarnDepositAudit(
+    c,
+    {
+      organizationId: auth.organizationId,
+      userId: auth.userId ?? null,
+      apiKeyId: auth.apiKeyId ?? null,
+    },
+    {
+      executionModel: "vault_direct",
+      signer: "external_wallet",
+      transactionId: body.transactionId,
+      requestId,
+    }
+  );
+
   const result = await submitExternalWalletDeposit(c.env, {
     organizationId: auth.organizationId,
     projectId,
@@ -830,6 +851,18 @@ export async function createEarnExternalWalletDeposit(
     requestId,
     userId: auth.userId ?? null,
     apiKeyId: auth.apiKeyId ?? null,
+  });
+
+  await completeEarnDepositAudit(c, auditIntent, {
+    resourceId: result.movement.id,
+    metadata: {
+      movementId: result.movement.id,
+      ownerAddress: result.movement.owner_address,
+      amount: result.movement.amount_requested,
+      denomination: result.movement.denomination,
+      signature: result.movement.signature,
+      replayed: result.replayed,
+    },
   });
 
   const response: EarnExternalWalletDepositResponse = {
@@ -858,6 +891,30 @@ export async function createEarnExternalWalletWithdrawal(
     userId: auth.userId ?? null,
     apiKeyId: auth.apiKeyId ?? null,
   });
+
+  // Best-effort, post-effect, never on a replay (PRO-1866): a fail-closed
+  // audit write would be a new way for the exit submit to 5xx (ADR 0002).
+  if (!result.replayed) {
+    await recordEarnWithdrawalAudit(
+      c,
+      {
+        organizationId: auth.organizationId,
+        userId: result.movement.created_by,
+        apiKeyId: result.movement.initiated_by_key_id,
+      },
+      result.movement.id,
+      {
+        executionModel: "vault_direct",
+        signer: "external_wallet",
+        transactionId: body.transactionId,
+        ownerAddress: result.movement.owner_address,
+        amount: result.movement.amount_requested,
+        denomination: result.movement.denomination,
+        signature: result.movement.signature,
+        requestId,
+      }
+    );
+  }
 
   const response: EarnExternalWalletWithdrawalResponse = {
     withdrawal: toExternalWalletMovementWire(result.movement, result.replayed),

--- a/apps/sdp-api/src/routes/earn/handlers/external-wallet.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/external-wallet.ts
@@ -76,6 +76,7 @@ import { assertStrategyDepositable } from "./admission";
 import {
   beginEarnDepositAudit,
   completeEarnDepositAudit,
+  failEarnDepositAudit,
   recordEarnWithdrawalAudit,
 } from "./movement-audit";
 import { decodeMovementCursor } from "./movements";
@@ -842,16 +843,25 @@ export async function createEarnExternalWalletDeposit(
     }
   );
 
-  const result = await submitExternalWalletDeposit(c.env, {
-    organizationId: auth.organizationId,
-    projectId,
-    environment,
-    transactionId: body.transactionId,
-    signedTransaction: body.signedTransaction,
-    requestId,
-    userId: auth.userId ?? null,
-    apiKeyId: auth.apiKeyId ?? null,
-  });
+  let result: Awaited<ReturnType<typeof submitExternalWalletDeposit>>;
+  try {
+    result = await submitExternalWalletDeposit(c.env, {
+      organizationId: auth.organizationId,
+      projectId,
+      environment,
+      transactionId: body.transactionId,
+      signedTransaction: body.signedTransaction,
+      requestId,
+      userId: auth.userId ?? null,
+      apiKeyId: auth.apiKeyId ?? null,
+    });
+  } catch (error) {
+    // The submit throws only before any broadcast (verification, build
+    // consumption, recording; a send error returns normally), so this is a
+    // definitive refusal: close the intent instead of paging verification.
+    await failEarnDepositAudit(c, auditIntent, error);
+    throw error;
+  }
 
   await completeEarnDepositAudit(c, auditIntent, {
     resourceId: result.movement.id,
@@ -892,29 +902,29 @@ export async function createEarnExternalWalletWithdrawal(
     apiKeyId: auth.apiKeyId ?? null,
   });
 
-  // Best-effort, post-effect, never on a replay (PRO-1866): a fail-closed
-  // audit write would be a new way for the exit submit to 5xx (ADR 0002).
-  if (!result.replayed) {
-    await recordEarnWithdrawalAudit(
-      c,
-      {
-        organizationId: auth.organizationId,
-        userId: result.movement.created_by,
-        apiKeyId: result.movement.initiated_by_key_id,
-      },
-      result.movement.id,
-      {
-        executionModel: "vault_direct",
-        signer: "external_wallet",
-        transactionId: body.transactionId,
-        ownerAddress: result.movement.owner_address,
-        amount: result.movement.amount_requested,
-        denomination: result.movement.denomination,
-        signature: result.movement.signature,
-        requestId,
-      }
-    );
-  }
+  // Best-effort and post-effect (PRO-1866): a fail-closed audit write would
+  // be a new way for the exit submit to 5xx (ADR 0002). A replay only
+  // backfills an audit row the crashed original never wrote.
+  await recordEarnWithdrawalAudit(
+    c,
+    {
+      organizationId: auth.organizationId,
+      userId: result.movement.created_by,
+      apiKeyId: result.movement.initiated_by_key_id,
+    },
+    result.movement.id,
+    {
+      executionModel: "vault_direct",
+      signer: "external_wallet",
+      transactionId: body.transactionId,
+      ownerAddress: result.movement.owner_address,
+      amount: result.movement.amount_requested,
+      denomination: result.movement.denomination,
+      signature: result.movement.signature,
+      requestId,
+    },
+    { replayed: result.replayed }
+  );
 
   const response: EarnExternalWalletWithdrawalResponse = {
     withdrawal: toExternalWalletMovementWire(result.movement, result.replayed),

--- a/apps/sdp-api/src/routes/earn/handlers/movement-audit.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/movement-audit.ts
@@ -1,4 +1,6 @@
 import { getDb } from "@/db";
+import { isPostgresUniqueViolation } from "@/db/postgres-utils";
+import { AppError } from "@/lib/errors";
 import { getLogger } from "@/runtime/logger";
 import { type AuditIntent, type AuditLogEntry, AuditService } from "@/services/audit.service";
 import type { AppContext } from "../context";
@@ -19,12 +21,13 @@ import type { AppContext } from "../context";
  *   new money IN, which costs the caller a retry and nothing else. Replays
  *   still produce an intent/outcome pair (the handler cannot tell a replay
  *   from a first send before the service runs); the outcome says `replayed`.
- *   A deposit the service REFUSES closes its intent with a failure outcome:
- *   both deposit services throw only before any broadcast (a send error
- *   returns normally, record-before-broadcast), so an unresolved intent
- *   would page verification over money that never moved. Only the
- *   approved-operation fence leaves an intent unresolved, and that state is
- *   genuinely ambiguous and needs reconciliation.
+ *   A deposit the service REFUSES with a 4xx closes its intent with a
+ *   failure outcome: both services 4xx only before any broadcast, so an
+ *   unresolved intent would page verification over money that never moved.
+ *   Every other throw leaves the intent UNRESOLVED on purpose: the services
+ *   can throw a 5xx after a successful send (a post-broadcast ledger
+ *   transition that could not be verified), and "unresolved" is exactly the
+ *   signal that sends an operator to reconcile against the movement ledger.
  * - WITHDRAWALS log best-effort AFTER the money effect. The audit persist
  *   path fail-closes on its external checkpoint store, and a store outage
  *   that 5xxes a customer's way OUT of a position is exactly what ADR 0002
@@ -35,7 +38,10 @@ import type { AppContext } from "../context";
  *   crash between the money effect and the audit write is repaired on the
  *   retry: a replayed movement with no audit row gets one, marked
  *   `backfilledOnReplay`, so the ledger cannot stay permanently silent about
- *   a movement that exists.
+ *   a movement that exists. One-event-per-movement is enforced by the
+ *   database (migration 0083's partial unique index), so concurrent replays
+ *   racing past the existence check cannot append twice: the losing insert's
+ *   unique violation is treated as "already audited".
  */
 
 export interface EarnMovementAuditActor {
@@ -92,20 +98,29 @@ export async function completeEarnDepositAudit(
 }
 
 /**
- * Close a deposit intent whose service call THREW. Both deposit services
- * throw only before any broadcast, so this is a definitive no-money-moved
- * refusal: recorded as a failure outcome rather than left unresolved, which
- * would page audit-ledger verification over nothing. Never throws.
+ * Conclude a deposit intent whose service call THREW.
+ *
+ * A definitive caller refusal (an `AppError` with a 4xx status) is recorded
+ * as a failure outcome: both deposit services 4xx only before any broadcast,
+ * so verification must not page over money that never moved. Anything else
+ * leaves the intent UNRESOLVED on purpose: `broadcastRecordedVaultMovement`
+ * can throw a 5xx AFTER a successful send (the post-broadcast ledger
+ * transition failed to verify), where a "failure" outcome would be a
+ * materially false audit record. Unresolved is the designed signal for that
+ * ambiguity: verification pages it, and the movement ledger answers what
+ * actually happened. Never throws.
  */
-export async function failEarnDepositAudit(
+export async function concludeEarnDepositAuditOnError(
   c: AppContext,
   intent: AuditIntent,
   error: unknown
 ): Promise<void> {
+  if (!(error instanceof AppError) || error.statusCode >= 500) return;
   await new AuditService(getDb(c.env)).completeCritical(c, intent, {
     status: "failure",
     metadata: {
-      failureReason: (error instanceof Error ? error.message : String(error)).slice(0, 300),
+      failureReason: error.message.slice(0, 300),
+      failureCode: error.code,
     },
   });
 }
@@ -144,6 +159,10 @@ export async function recordEarnWithdrawalAudit(
       earnMovementEntry("withdraw", actor, entryMetadata, resourceId)
     );
   } catch (error) {
+    // Migration 0083's partial unique index is the atomic form of the
+    // existence check above: a concurrent writer already audited this
+    // movement, which is the outcome we wanted, not a failure.
+    if (isUniqueViolationDeep(error)) return;
     getLogger().error(
       {
         event: "earn_audit_write_failed",
@@ -154,4 +173,14 @@ export async function recordEarnWithdrawalAudit(
       "Earn withdrawal audit record was not persisted; the movement ledger row remains authoritative"
     );
   }
+}
+
+/** The pg error sits behind AuditPersistenceError (and possibly a tx wrapper). */
+function isUniqueViolationDeep(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current; depth += 1) {
+    if (isPostgresUniqueViolation(current)) return true;
+    current = current instanceof Error ? current.cause : undefined;
+  }
+  return false;
 }

--- a/apps/sdp-api/src/routes/earn/handlers/movement-audit.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/movement-audit.ts
@@ -19,13 +19,23 @@ import type { AppContext } from "../context";
  *   new money IN, which costs the caller a retry and nothing else. Replays
  *   still produce an intent/outcome pair (the handler cannot tell a replay
  *   from a first send before the service runs); the outcome says `replayed`.
- * - WITHDRAWALS log best-effort AFTER the money effect, and replays log
- *   nothing (no new money moved; the original attempt logged). The audit
- *   persist path fail-closes on its external checkpoint store, and a store
- *   outage that 5xxes a customer's way OUT of a position is exactly what
- *   ADR 0002 exit safety rules out. The movement ledger row (durable before
- *   the effect) remains the authoritative money record; a failed audit
- *   write is loud (`earn_audit_write_failed`) instead of load-bearing.
+ *   A deposit the service REFUSES closes its intent with a failure outcome:
+ *   both deposit services throw only before any broadcast (a send error
+ *   returns normally, record-before-broadcast), so an unresolved intent
+ *   would page verification over money that never moved. Only the
+ *   approved-operation fence leaves an intent unresolved, and that state is
+ *   genuinely ambiguous and needs reconciliation.
+ * - WITHDRAWALS log best-effort AFTER the money effect. The audit persist
+ *   path fail-closes on its external checkpoint store, and a store outage
+ *   that 5xxes a customer's way OUT of a position is exactly what ADR 0002
+ *   exit safety rules out. The movement ledger row (durable before the
+ *   effect) remains the authoritative money record; a failed audit write is
+ *   loud (`earn_audit_write_failed`) instead of load-bearing. A REPLAY
+ *   normally re-serves an already-audited movement and writes nothing, but a
+ *   crash between the money effect and the audit write is repaired on the
+ *   retry: a replayed movement with no audit row gets one, marked
+ *   `backfilledOnReplay`, so the ledger cannot stay permanently silent about
+ *   a movement that exists.
  */
 
 export interface EarnMovementAuditActor {
@@ -81,17 +91,57 @@ export async function completeEarnDepositAudit(
   await new AuditService(getDb(c.env)).completeCritical(c, intent, outcome);
 }
 
-/** Best-effort post-effect record for money OUT; never throws (see header). */
+/**
+ * Close a deposit intent whose service call THREW. Both deposit services
+ * throw only before any broadcast, so this is a definitive no-money-moved
+ * refusal: recorded as a failure outcome rather than left unresolved, which
+ * would page audit-ledger verification over nothing. Never throws.
+ */
+export async function failEarnDepositAudit(
+  c: AppContext,
+  intent: AuditIntent,
+  error: unknown
+): Promise<void> {
+  await new AuditService(getDb(c.env)).completeCritical(c, intent, {
+    status: "failure",
+    metadata: {
+      failureReason: (error instanceof Error ? error.message : String(error)).slice(0, 300),
+    },
+  });
+}
+
+/**
+ * Best-effort post-effect record for money OUT; never throws (see header).
+ *
+ * `replayed: true` switches to repair mode: write only when the movement has
+ * no audit row yet (the original attempt crashed between the money effect
+ * and its audit write), marked `backfilledOnReplay`.
+ */
 export async function recordEarnWithdrawalAudit(
   c: AppContext,
   actor: EarnMovementAuditActor,
   resourceId: string,
-  metadata: Record<string, unknown>
+  metadata: Record<string, unknown>,
+  options: { replayed?: boolean } = {}
 ): Promise<void> {
   try {
+    let entryMetadata = metadata;
+    if (options.replayed) {
+      const existing = await getDb(c.env)
+        .prepare(
+          `SELECT 1 AS present FROM audit_logs
+            WHERE organization_id = ? AND action = 'withdraw'
+              AND resource_type = 'earn_movement' AND resource_id = ?
+            LIMIT 1`
+        )
+        .bind(actor.organizationId, resourceId)
+        .first<{ present: number }>();
+      if (existing) return;
+      entryMetadata = { ...metadata, backfilledOnReplay: true };
+    }
     await new AuditService(getDb(c.env)).log(
       c,
-      earnMovementEntry("withdraw", actor, metadata, resourceId)
+      earnMovementEntry("withdraw", actor, entryMetadata, resourceId)
     );
   } catch (error) {
     getLogger().error(

--- a/apps/sdp-api/src/routes/earn/handlers/movement-audit.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/movement-audit.ts
@@ -1,0 +1,107 @@
+import { getDb } from "@/db";
+import { getLogger } from "@/runtime/logger";
+import { type AuditIntent, type AuditLogEntry, AuditService } from "@/services/audit.service";
+import type { AppContext } from "../context";
+
+/**
+ * Audit-ledger parity for earn money movements (PRO-1866).
+ *
+ * Every earn money write lands one hash-chained audit event whose actor is
+ * the movement row's own attribution (`created_by`/`initiated_by_key_id`),
+ * passed explicitly so the two records cannot disagree: the audit feed and
+ * the wire-level movement must name the same key or user.
+ *
+ * The two directions deliberately take different failure postures, the same
+ * asymmetry the metered quotas follow (routes/earn/CLAUDE.md):
+ *
+ * - DEPOSITS are admitted through a fail-closed `beginCritical` intent before
+ *   the money side effect, mirroring issuance mint: an audit outage refuses
+ *   new money IN, which costs the caller a retry and nothing else. Replays
+ *   still produce an intent/outcome pair (the handler cannot tell a replay
+ *   from a first send before the service runs); the outcome says `replayed`.
+ * - WITHDRAWALS log best-effort AFTER the money effect, and replays log
+ *   nothing (no new money moved; the original attempt logged). The audit
+ *   persist path fail-closes on its external checkpoint store, and a store
+ *   outage that 5xxes a customer's way OUT of a position is exactly what
+ *   ADR 0002 exit safety rules out. The movement ledger row (durable before
+ *   the effect) remains the authoritative money record; a failed audit
+ *   write is loud (`earn_audit_write_failed`) instead of load-bearing.
+ */
+
+export interface EarnMovementAuditActor {
+  organizationId: string;
+  userId: string | null;
+  apiKeyId: string | null;
+}
+
+function earnMovementEntry(
+  action: "deposit" | "withdraw",
+  actor: EarnMovementAuditActor,
+  metadata: Record<string, unknown>,
+  resourceId?: string
+): AuditLogEntry {
+  return {
+    organizationId: actor.organizationId,
+    // `log()` falls back to the request context for absent actor fields; the
+    // movement's own values are passed so a mismatch is unrepresentable.
+    userId: actor.userId ?? undefined,
+    apiKeyId: actor.apiKeyId ?? undefined,
+    action,
+    resourceType: "earn_movement",
+    ...(resourceId === undefined ? {} : { resourceId }),
+    metadata,
+  };
+}
+
+/**
+ * Fail-closed deposit admission. A throw here means the intent was not
+ * persisted and the caller must not run the deposit.
+ */
+export async function beginEarnDepositAudit(
+  c: AppContext,
+  actor: EarnMovementAuditActor,
+  metadata: Record<string, unknown>
+): Promise<AuditIntent> {
+  return new AuditService(getDb(c.env)).beginCritical(
+    c,
+    earnMovementEntry("deposit", actor, metadata)
+  );
+}
+
+/**
+ * Outcome for an admitted deposit. Never throws: the money already moved, and
+ * `completeCritical` leaves the durable unresolved intent for reconciliation
+ * when the outcome write fails.
+ */
+export async function completeEarnDepositAudit(
+  c: AppContext,
+  intent: AuditIntent,
+  outcome: { resourceId: string; metadata: Record<string, unknown> }
+): Promise<void> {
+  await new AuditService(getDb(c.env)).completeCritical(c, intent, outcome);
+}
+
+/** Best-effort post-effect record for money OUT; never throws (see header). */
+export async function recordEarnWithdrawalAudit(
+  c: AppContext,
+  actor: EarnMovementAuditActor,
+  resourceId: string,
+  metadata: Record<string, unknown>
+): Promise<void> {
+  try {
+    await new AuditService(getDb(c.env)).log(
+      c,
+      earnMovementEntry("withdraw", actor, metadata, resourceId)
+    );
+  } catch (error) {
+    getLogger().error(
+      {
+        event: "earn_audit_write_failed",
+        movementId: resourceId,
+        organizationId: actor.organizationId,
+        error,
+      },
+      "Earn withdrawal audit record was not persisted; the movement ledger row remains authoritative"
+    );
+  }
+}

--- a/apps/sdp-api/src/routes/earn/handlers/program.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/program.ts
@@ -63,6 +63,7 @@ import {
   type earnProgramWithdrawalPreviewSchema,
   earnProgramWithdrawalsListQuerySchema,
 } from "../schemas";
+import { recordEarnWithdrawalAudit } from "./movement-audit";
 import { throwOnPriorEarnPolicyOperation } from "./policy-replay";
 import { listResponse, pageWindow, parseParams, parseQuery } from "./shared";
 
@@ -1011,6 +1012,30 @@ export const createEarnProgramWithdrawal = async (
   });
 
   await persistWithdrawalObservation(ledger, intentRow, withdrawal);
+
+  // Best-effort, post-effect, and only on the fresh-payout path: the replay
+  // returns above moved no new money (PRO-1866). A fail-closed audit write
+  // would be a new way for the payout to 5xx (ADR 0002 exit safety). Actor
+  // comes from the intent row, which survives the crash-window replay whose
+  // original request carried the attribution.
+  await recordEarnWithdrawalAudit(
+    c,
+    {
+      organizationId: auth.organizationId,
+      userId: intentRow.created_by,
+      apiKeyId: intentRow.initiated_by_key_id,
+    },
+    intentRow.id,
+    {
+      executionModel: "custodial",
+      programId: row.id,
+      provider: client.provider,
+      amountUsd: body.amountUsd,
+      token: body.token,
+      destinationAddress: body.destinationAddress,
+      requestId,
+    }
+  );
 
   const response: EarnProgramWithdrawalResponse = { withdrawal };
   return success(c, response, 201);

--- a/apps/sdp-api/src/routes/earn/handlers/program.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/program.ts
@@ -910,6 +910,28 @@ async function serveEarnProgramWithdrawalReplay(
     withdrawalRef: providerReference,
   });
   await persistWithdrawalObservation(ledger, intent, withdrawal);
+  // Repair-only audit (PRO-1866): a crash between the original payout and its
+  // audit write must not leave the movement permanently unaudited; an
+  // already-audited movement writes nothing.
+  await recordEarnWithdrawalAudit(
+    c,
+    {
+      organizationId: resolved.auth.organizationId,
+      userId: intent.created_by,
+      apiKeyId: intent.initiated_by_key_id,
+    },
+    intent.id,
+    {
+      executionModel: "custodial",
+      programId: resolved.row.id,
+      provider: resolved.client.provider,
+      amountUsd: intent.amount_requested,
+      token: intent.payout_token,
+      destinationAddress: intent.destination_address,
+      requestId: resolved.requestId,
+    },
+    { replayed: true }
+  );
   const response: EarnProgramWithdrawalResponse = { withdrawal };
   return success(c, response, 200);
 }

--- a/apps/sdp-api/src/routes/earn/handlers/vault.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/vault.ts
@@ -90,7 +90,7 @@ import { assertStrategyDepositable, assertVaultDepositAdmissible } from "./admis
 import {
   beginEarnDepositAudit,
   completeEarnDepositAudit,
-  failEarnDepositAudit,
+  concludeEarnDepositAuditOnError,
   recordEarnWithdrawalAudit,
 } from "./movement-audit";
 import { throwOnPriorEarnPolicyOperation } from "./policy-replay";
@@ -257,10 +257,10 @@ export async function createEarnVaultDeposit(
       }
     );
   } catch (error) {
-    // The service throws only before any broadcast (a send error returns
-    // normally, record-before-broadcast), so this is a definitive refusal:
-    // close the intent instead of paging verification over it.
-    await failEarnDepositAudit(c, auditIntent, error);
+    // A 4xx is a definitive pre-broadcast refusal: close the intent instead
+    // of paging verification over it. Anything else stays UNRESOLVED (the
+    // service can 5xx after a successful send; see movement-audit.ts).
+    await concludeEarnDepositAuditOnError(c, auditIntent, error);
     throw error;
   }
 

--- a/apps/sdp-api/src/routes/earn/handlers/vault.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/vault.ts
@@ -87,6 +87,11 @@ import {
   earnVaultWithdrawalsQuerySchema,
 } from "../schemas";
 import { assertStrategyDepositable, assertVaultDepositAdmissible } from "./admission";
+import {
+  beginEarnDepositAudit,
+  completeEarnDepositAudit,
+  recordEarnWithdrawalAudit,
+} from "./movement-audit";
 import { throwOnPriorEarnPolicyOperation } from "./policy-replay";
 import { parseParams, parseQuery, resolveDepositSwapRequest } from "./shared";
 import { decodeVaultPositionCursor, encodeVaultPositionCursor } from "./vault-position-cursor";
@@ -204,6 +209,26 @@ export async function createEarnVaultDeposit(
     throw internalError("Vault deposit execution reached the handler without an idempotency key");
   }
 
+  // Fail-closed audit admission (PRO-1866): no durable intent, no deposit.
+  const auditIntent = await beginEarnDepositAudit(
+    c,
+    {
+      organizationId: auth.organizationId,
+      userId: auth.userId ?? null,
+      apiKeyId: auth.apiKeyId ?? null,
+    },
+    {
+      executionModel: "vault_direct",
+      signer: "custody",
+      provider,
+      strategyId: strategy.id,
+      custodyWalletId: wallet.id,
+      tokenMint,
+      amount: parsedData.amount,
+      requestId,
+    }
+  );
+
   const result = await depositIntoVault(
     c.env,
     {
@@ -239,6 +264,18 @@ export async function createEarnVaultDeposit(
       );
     }
   }
+
+  // A thrown path above leaves the intent unresolved on purpose: verification
+  // pages that as an operation needing reconciliation.
+  await completeEarnDepositAudit(c, auditIntent, {
+    resourceId: result.movement.id,
+    metadata: {
+      movementId: result.movement.id,
+      signature: result.movement.signature,
+      status: result.movement.status,
+      replayed: result.replayed,
+    },
+  });
 
   return success(c, buildEarnVaultDepositResponse(result, strategy));
 }
@@ -1386,6 +1423,31 @@ export async function createEarnVaultWithdrawal(
         "Approved vault withdrawal execution is incomplete and requires manual reconciliation"
       );
     }
+  }
+
+  // Best-effort, post-effect, and never on a replay (PRO-1866): a fail-closed
+  // audit write here would be a new way for an exit to 5xx, the exact shape
+  // ADR 0002 exit safety rules out. Actor comes from the movement row itself.
+  if (!result.replayed) {
+    await recordEarnWithdrawalAudit(
+      c,
+      {
+        organizationId: auth.organizationId,
+        userId: result.movement.created_by,
+        apiKeyId: result.movement.initiated_by_key_id,
+      },
+      result.movement.id,
+      {
+        executionModel: "vault_direct",
+        signer: "custody",
+        provider: position.provider,
+        positionId: position.id,
+        shares: parsedData.shares,
+        minAmountOut: parsedData.minAmountOut ?? null,
+        signature: result.movement.signature,
+        requestId,
+      }
+    );
   }
 
   return success(

--- a/apps/sdp-api/src/routes/earn/handlers/vault.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/vault.ts
@@ -90,6 +90,7 @@ import { assertStrategyDepositable, assertVaultDepositAdmissible } from "./admis
 import {
   beginEarnDepositAudit,
   completeEarnDepositAudit,
+  failEarnDepositAudit,
   recordEarnWithdrawalAudit,
 } from "./movement-audit";
 import { throwOnPriorEarnPolicyOperation } from "./policy-replay";
@@ -229,29 +230,39 @@ export async function createEarnVaultDeposit(
     }
   );
 
-  const result = await depositIntoVault(
-    c.env,
-    {
-      organizationId: auth.organizationId,
-      projectId,
-      environment,
-      provider,
-      providerReference: strategy.provider_reference,
-      wallet,
-      tokenMint,
-      shareMint,
-      label: strategy.name,
-      amount: parsedData.amount,
-      requestId,
-      minSharesOut: parsedData.minSharesOut,
-      ...(resolved.swap === null ? {} : { swap: resolved.swap }),
-      userId: auth.userId ?? null,
-      apiKeyId: auth.apiKeyId ?? null,
-    },
-    {
-      runIntentTransaction: (mutation) => runApprovedWalletOperationEffectTransaction(c, mutation),
-    }
-  );
+  let result: Awaited<ReturnType<typeof depositIntoVault>>;
+  try {
+    result = await depositIntoVault(
+      c.env,
+      {
+        organizationId: auth.organizationId,
+        projectId,
+        environment,
+        provider,
+        providerReference: strategy.provider_reference,
+        wallet,
+        tokenMint,
+        shareMint,
+        label: strategy.name,
+        amount: parsedData.amount,
+        requestId,
+        minSharesOut: parsedData.minSharesOut,
+        ...(resolved.swap === null ? {} : { swap: resolved.swap }),
+        userId: auth.userId ?? null,
+        apiKeyId: auth.apiKeyId ?? null,
+      },
+      {
+        runIntentTransaction: (mutation) =>
+          runApprovedWalletOperationEffectTransaction(c, mutation),
+      }
+    );
+  } catch (error) {
+    // The service throws only before any broadcast (a send error returns
+    // normally, record-before-broadcast), so this is a definitive refusal:
+    // close the intent instead of paging verification over it.
+    await failEarnDepositAudit(c, auditIntent, error);
+    throw error;
+  }
 
   if (result.replayed && approvedWalletOperationId(c)) {
     // Sequential replays do not pass through the insert transaction, so fence
@@ -265,8 +276,9 @@ export async function createEarnVaultDeposit(
     }
   }
 
-  // A thrown path above leaves the intent unresolved on purpose: verification
-  // pages that as an operation needing reconciliation.
+  // The approved-operation fence above deliberately leaves the intent
+  // unresolved when it throws: that outcome is genuinely ambiguous, and
+  // verification paging it for reconciliation is the point.
   await completeEarnDepositAudit(c, auditIntent, {
     resourceId: result.movement.id,
     metadata: {
@@ -1425,30 +1437,30 @@ export async function createEarnVaultWithdrawal(
     }
   }
 
-  // Best-effort, post-effect, and never on a replay (PRO-1866): a fail-closed
-  // audit write here would be a new way for an exit to 5xx, the exact shape
-  // ADR 0002 exit safety rules out. Actor comes from the movement row itself.
-  if (!result.replayed) {
-    await recordEarnWithdrawalAudit(
-      c,
-      {
-        organizationId: auth.organizationId,
-        userId: result.movement.created_by,
-        apiKeyId: result.movement.initiated_by_key_id,
-      },
-      result.movement.id,
-      {
-        executionModel: "vault_direct",
-        signer: "custody",
-        provider: position.provider,
-        positionId: position.id,
-        shares: parsedData.shares,
-        minAmountOut: parsedData.minAmountOut ?? null,
-        signature: result.movement.signature,
-        requestId,
-      }
-    );
-  }
+  // Best-effort and post-effect (PRO-1866): a fail-closed audit write here
+  // would be a new way for an exit to 5xx, the exact shape ADR 0002 exit
+  // safety rules out. Actor comes from the movement row itself; a replay only
+  // backfills an audit row the crashed original never wrote.
+  await recordEarnWithdrawalAudit(
+    c,
+    {
+      organizationId: auth.organizationId,
+      userId: result.movement.created_by,
+      apiKeyId: result.movement.initiated_by_key_id,
+    },
+    result.movement.id,
+    {
+      executionModel: "vault_direct",
+      signer: "custody",
+      provider: position.provider,
+      positionId: position.id,
+      shares: parsedData.shares,
+      minAmountOut: parsedData.minAmountOut ?? null,
+      signature: result.movement.signature,
+      requestId,
+    },
+    { replayed: result.replayed }
+  );
 
   return success(
     c,

--- a/apps/sdp-api/src/services/audit.service.ts
+++ b/apps/sdp-api/src/services/audit.service.ts
@@ -57,6 +57,10 @@ export const AUDIT_ACTIONS = [
   "workflow_execution_approved",
   "workflow_execution_rejected",
   "workflow_execution_retried",
+  // Earn money movements (PRO-1866): resourceType "earn_movement", resourceId
+  // the ledger movement id, actor matching the row's createdBy/initiatedByKeyId.
+  "deposit",
+  "withdraw",
   // Privileged audit-ledger operations (verification checkpoints, restore evidence).
   "maintenance",
 ] as const;
@@ -93,6 +97,7 @@ export type ResourceType =
   | "custody_connection"
   | "workflow"
   | "workflow_execution"
+  | "earn_movement"
   | "audit_ledger";
 
 export interface AuditLogEntry {


### PR DESCRIPTION
Every earn money write now lands a hash-chained audit event ([PRO-1866](https://linear.app/solana-fndn/issue/PRO-1866/threat-model-record-earn-money-actions-in-the-audit-ledger)): new `deposit`/`withdraw` audit actions plus an `earn_movement` resource type (plain TEXT column, no migration), wired at all five money seams through one shared helper (`handlers/movement-audit.ts`): custody vault deposit and withdrawal, both external-wallet submits, and the program withdrawal. Actor fields are passed explicitly from the values the movement row records, so `user_id`/`api_key_id` always equal `created_by`/`initiated_by_key_id`.

**before**: `audit.service` had zero earn usage; actor attribution lived only on movement rows, invisible to the org audit feed.

**after (deposit)**:

1. fail-closed `beginCritical` intent (audit outage refuses the deposit before any side effect)
2. build/sign/record/broadcast unchanged
3. outcome row keyed to the movement id, `replayed` marked

**after (withdrawal)**:

1. build/sign/record/broadcast unchanged
2. best-effort audit row after the effect, skipped on replay
3. a failed write logs `earn_audit_write_failed` and never fails the response
4. one event per movement is DB-enforced (migration 0083's partial unique index), so concurrent replay backfills cannot duplicate; a refused deposit closes its intent as a failure only on a 4xx, anything else stays unresolved for reconciliation

**Reviewer note: one deliberate divergence from the ticket.** It asked for `beginCritical` on every seam; on exits a fail-closed audit write would let an audit/checkpoint-store outage 5xx a customer's way out of a position (ADR 0002 exit safety), the same reason metered quotas stay off exit routes. So money-in fails closed, money-out logs best-effort. Rationale in the helper header and routes/earn/CLAUDE.md.

**Verification**

- 9 new tests: actor parity at every seam (the program one asserts against the real ledger row), deposit fail-closed (audit down: 500, service never called), exit fail-open (audit down: still 200), replays not re-audited, org feed surfaces a deposit and a withdrawal
- all earn suites + audit service/integration suites: 383 passed; `tsc --noEmit` and biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)