### PR TITLE
fix(earn): make the project a boundary on earn programs

### DIFF
--- a/apps/sdp-api/src/db/repositories/earn.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/earn.repository.postgres.ts
@@ -409,8 +409,8 @@ export function createPostgresEarnRepository(db: AppDb): EarnRepository {
     async listProviderWallets(
       input: ListEarnProviderWalletsInput
     ): Promise<ListEarnProviderWalletsResult> {
-      const conditions = ["organization_id = ?", "environment = ?"];
-      const bindings: unknown[] = [input.organizationId, input.environment];
+      const conditions = ["organization_id = ?", "project_id = ?", "environment = ?"];
+      const bindings: unknown[] = [input.organizationId, input.projectId, input.environment];
 
       if (input.provider) {
         conditions.push("provider = ?");

--- a/apps/sdp-api/src/db/repositories/earn.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/earn.repository.test.ts
@@ -880,6 +880,7 @@ describe("EarnRepository (postgres)", () => {
     ): Promise<ListEarnProviderWalletsResult> {
       return repo.listProviderWallets({
         organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
         environment: "sandbox",
         limit: 20,
         offset: 0,
@@ -1047,7 +1048,10 @@ describe("EarnRepository (postgres)", () => {
         await expect(listPrograms({ environment: "production" })).resolves.toMatchObject({
           total: 1,
         });
-        const theirs = await listPrograms({ organizationId: OTHER_ORG.id });
+        const theirs = await listPrograms({
+          organizationId: OTHER_ORG.id,
+          projectId: OTHER_ORG_PROJECT_ID,
+        });
         expect(theirs.rows.map((row) => row.id)).toEqual([sibling.id]);
       });
 
@@ -1108,14 +1112,18 @@ describe("EarnRepository (postgres)", () => {
       await expect(seedProviderWallet({ provider: "veda" })).resolves.toMatchObject({
         provider: "veda",
       });
-      // project_id is still provisioning context only — a program created from a
-      // sibling project joins the same org+environment collection.
+      // A sibling project may hold its own program, but it belongs to THAT
+      // project's collection: the project is a boundary on the list exactly as
+      // it is on every per-program route (HOO-1563).
       await expect(seedProviderWallet({ projectId: OTHER_PROJECT_ID })).resolves.toMatchObject({
         project_id: OTHER_PROJECT_ID,
       });
+      await expect(listPrograms({ projectId: OTHER_PROJECT_ID })).resolves.toMatchObject({
+        total: 1,
+      });
 
       const { total } = await listPrograms();
-      expect(total).toBe(4);
+      expect(total).toBe(3);
     });
 
     it("still allows ONE link row per provider wallet — globally (migration 0056)", async () => {

--- a/apps/sdp-api/src/db/repositories/earn.repository.ts
+++ b/apps/sdp-api/src/db/repositories/earn.repository.ts
@@ -228,6 +228,8 @@ export interface InsertEarnProviderWalletInput {
 
 export interface ListEarnProviderWalletsInput {
   organizationId: string;
+  /** The owning project; the list is a project boundary like every per-program route. */
+  projectId: string;
   environment: SdpEnvironment;
   /** Optional filter; omitted lists every provider's programs. */
   provider?: EarnProviderId;

--- a/apps/sdp-api/src/routes/earn-program.test.ts
+++ b/apps/sdp-api/src/routes/earn-program.test.ts
@@ -410,8 +410,11 @@ const createProgramBody = (extra: Record<string, unknown> = {}) => ({
 });
 
 /** The derived id the provider actually dedupes a program CREATE on. */
-const derivedCreateId = (callerKey: string, environment = "sandbox") =>
-  deriveProviderRequestId(["earn_program_create", TEST_ORG.id, environment, "ground"], callerKey);
+const derivedCreateId = (callerKey: string, environment = "sandbox", projectId = TEST_PROJECT.id) =>
+  deriveProviderRequestId(
+    ["earn_program_create", TEST_ORG.id, projectId, environment, "ground"],
+    callerKey
+  );
 
 interface ProgramEnvelope {
   id: string;
@@ -1313,7 +1316,7 @@ describe("Earn program — session callers and environment isolation", () => {
         allocations: VALID_ALLOCATIONS,
         // Environment is part of the derivation scope, so the same caller key
         // in sandbox is a different provider request.
-        requestId: derivedCreateId(callerKey, "production"),
+        requestId: derivedCreateId(callerKey, "production", TEST_PRODUCTION_PROJECT.id),
       })
     );
 
@@ -1329,6 +1332,7 @@ describe("Earn program — session callers and environment isolation", () => {
     await expect(
       repo.listProviderWallets({
         organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT.id,
         environment: "sandbox",
         limit: 20,
         offset: 0,
@@ -2540,7 +2544,40 @@ describe("Earn program — withdrawal authorization (HOO-1559)", () => {
     expect(operations).toHaveLength(1);
   });
 
-  it("re-answers the same hold when the retry arrives under a sibling project", async () => {
+  it("hides the program from a sibling project on every per-program route (HOO-1563)", async () => {
+    // The decision is that the project is the boundary for deposits, withdrawals
+    // and previews alike, so it is enforced where every per-program route
+    // resolves its row rather than route by route.
+    await seedAuth();
+    await seedSiblingProjectAuth();
+    const program = await seedProgramWallet();
+    const siblingAuth = { Authorization: `Bearer ${TEST_SIBLING_API_KEY.raw}` };
+
+    const read = await requestEarn("GET", programPath(program.id), undefined, siblingAuth);
+    expect(read.status).toBe(404);
+
+    const deposits = await requestEarn(
+      "GET",
+      programPath(program.id, "/deposits"),
+      undefined,
+      siblingAuth
+    );
+    expect(deposits.status).toBe(404);
+
+    const preview = await requestEarn(
+      "POST",
+      programPath(program.id, "/withdrawal-preview"),
+      { amountUsd: "25.50", token: "usdc" },
+      siblingAuth
+    );
+    expect(preview.status).toBe(404);
+  });
+
+  it("refuses a sibling project's key on the same program (HOO-1563)", async () => {
+    // The project is the boundary: a key scoped to a sibling project cannot
+    // reach this program at all, so it can never open a second approval for one
+    // payout. 404, not 403 — a caller who may not see the program must not
+    // learn that it exists.
     await seedAuth();
     await seedSiblingProjectAuth();
     const program = await seedProgramWallet();
@@ -2555,15 +2592,10 @@ describe("Earn program — withdrawal authorization (HOO-1559)", () => {
     const held = await requestEarn("POST", programPath(program.id, "/withdrawals"), body);
     expect(held.status).toBe(202);
 
-    // A program is addressed per (organization, environment) and its payout
-    // ledger is keyed by organization + provider wallet + request id, so the
-    // hold must answer the same key from any project in the organization. A
-    // project-scoped lookup would miss it and open a SECOND approval for one
-    // payout — two approvers, each able to release it.
-    const retried = await requestEarn("POST", programPath(program.id, "/withdrawals"), body, {
+    const sibling = await requestEarn("POST", programPath(program.id, "/withdrawals"), body, {
       Authorization: `Bearer ${TEST_SIBLING_API_KEY.raw}`,
     });
-    expect(retried.status).toBe(202);
+    expect(sibling.status).toBe(404);
 
     expect(createWithdrawal).not.toHaveBeenCalled();
     await expect(countMovements()).resolves.toBe(0);

--- a/apps/sdp-api/src/routes/earn-program.test.ts
+++ b/apps/sdp-api/src/routes/earn-program.test.ts
@@ -410,11 +410,8 @@ const createProgramBody = (extra: Record<string, unknown> = {}) => ({
 });
 
 /** The derived id the provider actually dedupes a program CREATE on. */
-const derivedCreateId = (callerKey: string, environment = "sandbox", projectId = TEST_PROJECT.id) =>
-  deriveProviderRequestId(
-    ["earn_program_create", TEST_ORG.id, projectId, environment, "ground"],
-    callerKey
-  );
+const derivedCreateId = (callerKey: string, environment = "sandbox") =>
+  deriveProviderRequestId(["earn_program_create", TEST_ORG.id, environment, "ground"], callerKey);
 
 interface ProgramEnvelope {
   id: string;
@@ -1316,7 +1313,7 @@ describe("Earn program — session callers and environment isolation", () => {
         allocations: VALID_ALLOCATIONS,
         // Environment is part of the derivation scope, so the same caller key
         // in sandbox is a different provider request.
-        requestId: derivedCreateId(callerKey, "production", TEST_PRODUCTION_PROJECT.id),
+        requestId: derivedCreateId(callerKey, "production"),
       })
     );
 
@@ -2542,6 +2539,47 @@ describe("Earn program — withdrawal authorization (HOO-1559)", () => {
 
     const operations = await readWalletOperations();
     expect(operations).toHaveLength(1);
+  });
+
+  it("refuses a create whose replayed program belongs to a sibling project (HOO-1563)", async () => {
+    // The create key is derived organization-wide on purpose — narrowing it
+    // would give a retry spanning a deploy a NEW key, and the provider answers a
+    // new key with a SECOND wallet holding real funds. So a sibling project can
+    // still land on the first project's program, and the boundary is enforced
+    // here: say the key is taken rather than hand back a program it cannot use.
+    await seedAuth();
+    await seedSiblingProjectAuth();
+    await seedGroundStrategy();
+    const createWallet = vi
+      .spyOn(EARN_PROVIDER_CLIENTS.ground, "createPortfolioWallet")
+      .mockResolvedValue({ providerWalletRef: WALLET_REF, status: "creating" });
+    stubProgramReads();
+    const callerKey = crypto.randomUUID();
+
+    const created = await requestEarn(
+      "POST",
+      PROGRAMS_PATH,
+      createProgramBody({ requestId: callerKey })
+    );
+    expect(created.status).toBe(201);
+
+    const sibling = await requestEarn(
+      "POST",
+      PROGRAMS_PATH,
+      createProgramBody({ requestId: callerKey }),
+      { Authorization: `Bearer ${TEST_SIBLING_API_KEY.raw}` }
+    );
+    expect(sibling.status).toBe(409);
+    const body = (await sibling.json()) as { error: { message: string } };
+    expect(body.error.message).toContain("another project");
+
+    // Still exactly one program: the refusal happens on the link row, so the
+    // provider was asked once for this key and no second wallet was persisted.
+    expect(createWallet).toHaveBeenCalledTimes(2);
+    const rows = await getDb(env)
+      .prepare("SELECT COUNT(*)::int AS count FROM earn_provider_wallets")
+      .first<{ count: number }>();
+    expect(rows?.count).toBe(1);
   });
 
   it("hides the program from a sibling project on every per-program route (HOO-1563)", async () => {

--- a/apps/sdp-api/src/routes/earn/handlers/program.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/program.ts
@@ -25,7 +25,7 @@ import {
   type EarnMovementRow,
   type EarnMovementsRepository,
 } from "@/db/repositories/earn-movements.repository";
-import { getAuth } from "@/lib/auth";
+import { getAuth, requireProjectId } from "@/lib/auth";
 import { resolveCreatorUserId } from "@/lib/creator";
 import { badRequest, conflict, internalError, notFound } from "@/lib/errors";
 import {
@@ -88,9 +88,10 @@ export type {
  * program exists.
  *
  * Because the id is now caller-supplied, every `:programId` lookup carries its
- * own tenancy proof (`getProviderWalletById` scopes to organization AND
- * environment). The old triple lookup made a guessed id structurally
- * impossible; an addressable id does not, so the scoping is explicit.
+ * own tenancy proof: `getProviderWalletById` scopes to organization AND
+ * environment, and `requireProgram` compares the owning project on top of that
+ * (HOO-1563). The old triple lookup made a guessed id structurally impossible;
+ * an addressable id does not, so the scoping is explicit.
  *
  * Source of truth per surface (PRO-1628): balances/positions/yield/deposits
  * are NEVER persisted — every read is a live provider fetch. Withdrawals are
@@ -179,7 +180,19 @@ async function requireProgram(c: AppContext, programId: string): Promise<EarnPro
     walletId: programId,
   });
 
-  if (!row) {
+  // The project is a boundary here as it is everywhere else money moves
+  // (HOO-1563). Organization scope alone let a key scoped to project B preview
+  // and withdraw from a program provisioned under project A, while the
+  // neighbouring vault-exit and external-wallet paths already compared
+  // `project_id` before releasing funds. This is the single place every
+  // per-program route resolves its row, so deposits, withdrawals and previews
+  // all get the same answer.
+  //
+  // An EXACT match, with no null exception, for the reason `isMovementInProject`
+  // spells out: the insert writes a real project id and NULL appears only after
+  // the owning project was deleted (migration 0062), so a null is a deleted
+  // project rather than a public row.
+  if (!row || row.project_id !== requireProjectId(c)) {
     throw notFound("Earn program");
   }
 
@@ -321,17 +334,18 @@ function requireCallerIdempotencyKey(
  * would be answered with a replay of the FIRST organization's wallet — which SDP
  * would then link to the wrong tenant.
  *
- * Deliberately NOT in scope: `projectId`, because sibling projects in one
- * environment share programs and two retries arriving through different projects
- * must derive the same id (project_id is provisioning audit only). And not the
- * allocations or label — scope separates tenants, payload equality is a
+ * `projectId` IS in scope, because the project is a boundary on every
+ * per-program route (HOO-1563): a create arriving through a sibling project is
+ * a different program, not a retry of this one, and deriving the same id would
+ * replay the first project's wallet into a project that could not then reach
+ * it. Not the allocations or label — scope separates tenants, payload equality is a
  * different question, and mixing payload in would turn a retry with a corrected
  * allocation into a second program instead of a conflict.
  */
 function resolveProgramCreateRequestId(
   c: AppContext,
   requestId: string | undefined,
-  scope: { organizationId: string; environment: string; provider: string }
+  scope: { organizationId: string; projectId: string; environment: string; provider: string }
 ): string {
   const callerKey = requireCallerIdempotencyKey(
     c,
@@ -340,7 +354,13 @@ function resolveProgramCreateRequestId(
     "provision a second program the first deposit would not reach"
   );
   return deriveProviderRequestId(
-    ["earn_program_create", scope.organizationId, scope.environment, scope.provider],
+    [
+      "earn_program_create",
+      scope.organizationId,
+      scope.projectId,
+      scope.environment,
+      scope.provider,
+    ],
     callerKey
   );
 }
@@ -397,6 +417,10 @@ export const listEarnPrograms = async (c: AppContext) => {
 
   const { rows, total } = await getEarnRepository(c).listProviderWallets({
     organizationId: getAuth(c).organizationId,
+    // Listed and addressable must agree: without this the list advertises
+    // sibling projects' programs that every per-program route then 404s
+    // (HOO-1563).
+    projectId: requireProjectId(c),
     environment,
     ...(query.provider !== undefined && { provider: query.provider }),
     ...pageWindow(query),
@@ -479,6 +503,7 @@ export const createEarnProgram = async (
   // generic "missing idempotency key" that hides why the call could never work.
   const requestId = resolveProgramCreateRequestId(c, body.requestId, {
     organizationId: auth.organizationId,
+    projectId: auth.projectId,
     environment,
     provider: client.provider,
   });
@@ -830,10 +855,11 @@ export async function extractEarnProgramWithdrawalPolicyCandidate(
     // than starting a second approval.
     await throwOnPriorEarnPolicyOperation(c, {
       organizationId: auth.organizationId,
-      // Organization-scoped on purpose: the ledger's replay above is keyed by
-      // organization + provider wallet + request id, so a per-project lookup
-      // here would miss a held operation a sibling project created and mint a
-      // second approval for the same payout.
+      // Organization-scoped on purpose, matching the ledger replay above, which
+      // is keyed by organization + provider wallet + request id. Since HOO-1563
+      // a sibling project cannot reach this program at all, so the wider scope
+      // no longer carries the check by itself — it stays because the ledger key
+      // is the wider one, and a narrower lookup here could disagree with it.
       scope: { kind: "organization" },
       idempotencyKey: requestId,
       idempotencyFingerprint,

--- a/apps/sdp-api/src/routes/earn/handlers/program.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/program.ts
@@ -334,18 +334,19 @@ function requireCallerIdempotencyKey(
  * would be answered with a replay of the FIRST organization's wallet — which SDP
  * would then link to the wrong tenant.
  *
- * `projectId` IS in scope, because the project is a boundary on every
- * per-program route (HOO-1563): a create arriving through a sibling project is
- * a different program, not a retry of this one, and deriving the same id would
- * replay the first project's wallet into a project that could not then reach
- * it. Not the allocations or label — scope separates tenants, payload equality is a
+ * Deliberately NOT in scope: `projectId`. The project IS a boundary on every
+ * per-program route (HOO-1563), but putting it in the derivation would change
+ * the key for creates already in flight, and a retry deriving a NEW key is
+ * answered by the provider with a SECOND wallet holding real funds. The
+ * boundary is enforced on the replayed row instead, below. And not the
+ * allocations or label — scope separates tenants, payload equality is a
  * different question, and mixing payload in would turn a retry with a corrected
  * allocation into a second program instead of a conflict.
  */
 function resolveProgramCreateRequestId(
   c: AppContext,
   requestId: string | undefined,
-  scope: { organizationId: string; projectId: string; environment: string; provider: string }
+  scope: { organizationId: string; environment: string; provider: string }
 ): string {
   const callerKey = requireCallerIdempotencyKey(
     c,
@@ -354,13 +355,7 @@ function resolveProgramCreateRequestId(
     "provision a second program the first deposit would not reach"
   );
   return deriveProviderRequestId(
-    [
-      "earn_program_create",
-      scope.organizationId,
-      scope.projectId,
-      scope.environment,
-      scope.provider,
-    ],
+    ["earn_program_create", scope.organizationId, scope.environment, scope.provider],
     callerKey
   );
 }
@@ -503,7 +498,6 @@ export const createEarnProgram = async (
   // generic "missing idempotency key" that hides why the call could never work.
   const requestId = resolveProgramCreateRequestId(c, body.requestId, {
     organizationId: auth.organizationId,
-    projectId: auth.projectId,
     environment,
     provider: client.provider,
   });
@@ -546,6 +540,14 @@ export const createEarnProgram = async (
       // unreachable; if it happens the provider handed us someone else's wallet,
       // and linking it would expose their funds. Refuse rather than adopt it.
       throw conflict("Earn program wallet is already linked to another account");
+    }
+    if (row.project_id !== auth.projectId) {
+      // Same organization, different project. The derivation is deliberately
+      // organization-wide (see `resolveProgramCreateRequestId`), so a sibling
+      // project reusing a caller key lands on the first project's program —
+      // which the project boundary then makes unreachable to it (HOO-1563).
+      // Say so, rather than answering 200 with a program it cannot use.
+      throw conflict("Earn program request id already used by another project");
     }
     replayed = true;
   }


### PR DESCRIPTION
Implements the product decision on HOO-1563: the project is the boundary for Earn programs, for deposits, withdrawals and previews alike.

- Earn programs were addressed per organization and environment, so an API key scoped to project B could read, preview and withdraw from a program provisioned under project A. Tenant isolation held — it is all one organization — but project scoping did not.
- What made it worth a decision rather than a patch is that the neighbouring paths already do the opposite: vault exits and external wallet withdrawals both compare `project_id` on the position before any money leaves. One Earn surface treated the project as a boundary for money out and the other did not.
- The check goes where every per-program route resolves its row, so read, deposits, withdrawal-preview, withdrawal, withdrawal detail/list and re-target all get the same answer rather than each route growing its own guard.
- An exact match with no null exception, for the reason `isMovementInProject` already spells out for vault movements: the insert writes a real project id, and NULL appears only after the owning project was deleted. 404, not 403 — a caller who may not see a program must not learn that it exists.
- The program list is scoped the same way. Listed and addressable have to agree; otherwise the list advertises programs every per-program route then 404s.

**before** — organization-wide:

1. Key scoped to project B calls `POST /earn/programs/:programId/withdrawal-preview` for a program provisioned under project A.
2. `requireProgram` looks the row up by organization and environment, finds it, and answers.
3. The withdrawal that follows pays out of the organization's provider account.

**after** — project-scoped:

1. The same call resolves the row, compares the owning project, and 404s.
2. The list no longer returns that program to project B at all.

## The create key stays organization-wide

Narrowing the create idempotency derivation to the project was the obvious follow-through, and it is wrong: a create already in flight would derive a *different* provider request id across the deploy, and a provider answers an unrecognised key by creating a SECOND wallet — one that holds real funds. So the derivation is unchanged, and the boundary is enforced one step later, on the row the replay resolves:

```
sibling project reuses a caller key
  -> provider replays the ORIGINAL wallet ref
  -> link row already exists, owned by project A
  -> 409 "request id already used by another project"   (not a 200 with a program it cannot reach)
```

**Verification**

- `vitest run src/db/repositories/earn.repository.test.ts src/routes/earn.test.ts src/routes/earn src/routes/earn-program.test.ts src/routes/earn-program-ledger-failure.test.ts src/openapi` — 17 files, 450 tests passed.
- New tests: a sibling project's key gets 404 on read, deposits and withdrawal-preview; it gets 404 on withdrawals with no second approval opened; a cross-project create replay gets 409 with exactly one link row persisted; the repository list is bounded to the project.
- `tsc --noEmit`, `biome check` — clean.
- The approval executor still resolves the program: it replays the original request with `x-project-id` taken from the operation, so it arrives under the project that owns the program. Covered by the existing governed-payout execution tests.

One existing test asserted the opposite behaviour — that a withdrawal retry arriving under a sibling project re-answers the same hold. It encoded the org-wide sharing this decision reverses, so it now asserts the 404. The property it protected still holds, more directly: a sibling project cannot reach the program, so it cannot open a second approval for one payout.

Known gaps
- A program whose project has been deleted keeps its funds but is no longer addressable through the API, because the deletion nulls `project_id`. That follows from the decision rather than from this diff, and it is the same trade-off the vault movements made, but a program can hold a balance where a movement cannot — worth a separate look at whether project deletion should require draining first.
