### PR TITLE
feat(earn): PRO-1863 emit reconciliation sweep tick events and fail loudly

### DIFF
--- a/apps/sdp-api/src/db/repositories/CLAUDE.md
+++ b/apps/sdp-api/src/db/repositories/CLAUDE.md
@@ -51,6 +51,15 @@ Things that will bite:
   as a vault deposit.
 - **Ids are heterogeneous by design.** History keeps the ids the projection
   preserved, so nothing may parse an id for its kind — read `execution_model`.
+- **`getUnsettledVaultMovementStats` duplicates `claimUnsettledVaultMovements`'
+  predicate by copy, and only a test binds them** (PRO-1863). The stats read
+  feeds the backlog and movement-age alerts, so a predicate that drifts from
+  the claim reports a backlog the sweep is not actually working through. The
+  binding test seeds one row in every reachable status and asserts the stats
+  count equals the claimed id SET, not a literal, so the two fail together;
+  it lives in `../../services/jobs/reconcile-earn-vault-movements.test.ts`
+  ("reports exactly the rows the next claim would take"). Change one predicate
+  and you must change both.
 - **A vault row's signer is a column pair, not a new model** (PRO-1722,
   migration 0070): exactly one of `custody_wallet_id` (SDP signs) and
   `owner_address` (an external wallet SDP holds no key for signs) is set, on

--- a/apps/sdp-api/src/db/repositories/earn-movements.repository.ts
+++ b/apps/sdp-api/src/db/repositories/earn-movements.repository.ts
@@ -433,6 +433,15 @@ export interface EarnMovementsRepository {
   }): Promise<{ rows: EarnMovementRow[]; hasMore: boolean }>;
   /** Atomically select a fair, bounded batch and rotate its attempt cursor; not a work lease. */
   claimUnsettledVaultMovements(limit: number): Promise<EarnMovementRow[]>;
+  /**
+   * Backlog telemetry over the SAME predicate the claim uses (PRO-1863): how
+   * many vault movements remain unsettled, and how old the oldest one is. Read
+   * after a sweep tick so the reported backlog is what the tick left behind.
+   */
+  getUnsettledVaultMovementStats(): Promise<{
+    backlog: number;
+    oldestUnsettledCreatedAt: string | null;
+  }>;
 
   // ── Writes ───────────────────────────────────────────────────────────────
 
@@ -1320,6 +1329,23 @@ export function createPostgresEarnMovementsRepository(db: AppDb): EarnMovementsR
         .bind(blockhashBoundQuota, confirmedQuota, limit)
         .all<Record<string, unknown>>();
       return (result.results ?? []).map(mapMovementRow);
+    },
+
+    async getUnsettledVaultMovementStats() {
+      // Keep this predicate in lockstep with claimUnsettledVaultMovements: the
+      // backlog it reports must be the same set the sweep would claim.
+      const row = await db
+        .prepare(
+          `SELECT COUNT(*) AS backlog, MIN(created_at) AS oldest_created_at
+             FROM earn_movements
+            WHERE execution_model = 'vault_direct'
+              AND status IN ('requested', 'submitted', 'confirmed')`
+        )
+        .first<{ backlog: number | string; oldest_created_at: string | null }>();
+      return {
+        backlog: Number(row?.backlog ?? 0),
+        oldestUnsettledCreatedAt: row?.oldest_created_at ?? null,
+      };
     },
 
     async createSignedVaultDepositIntent(input) {

--- a/apps/sdp-api/src/db/repositories/earn-movements.repository.ts
+++ b/apps/sdp-api/src/db/repositories/earn-movements.repository.ts
@@ -1346,9 +1346,12 @@ export function createPostgresEarnMovementsRepository(db: AppDb): EarnMovementsR
 
     async getUnsettledVaultMovementStats() {
       // Keep this predicate in lockstep with claimUnsettledVaultMovements: the
-      // backlog it reports must be the same set the sweep would claim. A test
-      // asserts `backlog === claimUnsettledVaultMovements(...).length` rather
-      // than a literal, so the two fail together instead of drifting silently.
+      // backlog it reports must be the same set the sweep would claim. Bound by
+      // the "reports exactly the rows the next claim would take" test in
+      // services/jobs/reconcile-earn-vault-movements.test.ts, which seeds one
+      // row in every reachable status and asserts this count against the
+      // claimed id SET rather than a literal, so the two fail together instead
+      // of drifting silently.
       const row = await db
         .prepare(
           `SELECT COUNT(*) AS backlog,

--- a/apps/sdp-api/src/db/repositories/earn-movements.repository.ts
+++ b/apps/sdp-api/src/db/repositories/earn-movements.repository.ts
@@ -437,10 +437,23 @@ export interface EarnMovementsRepository {
    * Backlog telemetry over the SAME predicate the claim uses (PRO-1863): how
    * many vault movements remain unsettled, and how old the oldest one is. Read
    * after a sweep tick so the reported backlog is what the tick left behind.
+   *
+   * Dimensioned, because the flat total is not alertable. A `confirmed` row
+   * whose signature ages out of RPC history is a PERMANENT member of this set
+   * (PRO-1716 gives `confirmed` no exit but `finalized`, and the sweep must
+   * neither expire nor rebroadcast it), so a total-only age would latch and
+   * page forever. `blockhashBound` is the actionable subset the sweep can
+   * still act on, and the withdrawal split keeps the exit path visible on its
+   * own (ADR 0002).
    */
   getUnsettledVaultMovementStats(): Promise<{
     backlog: number;
+    backlogBlockhashBound: number;
+    backlogConfirmed: number;
+    backlogWithdrawals: number;
     oldestUnsettledCreatedAt: string | null;
+    oldestBlockhashBoundCreatedAt: string | null;
+    oldestWithdrawalCreatedAt: string | null;
   }>;
 
   // ── Writes ───────────────────────────────────────────────────────────────
@@ -1333,18 +1346,41 @@ export function createPostgresEarnMovementsRepository(db: AppDb): EarnMovementsR
 
     async getUnsettledVaultMovementStats() {
       // Keep this predicate in lockstep with claimUnsettledVaultMovements: the
-      // backlog it reports must be the same set the sweep would claim.
+      // backlog it reports must be the same set the sweep would claim. A test
+      // asserts `backlog === claimUnsettledVaultMovements(...).length` rather
+      // than a literal, so the two fail together instead of drifting silently.
       const row = await db
         .prepare(
-          `SELECT COUNT(*) AS backlog, MIN(created_at) AS oldest_created_at
+          `SELECT COUNT(*) AS backlog,
+                  COUNT(*) FILTER (WHERE status IN ('requested', 'submitted')) AS backlog_blockhash_bound,
+                  COUNT(*) FILTER (WHERE status = 'confirmed') AS backlog_confirmed,
+                  COUNT(*) FILTER (WHERE direction = 'withdrawal') AS backlog_withdrawals,
+                  MIN(created_at) AS oldest_created_at,
+                  MIN(created_at) FILTER (WHERE status IN ('requested', 'submitted'))
+                    AS oldest_blockhash_bound_created_at,
+                  MIN(created_at) FILTER (WHERE direction = 'withdrawal')
+                    AS oldest_withdrawal_created_at
              FROM earn_movements
             WHERE execution_model = 'vault_direct'
               AND status IN ('requested', 'submitted', 'confirmed')`
         )
-        .first<{ backlog: number | string; oldest_created_at: string | null }>();
+        .first<{
+          backlog: number | string;
+          backlog_blockhash_bound: number | string;
+          backlog_confirmed: number | string;
+          backlog_withdrawals: number | string;
+          oldest_created_at: string | null;
+          oldest_blockhash_bound_created_at: string | null;
+          oldest_withdrawal_created_at: string | null;
+        }>();
       return {
         backlog: Number(row?.backlog ?? 0),
+        backlogBlockhashBound: Number(row?.backlog_blockhash_bound ?? 0),
+        backlogConfirmed: Number(row?.backlog_confirmed ?? 0),
+        backlogWithdrawals: Number(row?.backlog_withdrawals ?? 0),
         oldestUnsettledCreatedAt: row?.oldest_created_at ?? null,
+        oldestBlockhashBoundCreatedAt: row?.oldest_blockhash_bound_created_at ?? null,
+        oldestWithdrawalCreatedAt: row?.oldest_withdrawal_created_at ?? null,
       };
     },
 

--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -767,19 +767,45 @@ Never rebuild a transaction during recovery.
 **The sweep must fail LOUDLY, and that is a correctness property** (PRO-1863,
 threat model EARN-006). A chain read failure used to `return` cleanly, so the
 batch went unjudged while `sdp_cron_run` recorded `ok` and no signal existed
-anywhere that money had stopped settling. Now every tick emits
+anywhere that money had stopped settling. Now a completed tick emits
 `sdp_api_earn_vault_reconciliation_tick` (the
 `sdp_api_sponsorship_reconciliation_tick` precedent) carrying the batch outcome
-counts plus `backlog` and `oldest_unsettled_age_seconds` read AFTER the tick,
-and a status or block-height read failure emits its own error event, marks the
-tick error-level, and THROWS so `runWithCronRunEvent` records `status: "error"`.
-Both runners already absorb a throw: the managed job's `collect` records the
-failure without starving later ticks, and `NodeBackgroundRunner.run` attaches
-its own catch. Do not "helpfully" swallow that throw: the backlog and
-movement-age alerts are keyed on those two fields, and an ok tick over an
-unjudged batch is the exact failure this closed. Pinned by the "sweep
-telemetry" describe in `../../services/jobs/reconcile-earn-vault-movements.test.ts`,
-whose last test composes the real `runWithCronRunEvent`.
+counts plus the backlog gauges read AFTER the tick, and any failure (a status
+read, a block-height read, or a per-movement error) marks the tick
+error-level and THROWS so `runWithCronRunEvent` records `status: "error"`.
+Per-movement errors count too, deliberately: reads can answer perfectly while
+the write side is down (pool exhaustion, a send-side RPC outage), and an ok
+tick over a batch where nothing settled is the same silence. The sponsorship
+reconciler takes the identical posture, emitting its tick and then throwing
+when any item failed. Both runners absorb the throw: the managed job's
+`collect` records the failure without starving later ticks, and
+`NodeBackgroundRunner.run` attaches its own catch. Do not "helpfully" swallow
+it.
+
+Three details that look like bugs and are not:
+
+- **The block-height read is gated on rows that can CONSUME a height**: a null
+  RPC status on a row not already `confirmed`. A `confirmed` row whose
+  signature aged out of RPC history short-circuits to `unchanged` before the
+  height is read, and is a permanent member of the claim set, so gating on the
+  RPC answer alone spent a discarded call every minute and let its failure fail
+  a tick that had done its whole job.
+- **The backlog is dimensioned for the same reason.** Those parked `confirmed`
+  rows never leave the queue, so a total-only age latches and pages forever;
+  `backlog_blockhash_bound` / `oldest_blockhash_bound_age_seconds` are the
+  actionable subset, and the withdrawal split keeps the exit path visible on
+  its own axis (ADR 0002).
+- **"Completed tick" is the honest qualifier.** A rejection from the claim or
+  backlog QUERY skips the event, exactly as the sponsorship reconciler skips
+  its tick when its own candidate read fails. The run is still loud
+  (`sdp_cron_run` error, non-zero exit). Do not synthesize a fallback tick: it
+  could only carry a null backlog (invisible to a threshold rule) or a zero,
+  which reads as a drained queue and would CLEAR a firing alert mid-incident.
+  Alert on the ABSENCE of the tick instead.
+
+Pinned by the "sweep telemetry" describe in
+`../../services/jobs/reconcile-earn-vault-movements.test.ts`, whose
+`runWithCronRunEvent` test composes the real wrapper.
 
 ### Vault withdrawals — the exit half (PRO-1702)
 

--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -766,8 +766,9 @@ Never rebuild a transaction during recovery.
 
 **The sweep must fail LOUDLY, and that is a correctness property** (PRO-1863,
 threat model EARN-006). A chain read failure used to `return` cleanly, so the
-batch went unjudged while `sdp_cron_run` recorded `ok` and no signal existed
-anywhere that money had stopped settling. Now a completed tick emits
+batch went unjudged while `sdp_cron_run` recorded `ok`: the only trace was an
+error log line, with no alertable event name and no backlog signal anywhere
+that money had stopped settling. Now a completed tick emits
 `sdp_api_earn_vault_reconciliation_tick` (the
 `sdp_api_sponsorship_reconciliation_tick` precedent) carrying the batch outcome
 counts plus the backlog gauges read AFTER the tick, and any failure (a status

--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -764,6 +764,23 @@ detail reads. The job additionally rebroadcasts the recorded signed bytes while
 the blockhash remains valid and marks an expired, unlanded movement failed.
 Never rebuild a transaction during recovery.
 
+**The sweep must fail LOUDLY, and that is a correctness property** (PRO-1863,
+threat model EARN-006). A chain read failure used to `return` cleanly, so the
+batch went unjudged while `sdp_cron_run` recorded `ok` and no signal existed
+anywhere that money had stopped settling. Now every tick emits
+`sdp_api_earn_vault_reconciliation_tick` (the
+`sdp_api_sponsorship_reconciliation_tick` precedent) carrying the batch outcome
+counts plus `backlog` and `oldest_unsettled_age_seconds` read AFTER the tick,
+and a status or block-height read failure emits its own error event, marks the
+tick error-level, and THROWS so `runWithCronRunEvent` records `status: "error"`.
+Both runners already absorb a throw: the managed job's `collect` records the
+failure without starving later ticks, and `NodeBackgroundRunner.run` attaches
+its own catch. Do not "helpfully" swallow that throw: the backlog and
+movement-age alerts are keyed on those two fields, and an ok tick over an
+unjudged batch is the exact failure this closed. Pinned by the "sweep
+telemetry" describe in `../../services/jobs/reconcile-earn-vault-movements.test.ts`,
+whose last test composes the real `runWithCronRunEvent`.
+
 ### Vault withdrawals — the exit half (PRO-1702)
 
 - `POST /vault-withdrawals` — **build + simulate + sign ALL legs + record ALL

--- a/apps/sdp-api/src/services/earn/vault-movement-reconciliation.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-movement-reconciliation.service.ts
@@ -11,6 +11,7 @@ import {
   type EarnMovementRow,
 } from "@/db/repositories/earn-movements.repository";
 import { getLogger } from "@/runtime/logger";
+import { describeError, logEvent } from "@/runtime/money-path-events";
 import {
   assertClusterEndpoint,
   earnClusterFor,
@@ -136,19 +137,64 @@ async function observeEarnVaultMovement(
   );
 }
 
+/**
+ * What one sweep tick did with the batch it claimed (PRO-1863). `settled` and
+ * `failed` count TRANSITIONS this tick performed, not steady state; the read
+ * failures are the counts that must make the tick read failed rather than ok.
+ */
+export interface EarnVaultReconciliationStats {
+  claimed: number;
+  settled: number;
+  failed: number;
+  confirmed: number;
+  resubmitted: number;
+  unchanged: number;
+  movementErrors: number;
+  statusReadFailures: number;
+  blockHeightReadFailures: number;
+}
+
+type MovementOutcome = "settled" | "failed" | "confirmed" | "resubmitted" | "unchanged";
+
+function emptyStats(claimed: number): EarnVaultReconciliationStats {
+  return {
+    claimed,
+    settled: 0,
+    failed: 0,
+    confirmed: 0,
+    resubmitted: 0,
+    unchanged: 0,
+    movementErrors: 0,
+    statusReadFailures: 0,
+    blockHeightReadFailures: 0,
+  };
+}
+
 /** Reconcile a claimed batch for the scheduled durable recovery job. */
 export async function reconcileEarnVaultMovementBatch(
   env: Env,
   movements: EarnMovementRow[]
-): Promise<void> {
+): Promise<EarnVaultReconciliationStats> {
   const ledger = createPostgresEarnMovementsRepository(getDb(env));
   const byEnvironment = groupByEnvironment(movements);
+  const stats = emptyStats(movements.length);
 
   // Sequential on purpose. Each environment opens its own RPC client and polls
   // a batch of signatures, so parallel environments only multiply endpoint load.
+  // One environment's RPC outage is counted and reported, never allowed to
+  // skip the other environment's batch.
   for (const [environment, rows] of byEnvironment) {
-    await reconcileEnvironment(env, ledger, environment, rows);
+    const outcome = await reconcileEnvironment(env, ledger, environment, rows);
+    stats.settled += outcome.settled;
+    stats.failed += outcome.failed;
+    stats.confirmed += outcome.confirmed;
+    stats.resubmitted += outcome.resubmitted;
+    stats.unchanged += outcome.unchanged;
+    stats.movementErrors += outcome.movementErrors;
+    stats.statusReadFailures += outcome.statusReadFailures;
+    stats.blockHeightReadFailures += outcome.blockHeightReadFailures;
   }
+  return stats;
 }
 
 function groupByEnvironment(movements: EarnMovementRow[]) {
@@ -166,7 +212,8 @@ async function reconcileEnvironment(
   ledger: EarnMovementsLedger,
   environment: SdpEnvironment,
   rows: EarnMovementRow[]
-): Promise<void> {
+): Promise<EarnVaultReconciliationStats> {
+  const stats = emptyStats(rows.length);
   const cluster = earnClusterFor(environment);
   const rpcUrl = resolveClusterRpcUrl(env, cluster);
   const rpc = createRpc(env, { rpcUrl });
@@ -179,11 +226,18 @@ async function reconcileEnvironment(
       { searchTransactionHistory: true }
     );
   } catch (error) {
-    getLogger().error(
-      { environment, error },
-      "earn vault reconciliation: failed to read transaction statuses"
-    );
-    return;
+    // The whole batch went unjudged: nothing settles this tick and the caller
+    // must not report an ok tick (EARN-006). Structured so Loki can alert on
+    // the event name rather than a log-line substring.
+    logEvent("error", {
+      event: "sdp_api_earn_vault_reconciliation_status_read_failed",
+      environment,
+      rows: rows.length,
+      ...describeError(error),
+    });
+    stats.statusReadFailures = 1;
+    stats.unchanged = rows.length;
+    return stats;
   }
 
   let currentBlockHeight: bigint | null = null;
@@ -191,10 +245,15 @@ async function reconcileEnvironment(
     try {
       currentBlockHeight = await rpc.getBlockHeight({ commitment: "confirmed" }).send();
     } catch (error) {
-      getLogger().error(
-        { environment, error },
-        "earn vault reconciliation: failed to read block height"
-      );
+      // Unknown signatures cannot be rebroadcast or expired without a height,
+      // so those rows are left for the next tick; the tick still must not
+      // read ok, because the sweep could not do its recovery duty.
+      logEvent("error", {
+        event: "sdp_api_earn_vault_reconciliation_block_height_read_failed",
+        environment,
+        ...describeError(error),
+      });
+      stats.blockHeightReadFailures = 1;
     }
   }
 
@@ -203,18 +262,25 @@ async function reconcileEnvironment(
   for (const [index, movement] of rows.entries()) {
     try {
       // react-doctor-disable-next-line react-doctor/async-await-in-loop -- reconciliation pacing is intentional.
-      await reconcileMovement(env, ledger, movement, statuses[index] ?? null, {
+      const outcome = await reconcileMovement(env, ledger, movement, statuses[index] ?? null, {
         cluster,
         rpcUrl,
         currentBlockHeight,
       });
+      if (outcome === "settled") stats.settled += 1;
+      else if (outcome === "failed") stats.failed += 1;
+      else if (outcome === "confirmed") stats.confirmed += 1;
+      else if (outcome === "resubmitted") stats.resubmitted += 1;
+      else stats.unchanged += 1;
     } catch (error) {
+      stats.movementErrors += 1;
       getLogger().error(
         { movementId: movement.id, signature: movement.signature, error },
         "earn vault reconciliation: movement remains unsettled"
       );
     }
   }
+  return stats;
 }
 
 async function reconcileMovement(
@@ -223,10 +289,10 @@ async function reconcileMovement(
   movement: EarnMovementRow,
   status: SignatureStatusInfo | null,
   chain: { cluster: SolanaCluster; rpcUrl: string; currentBlockHeight: bigint | null }
-): Promise<void> {
+): Promise<MovementOutcome> {
   if (status?.err) {
     await failMovement(ledger, movement, describeVaultSimulationError(status.err).message);
-    return;
+    return "failed";
   }
   if (status?.confirmationStatus === "finalized") {
     const observedAt = new Date().toISOString();
@@ -235,21 +301,20 @@ async function reconcileMovement(
       confirmedAt: observedAt,
       settledAt: observedAt,
     });
-    return;
+    return "settled";
   }
   if (status?.confirmationStatus === "confirmed") {
-    if (movement.status === "confirmed") return;
+    if (movement.status === "confirmed") return "unchanged";
     await advanceTransaction(ledger, movement, {
       toStatus: "confirmed",
       confirmedAt: new Date().toISOString(),
     });
-    return;
+    return "confirmed";
   }
   if (status !== null) {
-    await markSubmitted(ledger, movement);
-    return;
+    return (await markSubmitted(ledger, movement)) ? "resubmitted" : "unchanged";
   }
-  if (movement.status === "confirmed") return;
+  if (movement.status === "confirmed") return "unchanged";
 
   const signedTransaction = movement.signed_transaction;
   const lastValidBlockHeight = movement.last_valid_block_height;
@@ -264,9 +329,9 @@ async function reconcileMovement(
     chain.currentBlockHeight > BigInt(lastValidBlockHeight)
   ) {
     await failMovement(ledger, movement, "Transaction blockhash expired before confirmation");
-    return;
+    return "failed";
   }
-  if (chain.currentBlockHeight === null) return;
+  if (chain.currentBlockHeight === null) return "unchanged";
 
   await broadcastVaultTransaction(env, {
     cluster: chain.cluster,
@@ -275,14 +340,16 @@ async function reconcileMovement(
     rpcUrl: chain.rpcUrl,
   });
   await markSubmitted(ledger, movement);
+  return "resubmitted";
 }
 
 async function markSubmitted(
   ledger: EarnMovementsLedger,
   movement: EarnMovementRow
-): Promise<void> {
-  if (movement.status !== "requested") return;
+): Promise<boolean> {
+  if (movement.status !== "requested") return false;
   await advanceTransaction(ledger, movement, { toStatus: "submitted" });
+  return true;
 }
 
 async function failMovement(

--- a/apps/sdp-api/src/services/earn/vault-movement-reconciliation.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-movement-reconciliation.service.ts
@@ -139,7 +139,10 @@ async function observeEarnVaultMovement(
 
 /**
  * What one sweep tick did with the batch it claimed (PRO-1863). `settled` and
- * `failed` count TRANSITIONS this tick performed, not steady state; the read
+ * `failed` count transitions this tick ATTEMPTED, not steady state and not
+ * transitions that provably landed: the ledger's guarded CAS decides that, and
+ * `advanceTransaction` discards its result, so a row an overlapping tick or the
+ * interactive read-through advanced first is still counted here. The read
  * failures are the counts that must make the tick read failed rather than ok.
  */
 export interface EarnVaultReconciliationStats {

--- a/apps/sdp-api/src/services/earn/vault-movement-reconciliation.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-movement-reconciliation.service.ts
@@ -156,6 +156,10 @@ export interface EarnVaultReconciliationStats {
 
 type MovementOutcome = "settled" | "failed" | "confirmed" | "resubmitted" | "unchanged";
 
+function errorMessage(error: unknown): string {
+  return (error instanceof Error ? error.message : String(error)).slice(0, 300);
+}
+
 function emptyStats(claimed: number): EarnVaultReconciliationStats {
   return {
     claimed,
@@ -234,14 +238,28 @@ async function reconcileEnvironment(
       environment,
       rows: rows.length,
       ...describeError(error),
+      // describeError carries only the error NAME and code; without the message
+      // the alert this event feeds fires with nothing to diagnose from.
+      error_message: errorMessage(error),
     });
     stats.statusReadFailures = 1;
     stats.unchanged = rows.length;
     return stats;
   }
 
+  // Only a null-status row that is NOT already confirmed can consume the
+  // height: reconcileMovement short-circuits a confirmed row to "unchanged"
+  // before ever reading it. A confirmed signature that has aged out of RPC
+  // history is a permanent, expected member of the claim set (PRO-1716 plus
+  // the claim query's reserved confirmed quota), so gating on the RPC answer
+  // alone spent a discarded chain call every minute AND let its failure fail a
+  // tick that had done its entire job. Gate the READ, so the failure
+  // accounting below is correct by construction.
+  const needsBlockHeight = rows.some(
+    (row, index) => (statuses[index] ?? null) === null && row.status !== "confirmed"
+  );
   let currentBlockHeight: bigint | null = null;
-  if (statuses.some((status) => status === null)) {
+  if (needsBlockHeight) {
     try {
       currentBlockHeight = await rpc.getBlockHeight({ commitment: "confirmed" }).send();
     } catch (error) {
@@ -252,6 +270,7 @@ async function reconcileEnvironment(
         event: "sdp_api_earn_vault_reconciliation_block_height_read_failed",
         environment,
         ...describeError(error),
+        error_message: errorMessage(error),
       });
       stats.blockHeightReadFailures = 1;
     }

--- a/apps/sdp-api/src/services/jobs/reconcile-earn-vault-movements.test.ts
+++ b/apps/sdp-api/src/services/jobs/reconcile-earn-vault-movements.test.ts
@@ -8,6 +8,7 @@ import { seedTestDatabase } from "@/test/mocks/db";
 const getSignatureStatuses = vi.hoisted(() => vi.fn());
 const getBlockHeight = vi.hoisted(() => vi.fn());
 const broadcastVaultTransaction = vi.hoisted(() => vi.fn());
+const logEvent = vi.hoisted(() => vi.fn());
 
 vi.mock("@sdp/rpc/solana", () => ({
   createRpc: () => ({ getBlockHeight: () => ({ send: getBlockHeight }) }),
@@ -19,8 +20,13 @@ vi.mock("@/services/earn/execution-registry", async (importOriginal) => ({
   resolveClusterRpcUrl: () => "https://rpc.example.invalid",
 }));
 vi.mock("@/services/earn/vault-execution.service", () => ({ broadcastVaultTransaction }));
+vi.mock("@/runtime/money-path-events", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/runtime/money-path-events")>()),
+  logEvent,
+}));
 
 const { reconcileEarnVaultMovements } = await import("./reconcile-earn-vault-movements");
+const { runWithCronRunEvent, CRON_RUN_EVENT } = await import("../../cron/run-event");
 const { reconcileEarnVaultMovementReadThrough } = await import(
   "../earn/vault-movement-reconciliation.service"
 );
@@ -462,5 +468,135 @@ describe("reconcileEarnVaultMovements", () => {
       status: "finalized",
       failure_reason: null,
     });
+  });
+});
+
+/**
+ * Sweep telemetry (PRO-1863, threat model EARN-006).
+ *
+ * The failure this pins: a chain read failure used to return cleanly, so the
+ * per-tick `sdp_cron_run` event read ok while nothing settled and no backlog
+ * signal existed anywhere.
+ */
+describe("reconcileEarnVaultMovements: sweep telemetry", () => {
+  function tickPayload(): Record<string, unknown> | undefined {
+    const call = logEvent.mock.calls.find(
+      ([, payload]) => payload?.event === "sdp_api_earn_vault_reconciliation_tick"
+    );
+    return call?.[1];
+  }
+
+  function tickLevel(): string | undefined {
+    const call = logEvent.mock.calls.find(
+      ([, payload]) => payload?.event === "sdp_api_earn_vault_reconciliation_tick"
+    );
+    return call?.[0];
+  }
+
+  it("emits an info tick with the batch outcome and an empty backlog", async () => {
+    await seedMovement();
+    getSignatureStatuses.mockResolvedValue([
+      { slot: 1n, confirmations: null, err: null, confirmationStatus: "finalized" },
+    ]);
+
+    await reconcileEarnVaultMovements(env);
+
+    expect(tickLevel()).toBe("info");
+    expect(tickPayload()).toMatchObject({
+      claimed: 1,
+      settled: 1,
+      failed: 0,
+      status_read_failures: 0,
+      block_height_read_failures: 0,
+      backlog: 0,
+      oldest_unsettled_age_seconds: null,
+      batch_saturated: false,
+    });
+  });
+
+  it("reports the backlog and the age of the oldest unsettled movement", async () => {
+    // `confirmed` is not settled (PRO-1716), so both rows stay in the queue and
+    // the tick has to say so: this is the number the backlog alert watches.
+    await seedMovement();
+    await seedMovement();
+    getSignatureStatuses.mockImplementation(async (_rpc: unknown, signatures: string[]) =>
+      signatures.map(() => ({
+        slot: 1n,
+        confirmations: 1n,
+        err: null,
+        confirmationStatus: "confirmed",
+      }))
+    );
+
+    await reconcileEarnVaultMovements(env);
+
+    const payload = tickPayload();
+    expect(payload).toMatchObject({ claimed: 2, confirmed: 2, settled: 0, backlog: 2 });
+    expect(payload?.oldest_unsettled_age_seconds).toBeGreaterThanOrEqual(0);
+  });
+
+  it("fails the tick loudly when the chain status read is unavailable", async () => {
+    // The EARN-006 case: an RPC outage must not read as an ok tick while every
+    // claimed movement goes unjudged.
+    const seeded = await seedMovement();
+    getSignatureStatuses.mockRejectedValue(new Error("rpc unavailable"));
+
+    await expect(reconcileEarnVaultMovements(env)).rejects.toThrow(/could not read chain state/);
+
+    expect(tickLevel()).toBe("error");
+    expect(tickPayload()).toMatchObject({
+      claimed: 1,
+      settled: 0,
+      status_read_failures: 1,
+      unchanged: 1,
+      backlog: 1,
+    });
+    expect(logEvent).toHaveBeenCalledWith(
+      "error",
+      expect.objectContaining({
+        event: "sdp_api_earn_vault_reconciliation_status_read_failed",
+        environment: "sandbox",
+        rows: 1,
+      })
+    );
+    // The movement is untouched and stays claimable by the next tick.
+    await expect(ledgerRow(seeded.movement.id)).resolves.toMatchObject({ status: "requested" });
+  });
+
+  it("fails the tick when the block height needed for recovery is unavailable", async () => {
+    // Without a height the sweep can neither rebroadcast nor expire an unknown
+    // signature, so it did none of its recovery duty this tick.
+    await seedMovement();
+    getSignatureStatuses.mockResolvedValue([null]);
+    getBlockHeight.mockRejectedValue(new Error("rpc unavailable"));
+
+    await expect(reconcileEarnVaultMovements(env)).rejects.toThrow(/could not read chain state/);
+
+    expect(tickLevel()).toBe("error");
+    expect(tickPayload()).toMatchObject({ block_height_read_failures: 1, backlog: 1 });
+    expect(broadcastVaultTransaction).not.toHaveBeenCalled();
+  });
+
+  it("makes the cron run itself report error, not ok (EARN-006 end to end)", async () => {
+    // The literal acceptance criterion, composed with the REAL wrapper both
+    // runners use: before this, the read failure returned cleanly and the tick
+    // event said `ok` while nothing settled.
+    await seedMovement();
+    getSignatureStatuses.mockRejectedValue(new Error("rpc unavailable"));
+
+    await expect(
+      runWithCronRunEvent("sdp-api-reconcile-earn-vault-movements", () =>
+        reconcileEarnVaultMovements(env)
+      )
+    ).rejects.toThrow(/could not read chain state/);
+
+    expect(logEvent).toHaveBeenCalledWith(
+      "error",
+      expect.objectContaining({ event: CRON_RUN_EVENT, status: "error" })
+    );
+    expect(logEvent).not.toHaveBeenCalledWith(
+      "info",
+      expect.objectContaining({ event: CRON_RUN_EVENT, status: "ok" })
+    );
   });
 });

--- a/apps/sdp-api/src/services/jobs/reconcile-earn-vault-movements.test.ts
+++ b/apps/sdp-api/src/services/jobs/reconcile-earn-vault-movements.test.ts
@@ -437,11 +437,13 @@ describe("reconcileEarnVaultMovements", () => {
     // RPC forgetting it — never grounds to expire it on the blockhash rule, which
     // only ever applied to a transaction that never made it on chain.
     getSignatureStatuses.mockResolvedValue([null]);
-    getBlockHeight.mockResolvedValue(100_000n);
     await reconcileEarnVaultMovements(env);
 
     await expect(ledgerRow(seeded.movement.id)).resolves.toMatchObject({ status: "confirmed" });
     expect(broadcastVaultTransaction).not.toHaveBeenCalled();
+    // No stubbed height here on purpose: such a row can never consume one, so
+    // a stub would mask the gate that keeps its failure off the tick.
+    expect(getBlockHeight).not.toHaveBeenCalled();
   });
 
   it("fails a finalized-then-errored signature without regressing a settled row", async () => {
@@ -541,7 +543,7 @@ describe("reconcileEarnVaultMovements: sweep telemetry", () => {
     const seeded = await seedMovement();
     getSignatureStatuses.mockRejectedValue(new Error("rpc unavailable"));
 
-    await expect(reconcileEarnVaultMovements(env)).rejects.toThrow(/could not read chain state/);
+    await expect(reconcileEarnVaultMovements(env)).rejects.toThrow(/1 status-read/);
 
     expect(tickLevel()).toBe("error");
     expect(tickPayload()).toMatchObject({
@@ -570,11 +572,145 @@ describe("reconcileEarnVaultMovements: sweep telemetry", () => {
     getSignatureStatuses.mockResolvedValue([null]);
     getBlockHeight.mockRejectedValue(new Error("rpc unavailable"));
 
-    await expect(reconcileEarnVaultMovements(env)).rejects.toThrow(/could not read chain state/);
+    await expect(reconcileEarnVaultMovements(env)).rejects.toThrow(/1 block-height/);
 
     expect(tickLevel()).toBe("error");
     expect(tickPayload()).toMatchObject({ block_height_read_failures: 1, backlog: 1 });
     expect(broadcastVaultTransaction).not.toHaveBeenCalled();
+  });
+
+  it("does not read the block height when every unknown signature is already confirmed", async () => {
+    // The read is gated on rows that can CONSUME a height. A parked confirmed
+    // row (signature aged out of RPC history) is a permanent member of the
+    // claim set, so counting its unneeded read failure would page forever for
+    // a tick that did its whole job.
+    await seedMovement();
+    getSignatureStatuses.mockResolvedValue([
+      { slot: 1n, confirmations: 1n, err: null, confirmationStatus: "confirmed" },
+    ]);
+    await reconcileEarnVaultMovements(env);
+    logEvent.mockClear();
+
+    getSignatureStatuses.mockResolvedValue([null]);
+    getBlockHeight.mockRejectedValue(new Error("rpc unavailable"));
+
+    await expect(reconcileEarnVaultMovements(env)).resolves.toBeUndefined();
+
+    expect(getBlockHeight).not.toHaveBeenCalled();
+    expect(tickLevel()).toBe("info");
+    expect(tickPayload()).toMatchObject({
+      block_height_read_failures: 0,
+      unchanged: 1,
+      backlog: 1,
+      backlog_blockhash_bound: 0,
+      backlog_confirmed: 1,
+    });
+    // The parked row cannot pin the actionable age gauge.
+    expect(tickPayload()?.oldest_blockhash_bound_age_seconds).toBeNull();
+    expect(tickPayload()?.oldest_unsettled_age_seconds).toBeGreaterThanOrEqual(0);
+  });
+
+  it("still fails the tick when a blockhash-bound row in the same batch needs the height", async () => {
+    // Guards against over-narrowing: one parked confirmed row must not buy
+    // immunity for a requested row that genuinely needs recovery.
+    await seedMovement();
+    getSignatureStatuses.mockResolvedValue([
+      { slot: 1n, confirmations: 1n, err: null, confirmationStatus: "confirmed" },
+    ]);
+    await reconcileEarnVaultMovements(env);
+    await seedMovement();
+    logEvent.mockClear();
+
+    getSignatureStatuses.mockImplementation(async (_rpc: unknown, signatures: string[]) =>
+      signatures.map(() => null)
+    );
+    getBlockHeight.mockRejectedValue(new Error("rpc unavailable"));
+
+    await expect(reconcileEarnVaultMovements(env)).rejects.toThrow(/1 block-height/);
+
+    expect(getBlockHeight).toHaveBeenCalled();
+    expect(tickLevel()).toBe("error");
+    expect(tickPayload()).toMatchObject({ block_height_read_failures: 1 });
+    expect(broadcastVaultTransaction).not.toHaveBeenCalled();
+  });
+
+  it("fails the tick when the writes fail even though both chain reads answered", async () => {
+    // Reads fine, write side down (pool exhaustion, or a send-side RPC
+    // outage): counting only read failures reported this as an ok tick, which
+    // is the exact EARN-006 shape the job exists to close.
+    await seedMovement();
+    getSignatureStatuses.mockResolvedValue([null]);
+    getBlockHeight.mockResolvedValue(99n);
+    broadcastVaultTransaction.mockRejectedValue(new Error("node is behind"));
+
+    await expect(reconcileEarnVaultMovements(env)).rejects.toThrow(/per-movement failures/);
+
+    expect(tickLevel()).toBe("error");
+    expect(tickPayload()).toMatchObject({ movement_errors: 1, settled: 0 });
+  });
+
+  it("reports the exit path on its own axis (ADR 0002)", async () => {
+    const seeded = await seedWithdrawal();
+    getSignatureStatuses.mockResolvedValue([
+      { slot: 1n, confirmations: 1n, err: null, confirmationStatus: "confirmed" },
+    ]);
+
+    await reconcileEarnVaultMovements(env);
+
+    expect(tickPayload()).toMatchObject({ backlog: 1, backlog_withdrawals: 1 });
+    expect(tickPayload()?.oldest_withdrawal_age_seconds).toBeGreaterThanOrEqual(0);
+    await expect(ledgerRow(seeded.movement.id)).resolves.toMatchObject({ status: "confirmed" });
+  });
+
+  it("keeps the diagnosable cause on the chain-read failure event", async () => {
+    await seedMovement();
+    getSignatureStatuses.mockRejectedValue(new Error("429 rate limited by provider"));
+
+    await expect(reconcileEarnVaultMovements(env)).rejects.toThrow();
+
+    expect(logEvent).toHaveBeenCalledWith(
+      "error",
+      expect.objectContaining({
+        event: "sdp_api_earn_vault_reconciliation_status_read_failed",
+        error_message: "429 rate limited by provider",
+      })
+    );
+  });
+
+  it("reports exactly the backlog the next claim would take", async () => {
+    // The repository comment promises these two predicates stay in lockstep;
+    // this asserts it against the claim itself rather than a literal, so they
+    // fail together instead of drifting.
+    await seedMovement();
+    await seedMovement();
+    const settled = await seedMovement();
+    getSignatureStatuses.mockImplementation(async (_rpc: unknown, signatures: string[]) =>
+      signatures.map(() => null)
+    );
+    getBlockHeight.mockResolvedValue(99n);
+    await reconcileEarnVaultMovements(env);
+    await createPostgresEarnMovementsRepository(getDb(env)).advanceVaultMovement({
+      movementId: settled.movement.id,
+      organizationId: ORG,
+      toStatus: "failed",
+      failureReason: "test setup",
+    });
+    logEvent.mockClear();
+
+    getSignatureStatuses.mockImplementation(async (_rpc: unknown, signatures: string[]) =>
+      signatures.map(() => ({
+        slot: 1n,
+        confirmations: 1n,
+        err: null,
+        confirmationStatus: "confirmed",
+      }))
+    );
+    await reconcileEarnVaultMovements(env);
+
+    const claimable = await createPostgresEarnMovementsRepository(
+      getDb(env)
+    ).claimUnsettledVaultMovements(256);
+    expect(tickPayload()?.backlog).toBe(claimable.length);
   });
 
   it("makes the cron run itself report error, not ok (EARN-006 end to end)", async () => {
@@ -588,7 +724,7 @@ describe("reconcileEarnVaultMovements: sweep telemetry", () => {
       runWithCronRunEvent("sdp-api-reconcile-earn-vault-movements", () =>
         reconcileEarnVaultMovements(env)
       )
-    ).rejects.toThrow(/could not read chain state/);
+    ).rejects.toThrow(/Earn vault reconciliation failed/);
 
     expect(logEvent).toHaveBeenCalledWith(
       "error",

--- a/apps/sdp-api/src/services/jobs/reconcile-earn-vault-movements.test.ts
+++ b/apps/sdp-api/src/services/jobs/reconcile-earn-vault-movements.test.ts
@@ -677,40 +677,70 @@ describe("reconcileEarnVaultMovements: sweep telemetry", () => {
     );
   });
 
-  it("reports exactly the backlog the next claim would take", async () => {
-    // The repository comment promises these two predicates stay in lockstep;
-    // this asserts it against the claim itself rather than a literal, so they
-    // fail together instead of drifting.
-    await seedMovement();
-    await seedMovement();
-    const settled = await seedMovement();
-    getSignatureStatuses.mockImplementation(async (_rpc: unknown, signatures: string[]) =>
-      signatures.map(() => null)
-    );
-    getBlockHeight.mockResolvedValue(99n);
-    await reconcileEarnVaultMovements(env);
-    await createPostgresEarnMovementsRepository(getDb(env)).advanceVaultMovement({
-      movementId: settled.movement.id,
+  it("reports exactly the rows the next claim would take, across every status", async () => {
+    // The repository comment promises the backlog predicate and the claim
+    // predicate stay in lockstep. Assert it against the claim ITSELF, with one
+    // row in every reachable status so a predicate that drops or adds a status
+    // fails here instead of drifting silently into production. Comparing the
+    // id SETS (not just the counts) also catches a compensating drift that
+    // swaps one status for another.
+    const ledger = createPostgresEarnMovementsRepository(getDb(env));
+    const requested = await seedMovement();
+    const submitted = await seedMovement();
+    const confirmed = await seedMovement();
+    const failed = await seedMovement();
+    const finalized = await seedMovement();
+    const observedAt = new Date(0).toISOString();
+
+    await ledger.advanceVaultMovement({
+      movementId: submitted.movement.id,
+      organizationId: ORG,
+      toStatus: "submitted",
+    });
+    await ledger.advanceVaultMovement({
+      movementId: confirmed.movement.id,
+      organizationId: ORG,
+      toStatus: "confirmed",
+      confirmedAt: observedAt,
+    });
+    await ledger.advanceVaultMovement({
+      movementId: failed.movement.id,
       organizationId: ORG,
       toStatus: "failed",
       failureReason: "test setup",
     });
-    logEvent.mockClear();
+    await ledger.advanceVaultMovement({
+      movementId: finalized.movement.id,
+      organizationId: ORG,
+      toStatus: "finalized",
+      confirmedAt: observedAt,
+      settledAt: observedAt,
+    });
 
-    getSignatureStatuses.mockImplementation(async (_rpc: unknown, signatures: string[]) =>
-      signatures.map(() => ({
-        slot: 1n,
-        confirmations: 1n,
-        err: null,
-        confirmationStatus: "confirmed",
-      }))
+    const stats = await ledger.getUnsettledVaultMovementStats();
+    const claimable = await ledger.claimUnsettledVaultMovements(256);
+
+    // Unsettled: requested, submitted, confirmed. Terminal: failed, finalized.
+    expect(new Set(claimable.map((row) => row.id))).toEqual(
+      new Set([requested.movement.id, submitted.movement.id, confirmed.movement.id])
     );
-    await reconcileEarnVaultMovements(env);
+    expect(stats.backlog).toBe(claimable.length);
+    expect(stats.backlogBlockhashBound).toBe(2);
+    expect(stats.backlogConfirmed).toBe(1);
+    // Deposits here, so the exit axis stays empty and cannot be a false positive.
+    expect(stats.backlogWithdrawals).toBe(0);
+    expect(stats.oldestWithdrawalCreatedAt).toBeNull();
+    expect(stats.oldestBlockhashBoundCreatedAt).not.toBeNull();
+  });
 
-    const claimable = await createPostgresEarnMovementsRepository(
-      getDb(env)
-    ).claimUnsettledVaultMovements(256);
-    expect(tickPayload()?.backlog).toBe(claimable.length);
+  it("counts a withdrawal on the exit axis of the backlog", async () => {
+    const ledger = createPostgresEarnMovementsRepository(getDb(env));
+    await seedWithdrawal();
+
+    const stats = await ledger.getUnsettledVaultMovementStats();
+
+    expect(stats.backlogWithdrawals).toBe(1);
+    expect(stats.oldestWithdrawalCreatedAt).not.toBeNull();
   });
 
   it("makes the cron run itself report error, not ok (EARN-006 end to end)", async () => {

--- a/apps/sdp-api/src/services/jobs/reconcile-earn-vault-movements.ts
+++ b/apps/sdp-api/src/services/jobs/reconcile-earn-vault-movements.ts
@@ -1,5 +1,6 @@
 import { getDb } from "@/db";
 import { createPostgresEarnMovementsRepository } from "@/db/repositories/earn-movements.repository";
+import { logEvent } from "@/runtime/money-path-events";
 import { reconcileEarnVaultMovementBatch } from "@/services/earn/vault-movement-reconciliation.service";
 import type { Env } from "@/types/env";
 
@@ -17,9 +18,50 @@ const OUTBOX_BATCH_SIZE = 256;
  * Every transition goes through the one ledger writer, and every legal source
  * state comes from the shared transition matrix — so a status this sweep cannot
  * legitimately reach is unrepresentable rather than merely unlikely.
+ *
+ * Every tick emits `sdp_api_earn_vault_reconciliation_tick` (PRO-1863, the
+ * `sdp_api_sponsorship_reconciliation_tick` precedent): claimed/settled/failed
+ * counts plus the post-tick backlog and age-of-oldest-unsettled, which is what
+ * the Grafana backlog and movement-age alerts key on. A chain read failure
+ * still emits the tick (at error level, with the failure counts) and then
+ * THROWS, so the cron run reads failed instead of ok while nothing settles
+ * (EARN-006: an RPC outage used to be swallowed into an ok tick).
  */
 export async function reconcileEarnVaultMovements(env: Env): Promise<void> {
   const ledger = createPostgresEarnMovementsRepository(getDb(env));
   const movements = await ledger.claimUnsettledVaultMovements(OUTBOX_BATCH_SIZE);
-  await reconcileEarnVaultMovementBatch(env, movements);
+  const stats = await reconcileEarnVaultMovementBatch(env, movements);
+  const { backlog, oldestUnsettledCreatedAt } = await ledger.getUnsettledVaultMovementStats();
+
+  const readFailures = stats.statusReadFailures + stats.blockHeightReadFailures;
+  logEvent(readFailures > 0 ? "error" : "info", {
+    event: "sdp_api_earn_vault_reconciliation_tick",
+    claimed: stats.claimed,
+    settled: stats.settled,
+    failed: stats.failed,
+    confirmed: stats.confirmed,
+    resubmitted: stats.resubmitted,
+    unchanged: stats.unchanged,
+    movement_errors: stats.movementErrors,
+    status_read_failures: stats.statusReadFailures,
+    block_height_read_failures: stats.blockHeightReadFailures,
+    backlog,
+    oldest_unsettled_age_seconds: ageInSeconds(oldestUnsettledCreatedAt),
+    batch_saturated: movements.length === OUTBOX_BATCH_SIZE,
+  });
+
+  if (readFailures > 0) {
+    throw new Error(
+      `Earn vault reconciliation could not read chain state ` +
+        `(${stats.statusReadFailures} status, ${stats.blockHeightReadFailures} block-height failures); ` +
+        `${stats.unchanged} of ${stats.claimed} claimed movements went unjudged`
+    );
+  }
+}
+
+function ageInSeconds(createdAt: string | null): number | null {
+  if (createdAt === null) return null;
+  const created = new Date(createdAt).getTime();
+  if (Number.isNaN(created)) return null;
+  return Math.max(0, Math.round((Date.now() - created) / 1000));
 }

--- a/apps/sdp-api/src/services/jobs/reconcile-earn-vault-movements.ts
+++ b/apps/sdp-api/src/services/jobs/reconcile-earn-vault-movements.ts
@@ -19,22 +19,39 @@ const OUTBOX_BATCH_SIZE = 256;
  * state comes from the shared transition matrix — so a status this sweep cannot
  * legitimately reach is unrepresentable rather than merely unlikely.
  *
- * Every tick emits `sdp_api_earn_vault_reconciliation_tick` (PRO-1863, the
- * `sdp_api_sponsorship_reconciliation_tick` precedent): claimed/settled/failed
- * counts plus the post-tick backlog and age-of-oldest-unsettled, which is what
- * the Grafana backlog and movement-age alerts key on. A chain read failure
- * still emits the tick (at error level, with the failure counts) and then
- * THROWS, so the cron run reads failed instead of ok while nothing settles
- * (EARN-006: an RPC outage used to be swallowed into an ok tick).
+ * A completed tick emits `sdp_api_earn_vault_reconciliation_tick` (PRO-1863,
+ * the `sdp_api_sponsorship_reconciliation_tick` precedent): claimed/settled/
+ * failed counts plus the post-tick backlog and ages, which is what the Grafana
+ * backlog and movement-age alerts key on. A chain read failure or a
+ * per-movement failure still emits the tick (at error level, with the failure
+ * counts) and then THROWS, so the cron run reads failed instead of ok while
+ * nothing settles (EARN-006: an RPC outage used to be swallowed into an ok
+ * tick).
+ *
+ * "Completed" is the honest qualifier: a rejection from the claim or backlog
+ * QUERY itself skips the event, exactly as the sponsorship reconciler skips
+ * its tick when its own candidate read fails. That is deliberate, not a gap.
+ * The run is still loud (`sdp_cron_run` records `status: "error"` and the job
+ * exits non-zero), and a synthesized fallback tick could only carry a null
+ * backlog (invisible to a threshold rule, i.e. identical to no tick) or a zero
+ * (actively harmful: it reads as a drained queue and would CLEAR a firing
+ * backlog alert mid-incident). Alert on the absence of the tick, never on a
+ * fabricated one.
  */
 export async function reconcileEarnVaultMovements(env: Env): Promise<void> {
   const ledger = createPostgresEarnMovementsRepository(getDb(env));
   const movements = await ledger.claimUnsettledVaultMovements(OUTBOX_BATCH_SIZE);
   const stats = await reconcileEarnVaultMovementBatch(env, movements);
-  const { backlog, oldestUnsettledCreatedAt } = await ledger.getUnsettledVaultMovementStats();
+  const backlogStats = await ledger.getUnsettledVaultMovementStats();
 
-  const readFailures = stats.statusReadFailures + stats.blockHeightReadFailures;
-  logEvent(readFailures > 0 ? "error" : "info", {
+  // Per-movement failures count toward the verdict too, not just chain reads:
+  // a Postgres pool exhaustion or a send-side RPC outage makes every
+  // `advanceVaultMovement`/broadcast throw while both reads answer fine, and
+  // reporting that batch as an ok tick is the same EARN-006 silence this job
+  // exists to close. Same posture as the sponsorship reconciler, which emits
+  // its tick and then throws an AggregateError when any item failed.
+  const failures = stats.statusReadFailures + stats.blockHeightReadFailures + stats.movementErrors;
+  logEvent(failures > 0 ? "error" : "info", {
     event: "sdp_api_earn_vault_reconciliation_tick",
     claimed: stats.claimed,
     settled: stats.settled,
@@ -45,16 +62,25 @@ export async function reconcileEarnVaultMovements(env: Env): Promise<void> {
     movement_errors: stats.movementErrors,
     status_read_failures: stats.statusReadFailures,
     block_height_read_failures: stats.blockHeightReadFailures,
-    backlog,
-    oldest_unsettled_age_seconds: ageInSeconds(oldestUnsettledCreatedAt),
+    backlog: backlogStats.backlog,
+    // The actionable subset: a `confirmed` row whose signature aged out never
+    // leaves the backlog, so a total-only age would latch and page forever.
+    backlog_blockhash_bound: backlogStats.backlogBlockhashBound,
+    backlog_confirmed: backlogStats.backlogConfirmed,
+    backlog_withdrawals: backlogStats.backlogWithdrawals,
+    oldest_unsettled_age_seconds: ageInSeconds(backlogStats.oldestUnsettledCreatedAt),
+    oldest_blockhash_bound_age_seconds: ageInSeconds(backlogStats.oldestBlockhashBoundCreatedAt),
+    // ADR 0002: the exit path gets its own number rather than hiding inside the
+    // total, so a stuck withdrawal is visible without disaggregating.
+    oldest_withdrawal_age_seconds: ageInSeconds(backlogStats.oldestWithdrawalCreatedAt),
     batch_saturated: movements.length === OUTBOX_BATCH_SIZE,
   });
 
-  if (readFailures > 0) {
+  if (failures > 0) {
     throw new Error(
-      `Earn vault reconciliation could not read chain state ` +
-        `(${stats.statusReadFailures} status, ${stats.blockHeightReadFailures} block-height failures); ` +
-        `${stats.unchanged} of ${stats.claimed} claimed movements went unjudged`
+      `Earn vault reconciliation failed ` +
+        `(${stats.statusReadFailures} status-read, ${stats.blockHeightReadFailures} block-height, ` +
+        `${stats.movementErrors} per-movement failures) over ${stats.claimed} claimed movements`
     );
   }
 }

--- a/apps/sdp-api/src/services/jobs/reconcile-earn-vault-movements.ts
+++ b/apps/sdp-api/src/services/jobs/reconcile-earn-vault-movements.ts
@@ -21,8 +21,10 @@ const OUTBOX_BATCH_SIZE = 256;
  *
  * A completed tick emits `sdp_api_earn_vault_reconciliation_tick` (PRO-1863,
  * the `sdp_api_sponsorship_reconciliation_tick` precedent): claimed/settled/
- * failed counts plus the post-tick backlog and ages, which is what the Grafana
- * backlog and movement-age alerts key on. A chain read failure or a
+ * failed counts plus the post-tick backlog and ages. Those are what a backlog
+ * or movement-age rule needs to key on; no such rule exists yet (SDP's alerts
+ * live as code in the sdp-infra repo, and PRO-1863 tracks writing them).
+ * A chain read failure or a
  * per-movement failure still emits the tick (at error level, with the failure
  * counts) and then THROWS, so the cron run reads failed instead of ok while
  * nothing settles (EARN-006: an RPC outage used to be swallowed into an ok


### PR DESCRIPTION
The earn vault reconciliation sweep now reports what it did, and stops reporting success when it did nothing ([PRO-1863](https://linear.app/solana-fndn/issue/PRO-1863/threat-model-emit-reconciliation-sweep-events-and-alert-on-backlog), threat model EARN-006).

**before** (a devnet/mainnet RPC blip):

1. `getSignatureStatuses` throws
2. the catch logs one bare line and `return`s: the whole claimed batch goes unjudged
3. the job resolves, so `sdp_cron_run` records `status: "ok"`
4. nobody can tell money stopped settling; no backlog signal exists anywhere

**after**:

1. the read failure emits `sdp_api_earn_vault_reconciliation_status_read_failed` (or the block-height twin) with structured error fields
2. the tick emits `sdp_api_earn_vault_reconciliation_tick` at **error** level, carrying claimed/settled/failed/confirmed/resubmitted/unchanged plus `backlog` and `oldest_unsettled_age_seconds` read after the tick
3. the job **throws**, so `runWithCronRunEvent` records `status: "error"`
4. a healthy tick emits the same event at info level, which is what the backlog and movement-age alerts key on

## Reviewer notes

**The throw is the load-bearing part, and both runners already absorb it.** The managed job's `collect` records the failure without starving later ticks; `NodeBackgroundRunner.run` attaches its own catch, so no unhandled rejection. Verified by reading both, and jobs + cron suites are green.

**Backlog is read through the claim's own predicate.** `getUnsettledVaultMovementStats` repeats the `claimUnsettledVaultMovements` WHERE clause so the reported backlog is exactly the set the next tick would claim; a comment on both says to keep them in lockstep. `confirmed` counts as backlog, per PRO-1716.

**`reconcileEarnVaultMovementBatch` now returns stats instead of void.** Only the job calls it. One environment's RPC outage is counted and reported without skipping the other environment's batch, which the old early `return` also got wrong.

**Review round 2 changed three things beyond the flagged line.** A verification pass over the diff found that `movementErrors` fed neither the tick level nor the throw, so a batch where reads answered but every write failed (pool exhaustion, send-side RPC outage) still reported an ok tick: the exact EARN-006 shape this PR closes. Per-movement failures now escalate, matching the sponsorship reconciler's emit-then-throw. The backlog is also dimensioned now (`backlog_blockhash_bound`, `backlog_confirmed`, `backlog_withdrawals` plus matching ages), because a `confirmed` row whose signature ages out never leaves the queue and would have latched the age alert red forever. And the chain-read failure events carry `error_message` again, which `describeError` alone had dropped.

**Grafana alerts are deliberately not in this PR.** The events they need now exist; wiring the backlog and movement-age SLA alerts is ops work tracked on the ticket.

**Verification**

- 5 new tests incl. the acceptance criterion end to end: the last one composes the real `runWithCronRunEvent` and asserts `sdp_cron_run` is `error` and never `ok`
- 522 tests green across jobs, cron, earn routes, and the earn repositories; `tsc --noEmit` and biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)