### PR TITLE
feat(api): project-based cluster RPC resolution for onchain money paths

### DIFF
--- a/apps/sdp-api/src/cron/earn-catalogue-sync.ts
+++ b/apps/sdp-api/src/cron/earn-catalogue-sync.ts
@@ -40,7 +40,12 @@ import type {
   EarnVaultProvider,
   ProviderStrategySnapshot,
 } from "@sdp/earn/types";
-import { CLUSTER_BY_SDP_ENVIRONMENT, type SdpEnvironment, type SolanaCluster } from "@sdp/types";
+import {
+  CLUSTER_BY_SDP_ENVIRONMENT,
+  SDP_ENVIRONMENTS,
+  type SdpEnvironment,
+  type SolanaCluster,
+} from "@sdp/types";
 import { createEarnRepository, type EarnRepository } from "@/db/repositories";
 import type { BackgroundRunner } from "@/runtime/background";
 import type { KVStore } from "@/runtime/kv";
@@ -94,7 +99,6 @@ export const EARN_CATALOGUE_SYNC_DEADLINE_SECONDS = 600;
 // devnet mints, production rows mainnet mints), so each provider syncs once per
 // environment — plus, in every non-production environment, the mirrored
 // production mainnet shelf (PRO-1742).
-const SYNCED_ENVIRONMENTS: readonly SdpEnvironment[] = ["sandbox", "production"];
 
 // Expected steady states, not incidents: stub integrations report
 // NOT_IMPLEMENTED and environments without credentials report
@@ -140,7 +144,7 @@ async function syncProviderCatalogue(
     });
   }
 
-  for (const environment of SYNCED_ENVIRONMENTS) {
+  for (const environment of SDP_ENVIRONMENTS) {
     if (environment === "production") {
       continue;
     }

--- a/apps/sdp-api/src/cron/earn-metrics-refresh.ts
+++ b/apps/sdp-api/src/cron/earn-metrics-refresh.ts
@@ -38,7 +38,7 @@ import type {
   EarnRuntimeContext,
   ProviderStrategyMetrics,
 } from "@sdp/earn/types";
-import type { SdpEnvironment } from "@sdp/types";
+import { SDP_ENVIRONMENTS } from "@sdp/types";
 import { createEarnRepository, type EarnRepository } from "@/db/repositories";
 import type { BackgroundRunner } from "@/runtime/background";
 import { getLogger } from "@/runtime/logger";
@@ -73,7 +73,6 @@ export const EARN_METRICS_REFRESH_CRON = "*/5 * * * *";
 // five-minute-fresh production twin, fine for a browse-only, fundable:false
 // review shelf. (A provider whose catalogue snapshots omit the optional
 // currentApy would mirror with no rate at all; none does today.)
-const REFRESHED_ENVIRONMENTS: readonly SdpEnvironment[] = ["sandbox", "production"];
 
 // Expected steady states, not incidents — same taxonomy as the catalogue sync.
 const SKIPPABLE_REFRESH_ERROR_CODES: ReadonlySet<string> = new Set([
@@ -130,7 +129,7 @@ export async function refreshEarnStrategyMetrics(env: Env): Promise<void> {
   const repo = createEarnRepository(env);
   const providerEnv = env;
 
-  for (const environment of REFRESHED_ENVIRONMENTS) {
+  for (const environment of SDP_ENVIRONMENTS) {
     for (const client of Object.values(EARN_PROVIDER_CLIENTS)) {
       // Capability, not a provider list: a provider joins this pass by
       // implementing `listStrategyMetrics`.

--- a/apps/sdp-api/src/db/repositories/dvp-leg-funding-claim.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/dvp-leg-funding-claim.repository.test.ts
@@ -225,12 +225,29 @@ describe("DvpLegFundingClaimRepository", () => {
    * are swept for exactly this reason and this table was not, at first.
    */
   describe("releasing claims that can no longer land", () => {
+    it("leaves a production trade's claim untouched during a sandbox sweep", async () => {
+      await getDb(env)
+        .prepare("UPDATE projects SET environment = 'production' WHERE id = ?")
+        .bind(`prj_${AGENT_ORG}`)
+        .run();
+      await runWithTenantDatabaseIdentity({ organizationId: PARTY_A_ORG }, () =>
+        repo.claim({ ...claimInput(PARTY_A_ORG, "a", "sig_mainnet"), expiryHeight: "500" })
+      );
+
+      expect(await repo.releaseExpired(900n, "sandbox")).toBe(0);
+      await expect(
+        runWithTenantDatabaseIdentity({ organizationId: PARTY_A_ORG }, () =>
+          repo.listForTrade(TRADE_ID)
+        )
+      ).resolves.toHaveLength(1);
+    });
+
     it("frees a leg whose claim is past its last-valid height", async () => {
       await runWithTenantDatabaseIdentity({ organizationId: PARTY_A_ORG }, () =>
         repo.claim({ ...claimInput(PARTY_A_ORG, "a", "sig_dead"), expiryHeight: "500" })
       );
 
-      const released = await repo.releaseExpired(900n);
+      const released = await repo.releaseExpired(900n, "sandbox");
       expect(released).toBe(1);
 
       const retried = await runWithTenantDatabaseIdentity({ organizationId: PARTY_A_ORG }, () =>
@@ -246,7 +263,7 @@ describe("DvpLegFundingClaimRepository", () => {
         repo.claim({ ...claimInput(PARTY_A_ORG, "a", "sig_live"), expiryHeight: "5000" })
       );
 
-      expect(await repo.releaseExpired(900n)).toBe(0);
+      expect(await repo.releaseExpired(900n, "sandbox")).toBe(0);
     });
 
     // A broadcast claim is a receipt. Sweeping it would invite a second
@@ -257,7 +274,7 @@ describe("DvpLegFundingClaimRepository", () => {
         await repo.recordFundingTx(TRADE_ID, "a", "sig_sent");
       });
 
-      expect(await repo.releaseExpired(900n)).toBe(0);
+      expect(await repo.releaseExpired(900n, "sandbox")).toBe(0);
     });
   });
 
@@ -287,7 +304,7 @@ describe("DvpLegFundingClaimRepository", () => {
         });
       });
 
-      const listed = await repo.listExpiredBroadcast(900n);
+      const listed = await repo.listExpiredBroadcast(900n, "sandbox");
 
       expect(listed.map((claim) => claim.signature)).toEqual(["sig_brd_dead"]);
     });

--- a/apps/sdp-api/src/db/repositories/dvp-leg-funding-claim.repository.ts
+++ b/apps/sdp-api/src/db/repositories/dvp-leg-funding-claim.repository.ts
@@ -8,6 +8,7 @@
  * ordinary tenant isolation.
  */
 
+import type { SdpEnvironment } from "@sdp/types";
 import type { RepositoryDbClient } from "./base";
 
 export interface DvpLegFundingClaim {
@@ -64,8 +65,12 @@ export interface DvpLegFundingClaimRepository {
    *
    * Never touches a claim that was broadcast: `funding_tx` set means the row is
    * a receipt rather than a lock.
+   *
+   * @param blockHeight - Current block height for the environment's cluster.
+   * @param environment - Project environment whose claims may be released.
+   * @returns Number of released claims.
    */
-  releaseExpired(blockHeight: bigint): Promise<number>;
+  releaseExpired(blockHeight: bigint, environment: SdpEnvironment): Promise<number>;
   /**
    * Lists broadcast claims whose signed transaction can no longer be accepted.
    *
@@ -73,8 +78,15 @@ export interface DvpLegFundingClaimRepository {
    * on the wire means possibly landed. Past the last-valid height only the
    * chain can say which, so resolution belongs to the reconciler's RPC read,
    * never to the sweep.
+   *
+   * @param blockHeight - Current block height for the environment's cluster.
+   * @param environment - Project environment whose claims may be listed.
+   * @returns Expired broadcast claims in that environment.
    */
-  listExpiredBroadcast(blockHeight: bigint): Promise<DvpLegFundingClaim[]>;
+  listExpiredBroadcast(
+    blockHeight: bigint,
+    environment: SdpEnvironment
+  ): Promise<DvpLegFundingClaim[]>;
   /**
    * Deletes one broadcast claim whose transfer the chain confirmed never landed.
    *
@@ -150,15 +162,18 @@ export function createPostgresDvpLegFundingClaimRepository(
         .run();
     },
 
-    async releaseExpired(blockHeight) {
+    async releaseExpired(blockHeight, environment) {
       const result = await db
         .prepare(
-          `DELETE FROM dvp_leg_funding_claims
-            WHERE funding_tx IS NULL
-              AND CAST(expiry_height AS NUMERIC) < ?
-            RETURNING trade_id`
+          `DELETE FROM dvp_leg_funding_claims c
+           USING dvp_trades t
+           JOIN projects p ON p.id = t.project_id AND p.environment = ?
+            WHERE c.trade_id = t.id
+              AND c.funding_tx IS NULL
+              AND CAST(c.expiry_height AS NUMERIC) < ?
+            RETURNING c.trade_id`
         )
-        .bind(blockHeight.toString())
+        .bind(environment, blockHeight.toString())
         .all<{ trade_id: string }>();
       return result.results.length;
     },
@@ -176,7 +191,7 @@ export function createPostgresDvpLegFundingClaimRepository(
       return result.results.map(toDvpLegFundingClaim);
     },
 
-    async listExpiredBroadcast(blockHeight) {
+    async listExpiredBroadcast(blockHeight, environment) {
       // Open trades only: a closed trade's leg can never be funded again, so
       // its claims are history — without this bound every landed receipt would
       // be re-checked on chain every tick forever.
@@ -186,11 +201,12 @@ export function createPostgresDvpLegFundingClaimRepository(
                   c.signature, c.expiry_height, c.funding_tx
              FROM dvp_leg_funding_claims c
              JOIN dvp_trades t ON t.id = c.trade_id
+             JOIN projects p ON p.id = t.project_id AND p.environment = ?
             WHERE c.funding_tx IS NOT NULL
               AND CAST(c.expiry_height AS NUMERIC) < ?
               AND t.status IN ('created', 'partially_funded', 'funded')`
         )
-        .bind(blockHeight.toString())
+        .bind(environment, blockHeight.toString())
         .all<Record<string, unknown>>();
       return result.results.map(toDvpLegFundingClaim);
     },

--- a/apps/sdp-api/src/db/repositories/dvp-trade.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/dvp-trade.repository.postgres.ts
@@ -234,7 +234,7 @@ export function createPostgresDvpTradeRepository(db: AppDb): DvpTradeRepository 
       return row ? mapDvpTradeRow(row) : null;
     },
 
-    async listOpenForReconciliation(limit: number) {
+    async listOpenForReconciliation(limit: number, environment) {
       if (!Number.isInteger(limit) || limit < 1 || limit > 256) {
         throw new Error("listOpenForReconciliation limit must be an integer from 1 to 256");
       }
@@ -242,16 +242,17 @@ export function createPostgresDvpTradeRepository(db: AppDb): DvpTradeRepository 
       // starve the trades nothing is known about.
       const result = await db
         .prepare(
-          `SELECT ${SELECT_COLUMNS}
-             FROM dvp_trades
-            WHERE status IN ('creating', 'created', 'partially_funded', 'funded', 'expired')
-               OR (status IN ('settled', 'cancelled', 'rejected', 'closed_unknown')
-                   AND closed_at::timestamptz >= CURRENT_TIMESTAMP - INTERVAL '7 days')
-            ORDER BY CASE WHEN status IN ('creating', 'created', 'partially_funded', 'funded', 'expired') THEN 0 ELSE 1 END,
-                     observed_at ASC NULLS FIRST, created_at ASC, id ASC
+          `SELECT t.*
+             FROM dvp_trades t
+             JOIN projects p ON p.id = t.project_id AND p.environment = ?
+            WHERE t.status IN ('creating', 'created', 'partially_funded', 'funded', 'expired')
+               OR (t.status IN ('settled', 'cancelled', 'rejected', 'closed_unknown')
+                   AND t.closed_at::timestamptz >= CURRENT_TIMESTAMP - INTERVAL '7 days')
+            ORDER BY CASE WHEN t.status IN ('creating', 'created', 'partially_funded', 'funded', 'expired') THEN 0 ELSE 1 END,
+                     t.observed_at ASC NULLS FIRST, t.created_at ASC, t.id ASC
             LIMIT ?`
         )
-        .bind(limit)
+        .bind(environment, limit)
         .all<Record<string, unknown>>();
       return result.results.map((row) => mapDvpTradeRow(row));
     },

--- a/apps/sdp-api/src/db/repositories/dvp-trade.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/dvp-trade.repository.test.ts
@@ -364,7 +364,7 @@ describe("DvpTradeRepository (postgres)", () => {
       )
       .run();
 
-    const listed = await repo.listOpenForReconciliation(10);
+    const listed = await repo.listOpenForReconciliation(10, "sandbox");
 
     expect(listed.map((trade) => trade.id).sort()).toEqual(["dvp_closed_recent", "dvp_open_old"]);
   });

--- a/apps/sdp-api/src/db/repositories/dvp-trade.repository.ts
+++ b/apps/sdp-api/src/db/repositories/dvp-trade.repository.ts
@@ -6,7 +6,7 @@
 // derives a different SwapDvp address than the one a counterparty was told to
 // fund. Callers convert to bigint at the edge, never number.
 
-import type { DvpTradeStatus } from "@sdp/types";
+import type { DvpTradeStatus, SdpEnvironment } from "@sdp/types";
 import type { Address, Signature } from "@solana/kit";
 import type { RepositoryDbClient } from "./base";
 
@@ -173,15 +173,19 @@ export interface DvpTradeRepository {
   /** Null when unknown. Lookup by the address a counterparty actually sees. */
   getBySwapDvp(scope: DvpTradeScope, swapDvp: Address): Promise<DvpTradeRow | null>;
   /**
-   * Open trades and recently closed trades across every project, stalest
+   * Open trades and recently closed trades in one project environment, stalest
    * observation first. Closed trades remain eligible for seven days from the
    * first time their closed status was recorded.
    *
    * Deliberately UNSCOPED, unlike every read above. The reconciler is not acting
    * for a caller — it is a background sweep, and scoping it to a project would
    * mean a trade only advances while someone happens to be looking at it.
+   *
+   * @param limit - Maximum number of trades to return.
+   * @param environment - Project environment whose cluster is being reconciled.
+   * @returns Eligible trades belonging to projects in the environment.
    */
-  listOpenForReconciliation(limit: number): Promise<DvpTradeRow[]>;
+  listOpenForReconciliation(limit: number, environment: SdpEnvironment): Promise<DvpTradeRow[]>;
   /**
    * Writes an observation and the status derived from it.
    *

--- a/apps/sdp-api/src/lib/cluster-env.test.ts
+++ b/apps/sdp-api/src/lib/cluster-env.test.ts
@@ -1,0 +1,89 @@
+import { getSolanaConfig } from "@sdp/rpc";
+import { describe, expect, it } from "vitest";
+import type { Env } from "@/types/env";
+import { scopeEnvToCluster } from "./cluster-env";
+
+describe("scopeEnvToCluster", () => {
+  it("copies an already-devnet environment without changing its provider fan", () => {
+    const input = {
+      SOLANA_NETWORK: "devnet",
+      SOLANA_RPC_URL: "https://devnet.example.invalid",
+      SOLANA_RPC_HELIUS_URL: "https://helius-devnet.example.invalid",
+      KORA_RPC_URL: "https://kora.example.invalid",
+    } as Env;
+
+    const scoped = scopeEnvToCluster(input, "devnet");
+
+    expect(scoped).toEqual(input);
+    expect(scoped).not.toBe(input);
+  });
+
+  it("uses the mainnet override and clears default-cluster providers and Kora", () => {
+    const scoped = scopeEnvToCluster(
+      {
+        SOLANA_NETWORK: "devnet",
+        SOLANA_RPC_URL: "https://devnet.example.invalid",
+        SOLANA_MAINNET_RPC_URL: "https://mainnet.example.invalid",
+        SOLANA_RPC_DEFAULT_PROVIDER: "helius",
+        SOLANA_RPC_HELIUS_URL: "https://helius-devnet.example.invalid",
+        SOLANA_RPC_HELIUS_API_KEY: "secret",
+        KORA_RPC_URL: "https://kora.example.invalid",
+      } as Env,
+      "mainnet-beta"
+    );
+
+    expect(scoped).toMatchObject({
+      SOLANA_NETWORK: "mainnet-beta",
+      SOLANA_RPC_URL: "https://mainnet.example.invalid",
+    });
+    expect(scoped.SOLANA_RPC_DEFAULT_PROVIDER).toBeUndefined();
+    expect(scoped.SOLANA_RPC_HELIUS_URL).toBeUndefined();
+    expect(scoped.SOLANA_RPC_HELIUS_API_KEY).toBeUndefined();
+    expect(scoped.KORA_RPC_URL).toBeUndefined();
+  });
+
+  it("fails closed with a cluster-named error when mainnet has no override", () => {
+    const scoped = scopeEnvToCluster(
+      {
+        SOLANA_NETWORK: "devnet",
+        SOLANA_RPC_URL: "https://devnet.example.invalid",
+      } as Env,
+      "mainnet-beta"
+    );
+
+    expect(scoped.SOLANA_RPC_URL).toBeUndefined();
+    expect(() => getSolanaConfig(scoped)).toThrow(
+      "No Solana RPC endpoint is configured for mainnet-beta"
+    );
+  });
+
+  it("uses the devnet override from a mainnet-default deployment", () => {
+    const scoped = scopeEnvToCluster(
+      {
+        SOLANA_NETWORK: "mainnet-beta",
+        SOLANA_RPC_URL: "https://mainnet.example.invalid",
+        SOLANA_DEVNET_RPC_URL: "https://devnet.example.invalid",
+      } as Env,
+      "devnet"
+    );
+
+    expect(getSolanaConfig(scoped)).toEqual({
+      network: "devnet",
+      rpcUrl: "https://devnet.example.invalid",
+    });
+  });
+
+  it("never mutates the input", () => {
+    const input = {
+      SOLANA_NETWORK: "devnet",
+      SOLANA_RPC_URL: "https://devnet.example.invalid",
+      SOLANA_MAINNET_RPC_URL: "https://mainnet.example.invalid",
+      KORA_RPC_URL: "https://kora.example.invalid",
+    } as Env;
+    const snapshot = { ...input };
+
+    scopeEnvToCluster(input, "mainnet-beta");
+
+    expect(input).toEqual(snapshot);
+  });
+});

--- a/apps/sdp-api/src/lib/cluster-env.ts
+++ b/apps/sdp-api/src/lib/cluster-env.ts
@@ -1,0 +1,75 @@
+import { resolveDefaultCluster } from "@sdp/rpc";
+import { CLUSTER_BY_SDP_ENVIRONMENT, type SolanaCluster } from "@sdp/types";
+import { getDb } from "@/db";
+import { KORA_FEE_SPONSORSHIP_CLUSTERS } from "@/lib/feature-flags";
+import { projectEnvironment } from "@/services/project.service";
+import type { Env } from "@/types/env";
+
+const MANAGED_PROVIDER_KEYS = [
+  "SOLANA_RPC_DEFAULT_PROVIDER",
+  "SOLANA_RPC_TRITON_URL",
+  "SOLANA_RPC_TRITON_API_KEY",
+  "SOLANA_RPC_HELIUS_URL",
+  "SOLANA_RPC_HELIUS_API_KEY",
+  "SOLANA_RPC_ALCHEMY_URL",
+  "SOLANA_RPC_ALCHEMY_API_KEY",
+  "SOLANA_RPC_QUICKNODE_URL",
+  "SOLANA_RPC_QUICKNODE_API_KEY",
+  "SOLANA_RPC_VALIDATIONCLOUD_URL",
+  "SOLANA_RPC_VALIDATIONCLOUD_API_KEY",
+  "SOLANA_RPC_NODIT_URL",
+  "SOLANA_RPC_NODIT_API_KEY",
+] as const satisfies readonly (keyof Env)[];
+
+function unsetManagedProviders(env: Env): void {
+  for (const key of MANAGED_PROVIDER_KEYS) {
+    delete env[key];
+  }
+}
+
+/**
+ * Return an environment whose cluster-dependent configuration is scoped to one Solana cluster.
+ * The returned env is the env for `cluster`: every cluster-dependent reader (`createRpc`,
+ * `getSolanaConfig`, well-known mints, Kora gates, sponsorship network) is correct for that
+ * cluster by construction.
+ *
+ * @param env - Deployment environment to copy and scope.
+ * @param cluster - Solana cluster that the returned environment must describe.
+ * @returns A shallow copy with cluster-specific RPC and Kora configuration.
+ */
+export function scopeEnvToCluster(env: Env, cluster: SolanaCluster): Env {
+  const scoped = { ...env, SOLANA_NETWORK: cluster };
+  const override = cluster === "devnet" ? env.SOLANA_DEVNET_RPC_URL : env.SOLANA_MAINNET_RPC_URL;
+
+  if (override !== undefined) {
+    scoped.SOLANA_RPC_URL = override;
+    unsetManagedProviders(scoped);
+  } else if (cluster !== resolveDefaultCluster(env)) {
+    delete scoped.SOLANA_RPC_URL;
+    unsetManagedProviders(scoped);
+  }
+
+  if (!KORA_FEE_SPONSORSHIP_CLUSTERS.includes(cluster)) {
+    delete scoped.KORA_RPC_URL;
+  }
+
+  return scoped;
+}
+
+/**
+ * Create a per-run resolver that memoizes each project's cluster-scoped environment.
+ *
+ * @param env - Deployment environment used for project lookup and cluster scoping.
+ * @returns A resolver that returns the scoped environment for a project ID.
+ */
+export function createProjectEnvResolver(env: Env): (projectId: string) => Promise<Env> {
+  const scopedEnvs = new Map<string, Env>();
+  return async (projectId: string): Promise<Env> => {
+    const existing = scopedEnvs.get(projectId);
+    if (existing !== undefined) return existing;
+    const environment = await projectEnvironment(getDb(env), projectId);
+    const scoped = scopeEnvToCluster(env, CLUSTER_BY_SDP_ENVIRONMENT[environment]);
+    scopedEnvs.set(projectId, scoped);
+    return scoped;
+  };
+}

--- a/apps/sdp-api/src/lib/feature-flags.ts
+++ b/apps/sdp-api/src/lib/feature-flags.ts
@@ -97,6 +97,12 @@ export function isDvpEnabled(env: Pick<Env, "MARKETS_ENABLED" | "DVP_ENABLED">):
 const EARN_VAULT_SPONSORSHIP_CLUSTERS: readonly SolanaCluster[] = ["devnet"];
 
 /**
+ * Clusters on which the deployment's Kora service may sponsor transactions.
+ * Mainnet remains wallet-paid until its Kora policy and sponsorship budgets are opened safely.
+ */
+export const KORA_FEE_SPONSORSHIP_CLUSTERS: readonly SolanaCluster[] = ["devnet"];
+
+/**
  * Whether Kora sponsors an Earn vault movement on `cluster`: both the network
  * fee and the share-ATA rent a first deposit needs.
  *

--- a/apps/sdp-api/src/middleware/project-context.test.ts
+++ b/apps/sdp-api/src/middleware/project-context.test.ts
@@ -35,6 +35,7 @@ function buildApp(setup: (c: Context<{ Bindings: Env }>) => void) {
     c.json({
       projectId: c.get("projectId"),
       projectEnvironment: c.get("projectEnvironment"),
+      solanaNetwork: c.env.SOLANA_NETWORK,
     })
   );
 
@@ -110,9 +111,11 @@ describe("projectContextMiddleware", () => {
     const body = (await res.json()) as {
       projectId: string;
       projectEnvironment: string;
+      solanaNetwork: string;
     };
     expect(body.projectId).toBe(MEMBER_PROJECT_ID);
     expect(body.projectEnvironment).toBe("sandbox");
+    expect(body.solanaNetwork).toBe("devnet");
   });
 
   it("rejects an x-project-id header for a project in the same org the user does not belong to", async () => {
@@ -166,6 +169,26 @@ describe("projectContextMiddleware", () => {
     };
     expect(body.projectId).toBe(MEMBER_PROJECT_ID);
     expect(body.projectEnvironment).toBe("sandbox");
+  });
+
+  it("scopes an API-key production request to mainnet-beta", async () => {
+    const app = buildApp((c) =>
+      c.set("apiKey", {
+        id: "key_project_context_production",
+        organizationId: ORG_ID,
+        projectId: MEMBER_PROJECT_ID,
+        role: "api_admin",
+        permissions: ["*"],
+        environment: "production",
+        signingWalletId: null,
+      })
+    );
+
+    const res = await app.request("/probe", {}, env);
+    const body = (await res.json()) as { solanaNetwork: string };
+
+    expect(res.status).toBe(200);
+    expect(body.solanaNetwork).toBe("mainnet-beta");
   });
 
   it("returns 401 when neither API key nor session is present", async () => {

--- a/apps/sdp-api/src/middleware/project-context.ts
+++ b/apps/sdp-api/src/middleware/project-context.ts
@@ -1,5 +1,7 @@
+import { CLUSTER_BY_SDP_ENVIRONMENT, type SdpEnvironment } from "@sdp/types";
 import type { Context, Next } from "hono";
 import { getDb } from "@/db";
+import { scopeEnvToCluster } from "@/lib/cluster-env";
 import { badRequest, forbidden, unauthorized } from "@/lib/errors";
 import type { Env } from "@/types/env";
 
@@ -11,6 +13,7 @@ export function projectContextMiddleware() {
     if (apiKey) {
       c.set("projectId", apiKey.projectId);
       c.set("projectEnvironment", apiKey.environment);
+      c.env = scopeEnvToCluster(c.env, CLUSTER_BY_SDP_ENVIRONMENT[apiKey.environment]);
       return next();
     }
 
@@ -32,6 +35,7 @@ export function projectContextMiddleware() {
     const project = await assertProjectMembership(c, orgId, userId, requested);
     c.set("projectId", project.id);
     c.set("projectEnvironment", project.environment);
+    c.env = scopeEnvToCluster(c.env, CLUSTER_BY_SDP_ENVIRONMENT[project.environment]);
     await next();
   };
 }
@@ -41,7 +45,7 @@ async function assertProjectMembership(
   organizationId: string,
   userId: string,
   projectId: string
-): Promise<{ id: string; environment: "sandbox" | "production" }> {
+): Promise<{ id: string; environment: SdpEnvironment }> {
   const row = await getDb(c.env)
     .prepare(
       `SELECT p.id, p.environment
@@ -51,7 +55,7 @@ async function assertProjectMembership(
        LIMIT 1`
     )
     .bind(projectId, organizationId, userId)
-    .first<{ id: string; environment: "sandbox" | "production" }>();
+    .first<{ id: string; environment: SdpEnvironment }>();
 
   if (!row) {
     throw forbidden("Requested project is not accessible");

--- a/apps/sdp-api/src/routes/earn.vault-share-reconciliation.test.ts
+++ b/apps/sdp-api/src/routes/earn.vault-share-reconciliation.test.ts
@@ -19,13 +19,13 @@ vi.mock("@/routes/payments/token-accounts", async (importOriginal) => ({
 // The endpoint genesis-proof and per-cluster URL resolution are chain-facing;
 // balances themselves come from the mocked read above, so no RPC request is
 // ever issued by these tests.
-const { assertClusterEndpoint, resolveClusterRpcUrl } = vi.hoisted(() => ({
-  assertClusterEndpoint: vi.fn(async () => {}),
+const { createProvenClusterRpc, resolveClusterRpcUrl } = vi.hoisted(() => ({
+  createProvenClusterRpc: vi.fn(async () => ({})),
   resolveClusterRpcUrl: vi.fn(() => "http://127.0.0.1:8899"),
 }));
 vi.mock("@/services/earn/execution-registry", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/services/earn/execution-registry")>()),
-  assertClusterEndpoint,
+  createProvenClusterRpc,
   resolveClusterRpcUrl,
 }));
 
@@ -250,7 +250,7 @@ beforeEach(async () => {
   await seedScope();
   vi.clearAllMocks();
   deadlineTimeoutOverride.ms = null;
-  assertClusterEndpoint.mockResolvedValue(undefined);
+  createProvenClusterRpc.mockResolvedValue({} as never);
   resolveClusterRpcUrl.mockReturnValue("http://127.0.0.1:8899");
   getSplTokenBalances.mockResolvedValue([]);
 });

--- a/apps/sdp-api/src/routes/earn/handlers/vault-reconciliation.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/vault-reconciliation.ts
@@ -3,13 +3,10 @@ import { assertValidAddress } from "@sdp/solana/address";
 import { getDb } from "@/db";
 import { createPostgresEarnMovementsRepository } from "@/db/repositories/earn-movements.repository";
 import { getAuth, requireProjectId } from "@/lib/auth";
+import { scopeEnvToCluster } from "@/lib/cluster-env";
 import { success } from "@/lib/response";
 import { getSplTokenBalances } from "@/routes/payments/token-accounts";
-import {
-  assertClusterEndpoint,
-  earnClusterFor,
-  resolveClusterRpcUrl,
-} from "@/services/earn/execution-registry";
+import { earnClusterFor } from "@/services/earn/execution-registry";
 import { createVaultDeadline } from "@/services/earn/vault-deadline";
 import { reconcileVaultShareHoldings } from "@/services/earn/vault-share-reconciliation.service";
 import type { AppContext } from "../context";
@@ -69,9 +66,7 @@ export async function getEarnVaultShareReconciliation(c: AppContext) {
     getEarnRepository(c).listShareMintedStrategies({ environment, hostCluster: cluster }),
   ]);
 
-  const rpcUrl = resolveClusterRpcUrl(c.env, cluster);
-  await assertClusterEndpoint(c.env, cluster, rpcUrl);
-  const rpc = createRpc(c.env, { rpcUrl });
+  const rpc = createRpc(scopeEnvToCluster(c.env, cluster));
 
   const report = await reconcileVaultShareHoldings({
     wallets: [...walletsById.values()],

--- a/apps/sdp-api/src/routes/earn/handlers/vault-reconciliation.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/vault-reconciliation.ts
@@ -1,12 +1,10 @@
-import { createRpc } from "@sdp/rpc/solana";
 import { assertValidAddress } from "@sdp/solana/address";
 import { getDb } from "@/db";
 import { createPostgresEarnMovementsRepository } from "@/db/repositories/earn-movements.repository";
 import { getAuth, requireProjectId } from "@/lib/auth";
-import { scopeEnvToCluster } from "@/lib/cluster-env";
 import { success } from "@/lib/response";
 import { getSplTokenBalances } from "@/routes/payments/token-accounts";
-import { earnClusterFor } from "@/services/earn/execution-registry";
+import { createProvenClusterRpc, earnClusterFor } from "@/services/earn/execution-registry";
 import { createVaultDeadline } from "@/services/earn/vault-deadline";
 import { reconcileVaultShareHoldings } from "@/services/earn/vault-share-reconciliation.service";
 import type { AppContext } from "../context";
@@ -66,7 +64,7 @@ export async function getEarnVaultShareReconciliation(c: AppContext) {
     getEarnRepository(c).listShareMintedStrategies({ environment, hostCluster: cluster }),
   ]);
 
-  const rpc = createRpc(scopeEnvToCluster(c.env, cluster));
+  const rpc = await createProvenClusterRpc(c.env, cluster);
 
   const report = await reconcileVaultShareHoldings({
     wallets: [...walletsById.values()],

--- a/apps/sdp-api/src/routes/issuance.test.ts
+++ b/apps/sdp-api/src/routes/issuance.test.ts
@@ -4391,6 +4391,30 @@ describe("Issuance Routes", () => {
       const body = await res.json();
       expect(body.error.code).toBe("SOLANA_RPC_ERROR");
     });
+
+    it("returns 503 for a production project without a mainnet RPC URL", async () => {
+      await seedCachedApiKey(env, apiKeyHash, {
+        ...TEST_PROJECT_CACHED_KEY,
+        environment: "production",
+      });
+
+      const res = await app.request(
+        `/v1/issuance/tokens/${activeTokenId}/supply/refresh`,
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
+        },
+        { ...env, SOLANA_MAINNET_RPC_URL: undefined }
+      );
+
+      expect(res.status).toBe(503);
+      await expect(res.json()).resolves.toMatchObject({
+        error: {
+          code: "RPC_NOT_CONFIGURED",
+          message: "No Solana RPC endpoint is configured for mainnet-beta",
+        },
+      });
+    });
   });
 
   // ═══════════════════════════════════════════════════════════════════════════

--- a/apps/sdp-api/src/routes/issuance/handlers/supply.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/supply.ts
@@ -71,9 +71,9 @@ export const refreshTokenSupply = async (c: AppContext) => {
     throw new AppError("TOKEN_NOT_DEPLOYED", "Token must be deployed before refreshing supply");
   }
 
+  const { rpcUrl } = getSolanaConfig(c.env);
   let supplyBaseUnits: string;
   try {
-    const { rpcUrl } = getSolanaConfig(c.env);
     supplyBaseUnits = await fetchTokenSupplyBaseUnits(rpcUrl, token.mintAddress);
   } catch (error) {
     throw new AppError(

--- a/apps/sdp-api/src/routes/pay.ts
+++ b/apps/sdp-api/src/routes/pay.ts
@@ -2,7 +2,7 @@ import { getSolanaConfig } from "@sdp/rpc";
 import * as solanaRpc from "@sdp/rpc/solana";
 import { assertValidAddress } from "@sdp/solana/address";
 import { parseDecimalAmount } from "@sdp/solana/amount";
-import { getSdpDocsOrigin, SOL_DECIMALS } from "@sdp/types";
+import { CLUSTER_BY_SDP_ENVIRONMENT, getSdpDocsOrigin, SOL_DECIMALS } from "@sdp/types";
 import {
   type AccountMeta,
   AccountRole,
@@ -22,13 +22,16 @@ import { encodeURL } from "@solana/pay";
 import { getTransferSolInstruction } from "@solana-program/system";
 import { Hono } from "hono";
 import { z } from "zod";
+import { getDb } from "@/db";
 import { createSystemPaymentRequestsRepository } from "@/db/repositories/repository-factory";
+import { scopeEnvToCluster } from "@/lib/cluster-env";
 import { badRequest, notFound, rateLimited } from "@/lib/errors";
 import { type ValidatedBodyContext, validateBody } from "@/middleware/validate";
 import {
   isPaymentRequestExpired,
   reconcilePaymentRequest,
 } from "@/services/payments/payment-requests";
+import { projectEnvironment } from "@/services/project.service";
 import { createProjectSponsorshipFeePayment } from "@/services/sponsorship.service";
 import type { Env } from "@/types/env";
 import { solanaAddressSchema } from "./payments/schemas";
@@ -52,7 +55,14 @@ pay.get("/:token", async (c) => {
   if (!existing) {
     throw notFound("Payment request");
   }
-  const request = await reconcilePaymentRequest(c.env, existing, { bestEffort: true });
+  if (existing.project_id === null) {
+    throw badRequest("Payment request is not associated with a project");
+  }
+  const env = scopeEnvToCluster(
+    c.env,
+    CLUSTER_BY_SDP_ENVIRONMENT[await projectEnvironment(getDb(c.env), existing.project_id)]
+  );
+  const request = await reconcilePaymentRequest(env, existing, { bestEffort: true });
 
   const expired = isPaymentRequestExpired(request.expires_at);
   const status = expired && request.status === "awaiting_payment" ? "expired" : request.status;
@@ -73,7 +83,7 @@ pay.get("/:token", async (c) => {
     reference: request.reference,
     status,
     expiresAt: request.expires_at,
-    network: getSolanaConfig(c.env).network,
+    network: getSolanaConfig(env).network,
     solanaPayUrl,
   });
 });
@@ -93,19 +103,23 @@ pay.post(
     if (!existing) {
       throw notFound("Payment request");
     }
-    const request = await reconcilePaymentRequest(c.env, existing, { bestEffort: false });
+    if (existing.project_id === null) {
+      throw badRequest("Payment request is not associated with a project");
+    }
+    const projectId = existing.project_id;
+    const env = scopeEnvToCluster(
+      c.env,
+      CLUSTER_BY_SDP_ENVIRONMENT[await projectEnvironment(getDb(c.env), projectId)]
+    );
+    const request = await reconcilePaymentRequest(env, existing, { bestEffort: false });
     if (request.status !== "awaiting_payment" || isPaymentRequestExpired(request.expires_at)) {
       throw badRequest("Payment request is no longer payable");
     }
-    if (!request.project_id) {
-      throw badRequest("Payment request is not eligible for sponsored fees");
-    }
-
     const payer = assertValidAddress(c.req.valid("json").account, "account");
     const recipient = assertValidAddress(request.destination_address, "destinationAddress");
     const reference = assertValidAddress(request.reference, "reference");
 
-    const rpc = solanaRpc.createRpc(c.env);
+    const rpc = solanaRpc.createRpc(env);
     const currentBlockHeight = await rpc.getBlockHeight({ commitment: "confirmed" }).send();
 
     // One sponsored transaction per blockhash window, claimed on the request
@@ -140,9 +154,9 @@ pay.post(
     let feePaymentInstance: Awaited<ReturnType<typeof createProjectSponsorshipFeePayment>> | null =
       null;
     const getFeePayment = async () => {
-      feePaymentInstance ??= await createProjectSponsorshipFeePayment(c.env, {
+      feePaymentInstance ??= await createProjectSponsorshipFeePayment(env, {
         organizationId: request.organization_id,
-        projectId: request.project_id as string,
+        projectId,
         actor: { type: "wallet", id: request.wallet_id },
       });
       return feePaymentInstance;

--- a/apps/sdp-api/src/routes/payments.transfers.test.ts
+++ b/apps/sdp-api/src/routes/payments.transfers.test.ts
@@ -1,7 +1,13 @@
 import type * as feePaymentAdapters from "@sdp/payments/fee-payment";
 import { FeePaymentError } from "@sdp/payments/fee-payment";
 import type * as solanaRpc from "@sdp/rpc/solana";
-import { type Permission, type PolicyDefaultAction, type PolicyRule, SOL_MINT } from "@sdp/types";
+import {
+  type Permission,
+  type PolicyDefaultAction,
+  type PolicyRule,
+  SOL_MINT,
+  WELL_KNOWN_TOKENS,
+} from "@sdp/types";
 import {
   address,
   appendTransactionMessageInstructions,
@@ -69,6 +75,7 @@ const TEST_DUPLICATE_CUSTODY_WALLET_ID = "cwlt_payments_duplicate_test";
 
 const TEST_ALIAS_AUTHORIZED_CUSTODY_WALLET_ID = "cwlt_payments_alias_authorized_test";
 
+const MAINNET_USDC_MINT = WELL_KNOWN_TOKENS.USDC.mints["mainnet-beta"].address;
 const TEST_MAGICBLOCK_API_BASE_URL = "https://payments.magicblock.test";
 
 const TEST_MAGICBLOCK_SPONSOR_FEE_PAYER = "CrankS2fXgMGvQJ3VBrZmRfGrfogDY6pq5YcgkPEpSNf";
@@ -2127,6 +2134,82 @@ describe("Payments routes — transfers", () => {
       id: string;
     }>();
     expect(transfers.results).toHaveLength(0);
+  });
+
+  it("resolves mainnet USDC and a Kora-less env for a production project transfer", async () => {
+    await seedCachedKey({ environment: "production" });
+    const requestEnv = { ...env, SOLANA_MAINNET_RPC_URL: "https://mainnet.example.invalid" };
+    mockRecurringActivationRpc({
+      tokenAccounts: [
+        {
+          pubkey: TEST_SOLANA_ADDRESSES.wallet3,
+          mint: MAINNET_USDC_MINT,
+          amount: "1000000000",
+          decimals: 6,
+          uiAmountString: "1000",
+        },
+      ],
+    });
+
+    const res = await app.request(
+      "/v1/payments/transfers",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          sourceCustodyWalletId: TEST_CUSTODY_WALLET_ID,
+          destination: TEST_SOLANA_ADDRESSES.wallet2,
+          token: "USDC",
+          amount: "1",
+        }),
+      },
+      requestEnv
+    );
+
+    // Managed sponsorship has no production scope yet, so the mainnet leg fails
+    // closed after the row is created; the cluster resolution is what this proves.
+    expect(res.ok).toBe(false);
+    const transfer = await getDb(env)
+      .prepare("SELECT token, status FROM payment_transfers ORDER BY created_at DESC LIMIT 1")
+      .first<{ token: string; status: string }>();
+    expect(transfer).toMatchObject({ token: MAINNET_USDC_MINT, status: "failed" });
+    expect(createRpcMock).toHaveBeenCalledWith(
+      expect.objectContaining({ SOLANA_NETWORK: "mainnet-beta" })
+    );
+    const feePaymentEnv = createFeePaymentAdapterMock.mock.calls[0]?.[0];
+    expect(feePaymentEnv).toMatchObject({ SOLANA_NETWORK: "mainnet-beta" });
+    expect(feePaymentEnv?.KORA_RPC_URL).toBeUndefined();
+  });
+
+  it("returns 503 when a production project has no mainnet RPC URL", async () => {
+    await seedCachedKey({ environment: "production" });
+    const requestEnv = { ...env, SOLANA_MAINNET_RPC_URL: undefined };
+
+    const res = await app.request(
+      "/v1/payments/transfers",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          sourceCustodyWalletId: TEST_CUSTODY_WALLET_ID,
+          destination: TEST_SOLANA_ADDRESSES.wallet2,
+          token: "USDC",
+          amount: "1",
+        }),
+      },
+      requestEnv
+    );
+
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toMatchObject({
+      error: { code: "RPC_NOT_CONFIGURED" },
+    });
   });
 
   describe("execute transfer — happy path", () => {

--- a/apps/sdp-api/src/routes/webhooks/handlers.ts
+++ b/apps/sdp-api/src/routes/webhooks/handlers.ts
@@ -6,12 +6,13 @@ import type {
   UserJSON,
 } from "@clerk/backend";
 import { verifyWebhook, type WebhookEvent } from "@clerk/backend/webhooks";
-import type { SdpEnvironment } from "@sdp/types";
+import { CLUSTER_BY_SDP_ENVIRONMENT, type SdpEnvironment } from "@sdp/types";
 import type { RampProviderId } from "@sdp/types/provider-access";
 import type { Context } from "hono";
 import { getDb } from "@/db";
 import { refreshApiKeyCache } from "@/lib/api-key-cache";
 import { mapClerkRoleToOrgRole } from "@/lib/clerk-role";
+import { scopeEnvToCluster } from "@/lib/cluster-env";
 import { AppError, badRequest } from "@/lib/errors";
 import { invitationWasRevoked } from "@/lib/invitations";
 import { success } from "@/lib/response";
@@ -488,6 +489,7 @@ export const handleRampProviderWebhook = async (c: AppContext, environment: SdpE
     requestUrl: c.req.url,
   });
   const event = processor.parse(payload);
+  c.env = scopeEnvToCluster(c.env, CLUSTER_BY_SDP_ENVIRONMENT[environment]);
 
   // Signature is verified, so ack with 200 immediately and settle in the background: a
   // slow DB write must not delay the 2xx the provider expects.

--- a/apps/sdp-api/src/services/earn-provider-registry.ts
+++ b/apps/sdp-api/src/services/earn-provider-registry.ts
@@ -15,7 +15,7 @@ import {
   VedaVaultDirectClient,
 } from "@sdp/veda";
 import type { Env } from "@/types/env";
-import { assertClusterEndpoint, resolveClusterRpcUrl } from "./earn/execution-registry";
+import { resolveProvenClusterRpcUrl } from "./earn/execution-registry";
 import { createVaultDeadline } from "./earn/vault-deadline";
 
 /**
@@ -29,10 +29,7 @@ async function resolveProvenRpcUrl(
 ): Promise<string> {
   // The API constructs this runtime from `Env`; the shared provider contract
   // deliberately narrows it to a dependency-free string record.
-  const env = ctx.env as unknown as Env;
-  const rpcUrl = resolveClusterRpcUrl(env, cluster);
-  await assertClusterEndpoint(env, cluster, rpcUrl);
-  return rpcUrl;
+  return resolveProvenClusterRpcUrl(ctx.env as unknown as Env, cluster);
 }
 
 /** One fresh deadline per operation, since these clients are process singletons. */

--- a/apps/sdp-api/src/services/earn/execution-registry.test.ts
+++ b/apps/sdp-api/src/services/earn/execution-registry.test.ts
@@ -1,152 +1,24 @@
 import * as solanaRpc from "@sdp/rpc/solana";
-import { GENESIS_HASH_BY_CLUSTER } from "@sdp/types";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "@/types/env";
-import {
-  assertClusterEndpoint,
-  CLUSTER_ENDPOINT_PROOF_TTL_MS,
-  resetClusterEndpointProofs,
-  resolveClusterRpcUrl,
-  resolveVaultDirectClient,
-} from "./execution-registry";
+import { resolveVaultDirectClient } from "./execution-registry";
 import { createVaultDeadline } from "./vault-deadline";
 
-const env = {} as Env;
-const rpcUrl = "https://rpc.example.invalid";
-const executionEnv = { SOLANA_DEVNET_RPC_URL: rpcUrl } as Env;
-const runtime = { env: {}, environment: "sandbox" } as const;
+const executionEnv = {
+  SOLANA_NETWORK: "devnet",
+  SOLANA_DEVNET_RPC_URL: "https://rpc.example.invalid",
+} as Env;
 const depositInput = {
   providerReference: "7uib8xGAwkaPz4ZGCA6t8sSEid5Yp9ty13PHUweTypx",
   owner: "11111111111111111111111111111112",
   amount: "1",
 };
 
-function mockGenesisSend() {
-  const send = vi.fn();
-  vi.spyOn(solanaRpc, "createRpc").mockReturnValue({
-    getGenesisHash: () => ({ send }),
-  } as never);
-  return send;
-}
-
-beforeEach(() => {
-  resetClusterEndpointProofs();
-});
-
-afterEach(() => {
-  vi.useRealTimers();
-  vi.restoreAllMocks();
-});
-
-describe("assertClusterEndpoint", () => {
-  it("evicts a transient probe rejection so the endpoint can recover", async () => {
-    const send = mockGenesisSend()
-      .mockRejectedValueOnce(new Error("RPC request timed out after 30000ms"))
-      .mockResolvedValue(GENESIS_HASH_BY_CLUSTER.devnet);
-
-    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).rejects.toThrow(/Could not verify/);
-    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).resolves.toBeUndefined();
-    // The successful observation is cached only for the short trust window.
-    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).resolves.toBeUndefined();
-
-    expect(send).toHaveBeenCalledTimes(2);
-  });
-
-  it("caches an observed mismatch only within the short trust window", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-08-16T00:00:00.000Z"));
-    const send = mockGenesisSend().mockResolvedValue(GENESIS_HASH_BY_CLUSTER["mainnet-beta"]);
-
-    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).rejects.toThrow(/reports genesis/);
-    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).rejects.toThrow(/reports genesis/);
-    expect(send).toHaveBeenCalledOnce();
-
-    vi.advanceTimersByTime(CLUSTER_ENDPOINT_PROOF_TTL_MS);
-    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).rejects.toThrow(/reports genesis/);
-    expect(send).toHaveBeenCalledTimes(2);
-  });
-
-  it("coalesces concurrent probes and caches the successful observation", async () => {
-    let resolveGenesis!: (hash: string) => void;
-    const send = mockGenesisSend().mockReturnValue(
-      new Promise<string>((resolve) => {
-        resolveGenesis = resolve;
-      })
-    );
-
-    const first = assertClusterEndpoint(env, "devnet", rpcUrl);
-    const second = assertClusterEndpoint(env, "devnet", rpcUrl);
-    expect(send).toHaveBeenCalledOnce();
-
-    resolveGenesis(GENESIS_HASH_BY_CLUSTER.devnet);
-    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined]);
-    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).resolves.toBeUndefined();
-
-    expect(send).toHaveBeenCalledOnce();
-  });
-
-  it("re-proves a successful URL after its trust window expires", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-08-16T00:00:00.000Z"));
-    const send = mockGenesisSend().mockResolvedValue(GENESIS_HASH_BY_CLUSTER.devnet);
-
-    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).resolves.toBeUndefined();
-    vi.advanceTimersByTime(CLUSTER_ENDPOINT_PROOF_TTL_MS - 1);
-    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).resolves.toBeUndefined();
-    expect(send).toHaveBeenCalledOnce();
-
-    vi.advanceTimersByTime(1);
-    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).resolves.toBeUndefined();
-    expect(send).toHaveBeenCalledTimes(2);
-  });
-});
-
-describe("resolveClusterRpcUrl", () => {
-  it("prefers an explicit per-cluster endpoint", () => {
-    expect(
-      resolveClusterRpcUrl(
-        {
-          SOLANA_NETWORK: "devnet",
-          SOLANA_RPC_URL: "https://public.example.invalid",
-          SOLANA_DEVNET_RPC_URL: " https://earn-devnet.example.invalid ",
-        } as Env,
-        "devnet"
-      )
-    ).toBe("https://earn-devnet.example.invalid");
-  });
-
-  it("preserves the canonical managed-provider selection and API-key expansion", () => {
-    expect(
-      resolveClusterRpcUrl(
-        {
-          SOLANA_NETWORK: "devnet",
-          SOLANA_RPC_URL: "https://public.example.invalid",
-          SOLANA_RPC_DEFAULT_PROVIDER: "helius",
-          SOLANA_RPC_HELIUS_URL: "https://helius.example.invalid/?api-key={API_KEY}",
-          SOLANA_RPC_HELIUS_API_KEY: "secret key",
-        } as Env,
-        "devnet"
-      )
-    ).toBe("https://helius.example.invalid/?api-key=secret%20key");
-  });
-
-  it("does not reuse a canonical default for the other cluster", () => {
-    expect(
-      resolveClusterRpcUrl(
-        {
-          SOLANA_NETWORK: "devnet",
-          SOLANA_RPC_URL: "https://devnet.example.invalid",
-        } as Env,
-        "mainnet-beta"
-      )
-    ).toBe("");
-  });
-});
+afterEach(() => vi.restoreAllMocks());
 
 describe("resolveVaultDirectClient", () => {
   it("keeps resolution I/O-free and preserves inherited provider capabilities", () => {
     const createRpc = vi.spyOn(solanaRpc, "createRpc");
-
     const client = resolveVaultDirectClient(executionEnv, "kamino", createVaultDeadline());
 
     expect(client).not.toBeNull();
@@ -156,25 +28,16 @@ describe("resolveVaultDirectClient", () => {
     expect(createRpc).not.toHaveBeenCalled();
   });
 
-  it("resolves an executing client for every provider that can move money", () => {
-    const createRpc = vi.spyOn(solanaRpc, "createRpc");
-
+  it("resolves every provider that can move money", () => {
     for (const provider of ["kamino", "veda", "jupiter_lend"]) {
       const client = resolveVaultDirectClient(executionEnv, provider, createVaultDeadline());
       expect(client, provider).not.toBeNull();
       expect(client?.provider, provider).toBe(provider);
-      // The superset, not a replacement: the executing client still catalogues.
       expect(typeof client?.listStrategies, provider).toBe("function");
     }
-    expect(createRpc).not.toHaveBeenCalled();
   });
 
-  /**
-   * This resolver is the ONE sanctioned provider-id branch in the codebase, and
-   * unknown ids must answer null rather than throw: a strategy row written by a
-   * newer deploy would otherwise 500 a read that merely touched it.
-   */
-  it("answers null for anything this deployment cannot execute", () => {
+  it("answers null for providers this deployment cannot execute", () => {
     for (const provider of ["ground", "upshift", "perena", "not-a-provider", "__proto__", ""]) {
       expect(
         resolveVaultDirectClient(executionEnv, provider, createVaultDeadline()),
@@ -183,60 +46,17 @@ describe("resolveVaultDirectClient", () => {
     }
   });
 
-  /**
-   * SDP has no confirmed PRODUCTION Veda deployment (devnet is deployed;
-   * mainnet waits on PRO-1777), so a production deposit fails on THAT rather
-   * than on an RPC — and it fails before any endpoint work, because an
-   * unconfigured deployment is a fact about SDP that should not depend on a
-   * node being reachable.
-   */
-  it("refuses Veda work on the missing mainnet deployment, before any RPC", async () => {
+  it("refuses Veda work on the missing mainnet deployment before RPC", async () => {
     const createRpc = vi.spyOn(solanaRpc, "createRpc");
-    const productionRuntime = { env: {}, environment: "production" } as const;
     const client = resolveVaultDirectClient(executionEnv, "veda", createVaultDeadline());
     if (!client) throw new Error("expected a Veda vault-direct client");
 
     await expect(
-      client.buildVaultDeposit(productionRuntime, { ...depositInput, minSharesOut: "1" })
-    ).rejects.toMatchObject({ code: "DEPLOYMENT_NOT_CONFIGURED" });
-    await expect(
-      client.readVaultPositions(productionRuntime, {
-        owner: depositInput.owner,
-        providerReferences: [depositInput.providerReference],
-      })
+      client.buildVaultDeposit(
+        { env: {}, environment: "production" },
+        { ...depositInput, minSharesOut: "1" }
+      )
     ).rejects.toMatchObject({ code: "DEPLOYMENT_NOT_CONFIGURED" });
     expect(createRpc).not.toHaveBeenCalled();
-  });
-
-  it("refuses build and position work before the SDK when genesis is wrong", async () => {
-    mockGenesisSend().mockResolvedValue(GENESIS_HASH_BY_CLUSTER["mainnet-beta"]);
-    const client = resolveVaultDirectClient(executionEnv, "kamino", createVaultDeadline());
-    expect(client).not.toBeNull();
-    if (!client) throw new Error("expected Kamino vault-direct client");
-
-    await expect(client.buildVaultDeposit(runtime, depositInput)).rejects.toThrow(
-      /reports genesis/
-    );
-    await expect(
-      client.readVaultPositions(runtime, {
-        owner: depositInput.owner,
-        providerReferences: [depositInput.providerReference],
-      })
-    ).rejects.toThrow(/reports genesis/);
-  });
-
-  it("does not start provider work after endpoint proof exhausts the shared deadline", async () => {
-    vi.useFakeTimers();
-    mockGenesisSend().mockReturnValue(new Promise<never>(() => undefined));
-    const client = resolveVaultDirectClient(executionEnv, "kamino", createVaultDeadline(25));
-    expect(client).not.toBeNull();
-    if (!client) throw new Error("expected Kamino vault-direct client");
-
-    const result = client.buildVaultDeposit(runtime, depositInput);
-    const rejection = expect(result).rejects.toThrow(
-      "Building the vault deposit timed out after 25ms"
-    );
-    await vi.advanceTimersByTimeAsync(25);
-    await rejection;
   });
 });

--- a/apps/sdp-api/src/services/earn/execution-registry.ts
+++ b/apps/sdp-api/src/services/earn/execution-registry.ts
@@ -1,5 +1,4 @@
 import { supportsVaultDirect, supportsVaultWithdraw } from "@sdp/earn/capabilities";
-import { providerNotConfigured } from "@sdp/earn/errors";
 import type {
   EarnRuntimeContext,
   EarnVaultDirectProvider,
@@ -11,18 +10,14 @@ import {
   JupiterLendVaultDirectClient,
 } from "@sdp/jupiter-lend";
 import { assertNotPortfolioProvider, KaminoVaultDirectClient } from "@sdp/kamino";
-import { resolveDefaultSolanaRpcUrl } from "@sdp/rpc";
-import * as solanaRpc from "@sdp/rpc/solana";
-import {
-  CLUSTER_BY_SDP_ENVIRONMENT,
-  GENESIS_HASH_BY_CLUSTER,
-  type SdpEnvironment,
-  type SolanaCluster,
-} from "@sdp/types";
+import { getSolanaConfig } from "@sdp/rpc";
+import { assertClusterRpcUrl } from "@sdp/rpc/solana";
+import { CLUSTER_BY_SDP_ENVIRONMENT, type SdpEnvironment, type SolanaCluster } from "@sdp/types";
 import {
   assertNotPortfolioProvider as assertVedaNotPortfolioProvider,
   VedaVaultDirectClient,
 } from "@sdp/veda";
+import { scopeEnvToCluster } from "@/lib/cluster-env";
 import { instrumentVendorPort } from "@/runtime/vendor-calls";
 import type { Env } from "@/types/env";
 import type { VaultDeadline } from "./vault-deadline";
@@ -51,116 +46,28 @@ import type { VaultDeadline } from "./vault-deadline";
  * `SOLANA_DEVNET_RPC_URL` / `SOLANA_MAINNET_RPC_URL` are optional overrides.
  * The configured cluster may fall back through the canonical default resolver,
  * preserving managed-provider selection and API-key expansion; the other
- * cluster requires an explicit override. `assertClusterEndpoint` still makes
- * every selected URL prove which chain it serves before work begins.
+ * cluster requires an explicit override. Mainnet clients prove the selected
+ * endpoint's genesis inside `createRpc` before their first request.
  */
 export function resolveClusterRpcUrl(env: Env, cluster: SolanaCluster): string {
-  const perCluster = cluster === "devnet" ? env.SOLANA_DEVNET_RPC_URL : env.SOLANA_MAINNET_RPC_URL;
-  if (typeof perCluster === "string" && perCluster.trim() !== "") return perCluster.trim();
-
-  // The canonical default may be a managed provider with URL/API-key template
-  // expansion. It is safe only for the cluster the process config names; the
-  // other cluster needs an explicit override and must fail closed without one.
-  const defaultCluster = env.SOLANA_NETWORK ?? "devnet";
-  if (defaultCluster !== cluster) return "";
-  return resolveDefaultSolanaRpcUrl(env)?.trim() ?? "";
+  return getSolanaConfig(scopeEnvToCluster(env, cluster)).rpcUrl;
 }
 
 /**
- * Briefly memoised genesis observations, keyed by `cluster\nurl`.
+ * The cluster RPC URL for `cluster`, proven to serve that cluster before it is
+ * handed to a provider SDK that builds its own transport.
  *
- * The genesis hash returned by one backend is immutable, but a URL is not: DNS,
- * a load balancer, or deployment configuration can repoint the same string at a
- * different cluster. Cache only a short burst so concurrent/page fan-out stays
- * affordable without turning one old observation into a process-lifetime funds
- * authorization.
- *
- * A rejected RPC call is NOT an observation. Timeouts, 429s and network failures
- * are evicted immediately; successful matches and mismatches share the same
- * short TTL.
+ * @param env - Deployment environment.
+ * @param cluster - Cluster the URL must serve.
+ * @returns The proven RPC URL.
  */
-export const CLUSTER_ENDPOINT_PROOF_TTL_MS = 30_000;
-
-interface ClusterEndpointProof {
-  promise: Promise<string>;
-  /** Null while the shared probe is still in flight. */
-  expiresAt: number | null;
-}
-
-const clusterProofs = new Map<string, ClusterEndpointProof>();
-
-/**
- * Refuse to build against an endpoint that has not proved it serves `cluster`.
- *
- * This is the check the execution path was missing. The catalogue path already
- * had it — `listKaminoDevnetVaults` verifies genesis before returning anything —
- * but the money path trusted its URL, and a cluster mismatch does NOT surface as
- * an error: Kamino's mainnet kvault program id also resolves on devnet with no
- * accounts under it, so the failure mode is "this vault does not exist", or a
- * transaction built for the wrong deployment.
- *
- * Called before every build and every position read. Concurrent calls coalesce,
- * and a later call re-proves the URL after the short trust window expires.
- */
-export async function assertClusterEndpoint(
+export async function resolveProvenClusterRpcUrl(
   env: Env,
-  cluster: SolanaCluster,
-  rpcUrl: string
-): Promise<void> {
-  if (rpcUrl === "") {
-    throw providerNotConfigured(
-      `No Solana RPC endpoint is configured for ${cluster}. Set SOLANA_${
-        cluster === "devnet" ? "DEVNET" : "MAINNET"
-      }_RPC_URL, or configure the canonical default for ${cluster}.`
-    );
-  }
-
-  const key = `${cluster}\n${rpcUrl}`;
-  let proof = clusterProofs.get(key);
-  if (proof && proof.expiresAt !== null && proof.expiresAt <= Date.now()) {
-    clusterProofs.delete(key);
-    proof = undefined;
-  }
-  if (!proof) {
-    proof = { promise: getGenesisHash(env, rpcUrl), expiresAt: null };
-    clusterProofs.set(key, proof);
-  }
-
-  let observed: string;
-  try {
-    observed = await proof.promise;
-    if (clusterProofs.get(key) === proof && proof.expiresAt === null) {
-      proof.expiresAt = Date.now() + CLUSTER_ENDPOINT_PROOF_TTL_MS;
-    }
-  } catch (cause) {
-    // Delete only if this is still the promise stored for the key. Concurrent
-    // callers may all observe the same rejection; none may delete a newer probe
-    // started after this one failed.
-    if (clusterProofs.get(key) === proof) clusterProofs.delete(key);
-    throw providerNotConfigured(
-      `Could not verify that the configured ${cluster} RPC endpoint serves ${cluster}: ` +
-        `${cause instanceof Error ? cause.message : String(cause)}`
-    );
-  }
-
-  const expected = GENESIS_HASH_BY_CLUSTER[cluster];
-  if (observed !== expected) {
-    throw providerNotConfigured(
-      `The RPC endpoint configured for ${cluster} reports genesis ${observed}, not ${expected}. ` +
-        "Building against it would address the wrong chain — refusing. Set " +
-        `SOLANA_${cluster === "devnet" ? "DEVNET" : "MAINNET"}_RPC_URL to a ${cluster} endpoint.`
-    );
-  }
-}
-
-async function getGenesisHash(env: Env, rpcUrl: string): Promise<string> {
-  const rpc = solanaRpc.createRpc(env, { rpcUrl });
-  return String(await rpc.getGenesisHash().send());
-}
-
-/** Test seam: forget cached genesis verdicts. */
-export function resetClusterEndpointProofs(): void {
-  clusterProofs.clear();
+  cluster: SolanaCluster
+): Promise<string> {
+  const rpcUrl = resolveClusterRpcUrl(env, cluster);
+  await assertClusterRpcUrl(scopeEnvToCluster(env, cluster), rpcUrl);
+  return rpcUrl;
 }
 
 export function earnClusterFor(environment: SdpEnvironment): SolanaCluster {
@@ -181,11 +88,8 @@ export function resolveEarnExecutionClient(
   // Construction stays synchronous and I/O-free for every branch. The clients
   // await this resolver only when a chain method is invoked, so an idempotent
   // replay can return from durable state during an RPC outage.
-  const provenRpcUrl = async (_ctx: EarnRuntimeContext, cluster: SolanaCluster) => {
-    const rpcUrl = resolveClusterRpcUrl(env, cluster);
-    await assertClusterEndpoint(env, cluster, rpcUrl);
-    return rpcUrl;
-  };
+  const provenRpcUrl = (_ctx: EarnRuntimeContext, cluster: SolanaCluster) =>
+    resolveProvenClusterRpcUrl(env, cluster);
   const runOperation = <T>(label: string, operation: (assertActive: () => void) => Promise<T>) =>
     deadline.run(label, () => operation(() => deadline.assertActive(label)));
 

--- a/apps/sdp-api/src/services/earn/execution-registry.ts
+++ b/apps/sdp-api/src/services/earn/execution-registry.ts
@@ -11,7 +11,7 @@ import {
 } from "@sdp/jupiter-lend";
 import { assertNotPortfolioProvider, KaminoVaultDirectClient } from "@sdp/kamino";
 import { getSolanaConfig } from "@sdp/rpc";
-import { assertClusterRpcUrl } from "@sdp/rpc/solana";
+import * as solanaRpc from "@sdp/rpc/solana";
 import { CLUSTER_BY_SDP_ENVIRONMENT, type SdpEnvironment, type SolanaCluster } from "@sdp/types";
 import {
   assertNotPortfolioProvider as assertVedaNotPortfolioProvider,
@@ -66,8 +66,34 @@ export async function resolveProvenClusterRpcUrl(
   cluster: SolanaCluster
 ): Promise<string> {
   const rpcUrl = resolveClusterRpcUrl(env, cluster);
-  await assertClusterRpcUrl(scopeEnvToCluster(env, cluster), rpcUrl);
+  const scoped = scopeEnvToCluster(env, cluster);
+  await solanaRpc.assertClusterEndpoint(scoped, rpcUrl, solanaRpc.createRpc(scoped, { rpcUrl }));
   return rpcUrl;
+}
+
+/**
+ * Earn's RPC client for `cluster`: pinned to the cluster URL and proven to serve
+ * that cluster on every cluster, not just mainnet, because Earn provider program
+ * ids resolve on either chain without error.
+ *
+ * @param env - Deployment environment.
+ * @param cluster - Cluster the client must serve.
+ * @param requestTimeoutMs - Optional per-request transport deadline.
+ * @returns A proven, cluster-pinned RPC client.
+ */
+export async function createProvenClusterRpc(
+  env: Env,
+  cluster: SolanaCluster,
+  requestTimeoutMs?: number
+): Promise<solanaRpc.SolanaRpc> {
+  const scoped = scopeEnvToCluster(env, cluster);
+  const rpcUrl = getSolanaConfig(scoped).rpcUrl;
+  const rpc = solanaRpc.createRpc(
+    scoped,
+    requestTimeoutMs === undefined ? { rpcUrl } : { rpcUrl, requestTimeoutMs }
+  );
+  await solanaRpc.assertClusterEndpoint(scoped, rpcUrl, rpc);
+  return rpc;
 }
 
 export function earnClusterFor(environment: SdpEnvironment): SolanaCluster {

--- a/apps/sdp-api/src/services/earn/owner-token-balance.test.ts
+++ b/apps/sdp-api/src/services/earn/owner-token-balance.test.ts
@@ -1,8 +1,8 @@
 import { createServer, type Server } from "node:http";
+import { resetClusterEndpointProofs } from "@sdp/rpc/solana";
 import { GENESIS_HASH_BY_CLUSTER } from "@sdp/types";
 import { afterEach, describe, expect, it } from "vitest";
 import { z } from "zod";
-import { resetClusterEndpointProofs } from "./execution-registry";
 import { readOwnerMintBalance } from "./owner-token-balance";
 
 const OWNER = "3nMFwZXwY1s1M5s8vYAHqd4wGs4iSxXE4LRoUMMYqEgF";

--- a/apps/sdp-api/src/services/earn/owner-token-balance.ts
+++ b/apps/sdp-api/src/services/earn/owner-token-balance.ts
@@ -2,11 +2,8 @@ import { createRpc } from "@sdp/rpc/solana";
 import type { SdpEnvironment } from "@sdp/types";
 import { address } from "@solana/kit";
 import { z } from "zod";
-import {
-  assertClusterEndpoint,
-  earnClusterFor,
-  resolveClusterRpcUrl,
-} from "@/services/earn/execution-registry";
+import { scopeEnvToCluster } from "@/lib/cluster-env";
+import { earnClusterFor } from "@/services/earn/execution-registry";
 import type { Env } from "@/types/env";
 
 /**
@@ -64,9 +61,7 @@ export async function readOwnerMintBalance(
   mint: string
 ): Promise<OwnerMintBalance> {
   const cluster = earnClusterFor(environment);
-  const rpcUrl = resolveClusterRpcUrl(env, cluster);
-  await assertClusterEndpoint(env, cluster, rpcUrl);
-  const response = await createRpc(env, { rpcUrl })
+  const response = await createRpc(scopeEnvToCluster(env, cluster))
     .getTokenAccountsByOwner(
       address(ownerAddress),
       { mint: address(mint) },

--- a/apps/sdp-api/src/services/earn/owner-token-balance.ts
+++ b/apps/sdp-api/src/services/earn/owner-token-balance.ts
@@ -1,9 +1,7 @@
-import { createRpc } from "@sdp/rpc/solana";
 import type { SdpEnvironment } from "@sdp/types";
 import { address } from "@solana/kit";
 import { z } from "zod";
-import { scopeEnvToCluster } from "@/lib/cluster-env";
-import { earnClusterFor } from "@/services/earn/execution-registry";
+import { createProvenClusterRpc, earnClusterFor } from "@/services/earn/execution-registry";
 import type { Env } from "@/types/env";
 
 /**
@@ -61,7 +59,7 @@ export async function readOwnerMintBalance(
   mint: string
 ): Promise<OwnerMintBalance> {
   const cluster = earnClusterFor(environment);
-  const response = await createRpc(scopeEnvToCluster(env, cluster))
+  const response = await (await createProvenClusterRpc(env, cluster))
     .getTokenAccountsByOwner(
       address(ownerAddress),
       { mint: address(mint) },

--- a/apps/sdp-api/src/services/earn/vault-execution.service.test.ts
+++ b/apps/sdp-api/src/services/earn/vault-execution.service.test.ts
@@ -1,6 +1,8 @@
 import type { EarnVaultTransactionPlan } from "@sdp/earn/types";
 import * as rpcCore from "@sdp/rpc";
 import * as solanaRpc from "@sdp/rpc/solana";
+import { resetClusterEndpointProofs } from "@sdp/rpc/solana";
+import { GENESIS_HASH_BY_CLUSTER } from "@sdp/types";
 import {
   AccountRole,
   type Address,
@@ -56,9 +58,11 @@ const plan: EarnVaultTransactionPlan = {
 };
 
 const simulateSend = vi.fn();
+const genesisSend = vi.fn();
 /** Base64 wire transactions handed to `simulateTransaction`, newest last. */
 const simulatedWire: string[] = [];
 const rpc = {
+  getGenesisHash: () => ({ send: genesisSend }),
   simulateTransaction: (wire: string) => {
     simulatedWire.push(wire);
     return { send: simulateSend };
@@ -98,6 +102,8 @@ function planForOwner(owner: Address): EarnVaultTransactionPlan {
 
 beforeEach(() => {
   simulatedWire.length = 0;
+  resetClusterEndpointProofs();
+  genesisSend.mockReset().mockResolvedValue(GENESIS_HASH_BY_CLUSTER.devnet);
   simulateSend.mockReset().mockResolvedValue({ value: { err: null, logs: [] } });
   vi.spyOn(solanaRpc, "createRpc").mockReturnValue(rpc as never);
   vi.spyOn(solanaRpc, "getRecentBlockhash").mockResolvedValue({
@@ -235,6 +241,46 @@ describe("vault execution validation", () => {
         fee: { kind: "caller-provided", feePayer: feePayerAddress },
       })
     ).rejects.toThrow("compile the transaction unsigned");
+  });
+
+  it("blocks every raw execution path before RPC or signing on wrong genesis", async () => {
+    genesisSend.mockResolvedValue(GENESIS_HASH_BY_CLUSTER["mainnet-beta"]);
+    const owner = createNoopSigner(ownerAddress);
+
+    await expect(
+      signVaultPlan(env, {
+        cluster: "devnet",
+        deadline: createVaultDeadline(),
+        expectedAssetIdentity: plan.assetIdentity,
+        plan,
+        owner,
+        rpcUrl,
+        fee: { kind: "wallet-pays" },
+      })
+    ).rejects.toThrow(/reports genesis/);
+    await expect(
+      simulateVaultPlan(env, {
+        cluster: "devnet",
+        deadline: createVaultDeadline(),
+        expectedAssetIdentity: plan.assetIdentity,
+        plan,
+        owner: ownerAddress,
+        rpcUrl,
+        fee: { kind: "wallet-pays" },
+      })
+    ).rejects.toThrow(/reports genesis/);
+    await expect(
+      broadcastVaultTransaction(env, {
+        cluster: "devnet",
+        deadline: createVaultDeadline(),
+        bytes: new Uint8Array(),
+        rpcUrl,
+      })
+    ).rejects.toThrow(/reports genesis/);
+
+    expect(solanaRpc.getRecentBlockhash).not.toHaveBeenCalled();
+    expect(solanaRpc.sendTransaction).not.toHaveBeenCalled();
+    expect(simulateSend).not.toHaveBeenCalled();
   });
 
   it("rejects a provider plan that disagrees with the environment-derived cluster", async () => {
@@ -443,6 +489,7 @@ describe("vault signing lifecycle", () => {
       prepared: simulation.prepared,
     });
 
+    expect(genesisSend).toHaveBeenCalledTimes(1);
     expect(solanaRpc.getRecentBlockhash).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/sdp-api/src/services/earn/vault-execution.service.test.ts
+++ b/apps/sdp-api/src/services/earn/vault-execution.service.test.ts
@@ -1,7 +1,6 @@
 import type { EarnVaultTransactionPlan } from "@sdp/earn/types";
 import * as rpcCore from "@sdp/rpc";
 import * as solanaRpc from "@sdp/rpc/solana";
-import { GENESIS_HASH_BY_CLUSTER } from "@sdp/types";
 import {
   AccountRole,
   type Address,
@@ -24,7 +23,6 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { FeePaymentPort } from "@/services/ports";
 import type { Env } from "@/types/env";
-import { resetClusterEndpointProofs } from "./execution-registry";
 import { createVaultDeadline } from "./vault-deadline";
 import {
   broadcastVaultTransaction,
@@ -57,12 +55,10 @@ const plan: EarnVaultTransactionPlan = {
   },
 };
 
-const genesisSend = vi.fn();
 const simulateSend = vi.fn();
 /** Base64 wire transactions handed to `simulateTransaction`, newest last. */
 const simulatedWire: string[] = [];
 const rpc = {
-  getGenesisHash: () => ({ send: genesisSend }),
   simulateTransaction: (wire: string) => {
     simulatedWire.push(wire);
     return { send: simulateSend };
@@ -102,8 +98,6 @@ function planForOwner(owner: Address): EarnVaultTransactionPlan {
 
 beforeEach(() => {
   simulatedWire.length = 0;
-  resetClusterEndpointProofs();
-  genesisSend.mockReset().mockResolvedValue(GENESIS_HASH_BY_CLUSTER.devnet);
   simulateSend.mockReset().mockResolvedValue({ value: { err: null, logs: [] } });
   vi.spyOn(solanaRpc, "createRpc").mockReturnValue(rpc as never);
   vi.spyOn(solanaRpc, "getRecentBlockhash").mockResolvedValue({
@@ -241,46 +235,6 @@ describe("vault execution validation", () => {
         fee: { kind: "caller-provided", feePayer: feePayerAddress },
       })
     ).rejects.toThrow("compile the transaction unsigned");
-  });
-
-  it("blocks every raw execution path before RPC or signing on wrong genesis", async () => {
-    genesisSend.mockResolvedValue(GENESIS_HASH_BY_CLUSTER["mainnet-beta"]);
-    const owner = createNoopSigner(ownerAddress);
-
-    await expect(
-      signVaultPlan(env, {
-        cluster: "devnet",
-        deadline: createVaultDeadline(),
-        expectedAssetIdentity: plan.assetIdentity,
-        plan,
-        owner,
-        rpcUrl,
-        fee: { kind: "wallet-pays" },
-      })
-    ).rejects.toThrow(/reports genesis/);
-    await expect(
-      simulateVaultPlan(env, {
-        cluster: "devnet",
-        deadline: createVaultDeadline(),
-        expectedAssetIdentity: plan.assetIdentity,
-        plan,
-        owner: ownerAddress,
-        rpcUrl,
-        fee: { kind: "wallet-pays" },
-      })
-    ).rejects.toThrow(/reports genesis/);
-    await expect(
-      broadcastVaultTransaction(env, {
-        cluster: "devnet",
-        deadline: createVaultDeadline(),
-        bytes: new Uint8Array(),
-        rpcUrl,
-      })
-    ).rejects.toThrow(/reports genesis/);
-
-    expect(solanaRpc.getRecentBlockhash).not.toHaveBeenCalled();
-    expect(solanaRpc.sendTransaction).not.toHaveBeenCalled();
-    expect(simulateSend).not.toHaveBeenCalled();
   });
 
   it("rejects a provider plan that disagrees with the environment-derived cluster", async () => {
@@ -489,7 +443,6 @@ describe("vault signing lifecycle", () => {
       prepared: simulation.prepared,
     });
 
-    expect(genesisSend).toHaveBeenCalledTimes(1);
     expect(solanaRpc.getRecentBlockhash).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/sdp-api/src/services/earn/vault-execution.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-execution.service.ts
@@ -30,8 +30,8 @@ import {
   partiallySignTransactionMessageWithSigners,
   signTransactionMessageWithSigners,
 } from "@solana/signers";
+import { scopeEnvToCluster } from "@/lib/cluster-env";
 import type { Env } from "@/types/env";
-import { assertClusterEndpoint } from "./execution-registry";
 import type { VaultDeadline } from "./vault-deadline";
 import { describeVaultSimulationError } from "./vault-simulation-error";
 import type { VaultFeeMode } from "./vault-sponsorship";
@@ -153,15 +153,6 @@ function assertExpectedPlan(
   }
 }
 
-async function verifyVaultRpc(
-  env: Env,
-  input: Pick<VaultExecutionScope, "cluster" | "deadline"> & { rpcUrl: string }
-): Promise<void> {
-  await input.deadline.run(`Verifying the ${input.cluster} RPC endpoint`, () =>
-    assertClusterEndpoint(env, input.cluster, input.rpcUrl)
-  );
-}
-
 /**
  * Resolve a plan's declared lookup tables to their address lists.
  *
@@ -177,7 +168,9 @@ async function resolveLookupTables(
   input: VaultExecutionScope & { plan: EarnVaultTransactionPlan; rpcUrl: string }
 ): Promise<AddressesByLookupTableAddress> {
   if (input.plan.lookupTables.length === 0) return {};
-  const rpc = solanaRpc.createRpc(env, { rpcUrl: input.rpcUrl });
+  const rpc = solanaRpc.createRpc(scopeEnvToCluster(env, input.cluster), {
+    rpcUrl: input.rpcUrl,
+  });
   return input.deadline.run("Fetching the vault lookup tables", () =>
     rpcCore.withTransientRpcRetry(() =>
       fetchAddressesForLookupTables(
@@ -269,8 +262,9 @@ export async function signVaultPlan(
     throw new Error("Vault execution preparation belongs to a different plan");
   }
   if (!prepared) {
-    await verifyVaultRpc(env, input);
-    const rpc = solanaRpc.createRpc(env, { rpcUrl: input.rpcUrl });
+    const rpc = solanaRpc.createRpc(scopeEnvToCluster(env, input.cluster), {
+      rpcUrl: input.rpcUrl,
+    });
     const [lookupTables, { blockhash, lastValidBlockHeight }] = await Promise.all([
       resolveLookupTables(env, input),
       input.deadline.run("Fetching the vault transaction blockhash", () =>
@@ -465,8 +459,9 @@ export async function broadcastVaultTransaction(
   env: Env,
   input: VaultExecutionScope & { bytes: Uint8Array; rpcUrl: string }
 ): Promise<void> {
-  await verifyVaultRpc(env, input);
-  const rpc = solanaRpc.createRpc(env, { rpcUrl: input.rpcUrl });
+  const rpc = solanaRpc.createRpc(scopeEnvToCluster(env, input.cluster), {
+    rpcUrl: input.rpcUrl,
+  });
   await input.deadline.run("Broadcasting the vault transaction", () =>
     solanaRpc.sendTransaction(rpc, input.bytes)
   );
@@ -533,8 +528,9 @@ export async function simulateVaultPlan(
     };
   }
 
-  await verifyVaultRpc(env, input);
-  const rpc = solanaRpc.createRpc(env, { rpcUrl: input.rpcUrl });
+  const rpc = solanaRpc.createRpc(scopeEnvToCluster(env, input.cluster), {
+    rpcUrl: input.rpcUrl,
+  });
   // Lookup-table transport failures are infrastructure failures, not a
   // program simulation verdict. Let them reject so callers preserve their
   // idempotency key and return a retryable 5xx instead of a caller-fault 400.

--- a/apps/sdp-api/src/services/earn/vault-execution.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-execution.service.ts
@@ -163,6 +163,29 @@ function assertExpectedPlan(
  * simulated. A fetch failure is therefore a retryable error, never a silent
  * fallback.
  */
+/**
+ * The cluster-pinned RPC client for one vault operation, proven to serve
+ * `input.cluster` first: provider program ids resolve on either chain silently.
+ *
+ * @param env - Deployment environment.
+ * @param input - Cluster, deadline and the URL the operation was planned against.
+ * @param input.cluster - Cluster the plan targets.
+ * @param input.deadline - Operation deadline the proof runs under.
+ * @param input.rpcUrl - Endpoint the plan was resolved against.
+ * @returns A proven RPC client pinned to `input.rpcUrl`.
+ */
+async function provenVaultRpc(
+  env: Env,
+  input: Pick<VaultExecutionScope, "cluster" | "deadline"> & { rpcUrl: string }
+): Promise<solanaRpc.SolanaRpc> {
+  const scoped = scopeEnvToCluster(env, input.cluster);
+  const rpc = solanaRpc.createRpc(scoped, { rpcUrl: input.rpcUrl });
+  await input.deadline.run(`Verifying the ${input.cluster} RPC endpoint`, () =>
+    solanaRpc.assertClusterEndpoint(scoped, input.rpcUrl, rpc)
+  );
+  return rpc;
+}
+
 async function resolveLookupTables(
   env: Env,
   input: VaultExecutionScope & { plan: EarnVaultTransactionPlan; rpcUrl: string }
@@ -262,9 +285,7 @@ export async function signVaultPlan(
     throw new Error("Vault execution preparation belongs to a different plan");
   }
   if (!prepared) {
-    const rpc = solanaRpc.createRpc(scopeEnvToCluster(env, input.cluster), {
-      rpcUrl: input.rpcUrl,
-    });
+    const rpc = await provenVaultRpc(env, input);
     const [lookupTables, { blockhash, lastValidBlockHeight }] = await Promise.all([
       resolveLookupTables(env, input),
       input.deadline.run("Fetching the vault transaction blockhash", () =>
@@ -459,9 +480,7 @@ export async function broadcastVaultTransaction(
   env: Env,
   input: VaultExecutionScope & { bytes: Uint8Array; rpcUrl: string }
 ): Promise<void> {
-  const rpc = solanaRpc.createRpc(scopeEnvToCluster(env, input.cluster), {
-    rpcUrl: input.rpcUrl,
-  });
+  const rpc = await provenVaultRpc(env, input);
   await input.deadline.run("Broadcasting the vault transaction", () =>
     solanaRpc.sendTransaction(rpc, input.bytes)
   );
@@ -528,9 +547,7 @@ export async function simulateVaultPlan(
     };
   }
 
-  const rpc = solanaRpc.createRpc(scopeEnvToCluster(env, input.cluster), {
-    rpcUrl: input.rpcUrl,
-  });
+  const rpc = await provenVaultRpc(env, input);
   // Lookup-table transport failures are infrastructure failures, not a
   // program simulation verdict. Let them reject so callers preserve their
   // idempotency key and return a retryable 5xx instead of a caller-fault 400.

--- a/apps/sdp-api/src/services/earn/vault-movement-reconciliation.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-movement-reconciliation.service.ts
@@ -1,4 +1,4 @@
-import { createRpc, getSignatureStatuses, type SignatureStatusInfo } from "@sdp/rpc/solana";
+import { getSignatureStatuses, type SignatureStatusInfo } from "@sdp/rpc/solana";
 import {
   EARN_TERMINAL_MOVEMENT_STATUSES,
   type SdpEnvironment,
@@ -13,7 +13,11 @@ import {
 import { scopeEnvToCluster } from "@/lib/cluster-env";
 import { getLogger } from "@/runtime/logger";
 import { describeError, logEvent } from "@/runtime/money-path-events";
-import { earnClusterFor, resolveClusterRpcUrl } from "@/services/earn/execution-registry";
+import {
+  createProvenClusterRpc,
+  earnClusterFor,
+  resolveClusterRpcUrl,
+} from "@/services/earn/execution-registry";
 import { createVaultDeadline } from "@/services/earn/vault-deadline";
 import { broadcastVaultTransaction } from "@/services/earn/vault-execution.service";
 import { describeVaultSimulationError } from "@/services/earn/vault-simulation-error";
@@ -110,7 +114,7 @@ async function observeEarnVaultMovement(
   const cluster = earnClusterFor(movement.environment);
   const rpcUrl = resolveClusterRpcUrl(env, cluster);
   const scopedEnv = scopeEnvToCluster(env, cluster);
-  const rpc = createRpc(scopedEnv, { rpcUrl, requestTimeoutMs: INTERACTIVE_RPC_TIMEOUT_MS });
+  const rpc = await createProvenClusterRpc(env, cluster, INTERACTIVE_RPC_TIMEOUT_MS);
 
   const [status] = await getSignatureStatuses(rpc, [movement.signature as Signature], {
     searchTransactionHistory: true,
@@ -221,7 +225,7 @@ async function reconcileEnvironment(
   const cluster = earnClusterFor(environment);
   const rpcUrl = resolveClusterRpcUrl(env, cluster);
   const scopedEnv = scopeEnvToCluster(env, cluster);
-  const rpc = createRpc(scopedEnv, { rpcUrl });
+  const rpc = await createProvenClusterRpc(env, cluster);
   let statuses: Array<SignatureStatusInfo | null>;
   try {
     statuses = await getSignatureStatuses(

--- a/apps/sdp-api/src/services/earn/vault-movement-reconciliation.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-movement-reconciliation.service.ts
@@ -10,13 +10,10 @@ import {
   createPostgresEarnMovementsRepository,
   type EarnMovementRow,
 } from "@/db/repositories/earn-movements.repository";
+import { scopeEnvToCluster } from "@/lib/cluster-env";
 import { getLogger } from "@/runtime/logger";
 import { describeError, logEvent } from "@/runtime/money-path-events";
-import {
-  assertClusterEndpoint,
-  earnClusterFor,
-  resolveClusterRpcUrl,
-} from "@/services/earn/execution-registry";
+import { earnClusterFor, resolveClusterRpcUrl } from "@/services/earn/execution-registry";
 import { createVaultDeadline } from "@/services/earn/vault-deadline";
 import { broadcastVaultTransaction } from "@/services/earn/vault-execution.service";
 import { describeVaultSimulationError } from "@/services/earn/vault-simulation-error";
@@ -112,9 +109,9 @@ async function observeEarnVaultMovement(
   const ledger = createPostgresEarnMovementsRepository(getDb(env));
   const cluster = earnClusterFor(movement.environment);
   const rpcUrl = resolveClusterRpcUrl(env, cluster);
-  const rpc = createRpc(env, { rpcUrl, requestTimeoutMs: INTERACTIVE_RPC_TIMEOUT_MS });
+  const scopedEnv = scopeEnvToCluster(env, cluster);
+  const rpc = createRpc(scopedEnv, { rpcUrl, requestTimeoutMs: INTERACTIVE_RPC_TIMEOUT_MS });
 
-  await assertClusterEndpoint(env, cluster, rpcUrl);
   const [status] = await getSignatureStatuses(rpc, [movement.signature as Signature], {
     searchTransactionHistory: true,
     retryDelaysMs: [],
@@ -123,7 +120,7 @@ async function observeEarnVaultMovement(
   // A detail GET may observe and record chain truth, but it must not turn a read
   // into a rebroadcast or expiry decision. Passing no block height makes the
   // shared transition function leave an unknown signature for the durable job.
-  await reconcileMovement(env, ledger, movement, status ?? null, {
+  await reconcileMovement(scopedEnv, ledger, movement, status ?? null, {
     cluster,
     rpcUrl,
     currentBlockHeight: null,
@@ -223,10 +220,10 @@ async function reconcileEnvironment(
   const stats = emptyStats(rows.length);
   const cluster = earnClusterFor(environment);
   const rpcUrl = resolveClusterRpcUrl(env, cluster);
-  const rpc = createRpc(env, { rpcUrl });
+  const scopedEnv = scopeEnvToCluster(env, cluster);
+  const rpc = createRpc(scopedEnv, { rpcUrl });
   let statuses: Array<SignatureStatusInfo | null>;
   try {
-    await assertClusterEndpoint(env, cluster, rpcUrl);
     statuses = await getSignatureStatuses(
       rpc,
       rows.map((row) => row.signature as Signature),
@@ -284,11 +281,17 @@ async function reconcileEnvironment(
   for (const [index, movement] of rows.entries()) {
     try {
       // react-doctor-disable-next-line react-doctor/async-await-in-loop -- reconciliation pacing is intentional.
-      const outcome = await reconcileMovement(env, ledger, movement, statuses[index] ?? null, {
-        cluster,
-        rpcUrl,
-        currentBlockHeight,
-      });
+      const outcome = await reconcileMovement(
+        scopedEnv,
+        ledger,
+        movement,
+        statuses[index] ?? null,
+        {
+          cluster,
+          rpcUrl,
+          currentBlockHeight,
+        }
+      );
       if (outcome === "settled") stats.settled += 1;
       else if (outcome === "failed") stats.failed += 1;
       else if (outcome === "confirmed") stats.confirmed += 1;

--- a/apps/sdp-api/src/services/jobs/collect-recurring-payments.node.test.ts
+++ b/apps/sdp-api/src/services/jobs/collect-recurring-payments.node.test.ts
@@ -47,6 +47,10 @@ vi.mock("@/db", () => ({
   }),
 }));
 
+vi.mock("@/services/project.service", () => ({
+  projectEnvironment: () => Promise.resolve("sandbox"),
+}));
+
 vi.mock("@/services/domain/signing/custody-runtime-target", () => ({
   CustodyRuntimeTargets: class {
     findOperationalWalletById = mocks.findOperationalWalletById;

--- a/apps/sdp-api/src/services/jobs/collect-recurring-payments.ts
+++ b/apps/sdp-api/src/services/jobs/collect-recurring-payments.ts
@@ -1,5 +1,6 @@
 import { getDb } from "@/db";
 import type { PaymentRecurringPaymentRow } from "@/db/repositories";
+import { createProjectEnvResolver } from "@/lib/cluster-env";
 import { AppError } from "@/lib/errors";
 import { getLogger } from "@/runtime/logger";
 import { CustodyRuntimeTargets } from "@/services/domain/signing/custody-runtime-target";
@@ -244,6 +245,7 @@ export async function collectDueRecurringPayments(
   now = new Date()
 ): Promise<CollectDueRecurringPaymentsResult> {
   const result = emptyResult();
+  const envForProject = createProjectEnvResolver(env);
   const limit = batchSize(env);
   const dueBefore = now.toISOString();
   const staleBefore = new Date(now.getTime() - STALE_AFTER_MS).toISOString();
@@ -261,7 +263,11 @@ export async function collectDueRecurringPayments(
     limit
   );
   for (const row of staleLifecyclePayments) {
-    addOutcome(result, await recoverLifecycleRow(env, row), "recovered");
+    addOutcome(
+      result,
+      await recoverLifecycleRow(await envForProject(row.project_id), row),
+      "recovered"
+    );
   }
 
   // Report only. Retrying the same update recovers it; automatic replay is
@@ -335,7 +341,7 @@ export async function collectDueRecurringPayments(
     limit
   );
   for (const row of staleCollectionPayments) {
-    addOutcome(result, await collectRow(env, row), "recovered");
+    addOutcome(result, await collectRow(await envForProject(row.project_id), row), "recovered");
   }
 
   const duePayments = await rowsForQuery(
@@ -371,7 +377,7 @@ export async function collectDueRecurringPayments(
     limit
   );
   for (const row of duePayments) {
-    addOutcome(result, await collectRow(env, row), "collected");
+    addOutcome(result, await collectRow(await envForProject(row.project_id), row), "collected");
   }
 
   return result;

--- a/apps/sdp-api/src/services/jobs/detect-orphaned-earn-split-swaps.test.ts
+++ b/apps/sdp-api/src/services/jobs/detect-orphaned-earn-split-swaps.test.ts
@@ -13,12 +13,9 @@ const getBlockHeight = vi.hoisted(() => vi.fn());
 const readOwnerMintBalance = vi.hoisted(() => vi.fn());
 const logEvent = vi.hoisted(() => vi.fn());
 
-vi.mock("@sdp/rpc/solana", () => ({
-  createRpc: () => ({ getBlockHeight: () => ({ send: getBlockHeight }) }),
-}));
 vi.mock("@/services/earn/execution-registry", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/services/earn/execution-registry")>()),
-  assertClusterEndpoint: vi.fn(async () => {}),
+  createProvenClusterRpc: async () => ({ getBlockHeight: () => ({ send: getBlockHeight }) }),
   resolveClusterRpcUrl: () => "https://rpc.example.invalid",
 }));
 vi.mock("@/services/earn/owner-token-balance", () => ({ readOwnerMintBalance }));

--- a/apps/sdp-api/src/services/jobs/detect-orphaned-earn-split-swaps.ts
+++ b/apps/sdp-api/src/services/jobs/detect-orphaned-earn-split-swaps.ts
@@ -8,12 +8,9 @@ import {
   createPostgresEarnSplitSwapAdvisoriesRepository,
   type EarnSplitSwapAdvisoryRow,
 } from "@/db/repositories/earn-split-swap-advisories.repository";
+import { scopeEnvToCluster } from "@/lib/cluster-env";
 import { describeError, logEvent } from "@/runtime/money-path-events";
-import {
-  assertClusterEndpoint,
-  earnClusterFor,
-  resolveClusterRpcUrl,
-} from "@/services/earn/execution-registry";
+import { earnClusterFor } from "@/services/earn/execution-registry";
 import { readOwnerMintBalance } from "@/services/earn/owner-token-balance";
 import type { Env } from "@/types/env";
 
@@ -137,9 +134,7 @@ export async function detectOrphanedEarnSplitSwaps(
     let blockHeight: bigint | null = null;
     try {
       const cluster = earnClusterFor(environment);
-      const rpcUrl = resolveClusterRpcUrl(env, cluster);
-      await assertClusterEndpoint(env, cluster, rpcUrl);
-      blockHeight = await createRpc(env, { rpcUrl })
+      blockHeight = await createRpc(scopeEnvToCluster(env, cluster))
         .getBlockHeight({ commitment: "confirmed" })
         .send();
     } catch (error) {

--- a/apps/sdp-api/src/services/jobs/detect-orphaned-earn-split-swaps.ts
+++ b/apps/sdp-api/src/services/jobs/detect-orphaned-earn-split-swaps.ts
@@ -1,4 +1,3 @@
-import { createRpc } from "@sdp/rpc/solana";
 import { parseDecimalAmount } from "@sdp/solana/amount";
 import type { SdpEnvironment } from "@sdp/types";
 import { getDb } from "@/db";
@@ -8,9 +7,8 @@ import {
   createPostgresEarnSplitSwapAdvisoriesRepository,
   type EarnSplitSwapAdvisoryRow,
 } from "@/db/repositories/earn-split-swap-advisories.repository";
-import { scopeEnvToCluster } from "@/lib/cluster-env";
 import { describeError, logEvent } from "@/runtime/money-path-events";
-import { earnClusterFor } from "@/services/earn/execution-registry";
+import { createProvenClusterRpc, earnClusterFor } from "@/services/earn/execution-registry";
 import { readOwnerMintBalance } from "@/services/earn/owner-token-balance";
 import type { Env } from "@/types/env";
 
@@ -134,7 +132,7 @@ export async function detectOrphanedEarnSplitSwaps(
     let blockHeight: bigint | null = null;
     try {
       const cluster = earnClusterFor(environment);
-      blockHeight = await createRpc(scopeEnvToCluster(env, cluster))
+      blockHeight = await (await createProvenClusterRpc(env, cluster))
         .getBlockHeight({ commitment: "confirmed" })
         .send();
     } catch (error) {

--- a/apps/sdp-api/src/services/jobs/reconcile-dvp-trades.test.ts
+++ b/apps/sdp-api/src/services/jobs/reconcile-dvp-trades.test.ts
@@ -8,12 +8,13 @@ import { env } from "@/test/helpers/env";
 import { seedTestDatabase } from "@/test/mocks/db";
 
 const getBlockHeight = vi.hoisted(() => vi.fn());
+const createRpcMock = vi.hoisted(() => vi.fn());
 const readDvpTradeObservation = vi.hoisted(() => vi.fn());
 const getSignatureStatusesMock = vi.hoisted(() => vi.fn());
 const resolveDvpClose = vi.hoisted(() => vi.fn());
 
 vi.mock("@sdp/rpc/solana", () => ({
-  createRpc: () => ({ getBlockHeight: () => ({ send: getBlockHeight }) }),
+  createRpc: createRpcMock,
   getSignatureStatuses: getSignatureStatusesMock,
 }));
 vi.mock("@/services/dvp/read-chain", () => ({ readDvpTradeObservation }));
@@ -100,6 +101,14 @@ async function seedTrade(id: string, status: string, overrides: Record<string, s
     .run();
 }
 
+async function seedTradeForProject(id: string, status: string, projectId: string): Promise<void> {
+  await seedTrade(id, status);
+  await getDb(env)
+    .prepare("UPDATE dvp_trades SET project_id = ? WHERE id = ?")
+    .bind(projectId, id)
+    .run();
+}
+
 async function statusOf(id: string): Promise<Record<string, unknown> | null> {
   return getDb(env)
     .prepare(
@@ -115,6 +124,9 @@ describe("reconcileDvpTrades", () => {
     env.MARKETS_ENABLED = "true";
     env.DVP_ENABLED = "true";
     getBlockHeight.mockResolvedValue(1_000n);
+    createRpcMock.mockImplementation(() => ({
+      getBlockHeight: () => ({ send: getBlockHeight }),
+    }));
     // Default: broadcast claims check out on chain as landed, so existing
     // receipt rows survive. Tests that exercise a dead broadcast override.
     getSignatureStatusesMock.mockResolvedValue(LANDED_STATUS);
@@ -171,6 +183,27 @@ describe("reconcileDvpTrades", () => {
     expect(readDvpTradeObservation).not.toHaveBeenCalled();
     await expect(statusOf("dvp_flagged_off")).resolves.toMatchObject({ observed_at: null });
     env.DVP_ENABLED = "true";
+  });
+
+  it("creates one cluster-scoped RPC for each environment with open trades", async () => {
+    const productionProjectId = "prj_dvp_job_production";
+    await getDb(env)
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, 'Production Project', ?, 'production', 'active', ?)`
+      )
+      .bind(productionProjectId, TEST_ORG.id, productionProjectId, TEST_USER.id)
+      .run();
+    await seedTrade("dvp_sandbox_trade", "created");
+    await seedTradeForProject("dvp_production_trade", "created", productionProjectId);
+
+    await reconcileDvpTrades({ ...env, SOLANA_MAINNET_RPC_URL: "https://mainnet.example.test" });
+
+    expect(createRpcMock).toHaveBeenCalledTimes(2);
+    expect(createRpcMock.mock.calls.map(([rpcEnv]) => rpcEnv.SOLANA_NETWORK)).toEqual([
+      "devnet",
+      "mainnet-beta",
+    ]);
   });
 
   it("records the observed balances and advances the status", async () => {

--- a/apps/sdp-api/src/services/jobs/reconcile-dvp-trades.ts
+++ b/apps/sdp-api/src/services/jobs/reconcile-dvp-trades.ts
@@ -12,10 +12,12 @@
  */
 
 import { createRpc, getSignatureStatuses } from "@sdp/rpc/solana";
+import { CLUSTER_BY_SDP_ENVIRONMENT, SDP_ENVIRONMENTS, type SdpEnvironment } from "@sdp/types";
 import { type Address, assertIsSignature } from "@solana/kit";
 import { getDb } from "@/db";
 import { createDvpTradeRepository, type DvpTradeRow } from "@/db/repositories";
 import { createPostgresDvpLegFundingClaimRepository } from "@/db/repositories/dvp-leg-funding-claim.repository";
+import { scopeEnvToCluster } from "@/lib/cluster-env";
 import { isDvpEnabled } from "@/lib/feature-flags";
 import { getLogger } from "@/runtime/logger";
 import { resolveDvpClose } from "@/services/dvp/closing-transaction";
@@ -40,12 +42,23 @@ export async function reconcileDvpTrades(env: Env): Promise<void> {
   }
 
   const repository = createDvpTradeRepository(env);
-  const trades = await repository.listOpenForReconciliation(BATCH_SIZE);
+  for (const environment of SDP_ENVIRONMENTS) {
+    await reconcileDvpEnvironment(env, repository, environment);
+  }
+}
+
+async function reconcileDvpEnvironment(
+  env: Env,
+  repository: ReturnType<typeof createDvpTradeRepository>,
+  environment: SdpEnvironment
+): Promise<void> {
+  const trades = await repository.listOpenForReconciliation(BATCH_SIZE, environment);
   if (trades.length === 0) {
     return;
   }
 
-  const rpc = createRpc(env);
+  const scoped = scopeEnvToCluster(env, CLUSTER_BY_SDP_ENVIRONMENT[environment]);
+  const rpc = createRpc(scoped);
 
   // Read once for the whole batch. Every trade's create-expiry decision is made
   // against the same height, which also keeps the sweep internally consistent:
@@ -69,7 +82,8 @@ export async function reconcileDvpTrades(env: Env): Promise<void> {
     // used to release alongside are gone, and one table now carries every
     // funder — creator and party alike.
     const released = await createPostgresDvpLegFundingClaimRepository(getDb(env)).releaseExpired(
-      blockHeight
+      blockHeight,
+      environment
     );
     if (released > 0) {
       getLogger().info(
@@ -91,7 +105,7 @@ export async function reconcileDvpTrades(env: Env): Promise<void> {
   // decides a DB deletion — the chain's answer is final here.
   try {
     const claims = createPostgresDvpLegFundingClaimRepository(getDb(env));
-    const expiredBroadcast = await claims.listExpiredBroadcast(blockHeight);
+    const expiredBroadcast = await claims.listExpiredBroadcast(blockHeight, environment);
     for (const claim of expiredBroadcast) {
       try {
         assertIsSignature(claim.signature);

--- a/apps/sdp-api/src/services/jobs/reconcile-earn-vault-movements.test.ts
+++ b/apps/sdp-api/src/services/jobs/reconcile-earn-vault-movements.test.ts
@@ -10,13 +10,10 @@ const getBlockHeight = vi.hoisted(() => vi.fn());
 const broadcastVaultTransaction = vi.hoisted(() => vi.fn());
 const logEvent = vi.hoisted(() => vi.fn());
 
-vi.mock("@sdp/rpc/solana", () => ({
-  createRpc: () => ({ getBlockHeight: () => ({ send: getBlockHeight }) }),
-  getSignatureStatuses,
-}));
+vi.mock("@sdp/rpc/solana", () => ({ getSignatureStatuses }));
 vi.mock("@/services/earn/execution-registry", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/services/earn/execution-registry")>()),
-  assertClusterEndpoint: vi.fn(async () => {}),
+  createProvenClusterRpc: async () => ({ getBlockHeight: () => ({ send: getBlockHeight }) }),
   resolveClusterRpcUrl: () => "https://rpc.example.invalid",
 }));
 vi.mock("@/services/earn/vault-execution.service", () => ({ broadcastVaultTransaction }));

--- a/apps/sdp-api/src/services/jobs/reconcile-sponsorship-budgets.ts
+++ b/apps/sdp-api/src/services/jobs/reconcile-sponsorship-budgets.ts
@@ -9,12 +9,16 @@ import {
   type SponsorshipNetwork,
   type SponsorshipReconciliationReservation,
 } from "@/db/repositories/sponsorship-budget.repository";
+import { scopeEnvToCluster } from "@/lib/cluster-env";
 import { getLogger } from "@/runtime/logger";
 import { logEvent } from "@/runtime/money-path-events";
 import { SponsorshipBudgetRedis } from "@/runtime/sponsorship-budget-redis";
 import type { Env } from "@/types/env";
 import { getManagedSponsorshipProviderConfiguration } from "../sponsorship.service";
-import { sponsorshipProviderConfigFingerprint } from "../sponsorship-budget.service";
+import {
+  resolveNetwork,
+  sponsorshipProviderConfigFingerprint,
+} from "../sponsorship-budget.service";
 
 const RECONCILIATION_DELAY_MS = 2 * 60_000;
 const RECONCILIATION_BATCH_SIZE = 250;
@@ -77,8 +81,12 @@ export async function reconcileSponsorshipBudgets(
 ): Promise<void> {
   const repository = dependencies.repository ?? new SponsorshipBudgetRepository(getDb(env));
   const budgetRedis = dependencies.budgetRedis ?? new SponsorshipBudgetRedis(env);
+  const network = resolveNetwork(env);
+  const rpcEnv = scopeEnvToCluster(env, network === "mainnet" ? "mainnet-beta" : "devnet");
   const rpc =
-    dependencies.getTransaction || dependencies.isBlockhashValid ? null : solanaRpc.createRpc(env);
+    dependencies.getTransaction || dependencies.isBlockhashValid
+      ? null
+      : solanaRpc.createRpc(rpcEnv);
   const getTransaction =
     dependencies.getTransaction ??
     ((signature: Signature) => solanaRpc.getTransaction(assertRpc(rpc), signature));
@@ -89,7 +97,6 @@ export async function reconcileSponsorshipBudgets(
   const sleep =
     dependencies.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
   const updatedBefore = new Date(now.getTime() - RECONCILIATION_DELAY_MS).toISOString();
-  const network = env.SOLANA_NETWORK === "mainnet-beta" ? "mainnet" : "devnet";
   const reservations = await repository.listReconciliationCandidates(
     network,
     updatedBefore,

--- a/apps/sdp-api/src/services/jobs/track-pending-transfers.test.ts
+++ b/apps/sdp-api/src/services/jobs/track-pending-transfers.test.ts
@@ -22,11 +22,25 @@ const TEST_SIG_4 =
   "7hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy" as unknown as Signature;
 
 const TEST_ORG_ID = "org_job_test_001";
+const TEST_PROJECT_ID = "prj_job_test_001";
+const TEST_USER_ID = "usr_job_test_001";
 
 async function seedOrg(): Promise<void> {
   await getDb(env)
     .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
     .bind(TEST_ORG_ID, "Job Test Org", "job-test-org", "individual", "active")
+    .run();
+  await getDb(env)
+    .prepare(
+      "INSERT INTO users (id, email, email_verified, status) VALUES (?, 'job-test@example.com', 1, 'active') ON CONFLICT (id) DO NOTHING"
+    )
+    .bind(TEST_USER_ID)
+    .run();
+  await getDb(env)
+    .prepare(
+      "INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by) VALUES (?, ?, ?, ?, 'production', 'active', ?)"
+    )
+    .bind(TEST_PROJECT_ID, TEST_ORG_ID, "Job Test Project", "job-test-project", TEST_USER_ID)
     .run();
 }
 
@@ -45,14 +59,15 @@ async function insertTransfer(params: {
   await getDb(env)
     .prepare(
       `INSERT INTO payment_transfers
-       (id, organization_id, wallet_id, source_address, destination_address,
+       (id, organization_id, project_id, wallet_id, source_address, destination_address,
         token, amount, type, direction, status, signature, signed_transaction,
         last_valid_block_height, submission_started_at, confirmed_at, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::numeric, ?, ?, ?, ?)`
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::numeric, ?, ?, ?, ?)`
     )
     .bind(
       params.id,
       TEST_ORG_ID,
+      TEST_PROJECT_ID,
       "wal_test",
       "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ",
       "9dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ",
@@ -137,6 +152,21 @@ describe("trackPendingTransfers", () => {
   });
 
   describe("syncProcessingTransfersOnChain", () => {
+    it("passes a mainnet-scoped env to createRpc for a production project", async () => {
+      await insertTransfer({
+        id: "xfr_production_rpc_scope",
+        status: "processing",
+        signature: String(TEST_SIG_1),
+        createdAt: minutesAgo(1),
+        updatedAt: minutesAgo(1),
+      });
+
+      await trackPendingTransfers(env);
+
+      expect(createRpcMock).toHaveBeenCalledWith(
+        expect.objectContaining({ SOLANA_NETWORK: "mainnet-beta" })
+      );
+    });
     it("updates processing transfer to confirmed when signature is confirmed on-chain", async () => {
       getSignatureStatusesMock.mockResolvedValueOnce([
         {
@@ -314,7 +344,7 @@ describe("trackPendingTransfers", () => {
             flow: "reconciler",
             reason: "history_absent",
             organization_id: TEST_ORG_ID,
-            project_id: null,
+            project_id: TEST_PROJECT_ID,
             transfer_id: "xfr_started_outbox_not_found",
             transfer_type: "transfer",
             signature: TEST_SIG_1,

--- a/apps/sdp-api/src/services/jobs/track-pending-transfers.ts
+++ b/apps/sdp-api/src/services/jobs/track-pending-transfers.ts
@@ -31,6 +31,7 @@ import type {
   PaymentTransferRow,
   UpdatePaymentTransferInput,
 } from "@/db/repositories/payments.repository";
+import { createProjectEnvResolver } from "@/lib/cluster-env";
 import { internalError } from "@/lib/errors";
 import { getLogger } from "@/runtime/logger";
 import { logEvent } from "@/runtime/money-path-events";
@@ -51,6 +52,30 @@ type PaymentTransferWithSignedSubmission = PaymentTransferWithSignature & {
   signed_transaction: string;
   last_valid_block_height: string;
 };
+
+async function groupTransfersByProjectEnv<TTransfer extends PaymentTransferRow>(
+  env: Env,
+  transfers: readonly TTransfer[]
+): Promise<Array<{ env: Env; transfers: TTransfer[] }>> {
+  const envForProject = createProjectEnvResolver(env);
+  const byProject = new Map<string, TTransfer[]>();
+  for (const transfer of transfers) {
+    if (transfer.project_id === null) {
+      throw internalError(`On-chain transfer ${transfer.id} is missing a project`);
+    }
+    const group = byProject.get(transfer.project_id);
+    if (group === undefined) {
+      byProject.set(transfer.project_id, [transfer]);
+    } else {
+      group.push(transfer);
+    }
+  }
+  const groups: Array<{ env: Env; transfers: TTransfer[] }> = [];
+  for (const [projectId, group] of byProject) {
+    groups.push({ env: await envForProject(projectId), transfers: group });
+  }
+  return groups;
+}
 
 function hasValidStoredSignature(
   transfer: PaymentTransferRow
@@ -264,6 +289,17 @@ async function finalizeConfirmedTransfers(
     return;
   }
 
+  for (const group of await groupTransfersByProjectEnv(env, confirmedTransfers)) {
+    await finalizeConfirmedTransferGroup(repo, group.env, group.transfers, nowIso);
+  }
+}
+
+async function finalizeConfirmedTransferGroup(
+  repo: PaymentsRepository,
+  env: Env,
+  confirmedTransfers: PaymentTransferWithSignature[],
+  nowIso: string
+): Promise<void> {
   const signatures = confirmedTransfers.map((transfer) => transfer.signature);
 
   let statuses: Array<SignatureStatusInfo | null>;
@@ -416,6 +452,17 @@ async function syncProcessingTransfersOnChain(
     return;
   }
 
+  for (const group of await groupTransfersByProjectEnv(env, processingWithSig)) {
+    await syncProcessingTransferGroup(repo, group.env, group.transfers, nowIso);
+  }
+}
+
+async function syncProcessingTransferGroup(
+  repo: PaymentsRepository,
+  env: Env,
+  processingWithSig: PaymentTransferWithSignature[],
+  nowIso: string
+): Promise<void> {
   const signatures = processingWithSig.map((transfer) => transfer.signature);
 
   let statuses: Array<SignatureStatusInfo | null>;

--- a/apps/sdp-api/src/services/payment-operation.service.test.ts
+++ b/apps/sdp-api/src/services/payment-operation.service.test.ts
@@ -1,0 +1,30 @@
+import { SOL_MINT, wellKnownMint } from "@sdp/types";
+import { describe, expect, it } from "vitest";
+import type { Env } from "@/types/env";
+import { normalizePaymentToken, rampTransferTokenMint } from "./payment-operation.service";
+
+const envFor = (network: "devnet" | "mainnet-beta") =>
+  ({ SOLANA_NETWORK: network, SOLANA_RPC_URL: "https://rpc.example.invalid" }) as Env;
+
+describe("cluster-scoped payment token normalization", () => {
+  it("resolves well-known symbols to the scoped cluster mint", () => {
+    expect(normalizePaymentToken("USDC", envFor("devnet"))).toBe(wellKnownMint("USDC", "devnet"));
+    expect(normalizePaymentToken("usdc", envFor("mainnet-beta"))).toBe(
+      wellKnownMint("USDC", "mainnet-beta")
+    );
+  });
+
+  it("resolves native SOL independently of cluster", () => {
+    expect(normalizePaymentToken("SOL", envFor("devnet"))).toBe(SOL_MINT);
+    expect(normalizePaymentToken("sol", envFor("mainnet-beta"))).toBe(SOL_MINT);
+  });
+
+  it("resolves ramp rails to the scoped cluster mint", () => {
+    expect(rampTransferTokenMint("usdc.solana", envFor("devnet"))).toBe(
+      wellKnownMint("USDC", "devnet")
+    );
+    expect(rampTransferTokenMint("usdc.solana", envFor("mainnet-beta"))).toBe(
+      wellKnownMint("USDC", "mainnet-beta")
+    );
+  });
+});

--- a/apps/sdp-api/src/services/project.service.ts
+++ b/apps/sdp-api/src/services/project.service.ts
@@ -11,6 +11,7 @@ import type {
   ProjectMember,
   ProjectRole,
   ProjectSettings,
+  SdpEnvironment,
 } from "@sdp/types";
 import { parsePostgresJsonOr } from "@/db/postgres-utils";
 import { badRequest, internalError, notFound } from "@/lib/errors";
@@ -19,6 +20,27 @@ export interface UpdateProjectInput {
   name?: string;
   description?: string | null;
   settings?: ProjectSettings | null;
+}
+
+/**
+ * Read the environment that determines a project's Solana cluster.
+ *
+ * @param db - Database connection used for the project lookup.
+ * @param projectId - Project whose environment is required.
+ * @returns The project's SDP environment.
+ */
+export async function projectEnvironment(
+  db: DatabaseClient,
+  projectId: string
+): Promise<SdpEnvironment> {
+  const row = await db
+    .prepare("SELECT environment FROM projects WHERE id = ?")
+    .bind(projectId)
+    .first<{ environment: SdpEnvironment }>();
+  if (!row) {
+    throw notFound("Project");
+  }
+  return row.environment;
 }
 
 export class ProjectService {

--- a/apps/sdp-api/src/services/solana/factory.test.ts
+++ b/apps/sdp-api/src/services/solana/factory.test.ts
@@ -1,0 +1,46 @@
+import * as solanaRpc from "@sdp/rpc/solana";
+import { address, createNoopSigner } from "@solana/kit";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { scopeEnvToCluster } from "@/lib/cluster-env";
+import * as sponsorshipService from "@/services/sponsorship.service";
+import type { Env } from "@/types/env";
+import { createToken2022Service } from "./factory";
+
+const signer = createNoopSigner(address("8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ"));
+const deploymentEnv = {
+  SOLANA_NETWORK: "devnet",
+  SOLANA_RPC_URL: "https://devnet.example.invalid",
+  SOLANA_MAINNET_RPC_URL: "https://mainnet.example.invalid",
+  KORA_RPC_URL: "https://kora.example.invalid",
+} as Env;
+
+vi.spyOn(solanaRpc, "createRpc").mockReturnValue({} as ReturnType<typeof solanaRpc.createRpc>);
+
+describe("createToken2022Service with a cluster-scoped env", () => {
+  afterEach(() => vi.clearAllMocks());
+  afterAll(() => vi.restoreAllMocks());
+
+  it("attaches Kora on devnet", () => {
+    const sponsorship = vi
+      .spyOn(sponsorshipService, "createUnscopedSponsorshipFeePayment")
+      .mockReturnValue(
+        {} as ReturnType<typeof sponsorshipService.createUnscopedSponsorshipFeePayment>
+      );
+
+    createToken2022Service(scopeEnvToCluster(deploymentEnv, "devnet"), signer);
+
+    expect(sponsorship).toHaveBeenCalledOnce();
+  });
+
+  it("leaves mainnet wallet-paid", () => {
+    const sponsorship = vi
+      .spyOn(sponsorshipService, "createUnscopedSponsorshipFeePayment")
+      .mockReturnValue(
+        {} as ReturnType<typeof sponsorshipService.createUnscopedSponsorshipFeePayment>
+      );
+
+    createToken2022Service(scopeEnvToCluster(deploymentEnv, "mainnet-beta"), signer);
+
+    expect(sponsorship).not.toHaveBeenCalled();
+  });
+});

--- a/apps/sdp-api/src/services/sponsorship-budget.service.ts
+++ b/apps/sdp-api/src/services/sponsorship-budget.service.ts
@@ -102,7 +102,13 @@ type AdmissionContext = {
   dayBucket: string;
 };
 
-function resolveNetwork(env: Pick<Env, "SOLANA_NETWORK">): SponsorshipNetwork {
+/**
+ * Translate the Solana cluster vocabulary into sponsorship's persisted network vocabulary.
+ *
+ * @param env - Environment containing the scoped Solana cluster.
+ * @returns The corresponding sponsorship network.
+ */
+export function resolveNetwork(env: Pick<Env, "SOLANA_NETWORK">): SponsorshipNetwork {
   return env.SOLANA_NETWORK === "mainnet-beta" ? "mainnet" : "devnet";
 }
 

--- a/apps/sdp-api/src/types/env.d.ts
+++ b/apps/sdp-api/src/types/env.d.ts
@@ -87,14 +87,12 @@ export interface Env {
   // Solana configuration
   SOLANA_RPC_URL?: string;
   /**
-   * Optional PER-CLUSTER overrides for the Earn execution path.
+   * Optional per-cluster overrides for project-scoped Solana access.
    *
    * One API process serves both clusters — sandbox projects are devnet,
    * production projects are mainnet-beta — so a single `SOLANA_RPC_URL` cannot
-   * be correct for both. Unset falls back to `SOLANA_RPC_URL`, which must then
-   * prove its chain by genesis hash before anything is built against it
-   * (`assertClusterEndpoint`), so a single-cluster deployment keeps working and
-   * a mismatch is a refusal rather than a confidently wrong transaction.
+   * be correct for both. The deployment default keeps its provider fan; the
+   * other cluster requires its explicit override and fails closed when absent.
    */
   SOLANA_DEVNET_RPC_URL?: string;
   SOLANA_MAINNET_RPC_URL?: string;

--- a/packages/sdp-payments/src/fee-payment/index.ts
+++ b/packages/sdp-payments/src/fee-payment/index.ts
@@ -29,15 +29,6 @@ export type FeePaymentProviderType = "kora" | "native";
 // Default URLs
 // ═══════════════════════════════════════════════════════════════════════════
 
-/**
- * Default Kora RPC URLs by network.
- * These may need to be updated based on Solana Foundation's deployment.
- */
-const DEFAULT_KORA_URLS: Record<string, string> = {
-  devnet: "https://kora-devnet.solana.com",
-  "mainnet-beta": "https://kora.solana.com",
-};
-
 // ═══════════════════════════════════════════════════════════════════════════
 // Factory Functions
 // ═══════════════════════════════════════════════════════════════════════════
@@ -70,12 +61,11 @@ export function createFeePaymentAdapter(env: FeePaymentEnv, userId?: string): Fe
  * fallback bucket rather than bypassing Kora usage tracking.
  */
 export function createKoraAdapter(env: FeePaymentEnv, userId?: string): KoraAdapter {
-  // Get RPC URL from env or use default based on network
-  const rpcUrl = env.KORA_RPC_URL ?? getDefaultKoraUrl(env);
+  const rpcUrl = env.KORA_RPC_URL;
 
   if (!rpcUrl) {
     throw new FeePaymentError(
-      "KORA_RPC_URL not configured and no default URL for network",
+      "Kora fee sponsorship is not configured for this cluster: set KORA_RPC_URL",
       "PROVIDER_NOT_AVAILABLE"
     );
   }
@@ -101,11 +91,6 @@ export function createNativeAdapter(env: FeePaymentEnv): NativeAdapter {
 // ═══════════════════════════════════════════════════════════════════════════
 // Utilities
 // ═══════════════════════════════════════════════════════════════════════════
-
-function getDefaultKoraUrl(env: FeePaymentEnv): string | undefined {
-  const network = env.SOLANA_NETWORK ?? "devnet";
-  return DEFAULT_KORA_URLS[network];
-}
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Re-exports

--- a/packages/sdp-rpc/src/cluster-proof.test.ts
+++ b/packages/sdp-rpc/src/cluster-proof.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { afterEach, test } from "node:test";
 import { GENESIS_HASH_BY_CLUSTER } from "@sdp/types";
 import {
-  assertClusterRpcUrl,
+  assertClusterEndpoint,
   CLUSTER_ENDPOINT_PROOF_TTL_MS,
   createRpc,
   resetClusterEndpointProofs,
@@ -111,21 +111,19 @@ test("devnet skips genesis proof", async () => {
   assert.deepEqual(state.methods, ["getSlot"]);
 });
 
-test("assertClusterRpcUrl proves a bare mainnet URL and skips devnet", async () => {
-  const state = installRpcFetch(() => GENESIS_HASH_BY_CLUSTER.devnet);
-
-  await assertClusterRpcUrl(
-    { SOLANA_NETWORK: "devnet" } as RpcEnv,
-    "https://devnet.example.invalid"
-  );
-  assert.deepEqual(state.methods, []);
+test("assertClusterEndpoint proves any cluster, devnet included, and memoises per URL", async () => {
+  const state = installRpcFetch(() => GENESIS_HASH_BY_CLUSTER["mainnet-beta"]);
+  const devnetEnv = { SOLANA_NETWORK: "devnet" } as RpcEnv;
+  const url = "https://really-mainnet.example.invalid";
+  const devnetClient = createRpc(devnetEnv, { rpcUrl: url });
 
   await assert.rejects(
-    assertClusterRpcUrl(
-      { SOLANA_NETWORK: "mainnet-beta" } as RpcEnv,
-      "https://wrong.example.invalid"
-    ),
-    /reports genesis/
+    assertClusterEndpoint(devnetEnv, url, devnetClient),
+    /reports genesis .* not .*Set SOLANA_DEVNET_RPC_URL/
   );
+  await assert.rejects(assertClusterEndpoint(devnetEnv, url, devnetClient), /reports genesis/);
   assert.deepEqual(state.methods, ["getGenesisHash"]);
+
+  const mainnetEnv = { SOLANA_NETWORK: "mainnet-beta" } as RpcEnv;
+  await assertClusterEndpoint(mainnetEnv, url, createRpc(mainnetEnv, { rpcUrl: url }));
 });

--- a/packages/sdp-rpc/src/cluster-proof.test.ts
+++ b/packages/sdp-rpc/src/cluster-proof.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { GENESIS_HASH_BY_CLUSTER } from "@sdp/types";
+import {
+  assertClusterRpcUrl,
+  CLUSTER_ENDPOINT_PROOF_TTL_MS,
+  createRpc,
+  resetClusterEndpointProofs,
+} from "./solana";
+import { withTransientRpcRetry } from "./transient";
+import type { RpcEnv } from "./types";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  resetClusterEndpointProofs();
+});
+
+function installRpcFetch(genesis: () => Promise<string> | string): { methods: string[] } {
+  const state = { methods: [] as string[] };
+  globalThis.fetch = async (_input, init) => {
+    const payload = JSON.parse(String(init?.body)) as { id: string; method: string };
+    state.methods.push(payload.method);
+    const result = payload.method === "getGenesisHash" ? await genesis() : 123;
+    return new Response(JSON.stringify({ jsonrpc: "2.0", id: payload.id, result }), {
+      headers: { "content-type": "application/json" },
+    });
+  };
+  return state;
+}
+
+test("mainnet proves an explicit URL before its first request and caches the verdict", async () => {
+  const state = installRpcFetch(() => GENESIS_HASH_BY_CLUSTER["mainnet-beta"]);
+  const rpc = createRpc({ SOLANA_NETWORK: "mainnet-beta" } as RpcEnv, {
+    rpcUrl: "https://mainnet.example.invalid",
+  });
+
+  await rpc.getSlot().send();
+  await rpc.getSlot().send();
+
+  assert.deepEqual(state.methods, ["getGenesisHash", "getSlot", "getSlot"]);
+});
+
+test("mainnet rejects a mismatched genesis with observed, expected, and remediation", async () => {
+  const state = installRpcFetch(() => GENESIS_HASH_BY_CLUSTER.devnet);
+  const rpc = createRpc({
+    SOLANA_NETWORK: "mainnet-beta",
+    SOLANA_RPC_TRITON_URL: "https://wrong.example.invalid",
+    SOLANA_RPC_HELIUS_URL: "https://unused.example.invalid",
+  } as RpcEnv);
+
+  await assert.rejects(
+    () => withTransientRpcRetry(() => rpc.getSlot().send(), [0, 0]),
+    new RegExp(
+      `${GENESIS_HASH_BY_CLUSTER.devnet}.*${GENESIS_HASH_BY_CLUSTER["mainnet-beta"]}.*SOLANA_MAINNET_RPC_URL`
+    )
+  );
+  assert.deepEqual(state.methods, ["getGenesisHash"]);
+});
+
+test("a rejected probe is evicted and concurrent requests coalesce", async () => {
+  let calls = 0;
+  let release: ((hash: string) => void) | undefined;
+  const state = installRpcFetch(() => {
+    calls += 1;
+    if (calls === 1) throw new Error("temporary failure");
+    return new Promise<string>((resolve) => {
+      release = resolve;
+    });
+  });
+  const rpc = createRpc({ SOLANA_NETWORK: "mainnet-beta" } as RpcEnv, {
+    rpcUrl: "https://recovering.example.invalid",
+  });
+
+  await assert.rejects(() => rpc.getSlot().send(), /Could not verify/);
+  const first = rpc.getSlot().send();
+  const second = rpc.getSlot().send();
+  assert.equal(state.methods.filter((method) => method === "getGenesisHash").length, 2);
+  assert.ok(release);
+  release(GENESIS_HASH_BY_CLUSTER["mainnet-beta"]);
+  await Promise.all([first, second]);
+});
+
+test("mainnet re-proves after the short TTL", async () => {
+  const state = installRpcFetch(() => GENESIS_HASH_BY_CLUSTER["mainnet-beta"]);
+  const realNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now;
+  try {
+    const rpc = createRpc({ SOLANA_NETWORK: "mainnet-beta" } as RpcEnv, {
+      rpcUrl: "https://ttl.example.invalid",
+    });
+    await rpc.getSlot().send();
+    now += CLUSTER_ENDPOINT_PROOF_TTL_MS;
+    await rpc.getSlot().send();
+    assert.equal(state.methods.filter((method) => method === "getGenesisHash").length, 2);
+  } finally {
+    Date.now = realNow;
+  }
+});
+
+test("devnet skips genesis proof", async () => {
+  const state = installRpcFetch(() => GENESIS_HASH_BY_CLUSTER.devnet);
+  const rpc = createRpc({ SOLANA_NETWORK: "devnet" } as RpcEnv, {
+    rpcUrl: "https://localnet.example.invalid",
+  });
+
+  await rpc.getSlot().send();
+
+  assert.deepEqual(state.methods, ["getSlot"]);
+});
+
+test("assertClusterRpcUrl proves a bare mainnet URL and skips devnet", async () => {
+  const state = installRpcFetch(() => GENESIS_HASH_BY_CLUSTER.devnet);
+
+  await assertClusterRpcUrl(
+    { SOLANA_NETWORK: "devnet" } as RpcEnv,
+    "https://devnet.example.invalid"
+  );
+  assert.deepEqual(state.methods, []);
+
+  await assert.rejects(
+    assertClusterRpcUrl(
+      { SOLANA_NETWORK: "mainnet-beta" } as RpcEnv,
+      "https://wrong.example.invalid"
+    ),
+    /reports genesis/
+  );
+  assert.deepEqual(state.methods, ["getGenesisHash"]);
+});

--- a/packages/sdp-rpc/src/config.ts
+++ b/packages/sdp-rpc/src/config.ts
@@ -1,9 +1,20 @@
-import type { OrganizationRpcProvider } from "@sdp/types";
+import type { OrganizationRpcProvider, SolanaCluster } from "@sdp/types";
+import { rpcNotConfigured } from "./errors";
 import type { RpcEnv } from "./types";
 
 export interface SolanaConfig {
   rpcUrl: string;
-  network: "devnet" | "mainnet-beta";
+  network: SolanaCluster;
+}
+
+/**
+ * Resolve the deployment's configured Solana cluster.
+ *
+ * @param env - RPC environment whose deployment default is required.
+ * @returns The configured cluster, defaulting to devnet when it is absent.
+ */
+export function resolveDefaultCluster(env: RpcEnv): SolanaCluster {
+  return env.SOLANA_NETWORK ?? "devnet";
 }
 
 const API_KEY_TEMPLATE = ["$", "{API_KEY}"].join("");
@@ -148,12 +159,19 @@ export function resolveDefaultSolanaRpcUrl(env: RpcEnv): string | null {
   return resolveSolanaRpcProviderUrls(env)[0] ?? null;
 }
 
+/**
+ * Resolve the active cluster and its preferred RPC endpoint.
+ *
+ * @param env - RPC environment to resolve.
+ * @returns The configured cluster and preferred endpoint.
+ * @throws {SdpRpcError} When the active cluster has no configured endpoint.
+ */
 export function getSolanaConfig(env: RpcEnv): SolanaConfig {
   const rpcUrl = resolveDefaultSolanaRpcUrl(env);
-  const network = env.SOLANA_NETWORK ?? "devnet";
+  const network = resolveDefaultCluster(env);
 
   if (!rpcUrl) {
-    throw new Error("No Solana RPC endpoint is configured");
+    throw rpcNotConfigured(`No Solana RPC endpoint is configured for ${network}`);
   }
 
   return { rpcUrl, network };

--- a/packages/sdp-rpc/src/errors.ts
+++ b/packages/sdp-rpc/src/errors.ts
@@ -2,6 +2,7 @@ export type SdpRpcErrorCode =
   | "BAD_REQUEST"
   | "FORBIDDEN"
   | "NOT_FOUND"
+  | "RPC_NOT_CONFIGURED"
   | "INTERNAL_ERROR"
   | "SOLANA_RPC_ERROR";
 
@@ -9,6 +10,7 @@ const ERROR_STATUS_CODES: Record<SdpRpcErrorCode, number> = {
   BAD_REQUEST: 400,
   FORBIDDEN: 403,
   NOT_FOUND: 404,
+  RPC_NOT_CONFIGURED: 503,
   INTERNAL_ERROR: 500,
   SOLANA_RPC_ERROR: 502,
 };
@@ -29,4 +31,14 @@ export class SdpRpcError extends Error {
 
 export function solanaRpcError(message: string, details?: Record<string, unknown>): SdpRpcError {
   return new SdpRpcError("SOLANA_RPC_ERROR", message, details);
+}
+
+/**
+ * Create an unavailable error for a cluster without an RPC endpoint.
+ *
+ * @param message - Cluster-specific configuration error message.
+ * @returns An RPC package error mapped to HTTP 503.
+ */
+export function rpcNotConfigured(message: string): SdpRpcError {
+  return new SdpRpcError("RPC_NOT_CONFIGURED", message);
 }

--- a/packages/sdp-rpc/src/index.ts
+++ b/packages/sdp-rpc/src/index.ts
@@ -1,10 +1,11 @@
 export {
   getSolanaConfig,
+  resolveDefaultCluster,
   resolveDefaultSolanaRpcUrl,
   resolveSolanaRpcProviderUrls,
   type SolanaConfig,
 } from "./config";
-export { SdpRpcError, type SdpRpcErrorCode, solanaRpcError } from "./errors";
+export { rpcNotConfigured, SdpRpcError, type SdpRpcErrorCode, solanaRpcError } from "./errors";
 export {
   isForbiddenRpcError,
   isTransientRpcError,

--- a/packages/sdp-rpc/src/solana.ts
+++ b/packages/sdp-rpc/src/solana.ts
@@ -5,6 +5,7 @@
  * using the modern @solana/kit.
  */
 
+import { GENESIS_HASH_BY_CLUSTER } from "@sdp/types";
 import {
   type Address,
   airdropFactory,
@@ -25,8 +26,8 @@ import {
   type TransactionError,
   type TransactionMessageBytesBase64,
 } from "@solana/kit";
-import { getSolanaConfig, resolveSolanaRpcProviderUrls } from "./config";
-import { solanaRpcError } from "./errors";
+import { getSolanaConfig, resolveDefaultCluster, resolveSolanaRpcProviderUrls } from "./config";
+import { rpcNotConfigured, solanaRpcError } from "./errors";
 import { isTransientRpcError, withTransientRpcRetry } from "./transient";
 import type { RpcEnv } from "./types";
 
@@ -151,6 +152,97 @@ export function withRequestTimeout(transport: RpcTransport, timeoutMs: number): 
 
 const lastGoodTransportIndex = new Map<string, number>();
 
+export const CLUSTER_ENDPOINT_PROOF_TTL_MS = 30_000;
+
+interface ClusterEndpointProof {
+  promise: Promise<string>;
+  expiresAt: number | null;
+}
+
+const clusterEndpointProofs = new Map<string, ClusterEndpointProof>();
+
+async function observeGenesisHash(transport: RpcTransport): Promise<string> {
+  const response: unknown = await transport<unknown>({
+    payload: { jsonrpc: "2.0", method: "getGenesisHash", params: [] },
+  });
+  if (
+    typeof response !== "object" ||
+    response === null ||
+    !("result" in response) ||
+    typeof response.result !== "string"
+  ) {
+    throw solanaRpcError("Solana RPC returned a malformed getGenesisHash response");
+  }
+  return response.result;
+}
+
+async function proveMainnetEndpoint(transport: RpcTransport, url: string): Promise<void> {
+  const cluster = "mainnet-beta";
+  const key = `${cluster}\n${url}`;
+  let proof = clusterEndpointProofs.get(key);
+  if (proof !== undefined && proof.expiresAt !== null && proof.expiresAt <= Date.now()) {
+    clusterEndpointProofs.delete(key);
+    proof = undefined;
+  }
+  if (proof === undefined) {
+    proof = { promise: observeGenesisHash(transport), expiresAt: null };
+    clusterEndpointProofs.set(key, proof);
+  }
+
+  let observed: string;
+  try {
+    observed = await proof.promise;
+    if (clusterEndpointProofs.get(key) === proof && proof.expiresAt === null) {
+      proof.expiresAt = Date.now() + CLUSTER_ENDPOINT_PROOF_TTL_MS;
+    }
+  } catch (cause) {
+    if (clusterEndpointProofs.get(key) === proof) {
+      clusterEndpointProofs.delete(key);
+    }
+    throw solanaRpcError(
+      `Could not verify that the configured ${cluster} RPC endpoint serves ${cluster}: ${cause instanceof Error ? cause.message : String(cause)}`
+    );
+  }
+
+  const expected = GENESIS_HASH_BY_CLUSTER[cluster];
+  if (observed !== expected) {
+    throw solanaRpcError(
+      `The RPC endpoint configured for ${cluster} reports genesis ${observed}, not ${expected}. Set SOLANA_MAINNET_RPC_URL to a ${cluster} endpoint.`
+    );
+  }
+}
+
+function withMainnetEndpointProof(transport: RpcTransport, url: string): RpcTransport {
+  return async <TResponse>(request: Parameters<RpcTransport>[0]): Promise<TResponse> => {
+    await proveMainnetEndpoint(transport, url);
+    return await transport<TResponse>(request);
+  };
+}
+
+/**
+ * Prove that `rpcUrl` serves the cluster `env` names before handing the bare URL
+ * to a client that builds its own transport (the Earn provider SDKs), where the
+ * proof inside `createRpc` cannot run. Mainnet only, like `createRpc`.
+ *
+ * @param env - Cluster-scoped RPC environment naming the cluster the URL must serve.
+ * @param rpcUrl - Endpoint about to be handed to a foreign client.
+ * @returns Resolves once the endpoint has proved its genesis; rejects on mismatch.
+ */
+export async function assertClusterRpcUrl(env: RpcEnv, rpcUrl: string): Promise<void> {
+  if (resolveDefaultCluster(env) !== "mainnet-beta") return;
+  await proveMainnetEndpoint(
+    withRequestTimeout(createDefaultRpcTransport({ url: rpcUrl }), DEFAULT_RPC_REQUEST_TIMEOUT_MS),
+    rpcUrl
+  );
+}
+
+/**
+ * Forget cached mainnet endpoint proofs for deterministic tests.
+ */
+export function resetClusterEndpointProofs(): void {
+  clusterEndpointProofs.clear();
+}
+
 /**
  * Wrap an ordered set of provider transports in per-request failover: a
  * transient failure (429/5xx/transport error) advances to the next provider,
@@ -195,38 +287,50 @@ export function createFailoverTransport(
 }
 
 /**
- * Create a configured Solana RPC client from environment
+ * Create a timeout-bounded Solana RPC client from environment or an explicit endpoint.
+ *
+ * @param env - RPC environment that selects the cluster and managed endpoints.
+ * @param options - Optional explicit endpoint, headers, and request timeout.
+ * @param options.rpcUrl - Explicit endpoint that bypasses managed endpoint selection.
+ * @param options.headers - Headers attached to requests for the explicit or managed endpoint.
+ * @param options.requestTimeoutMs - Deadline applied to each provider request.
+ * @returns A configured Solana RPC client.
  */
 export function createRpc(env: RpcEnv, options?: RpcClientOptions): SolanaRpc {
   const timeoutMs = options?.requestTimeoutMs ?? DEFAULT_RPC_REQUEST_TIMEOUT_MS;
+  const network = resolveDefaultCluster(env);
 
   const buildTransport = (url: string): RpcTransport => {
+    let transport: RpcTransport;
     if (options?.headers && Object.keys(options.headers).length > 0) {
       assertAllowedRpcHeaders(options.headers);
-      return createDefaultRpcTransport({ headers: options.headers, url });
+      transport = createDefaultRpcTransport({ headers: options.headers, url });
+    } else {
+      transport = createDefaultRpcTransport({ url });
     }
-    return createDefaultRpcTransport({ url });
+    const timedTransport = withRequestTimeout(transport, timeoutMs);
+    // ponytail: genesis proof guards the funds-bearing cluster only — devnet envs include surfpool/localnet whose genesis differs. Add a devnet proof if sandbox ever carries value.
+    return network === "mainnet-beta"
+      ? withMainnetEndpointProof(timedTransport, url)
+      : timedTransport;
   };
 
   // An explicit URL is already the complete endpoint selection. Do not force
   // callers with a per-request/per-cluster URL to also configure the legacy
   // process default merely to construct a client for that explicit endpoint.
   if (options?.rpcUrl) {
-    return createRpcFromTransport(buildTransport(options.rpcUrl), {
-      requestTimeoutMs: timeoutMs,
-    });
+    return createSolanaRpcFromTransport(buildTransport(options.rpcUrl));
   }
 
   const urls = resolveSolanaRpcProviderUrls(env);
   if (urls.length === 0) {
-    // Preserves the single-URL error message callers have always seen.
-    getSolanaConfig(env);
+    throw rpcNotConfigured(`No Solana RPC endpoint is configured for ${network}`);
   }
   // The deadline sits on each provider attempt, not around the whole failover:
   // an outer deadline lets one stalled provider consume the entire budget and
   // hands every later attempt an already-aborted signal. A stall costs at most
   // timeoutMs per provider before the hop.
-  const transports = urls.map((url) => withRequestTimeout(buildTransport(url), timeoutMs));
+  const transports = urls.map((url) => buildTransport(url));
   return createSolanaRpcFromTransport(
     createFailoverTransport(transports, { stickyKey: urls.join("|") })
   );

--- a/packages/sdp-rpc/src/solana.ts
+++ b/packages/sdp-rpc/src/solana.ts
@@ -5,7 +5,7 @@
  * using the modern @solana/kit.
  */
 
-import { GENESIS_HASH_BY_CLUSTER } from "@sdp/types";
+import { GENESIS_HASH_BY_CLUSTER, type SolanaCluster } from "@sdp/types";
 import {
   type Address,
   airdropFactory,
@@ -176,16 +176,18 @@ async function observeGenesisHash(transport: RpcTransport): Promise<string> {
   return response.result;
 }
 
-async function proveMainnetEndpoint(transport: RpcTransport, url: string): Promise<void> {
-  const cluster = "mainnet-beta";
-  const key = `${cluster}\n${url}`;
+async function proveClusterEndpoint(
+  key: string,
+  cluster: SolanaCluster,
+  observe: () => Promise<string>
+): Promise<void> {
   let proof = clusterEndpointProofs.get(key);
   if (proof !== undefined && proof.expiresAt !== null && proof.expiresAt <= Date.now()) {
     clusterEndpointProofs.delete(key);
     proof = undefined;
   }
   if (proof === undefined) {
-    proof = { promise: observeGenesisHash(transport), expiresAt: null };
+    proof = { promise: observe(), expiresAt: null };
     clusterEndpointProofs.set(key, proof);
   }
 
@@ -207,32 +209,45 @@ async function proveMainnetEndpoint(transport: RpcTransport, url: string): Promi
   const expected = GENESIS_HASH_BY_CLUSTER[cluster];
   if (observed !== expected) {
     throw solanaRpcError(
-      `The RPC endpoint configured for ${cluster} reports genesis ${observed}, not ${expected}. Set SOLANA_MAINNET_RPC_URL to a ${cluster} endpoint.`
+      `The RPC endpoint configured for ${cluster} reports genesis ${observed}, not ${expected}. Set SOLANA_${
+        cluster === "devnet" ? "DEVNET" : "MAINNET"
+      }_RPC_URL to a ${cluster} endpoint.`
     );
   }
 }
 
 function withMainnetEndpointProof(transport: RpcTransport, url: string): RpcTransport {
   return async <TResponse>(request: Parameters<RpcTransport>[0]): Promise<TResponse> => {
-    await proveMainnetEndpoint(transport, url);
+    await proveClusterEndpoint(`mainnet-beta\n${url}`, "mainnet-beta", () =>
+      observeGenesisHash(transport)
+    );
     return await transport<TResponse>(request);
   };
 }
 
 /**
- * Prove that `rpcUrl` serves the cluster `env` names before handing the bare URL
- * to a client that builds its own transport (the Earn provider SDKs), where the
- * proof inside `createRpc` cannot run. Mainnet only, like `createRpc`.
+ * Prove that `rpc`, bound to `rpcUrl`, serves the cluster `env` names — for ANY
+ * cluster, before a caller relies on it. Two callers need this beyond the
+ * mainnet-only transport proof in `createRpc`: code that hands the bare URL to a
+ * client with its own transport (the Earn provider SDKs), and Earn generally,
+ * whose provider program ids resolve on either chain with no error, so a devnet
+ * endpoint that is really mainnet fails as "vault does not exist" instead of
+ * loudly. Memoised per cluster and URL like the transport proof. The caller
+ * supplies the client so the probe goes through its own `createRpc` seam.
  *
  * @param env - Cluster-scoped RPC environment naming the cluster the URL must serve.
- * @param rpcUrl - Endpoint about to be handed to a foreign client.
+ * @param rpcUrl - Endpoint the client is bound to; the memo key.
+ * @param rpc - Client bound to `rpcUrl`, used for the genesis probe.
  * @returns Resolves once the endpoint has proved its genesis; rejects on mismatch.
  */
-export async function assertClusterRpcUrl(env: RpcEnv, rpcUrl: string): Promise<void> {
-  if (resolveDefaultCluster(env) !== "mainnet-beta") return;
-  await proveMainnetEndpoint(
-    withRequestTimeout(createDefaultRpcTransport({ url: rpcUrl }), DEFAULT_RPC_REQUEST_TIMEOUT_MS),
-    rpcUrl
+export async function assertClusterEndpoint(
+  env: RpcEnv,
+  rpcUrl: string,
+  rpc: SolanaRpc
+): Promise<void> {
+  const cluster = resolveDefaultCluster(env);
+  await proveClusterEndpoint(`assert\n${cluster}\n${rpcUrl}`, cluster, async () =>
+    String(await rpc.getGenesisHash().send())
   );
 }
 
@@ -309,7 +324,9 @@ export function createRpc(env: RpcEnv, options?: RpcClientOptions): SolanaRpc {
       transport = createDefaultRpcTransport({ url });
     }
     const timedTransport = withRequestTimeout(transport, timeoutMs);
-    // ponytail: genesis proof guards the funds-bearing cluster only — devnet envs include surfpool/localnet whose genesis differs. Add a devnet proof if sandbox ever carries value.
+    // ponytail: the transport proof guards mainnet only — CI and local surfpool
+    // run a mainnet fork under SOLANA_NETWORK=devnet, so a devnet proof here
+    // would refuse them. Callers that need devnet identity use assertClusterEndpoint.
     return network === "mainnet-beta"
       ? withMainnetEndpointProof(timedTransport, url)
       : timedTransport;

--- a/packages/sdp-types/src/api-keys.ts
+++ b/packages/sdp-types/src/api-keys.ts
@@ -7,6 +7,12 @@ import type { ApiKeyWalletPolicyBindingScope } from "./policy";
 
 export type SdpEnvironment = "sandbox" | "production";
 
+/** Every supported SDP project environment. */
+export const SDP_ENVIRONMENTS = [
+  "sandbox",
+  "production",
+] as const satisfies readonly SdpEnvironment[];
+
 export type ApiKeyEnvironment = SdpEnvironment;
 
 export type ApiKeyStatus = "active" | "revoked" | "expired" | "deactivated";


### PR DESCRIPTION
- Every onchain path derives its Solana cluster from the request's **project environment** (sandbox → devnet, production → mainnet-beta), served by one deployment. Rebuilt from the earlier revision of this PR: instead of threading a `cluster` argument through ~50 files, the project middleware swaps `c.env` for a **cluster-scoped copy** — every cluster reader already takes `env` (`createRpc`, `getSolanaConfig`, well-known mint lookups, Kora gates, sponsorship network, custody provisioning), so all ~60 call sites flip with no edits.
- `scopeEnvToCluster(env, cluster)` (`lib/cluster-env.ts`) sets `SOLANA_NETWORK`, picks the per-cluster RPC URL (`SOLANA_MAINNET_RPC_URL` / `SOLANA_DEVNET_RPC_URL`; else the deployment's provider fan only for its own cluster; else no endpoint), and keeps `KORA_RPC_URL` only on devnet (`KORA_FEE_SPONSORSHIP_CLUSTERS`).
- Fail-closed, lazily: a production project on a deployment without `SOLANA_MAINNET_RPC_URL` still serves offchain routes; the first onchain call answers **503 `RPC_NOT_CONFIGURED`** (new `@sdp/rpc` error code).
- Genesis-hash proof moves into `@sdp/rpc`: a **mainnet-only transport wrapper** inside `createRpc` (30 s memo, coalesced, no retry/failover on mismatch) covers every client; an explicit **any-cluster** `assertClusterEndpoint(env, rpcUrl, rpc)` covers Earn, whose provider program ids resolve on either chain silently. Earn's private resolver/proof is deleted; all Earn clients go through `createProvenClusterRpc` / `provenVaultRpc`, and the provider-SDK URL handoff (Kamino/Veda/Jupiter build their own transports) through `resolveProvenClusterRpcUrl`.
- Non-request entry points scope per project row: public Solana Pay route (null-project requests now **400** instead of reporting `devnet` to a paying wallet), ramp webhooks, pending-transfer + recurring-collection jobs (`createProjectEnvResolver`), and the DvP reconciler, which now sweeps **per environment** because block heights are per cluster (claim release/list queries join through `projects`).
- Removed the hardcoded `DEFAULT_KORA_URLS` fallback in `@sdp/payments`: a Kora-less env fails closed (`PROVIDER_NOT_AVAILABLE`) instead of routing fees to an unconfigured public endpoint.
- Issuance supply refresh no longer rewraps a missing-RPC config error as a 502 RPC failure.

**before** — deployment-determined cluster:

1. any request → `createRpc(c.env)` → whatever `SOLANA_NETWORK` / `SOLANA_RPC_URL` the process was booted with
2. well-known mints resolved against that same process cluster
3. a production project silently built, read and reconciled against devnet — wrong data, not an error

**after** — project-determined, endpoint-proven:

1. `projectContextMiddleware` → `c.env = scopeEnvToCluster(c.env, CLUSTER_BY_SDP_ENVIRONMENT[environment])`
2. downstream `createRpc(env)` / `getSolanaConfig(env)` / `wellKnownMint(symbol, getSolanaConfig(env).network)` are cluster-correct by construction; on mainnet the first RPC send proves `getGenesisHash` against the pinned constant, mismatch → refusal naming observed vs expected
3. no endpoint for the cluster → 503 `RPC_NOT_CONFIGURED` at the first onchain call; Kora absent off devnet → wallet path / `PROVIDER_NOT_AVAILABLE`, never a default URL

## How the scoping works

```ts
scoped = { ...env, SOLANA_NETWORK: cluster }
override = cluster === "devnet" ? env.SOLANA_DEVNET_RPC_URL : env.SOLANA_MAINNET_RPC_URL
if (override)                              scoped.SOLANA_RPC_URL = override; drop managed-provider keys
else if (cluster !== defaultCluster(env))  drop SOLANA_RPC_URL + managed-provider keys   // fails closed on use
if (!KORA_FEE_SPONSORSHIP_CLUSTERS.includes(cluster)) drop KORA_RPC_URL
```

**API before/after** (from the route tests; production API key, deployment without `SOLANA_MAINNET_RPC_URL`)

`POST /v1/payments/transfers` `{ token: "USDC", … }`

before → `200` built against devnet (devnet USDC mint persisted)
after → `503 { "error": { "code": "RPC_NOT_CONFIGURED", "message": "No Solana RPC endpoint is configured for mainnet-beta" } }`

With `SOLANA_MAINNET_RPC_URL` set: the persisted `token` is the **mainnet** USDC mint and fee payment receives an env without `KORA_RPC_URL`.

`GET /pay/:token` for a payment request with no project

before → `200 { …, "network": "devnet" }`
after → `400 { "error": { "code": "BAD_REQUEST", "message": "Payment request is not associated with a project" } }`

**Verification**

- `pnpm -C apps/sdp-api exec tsc --noEmit -p .` — clean; `@sdp/rpc`, `@sdp/payments`, `@sdp/types` typecheck clean
- `apps/sdp-api` vitest, full suite against Postgres — 391 files, 5643 passed, 0 failed, 14 skipped (a later run showed only the shared-Redis `kv-redis` / `sponsorship-budget-redis` cross-session flakes, files untouched here)
- `@sdp/rpc` node tests 33/33 (proof matrix: explicit URL, mismatch, rejected-probe eviction, TTL, coalescing, devnet transport skipped, no failover/retry on mismatch, any-cluster `assertClusterEndpoint`); `@sdp/payments` 67/67
- Biome clean on the changed set
- local app: not exercised — behaviour is covered by the new route tests above (production-project transfers/issuance 503, middleware env swap, per-project job scoping, DvP per-environment sweep, cross-environment claim isolation)

**Security notes**

- Error messages for a misconfigured cluster name the env var and the observed genesis hash; ops-useful, not secret, only on a misconfigured deployment.
- The transport-level proof is mainnet-only by design: CI and local surfpool run a **mainnet fork under `SOLANA_NETWORK=devnet`** (verified: surfpool answers `getGenesisHash` with the mainnet hash), so a devnet transport proof would refuse them. Earn keeps its devnet proof explicitly via `assertClusterEndpoint`; other devnet paths accept a misconfigured devnet URL as before this PR.

Known gaps
- Managed sponsorship has no production scope yet, so a production transfer resolves the mainnet mint and then fails closed at fee payment (`Sponsorship is disabled for this scope`). Real wallet-pays for payments on mainnet is a follow-up on the mainnet epic.
- RPC relay (`resolveRpcTarget`) / observed transfers / Helius DAS keep their own per-connection or per-process URL selection (unchanged).
- Ops prerequisite: set `SOLANA_MAINNET_RPC_URL` before enabling any production project.
