### PR TITLE
fix(smoke): activate the ticket session and org together

### DIFF
--- a/apps/sdp-web/playwright/tests/auth.global.setup.ts
+++ b/apps/sdp-web/playwright/tests/auth.global.setup.ts
@@ -61,15 +61,21 @@ setup("authenticate admin test user and save auth state", async ({ page, browser
     async ({ organizationId }) => {
       const clerkClient = (
         window as unknown as {
-          Clerk?: { setActive: (params: { organization: string }) => Promise<void> };
+          Clerk?: {
+            session?: { id?: string };
+            setActive: (params: { session?: string; organization?: string }) => Promise<void>;
+          };
         }
       ).Clerk;
 
-      if (!clerkClient) {
-        throw new Error("Clerk failed to load in Playwright global setup");
+      if (!clerkClient?.session?.id) {
+        throw new Error("Clerk session not established in Playwright global setup");
       }
 
-      await clerkClient.setActive({ organization: organizationId });
+      await clerkClient.setActive({
+        session: clerkClient.session.id,
+        organization: organizationId,
+      });
     },
     { organizationId: identity.organizationId }
   );


### PR DESCRIPTION
The stage smoke has failed every run at the org-id poll (`Clerk.organization` stays `undefined`). Root cause: `setActive({organization})` alone doesn't reliably activate the org on the URL-ticket session when that session isn't yet the client's active session — so the session JWT carries no `org_id` and `Clerk.organization` never populates. Fix: read the established `Clerk.session.id` (already waited for) and call `setActive({session, organization})` together, the canonical Clerk usage.

Can't be verified on a branch ref (the stage-smoke Doppler identity is main-pinned by design), so the post-merge run on main is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)