### PR TITLE
feat(payments): Coinbase requirements decide individuals only

### DIFF
--- a/packages/sdp-payments/src/ramps/providers/coinbase/client.ts
+++ b/packages/sdp-payments/src/ramps/providers/coinbase/client.ts
@@ -7,7 +7,6 @@ import { z } from "zod";
 import { divideDecimalAmounts, sumDecimalAmounts } from "../../../decimal";
 import { badRequest, providerNotConfigured, providerUnavailable } from "../../../errors";
 import { providerFetchJson } from "../../fetch";
-import { readyCounterparty } from "../../requirements";
 import {
   isSolanaCryptoAsset,
   RAMP_RAIL_DUMPS,
@@ -27,6 +26,7 @@ import type {
   RampRuntimeContext,
   ValidateCounterpartyOptions,
 } from "../../types";
+import { coinbaseCounterpartyRequirements } from "./counterparty";
 
 // v1 API (Bearer JWT): buy options, buy quote — used for rail discovery + estimates.
 const CDP_V1_API_BASE_URL = "https://api.developer.coinbase.com";
@@ -195,18 +195,10 @@ export class CoinbaseRampClient implements RampProvider {
   readonly declaredRailSupport = COINBASE_DECLARED_RAIL_SUPPORT;
 
   validateCounterparty(
-    _counterparty: Counterparty,
+    counterparty: Counterparty,
     options: ValidateCounterpartyOptions
   ): CounterpartyRequirements {
-    if (options.direction !== "onramp") {
-      return {
-        provider: this.id,
-        direction: options.direction,
-        status: "unsupported",
-        reason: "Coinbase Onramp supports on-ramp only.",
-      };
-    }
-    return readyCounterparty(this.id, options.direction);
+    return coinbaseCounterpartyRequirements(counterparty, options);
   }
 
   async discoverCurrencyAndRails(

--- a/packages/sdp-payments/src/ramps/providers/coinbase/counterparty.test.ts
+++ b/packages/sdp-payments/src/ramps/providers/coinbase/counterparty.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Counterparty } from "@sdp/types";
+import { coinbaseCounterpartyRequirements } from "./counterparty";
+
+const INDIVIDUAL: Counterparty = {
+  id: "cpty_123",
+  organizationId: "org_123",
+  projectId: "proj_123",
+  externalId: null,
+  entityType: "individual",
+  displayName: "Ada Lovelace",
+  status: "active",
+  createdBy: null,
+  createdAt: "2026-09-09T00:00:00.000Z",
+  updatedAt: "2026-09-09T00:00:00.000Z",
+};
+const BUSINESS: Counterparty = {
+  ...INDIVIDUAL,
+  id: "cpty_456",
+  entityType: "business",
+  displayName: "Acme Ltd",
+};
+
+describe("coinbaseCounterpartyRequirements", () => {
+  it("is ready for an individual on the on-ramp with nothing to collect", () => {
+    assert.deepEqual(
+      coinbaseCounterpartyRequirements(INDIVIDUAL, { direction: "onramp", providerData: {} }),
+      {
+        provider: "coinbase",
+        direction: "onramp",
+        status: "ready",
+      }
+    );
+  });
+
+  it("refuses a business counterparty with a reason", () => {
+    assert.deepEqual(
+      coinbaseCounterpartyRequirements(BUSINESS, { direction: "onramp", providerData: {} }),
+      {
+        provider: "coinbase",
+        direction: "onramp",
+        status: "unsupported",
+        reason: "Coinbase Onramp supports individual counterparties only.",
+      }
+    );
+  });
+
+  it("refuses the off-ramp for everyone", () => {
+    assert.deepEqual(
+      coinbaseCounterpartyRequirements(INDIVIDUAL, { direction: "offramp", providerData: {} }),
+      {
+        provider: "coinbase",
+        direction: "offramp",
+        status: "unsupported",
+        reason: "Coinbase Onramp supports on-ramp only.",
+      }
+    );
+  });
+});

--- a/packages/sdp-payments/src/ramps/providers/coinbase/counterparty.ts
+++ b/packages/sdp-payments/src/ramps/providers/coinbase/counterparty.ts
@@ -1,0 +1,34 @@
+import type { Counterparty } from "@sdp/types";
+import type { CounterpartyRequirements } from "@sdp/types/ramp-requirements";
+import { unsupportedCounterparty } from "../../../errors";
+import { readyCounterparty } from "../../requirements";
+import type { ValidateCounterpartyOptions } from "../../types";
+
+/**
+ * Coinbase's requirements decision. Pure: no HTTP, no DB.
+ *
+ * Coinbase Onramp is a consumer product that verifies one natural person inside its
+ * hosted flow (embedded orders), so there is nothing to collect here: an individual on
+ * the on-ramp is ready to quote, a business has no single person to verify and is
+ * refused with a reason the wizard can show, and off-ramp is not offered at all.
+ */
+export function coinbaseCounterpartyRequirements(
+  counterparty: Counterparty,
+  options: ValidateCounterpartyOptions
+): CounterpartyRequirements {
+  if (options.direction !== "onramp") {
+    return unsupportedCounterparty(
+      "coinbase",
+      options.direction,
+      "Coinbase Onramp supports on-ramp only."
+    );
+  }
+  if (counterparty.entityType !== "individual") {
+    return unsupportedCounterparty(
+      "coinbase",
+      options.direction,
+      "Coinbase Onramp supports individual counterparties only."
+    );
+  }
+  return readyCounterparty("coinbase", options.direction);
+}


### PR DESCRIPTION
HOO-1590. Third of three slices moving Coinbase on-ramp orders to embedded mode. Stacked on #1711; retargets to `main` once that merges.

- Coinbase's requirements step now refuses business counterparties with a reason, instead of answering `ready` and letting Coinbase reject the buyer later.
- Individuals on the on-ramp stay `ready` with nothing to collect: the hosted flow (embedded orders, #1711) gathers everything itself.
- Off-ramp stays `unsupported`, as before.
- Pure decision file, `coinbase/counterparty.ts`; the client's `validateCounterparty` delegates to it like the BVNK, Lightspark and Mural providers. No HTTP, no DB, no route or schema change.
- The support matrix already declares Coinbase individuals-only, so the wizard greys it out for businesses today; this is the API-side backstop for callers who skip the wizard.

**before** — business counterparty, Coinbase on-ramp:

1. `GET /v1/counterparties/{id}/requirements?provider=coinbase&direction=onramp` answers `ready`.
2. Caller requests a quote; Coinbase's order proceeds with a `partnerUserRef` for a company.
3. Verification inside the hosted flow fails or verifies the wrong thing; the failure surfaces late and without a reason SDP can show.

**after**:

1. Same GET answers `unsupported` with "Coinbase Onramp supports individual counterparties only".
2. The wizard shows the reason; an API caller gets it before quoting.
3. Individuals are unaffected: `ready`, then the embedded order.

**API before/after** (live, local API on this branch, sandbox org, key redacted)

`GET /v1/counterparties/{id}/requirements?provider=coinbase&direction=onramp&assetRail=usdc.solana&fiatCurrency=USD&destinationCustodyWalletId=cwlt_…`

Business counterparty `cpty_6854ff05…`, after:
```json
{ "data": { "provider": "coinbase", "direction": "onramp", "status": "unsupported", "reason": "Coinbase Onramp supports individual counterparties only." } }
```
Before (reconstructed from the removed inline decision): `{ "provider": "coinbase", "direction": "onramp", "status": "ready" }`.

Individual counterparty `cpty_433aaf6a…`, before and after:
```json
{ "data": { "provider": "coinbase", "direction": "onramp", "status": "ready" } }
```

Off-ramp: the requirements route schema does not admit `coinbase` for `direction=offramp` (400, discriminator lists the off-ramp providers), so the decision's off-ramp arm is reachable only through the provider client, where the unit test covers it. Unauthenticated: 401.

**Verification**

- `node --import tsx --test src/ramps/providers/coinbase/counterparty.test.ts` in `packages/sdp-payments` — 3 passed (individual ready, business unsupported, off-ramp unsupported)
- `pnpm --filter @sdp/payments test` — 74 passed
- `pnpm --filter @sdp/payments --filter @sdp/api typecheck` — clean
- `biome check` on the changed files — clean
- local API (`pnpm dev`, this branch): requirements GET for a business counterparty → `unsupported` with the reason; for an individual → `ready`; unauthenticated → 401. Responses above.

**Known gaps**
- None beyond the deferred web validation ticket already under the Coinbase epic.
