### PR TITLE
feat(earn): reject unavailable wallets before vault policy

### DIFF
--- a/apps/sdp-api/src/routes/earn.vault-withdrawals.test.ts
+++ b/apps/sdp-api/src/routes/earn.vault-withdrawals.test.ts
@@ -2,6 +2,7 @@ import { SdpEarnError } from "@sdp/earn";
 import { hashString } from "@sdp/payments/hash";
 import type { CachedApiKey } from "@sdp/types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import { getDb } from "@/db";
 import { createPostgresEarnRepository } from "@/db/repositories/earn.repository.postgres";
 import {
@@ -9,9 +10,12 @@ import {
   type EarnMovementRow,
   generateEarnPositionId,
 } from "@/db/repositories/earn-movements.repository";
+import { createPostgresPolicyRepository } from "@/db/repositories/policy.repository.postgres";
 import app from "@/index";
 import { buildEarnVaultWithdrawalFingerprint } from "@/lib/idempotency";
+import { createTenantScope } from "@/lib/tenant-scope";
 import { AuditService } from "@/services/audit.service";
+import { recoverApprovedWalletOperations } from "@/services/policy/approved-operation-replay";
 import { env } from "@/test/helpers/env";
 import { seedTestDatabase } from "@/test/mocks/db";
 import { clearKVStores, seedCachedApiKey } from "@/test/mocks/kv";
@@ -95,6 +99,7 @@ const CUSTODY_WALLET_ID = "cwlt_earn_vw";
 
 let originalMarketsEnabled: string | undefined;
 let originalEarnEnabled: string | undefined;
+let originalPrivyByokEnabled: string | undefined;
 
 async function seedAuth(): Promise<void> {
   const keyHash = await hashString(TEST_API_KEY.raw, env.API_KEY_PEPPER);
@@ -148,6 +153,42 @@ async function seedAuth(): Promise<void> {
          VALUES (?, 'cfg_earn_vw', 'privy_earn_vw', ?, 'active')`
       )
       .bind(CUSTODY_WALLET_ID, WALLET_ADDRESS),
+  ]);
+}
+
+async function useConnectionWallet(): Promise<void> {
+  await getDb(env).batch([
+    getDb(env)
+      .prepare(
+        `INSERT INTO provider_credentials (
+         id, organization_id, project_id, provider, label, scope, source,
+         storage_backend, status, created_by
+       ) VALUES ('pcred_earn_vw', ?, ?, 'privy', 'Exit BYOK', 'project',
+                 'runtime', 'runtime_env', 'active', ?)`
+      )
+      .bind(TEST_ORG.id, TEST_PROJECT.id, TEST_USER.id),
+    getDb(env)
+      .prepare(
+        `INSERT INTO custody_connections (
+         id, organization_id, project_id, provider, scope, provider_credential_id,
+         provider_credential_scope_key, status, provider_account_fingerprint, created_by
+       ) VALUES ('cconn_earn_vw', ?, ?, 'privy', 'project', 'pcred_earn_vw', ?,
+                 'pending', 'sha256:test', ?)`
+      )
+      .bind(TEST_ORG.id, TEST_PROJECT.id, TEST_PROJECT.id, TEST_USER.id),
+    getDb(env)
+      .prepare(
+        `UPDATE custody_wallets SET custody_config_id = NULL, custody_connection_id = 'cconn_earn_vw'
+       WHERE id = ?`
+      )
+      .bind(CUSTODY_WALLET_ID),
+    getDb(env)
+      .prepare(
+        `UPDATE custody_connections SET default_custody_wallet_id = ?, status = 'active',
+         last_check_status = 'success', last_check_at = sdp_iso_now(), activated_at = sdp_iso_now()
+       WHERE id = 'cconn_earn_vw'`
+      )
+      .bind(CUSTODY_WALLET_ID),
   ]);
 }
 
@@ -232,6 +273,32 @@ function movementRow(overrides: Partial<EarnMovementRow> = {}): EarnMovementRow 
   };
 }
 
+function recordConnectionWithdrawal(positionId: string, requestId: string) {
+  return createPostgresEarnMovementsRepository(getDb(env)).createSignedVaultWithdrawalIntent({
+    organizationId: TEST_ORG.id,
+    projectId: TEST_PROJECT.id,
+    environment: "sandbox",
+    provider: "kamino",
+    positionId,
+    vaultAddress: VAULT,
+    custodyWalletId: CUSTODY_WALLET_ID,
+    shareMint: SHARE_MINT,
+    requestedShares: "10",
+    walletAddress: WALLET_ADDRESS,
+    signature: "sig_recorded_withdrawal",
+    signedTransaction: "AQ==",
+    lastValidBlockHeight: "12345",
+    requestId,
+    idempotencyFingerprint: buildEarnVaultWithdrawalFingerprint({
+      environment: "sandbox",
+      provider: "kamino",
+      positionId,
+      shares: "10",
+      minAmountOut: null,
+    }),
+  });
+}
+
 function postVaultWithdrawal(
   body: Record<string, unknown>,
   options: { idempotencyKey?: string | null; apiKey?: string } = {}
@@ -263,6 +330,7 @@ function getWithdrawal(pathSuffix: string, apiKey = TEST_API_KEY.raw) {
 beforeEach(async () => {
   originalMarketsEnabled = env.MARKETS_ENABLED;
   originalEarnEnabled = env.EARN_ENABLED;
+  originalPrivyByokEnabled = env.PRIVY_BYOK_ENABLED;
   env.MARKETS_ENABLED = "true";
   env.EARN_ENABLED = "true";
   surfacingEnabled.value = true;
@@ -279,8 +347,158 @@ beforeEach(async () => {
 afterEach(() => {
   env.MARKETS_ENABLED = originalMarketsEnabled;
   env.EARN_ENABLED = originalEarnEnabled;
+  env.PRIVY_BYOK_ENABLED = originalPrivyByokEnabled;
   vaultWithdrawClientOverride.current = null;
   vi.restoreAllMocks();
+});
+
+describe("POST /v1/earn/vault-withdrawals — custody runtime admission", () => {
+  it("refuses a runtime-paused wallet before creating a withdrawal operation", async () => {
+    await seedAuth();
+    await useConnectionWallet();
+    const positionId = await seedPosition();
+    env.PRIVY_BYOK_ENABLED = "false";
+
+    const response = await postVaultWithdrawal({ positionId, shares: "10" });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: { code: "FORBIDDEN", details: { reason: "runtime_execution_paused" } },
+    });
+    const operations = await getDb(env)
+      .prepare("SELECT id FROM wallet_operations WHERE organization_id = ?")
+      .bind(TEST_ORG.id)
+      .all();
+    expect(operations.results).toEqual([]);
+    expect(withdrawFromVault).not.toHaveBeenCalled();
+  });
+
+  it("allows an advisory dry-run while custody execution is paused", async () => {
+    await seedAuth();
+    await useConnectionWallet();
+    const positionId = await seedPosition();
+    env.PRIVY_BYOK_ENABLED = "false";
+
+    const response = await app.request(
+      "/v1/earn/vault-withdrawals",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+          "Content-Type": "application/json",
+          "Dry-Run": "true",
+        },
+        body: JSON.stringify({ positionId, shares: "10" }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(withdrawFromVault).not.toHaveBeenCalled();
+  });
+
+  it("returns an ordinary recorded withdrawal while custody execution is paused", async () => {
+    await seedAuth();
+    await useConnectionWallet();
+    const positionId = await seedPosition();
+    const recorded = await recordConnectionWithdrawal(positionId, "recorded-withdrawal");
+    env.PRIVY_BYOK_ENABLED = "false";
+
+    const response = await postVaultWithdrawal(
+      { positionId, shares: "10" },
+      { idempotencyKey: "recorded-withdrawal" }
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      data: {
+        withdrawal: {
+          movementId: recorded.movement.id,
+          replayed: true,
+          signature: "sig_recorded_withdrawal",
+        },
+      },
+    });
+    expect(withdrawFromVault).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])(
+    "requires custody admission for an approved withdrawal only without a recorded result (%s)",
+    async (recorded) => {
+      await seedAuth();
+      await useConnectionWallet();
+      const positionId = await seedPosition();
+      const repo = createPostgresPolicyRepository(
+        getDb(env),
+        createTenantScope({ organizationId: TEST_ORG.id, projectId: TEST_PROJECT.id })
+      );
+      const profile = await repo.createApiKeyControlProfile({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT.id,
+        apiKeyId: TEST_API_KEY.id,
+        name: "Approve vault withdrawals",
+      });
+      if (!profile) throw new Error("Failed to create approval profile");
+      const revision = await repo.createApiKeyControlProfileRevision({
+        profileId: profile.id,
+        rules: [
+          { id: "approve-withdrawal", kind: "approval", operationTypes: ["earn_vault_withdrawal"] },
+        ],
+        defaultAction: "allow",
+        createdBy: TEST_USER.id,
+      });
+      if (!revision) throw new Error("Failed to create approval revision");
+      await repo.activateApiKeyControlProfileRevision({
+        profileId: profile.id,
+        revisionId: revision.id,
+      });
+      env.PRIVY_BYOK_ENABLED = "true";
+      const requestId = "approved-recorded-withdrawal";
+      const held = await postVaultWithdrawal(
+        { positionId, shares: "10" },
+        { idempotencyKey: requestId }
+      );
+      expect(held.status).toBe(202);
+      const {
+        error: { details },
+      } = z
+        .object({
+          error: z.object({
+            details: z.object({ approvalRequestId: z.string(), walletOperationId: z.string() }),
+          }),
+        })
+        .parse(await held.json());
+      if (recorded) await recordConnectionWithdrawal(positionId, requestId);
+      await repo.updateApprovalRequestStatus({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT.id,
+        approvalRequestId: details.approvalRequestId,
+        status: "approved",
+        operationStatus: "executing",
+        resolvedBy: TEST_USER.id,
+      });
+      env.PRIVY_BYOK_ENABLED = "false";
+      const actual = await vi.importActual<typeof import("@/services/earn/vault-withdraw.service")>(
+        "@/services/earn/vault-withdraw.service"
+      );
+      withdrawFromVault.mockImplementation(actual.withdrawFromVault);
+
+      expect(await recoverApprovedWalletOperations(env)).toBe(1);
+      const operation = await repo.getWalletOperationById(details.walletOperationId);
+      if (recorded) {
+        expect(operation).toMatchObject({ status: "completed", execution_error: null });
+        expect(operation?.execution_effect_started_at).toEqual(expect.any(String));
+        expect(withdrawFromVault).toHaveBeenCalledTimes(1);
+      } else {
+        expect(operation).toMatchObject({
+          status: "failed",
+          execution_error: "Wallet execution is paused. Retry after wallet execution is available.",
+          execution_effect_started_at: null,
+        });
+        expect(withdrawFromVault).not.toHaveBeenCalled();
+      }
+    }
+  );
 });
 
 describe("POST /v1/earn/vault-withdrawals — request validation", () => {
@@ -803,6 +1021,8 @@ describe("POST /v1/earn/vault-withdrawals — the exit slippage floor", () => {
   // only.
   it("refuses a floor-less exit for a provider with a withdrawal slippage policy", async () => {
     await seedAuth();
+    await useConnectionWallet();
+    env.PRIVY_BYOK_ENABLED = "false";
     const positionId = await seedPosition({ provider: "jupiter_lend" });
 
     const res = await postVaultWithdrawal({ positionId, shares: "5" });

--- a/apps/sdp-api/src/routes/earn.vault.test.ts
+++ b/apps/sdp-api/src/routes/earn.vault.test.ts
@@ -1,6 +1,7 @@
 import { hashString } from "@sdp/payments/hash";
 import type { CachedApiKey } from "@sdp/types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 
 /**
  * Surfacing is real by default here — Kamino AND Veda are offered, so both
@@ -36,6 +37,7 @@ import { badRequest } from "@/lib/errors";
 import { buildEarnVaultDepositFingerprint } from "@/lib/idempotency";
 import { createTenantScope } from "@/lib/tenant-scope";
 import { AuditService } from "@/services/audit.service";
+import { recoverApprovedWalletOperations } from "@/services/policy/approved-operation-replay";
 import { env } from "@/test/helpers/env";
 import { seedTestDatabase } from "@/test/mocks/db";
 import { clearKVStores, seedCachedApiKey } from "@/test/mocks/kv";
@@ -124,6 +126,7 @@ const WALLET_ADDRESS = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
 
 let originalMarketsEnabled: string | undefined;
 let originalEarnEnabled: string | undefined;
+let originalPrivyByokEnabled: string | undefined;
 
 async function seedWallet(params: {
   configId: string;
@@ -196,6 +199,61 @@ async function seedConnectionWallet(): Promise<void> {
          WHERE id = 'cconn_earn_vault'`
     ),
   ]);
+}
+
+async function requireDepositApproval() {
+  const repo = createPostgresPolicyRepository(
+    getDb(env),
+    createTenantScope({ organizationId: TEST_ORG.id, projectId: TEST_PROJECT.id })
+  );
+  const profile = await repo.createApiKeyControlProfile({
+    organizationId: TEST_ORG.id,
+    projectId: TEST_PROJECT.id,
+    apiKeyId: TEST_API_KEY.id,
+    name: "Approve vault deposits",
+  });
+  if (!profile) throw new Error("Failed to create approval profile");
+  const revision = await repo.createApiKeyControlProfileRevision({
+    profileId: profile.id,
+    rules: [{ id: "approve-deposit", kind: "approval", operationTypes: ["earn_vault_deposit"] }],
+    defaultAction: "allow",
+    createdBy: TEST_USER.id,
+  });
+  if (!revision) throw new Error("Failed to create approval revision");
+  await repo.activateApiKeyControlProfileRevision({
+    profileId: profile.id,
+    revisionId: revision.id,
+  });
+  return repo;
+}
+
+function recordConnectionDeposit(strategy: EarnStrategyRow, requestId: string) {
+  return createPostgresEarnMovementsRepository(getDb(env)).createSignedVaultDepositIntent({
+    organizationId: TEST_ORG.id,
+    projectId: TEST_PROJECT.id,
+    environment: "sandbox",
+    provider: strategy.provider,
+    vaultAddress: strategy.provider_reference,
+    custodyWalletId: "cwlt_earn_vault_connection",
+    sourceAddress: WALLET_ADDRESS,
+    tokenMint: USDC_MINT,
+    shareMint: SHARE_MINT,
+    label: strategy.name,
+    requestedAmount: "10",
+    signature: "sig_recorded_deposit",
+    signedTransaction: "AQ==",
+    lastValidBlockHeight: "12345",
+    requestId,
+    idempotencyFingerprint: buildEarnVaultDepositFingerprint({
+      environment: "sandbox",
+      provider: strategy.provider,
+      providerReference: strategy.provider_reference,
+      custodyWalletId: "cwlt_earn_vault_connection",
+      amount: "10",
+      minSharesOut: null,
+    }),
+    createdBy: TEST_USER.id,
+  });
 }
 
 async function seedAuth(): Promise<void> {
@@ -341,6 +399,7 @@ function postVaultDeposit(
 beforeEach(async () => {
   originalMarketsEnabled = env.MARKETS_ENABLED;
   originalEarnEnabled = env.EARN_ENABLED;
+  originalPrivyByokEnabled = env.PRIVY_BYOK_ENABLED;
   env.MARKETS_ENABLED = "true";
   env.EARN_ENABLED = "true";
   await seedTestDatabase(env);
@@ -361,9 +420,157 @@ beforeEach(async () => {
 afterEach(() => {
   env.MARKETS_ENABLED = originalMarketsEnabled;
   env.EARN_ENABLED = originalEarnEnabled;
+  env.PRIVY_BYOK_ENABLED = originalPrivyByokEnabled;
   surfacing.forceOn = false;
   vaultDirectClientOverride.current = null;
   vi.restoreAllMocks();
+});
+
+describe("POST /v1/earn/vault-deposits — custody runtime admission", () => {
+  it.each([
+    { state: "paused", status: 403, reason: "runtime_execution_paused" },
+    { state: "unavailable", status: 409, reason: "runtime_execution_unavailable" },
+  ])(
+    "refuses a $state wallet before creating an approval or deposit",
+    async ({ state, status, reason }) => {
+      await seedAuth();
+      await seedConnectionWallet();
+      const strategy = await seedStrategy();
+      const repo = await requireDepositApproval();
+      env.PRIVY_BYOK_ENABLED = state === "paused" ? "false" : "true";
+      if (state === "unavailable") {
+        await getDb(env)
+          .prepare(
+            "UPDATE provider_credentials SET status = 'retired' WHERE id = 'pcred_earn_vault'"
+          )
+          .run();
+      }
+      const audit = vi.spyOn(AuditService.prototype, "beginCritical");
+
+      const response = await postVaultDeposit(
+        { strategyId: strategy.id, custodyWalletId: "cwlt_earn_vault_connection", amount: "10" },
+        "paused-deposit"
+      );
+
+      expect(response.status).toBe(status);
+      expect(await response.json()).toMatchObject({
+        error: { details: { reason } },
+      });
+      expect(
+        await repo.listApprovalRequestDetails({
+          organizationId: TEST_ORG.id,
+          projectId: TEST_PROJECT.id,
+        })
+      ).toEqual([]);
+      expect(depositIntoVault).not.toHaveBeenCalled();
+      expect(audit).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(["matching", "missing", "different-payload", "different-project", "failed"])(
+    "preserves approved deposit replay with a %s movement while custody execution is paused",
+    async (record) => {
+      await seedAuth();
+      await seedConnectionWallet();
+      const strategy = await seedStrategy();
+      const repo = await requireDepositApproval();
+      env.PRIVY_BYOK_ENABLED = "true";
+      const requestId = "approved-recorded-deposit";
+      const held = await postVaultDeposit(
+        { strategyId: strategy.id, custodyWalletId: "cwlt_earn_vault_connection", amount: "10" },
+        requestId
+      );
+      expect(held.status).toBe(202);
+      const {
+        error: { details },
+      } = z
+        .object({
+          error: z.object({
+            details: z.object({ approvalRequestId: z.string(), walletOperationId: z.string() }),
+          }),
+        })
+        .parse(await held.json());
+      if (record !== "missing") {
+        const recorded = await recordConnectionDeposit(strategy, requestId);
+        if (record === "different-payload") {
+          await getDb(env)
+            .prepare("UPDATE earn_movements SET idempotency_fingerprint = ? WHERE id = ?")
+            .bind("another-deposit", recorded.movement.id)
+            .run();
+        } else if (record === "different-project") {
+          await getDb(env)
+            .prepare("UPDATE earn_movements SET project_id = ? WHERE id = ?")
+            .bind(TEST_PRODUCTION_PROJECT.id, recorded.movement.id)
+            .run();
+        } else if (record === "failed") {
+          await createPostgresEarnMovementsRepository(getDb(env)).advanceVaultMovement({
+            movementId: recorded.movement.id,
+            organizationId: TEST_ORG.id,
+            toStatus: "failed",
+            failureReason: "expired",
+          });
+        }
+      }
+      await repo.updateApprovalRequestStatus({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT.id,
+        approvalRequestId: details.approvalRequestId,
+        status: "approved",
+        operationStatus: "executing",
+        resolvedBy: TEST_USER.id,
+      });
+      env.PRIVY_BYOK_ENABLED = "false";
+
+      // Exercise the real service replay and the approval executor's effect fence.
+      const actual = await vi.importActual<typeof import("@/services/earn/vault-deposit.service")>(
+        "@/services/earn/vault-deposit.service"
+      );
+      depositIntoVault.mockImplementation(actual.depositIntoVault);
+      expect(await recoverApprovedWalletOperations(env)).toBe(1);
+      const operation = await repo.getWalletOperationById(details.walletOperationId);
+      if (record === "matching") {
+        expect(operation).toMatchObject({ status: "completed", execution_error: null });
+        expect(operation?.execution_effect_started_at).toEqual(expect.any(String));
+        expect(depositIntoVault).toHaveBeenCalledTimes(1);
+      } else if (record === "failed") {
+        expect(operation).toMatchObject({
+          status: "failed",
+          execution_error:
+            "Approved vault deposit execution is incomplete and requires manual reconciliation",
+        });
+        expect(operation?.execution_effect_started_at).toEqual(expect.any(String));
+      } else {
+        expect(operation).toMatchObject({
+          status: "failed",
+          execution_error:
+            record === "missing"
+              ? "Wallet execution is paused. Retry after wallet execution is available."
+              : "Idempotency key already used with different request payload",
+          execution_effect_started_at: null,
+        });
+        expect(depositIntoVault).not.toHaveBeenCalled();
+      }
+    }
+  );
+
+  it("returns an ordinary recorded deposit while custody execution is paused", async () => {
+    await seedAuth();
+    await seedConnectionWallet();
+    const strategy = await seedStrategy();
+    const recorded = await recordConnectionDeposit(strategy, "recorded-deposit");
+    env.PRIVY_BYOK_ENABLED = "false";
+
+    const response = await postVaultDeposit(
+      { strategyId: strategy.id, custodyWalletId: "cwlt_earn_vault_connection", amount: "10" },
+      "recorded-deposit"
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      data: { movementId: recorded.movement.id, replayed: true, signature: "sig_recorded_deposit" },
+    });
+    expect(depositIntoVault).not.toHaveBeenCalled();
+  });
 });
 
 describe("POST /v1/earn/vault-deposits — catalogue admission", () => {
@@ -478,11 +685,8 @@ describe("POST /v1/earn/vault-deposits — request validation", () => {
   it("allows a policy dry-run without a throwaway Idempotency-Key", async () => {
     await seedAuth();
     const strategy = await seedStrategy();
-    await seedWallet({
-      configId: "cfg_earn_vault_dry_run",
-      custodyWalletId: "cwlt_earn_vault_dry_run",
-      providerWalletId: "privy_earn_vault_dry_run",
-    });
+    await seedConnectionWallet();
+    env.PRIVY_BYOK_ENABLED = "false";
 
     const res = await app.request(
       "/v1/earn/vault-deposits",
@@ -495,7 +699,7 @@ describe("POST /v1/earn/vault-deposits — request validation", () => {
         },
         body: JSON.stringify({
           strategyId: strategy.id,
-          custodyWalletId: "cwlt_earn_vault_dry_run",
+          custodyWalletId: "cwlt_earn_vault_connection",
           amount: "10",
         }),
       },
@@ -670,6 +874,7 @@ describe("POST /v1/earn/vault-deposits — request validation", () => {
     await seedAuth();
     const strategy = await seedStrategy();
     await seedConnectionWallet();
+    env.PRIVY_BYOK_ENABLED = "true";
 
     const res = await postVaultDeposit({
       strategyId: strategy.id,

--- a/apps/sdp-api/src/routes/earn/handlers/vault.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/vault.ts
@@ -21,6 +21,7 @@ import { z } from "zod";
 import { getDb } from "@/db";
 import type { EarnStrategyRow } from "@/db/repositories/earn.repository";
 import {
+  assertMovementIsOwnReplay,
   createPostgresEarnMovementsRepository,
   type EarnMovementRow,
   type EarnPositionRow,
@@ -38,6 +39,7 @@ import { isEarnVaultSponsorshipEnabled } from "@/lib/feature-flags";
 import {
   buildEarnVaultDepositFingerprint,
   buildEarnVaultWithdrawalFingerprint,
+  resolveIdempotencyReplay,
 } from "@/lib/idempotency";
 import { decodeKeysetCursor, encodeKeysetCursor } from "@/lib/keyset-cursor";
 import { success } from "@/lib/response";
@@ -53,6 +55,7 @@ import {
   CustodyRuntimeTargets,
   type CustodyRuntimeWalletProjection,
 } from "@/services/domain/signing/custody-runtime-target";
+import { createSigningService } from "@/services/domain/signing.service";
 import {
   earnClusterFor,
   resolveVaultDirectClient,
@@ -539,6 +542,39 @@ export async function extractEarnVaultDepositPolicyCandidate(
     },
     idempotencyKey: requestId,
   };
+}
+
+/** Check custody execution separately from Earn strategy availability. */
+export async function admitEarnVaultRuntimeExecution(
+  c: AppContext,
+  extraction: PolicyGateExtraction
+): Promise<void> {
+  // SAFETY: wired only beside the two vault extractors, which authorize this exact wallet.
+  const resolved = extraction.resolved as EarnVaultDepositResolved | EarnVaultWithdrawalResolved;
+  // Approved requests cannot take the gate's replay response: policy resume and
+  // the handler's effect fence still apply. Skip only this new admission check
+  // when the service will return its own recorded movement without signing.
+  if (approvedWalletOperationId(c) && resolved.requestId !== null) {
+    const requestId = resolved.requestId;
+    const repo = createPostgresEarnMovementsRepository(getDb(c.env));
+    const movement = await resolveIdempotencyReplay(
+      () =>
+        repo.findVaultMovementByRequestId({
+          organizationId: resolved.auth.organizationId,
+          requestId,
+        }),
+      resolved.idempotencyFingerprint
+    );
+    if (movement) {
+      assertMovementIsOwnReplay(movement, resolved);
+      return;
+    }
+  }
+  await createSigningService(c.env).admitRuntimeExecution(
+    resolved.auth.organizationId,
+    resolved.projectId,
+    resolved.wallet.id
+  );
 }
 
 /** Resolve both durable movement replays and pre-execution policy replays. */
@@ -1129,14 +1165,14 @@ interface EarnVaultWithdrawalResolved {
  *
  * WHAT IS DELIBERATELY MISSING is the point (ADR 0002 exit safety, "money out
  * beats money off"): no surfacing gate, no entitlement gate, no availability
- * gate, no environment capability, no catalogue lookup and no admission check.
+ * gate, no environment capability, no catalogue lookup and no Earn-provider admission check.
  * The caller names its own POSITION — the org's recorded claim, which carries
  * the vault, the wallet and both mints — so an exit works for a paused
  * strategy, a delisted vault, an un-surfaced or un-entitled provider, and in
  * every environment a position exists in. The only refusals left are the ones
  * that protect the org itself: the position must belong to the caller's org
  * and environment (404), the key binding must carry a write scope for the
- * signing wallet, and the org's own wallet policy still runs. A shared
+ * signing wallet, and custody runtime admission precedes the org's wallet policy. A shared
  * organization-level custody wallet intentionally lets sibling projects exit
  * the same org-owned position, matching the deposit route's wallet boundary.
  */

--- a/apps/sdp-api/src/routes/earn/index.ts
+++ b/apps/sdp-api/src/routes/earn/index.ts
@@ -35,6 +35,7 @@ import {
 } from "./handlers/program";
 import { getEarnStrategy, listEarnStrategies } from "./handlers/strategies";
 import {
+  admitEarnVaultRuntimeExecution,
   assertEarnVaultWithdrawalFloor,
   createEarnVaultDeposit,
   createEarnVaultDepositPreview,
@@ -168,6 +169,7 @@ earn.post(
   policyGate({
     extract: extractEarnVaultDepositPolicyCandidate,
     findIdempotentKeyReplay: findEarnVaultDepositIdempotentKeyReplay,
+    beforeEnforce: admitEarnVaultRuntimeExecution,
   }),
   createEarnVaultDeposit
 );
@@ -217,7 +219,10 @@ earn.post(
     findIdempotentKeyReplay: findEarnVaultWithdrawalIdempotentKeyReplay,
     // Floor policy runs AFTER the completed-replay exit so a recorded
     // floor-less withdrawal stays replayable if the provider's policy flips.
-    beforeEnforce: assertEarnVaultWithdrawalFloor,
+    beforeEnforce: async (c, extraction) => {
+      await assertEarnVaultWithdrawalFloor(c, extraction);
+      await admitEarnVaultRuntimeExecution(c, extraction);
+    },
   }),
   createEarnVaultWithdrawal
 );


### PR DESCRIPTION
## What changed

- Add an early custody runtime check to vault Deposit and Withdraw through `policyGate.beforeEnforce`, using the exact wallet ID Earn already resolves.
- Reject unavailable wallet execution before creating a new policy operation/Approval or preparing the transaction. Keep the existing check immediately before signing.
- Preserve dry-run and recorded-result replay. Approved replays still verify project and fingerprint, resume policy, and pass the execution fence.

## Why

An unavailable wallet could previously reach policy evaluation and create an Approval, only to fail when execution reached the signer. Checking earlier avoids creating work that cannot currently execute.

## Impact

- Request and success-response schemas, wallet selection, database tables, and UI are unchanged.
- Runtime refusals surface earlier: `403` for paused execution or `409` for an unusable wallet/owner.
- These refusals use existing runtime telemetry instead of creating a new policy evaluation or Approval.
- This PR does not enable BYOK.

## Pre/post release actions

- Before release: obtain green CI and complete a local/staging smoke covering normal Config-wallet Deposit/Withdraw, runtime refusal, and recorded-result replay.
- No migration, backfill, or configuration change is required.
- After release: monitor custody runtime refusal telemetry and Earn failures.
- Rollback: redeploy the previous API image; no data rollback is needed.

## Result Validation

- `pnpm -C apps/sdp-api exec vitest run src/routes/earn.vault.test.ts src/routes/earn.vault-withdrawals.test.ts` — **73 passed**.
- API typecheck, changed-file Biome checks, and module-boundary checks passed.
- Tests cover runtime refusal before Approval, ordinary and approved replay, project/payload mismatches, failed recorded results, dry-run, and withdrawal validation precedence.
- Full API suite with coverage: **5036 passed, 14 skipped. 
- Live app/provider smoke has **not been run**.

## Does it affect current flows & behavior and how

Fresh execution, derived from the route code and tests:

```text
Before: wallet authorization → policy/Approval → prepare transaction → runtime check → sign
After:  wallet authorization → runtime check → policy/Approval → prepare transaction → runtime recheck → sign
```

Approval applies only when required by policy.

- Available wallets follow the existing execution flow.
- Withdraw still checks `minAmountOut` first and does not inherit Earn catalogue restrictions: paused or delisted strategies remain exitable when the custody wallet can execute.
- Matching recorded results remain retrievable without another signature or submission.

## Known gaps

- Shared Approve failure handling is unchanged: an already-approved operation can still be marked failed if its execution attempt encounters unavailable wallet execution.
- Existing wallet-lookup and validation restrictions on replay remain; this does not add recovery for inactive wallets.

## Notes

- Scope is limited to custodial vault Deposit/Withdraw. External-wallet flows, Programs, and background reconciliation are unchanged.
- Runtime admission permits an attempt; it does not guarantee provider availability, sufficient balance, or transaction success.