### PR TITLE
test(web): MoneyGram widget receives no phone or address prefill

### DIFF
--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/moneygram-prefill.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/moneygram-prefill.ts
@@ -1,0 +1,44 @@
+import { toNumberAmount } from "@sdp/solana/amount";
+import type { RampFiatCurrency } from "@sdp/types/generated/ramp";
+import type { CryptoAssetSymbol } from "@sdp/types/payment-rails";
+
+/**
+ * Transaction prefill handed to MoneyGram's Ramps SDK. Amounts, asset and
+ * destination only: the widget collects the customer's phone, address and
+ * identity itself, so nothing personal is ever passed through here.
+ */
+export interface MoneygramTransactionPrefill {
+  type: "off-ramp" | "on-ramp";
+  destinationCountry?: string;
+  destinationSubdivision?: string;
+  destinationCurrency?: string;
+  amount?: number;
+  asset?: CryptoAssetSymbol;
+}
+
+export function buildOfframpTransactionPrefill(
+  fiatCurrency: RampFiatCurrency,
+  cryptoAsset: CryptoAssetSymbol,
+  cryptoAmount: string
+): MoneygramTransactionPrefill {
+  const destinationCountry =
+    fiatCurrency === "USD" ? "USA" : fiatCurrency === "MXN" ? "MEX" : undefined;
+  return {
+    type: "off-ramp",
+    ...(destinationCountry ? { destinationCountry } : {}),
+    destinationCurrency: fiatCurrency,
+    amount: toNumberAmount(cryptoAmount),
+    asset: cryptoAsset,
+  };
+}
+
+export function buildOnrampTransactionPrefill(
+  fiatAmount: string,
+  cryptoAsset: CryptoAssetSymbol
+): MoneygramTransactionPrefill {
+  return {
+    type: "on-ramp",
+    amount: toNumberAmount(fiatAmount),
+    asset: cryptoAsset,
+  };
+}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/moneygram-prefill.unit.test.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/moneygram-prefill.unit.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  buildOfframpTransactionPrefill,
-  buildOnrampTransactionPrefill,
-} from "./moneygram-ramp-widget";
+import { buildOfframpTransactionPrefill, buildOnrampTransactionPrefill } from "./moneygram-prefill";
 
 // Personal data MoneyGram collects inside its own widget. The dashboard must
 // never hand any of it over through the transaction prefill; this list is the

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/moneygram-ramp-widget.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/moneygram-ramp-widget.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { toNumberAmount } from "@sdp/solana/amount";
 import type { MoneygramRampEvent, PaymentRampQuote } from "@sdp/types";
 import type { RampFiatCurrency } from "@sdp/types/generated/ramp";
 import type { CryptoAssetSymbol } from "@sdp/types/payment-rails";
@@ -17,6 +16,11 @@ import {
   isTrustedRampDestination,
   MONEYGRAM_WIDGET_APPROVED_HOSTS,
 } from "@/lib/trusted-ramp-destinations";
+import {
+  buildOfframpTransactionPrefill,
+  buildOnrampTransactionPrefill,
+  type MoneygramTransactionPrefill,
+} from "./moneygram-prefill";
 
 const SESSION_REFRESH_MS = 50 * 60 * 1000;
 
@@ -53,14 +57,7 @@ interface MoneygramRampsConfig {
     walletType: "custodial" | "non-custodial";
     displayName?: string;
   };
-  transaction?: {
-    type: "off-ramp" | "on-ramp";
-    destinationCountry?: string;
-    destinationSubdivision?: string;
-    destinationCurrency?: string;
-    amount?: number;
-    asset?: CryptoAssetSymbol;
-  };
+  transaction?: MoneygramTransactionPrefill;
   devConfig?: {
     apiBaseUrl: string;
     mockMode: boolean;
@@ -114,33 +111,6 @@ function loadRampsSdk(sdkUrl: string): Promise<NonNullable<Window["RampsSDK"]>> 
     rampsSdkPromise = null;
   });
   return rampsSdkPromise;
-}
-
-export function buildOfframpTransactionPrefill(
-  fiatCurrency: RampFiatCurrency,
-  cryptoAsset: CryptoAssetSymbol,
-  cryptoAmount: string
-): NonNullable<MoneygramRampsConfig["transaction"]> {
-  const destinationCountry =
-    fiatCurrency === "USD" ? "USA" : fiatCurrency === "MXN" ? "MEX" : undefined;
-  return {
-    type: "off-ramp",
-    ...(destinationCountry ? { destinationCountry } : {}),
-    destinationCurrency: fiatCurrency,
-    amount: toNumberAmount(cryptoAmount),
-    asset: cryptoAsset,
-  };
-}
-
-export function buildOnrampTransactionPrefill(
-  fiatAmount: string,
-  cryptoAsset: CryptoAssetSymbol
-): NonNullable<MoneygramRampsConfig["transaction"]> {
-  return {
-    type: "on-ramp",
-    amount: toNumberAmount(fiatAmount),
-    asset: cryptoAsset,
-  };
 }
 
 export interface MoneygramRampWidgetProps {

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/moneygram-ramp-widget.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/moneygram-ramp-widget.tsx
@@ -116,11 +116,11 @@ function loadRampsSdk(sdkUrl: string): Promise<NonNullable<Window["RampsSDK"]>> 
   return rampsSdkPromise;
 }
 
-function buildOfframpTransactionPrefill(
+export function buildOfframpTransactionPrefill(
   fiatCurrency: RampFiatCurrency,
   cryptoAsset: CryptoAssetSymbol,
   cryptoAmount: string
-): MoneygramRampsConfig["transaction"] {
+): NonNullable<MoneygramRampsConfig["transaction"]> {
   const destinationCountry =
     fiatCurrency === "USD" ? "USA" : fiatCurrency === "MXN" ? "MEX" : undefined;
   return {
@@ -132,10 +132,10 @@ function buildOfframpTransactionPrefill(
   };
 }
 
-function buildOnrampTransactionPrefill(
+export function buildOnrampTransactionPrefill(
   fiatAmount: string,
   cryptoAsset: CryptoAssetSymbol
-): MoneygramRampsConfig["transaction"] {
+): NonNullable<MoneygramRampsConfig["transaction"]> {
   return {
     type: "on-ramp",
     amount: toNumberAmount(fiatAmount),

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/moneygram-ramp-widget.unit.test.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/moneygram-ramp-widget.unit.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildOfframpTransactionPrefill,
+  buildOnrampTransactionPrefill,
+} from "./moneygram-ramp-widget";
+
+// Personal data MoneyGram collects inside its own widget. The dashboard must
+// never hand any of it over through the transaction prefill; this list is the
+// tripwire if a future edit tries.
+const PII_KEYS = [
+  "address",
+  "dateOfBirth",
+  "email",
+  "firstName",
+  "lastName",
+  "name",
+  "phone",
+  "phoneNumber",
+];
+
+function keysOf(prefill: ReturnType<typeof buildOnrampTransactionPrefill>): string[] {
+  return Object.keys(prefill).sort();
+}
+
+describe("MoneyGram transaction prefill", () => {
+  it("on-ramp carries only direction, amount and asset", () => {
+    const prefill = buildOnrampTransactionPrefill("25", "USDC");
+    expect(keysOf(prefill)).toEqual(["amount", "asset", "type"]);
+    expect(prefill).toEqual({ type: "on-ramp", amount: 25, asset: "USDC" });
+  });
+
+  it("off-ramp in USD adds the destination country and currency, nothing else", () => {
+    const prefill = buildOfframpTransactionPrefill("USD", "USDC", "25");
+    expect(keysOf(prefill)).toEqual([
+      "amount",
+      "asset",
+      "destinationCountry",
+      "destinationCurrency",
+      "type",
+    ]);
+    expect(prefill).toEqual({
+      type: "off-ramp",
+      destinationCountry: "USA",
+      destinationCurrency: "USD",
+      amount: 25,
+      asset: "USDC",
+    });
+  });
+
+  it("off-ramp in MXN maps to Mexico", () => {
+    const prefill = buildOfframpTransactionPrefill("MXN", "USDC", "25");
+    expect(prefill.destinationCountry).toBe("MEX");
+  });
+
+  it("off-ramp in a currency without a country mapping omits the country key", () => {
+    const prefill = buildOfframpTransactionPrefill("EUR", "USDC", "25");
+    expect(keysOf(prefill)).toEqual(["amount", "asset", "destinationCurrency", "type"]);
+  });
+
+  it("never includes personal data in either direction", () => {
+    const prefills = [
+      buildOnrampTransactionPrefill("25", "USDC"),
+      buildOfframpTransactionPrefill("USD", "USDC", "25"),
+      buildOfframpTransactionPrefill("MXN", "USDC", "25"),
+    ];
+    for (const prefill of prefills) {
+      for (const key of PII_KEYS) {
+        expect(prefill).not.toHaveProperty(key);
+      }
+    }
+  });
+});


### PR DESCRIPTION
The MoneyGram widget collects the customer's phone and address inside its own hosted flow, so the dashboard must never pass them through the SDK's transaction prefill. Nothing asserted that until now; this pins it.

**What changes**
- The two prefill builders move from `moneygram-ramp-widget.tsx` into `moneygram-prefill.ts` with a named `MoneygramTransactionPrefill` type; the widget imports them. No runtime change, and the component file keeps only component exports.
- New unit test pins the exact key set per direction and asserts no personal-data key (`phone`, `phoneNumber`, `email`, `address`, `firstName`, `lastName`, `name`, `dateOfBirth`) ever appears.

**before** — prefill contract was implicit:
1. Widget builds the transaction prefill from amount, asset and currency.
2. An edit adding `phoneNumber` to either builder would ship with no failing test.

**after** — prefill contract is pinned:
1. On-ramp prefill is exactly `type`, `amount`, `asset`.
2. Off-ramp prefill adds `destinationCurrency`, and `destinationCountry` only for USD (`USA`) and MXN (`MEX`); other currencies omit the key.
3. Any personal-data key added to either builder fails the unit test.

**Verification**
- `pnpm exec vitest run src/app/dashboard/payments/ramps/components/moneygram-prefill.unit.test.ts` (apps/sdp-web) — 5 passed
- `pnpm exec tsc --noEmit` (apps/sdp-web) — clean
- `pnpm exec biome check` on the two changed files — clean
- No UI change, so no screenshots.
