### PR TITLE
fix(ops): ship the sponsorship operator in the API image

### DIFF
--- a/apps/sdp-api/scripts/build-node.mjs
+++ b/apps/sdp-api/scripts/build-node.mjs
@@ -73,6 +73,8 @@ const entryPoints = {
   server: "src/server.ts",
   job: "src/job.ts",
   migrate: "scripts/migrate-postgres.mjs",
+  // Manual, audited sponsorship controls for infra-managed operator jobs.
+  "sponsorship-budget": "scripts/sponsorship-budget.ts",
   // custody-backfill.js re-encrypts legacy custody rows to KMS envelopes from the prebuilt image.
   "custody-backfill": "scripts/migrate-custody-encryption.ts",
   // configure.js generates a self-hosted .env in the terminal from the prebuilt image.

--- a/apps/sdp-api/scripts/sponsorship-budget.ts
+++ b/apps/sdp-api/scripts/sponsorship-budget.ts
@@ -4,6 +4,7 @@ import {
   type SponsorshipNetwork,
 } from "../src/db/repositories/sponsorship-budget.repository";
 import { getProcessEnv } from "../src/lib/runtime-env";
+import { closeAllRedisClients } from "../src/runtime/kv-redis";
 import { SponsorshipBudgetRedis } from "../src/runtime/sponsorship-budget-redis";
 import {
   isPolicyControlInSync,
@@ -37,7 +38,7 @@ async function persistGlobalEnabled(enabled: boolean) {
   const env = getProcessEnv();
   const repository = new SponsorshipBudgetRepository(getDb(env));
   const network = parseNetwork();
-  const policy = await repository.setPolicyEnabled({
+  let policy = await repository.setPolicyEnabled({
     network,
     scopeType: "global",
     scopeId: null,
@@ -46,15 +47,16 @@ async function persistGlobalEnabled(enabled: boolean) {
     reason: requireArg("reason"),
   });
   if (!policy) {
-    const current = (await repository.listPolicies(network)).find(
-      (candidate) => candidate.scopeType === "global" && candidate.scopeId === null
-    );
-    if (!current) {
+    policy =
+      (await repository.listPolicies(network)).find(
+        (candidate) => candidate.scopeType === "global" && candidate.scopeId === null
+      ) ?? null;
+    if (!policy) {
       throw new Error("No matching policy exists; use `set` with explicit limits first");
     }
-    console.log(JSON.stringify(current, null, 2));
-    return;
   }
+  // A prior attempt may have persisted Postgres but failed to sync Redis.
+  // Repeating the command must repair that split without another revision.
   await new SponsorshipBudgetRedis(env).syncPolicy(policy);
   console.log(JSON.stringify(policy, null, 2));
 }
@@ -125,4 +127,6 @@ runWithSystemDatabaseIdentity("script:sponsorship-budget", main)
     console.error(error instanceof Error ? error.message : error);
     process.exitCode = 1;
   })
-  .finally(closeDatabasePools);
+  .finally(async () => {
+    await Promise.all([closeDatabasePools(), closeAllRedisClients()]);
+  });

--- a/apps/sdp-api/src/services/sponsorship-budget-cli.test.ts
+++ b/apps/sdp-api/src/services/sponsorship-budget-cli.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  setPolicyEnabled: vi.fn(),
+  listPolicies: vi.fn(),
+  syncPolicy: vi.fn(),
+  closeDatabasePools: vi.fn(),
+  closeAllRedisClients: vi.fn(),
+}));
+
+vi.mock("../db", () => ({
+  getDb: vi.fn(),
+  runWithSystemDatabaseIdentity: (_name: string, fn: () => Promise<void>) => fn(),
+  closeDatabasePools: mocks.closeDatabasePools,
+}));
+vi.mock("../db/repositories/sponsorship-budget.repository", () => ({
+  SponsorshipBudgetRepository: class {
+    setPolicyEnabled = mocks.setPolicyEnabled;
+    listPolicies = mocks.listPolicies;
+  },
+}));
+vi.mock("../lib/runtime-env", () => ({ getProcessEnv: () => ({}) }));
+vi.mock("../runtime/sponsorship-budget-redis", () => ({
+  SponsorshipBudgetRedis: class {
+    syncPolicy = mocks.syncPolicy;
+  },
+}));
+vi.mock("../runtime/kv-redis", () => ({ closeAllRedisClients: mocks.closeAllRedisClients }));
+
+const policy = {
+  id: "sbp_devnet_global",
+  scopeType: "global",
+  scopeId: null,
+  enabled: true,
+  version: 3,
+  perTransactionLamports: 10_000_000,
+  hourlyLamports: 2_000_000_000,
+  dailyLamports: 10_000_000_000,
+};
+const originalArgv = process.argv;
+const originalExitCode = process.exitCode;
+
+async function run(network = "devnet") {
+  process.argv = [
+    "node",
+    "sponsorship-budget.js",
+    "resume",
+    "--network",
+    network,
+    "--operator",
+    "github:operator",
+    "--reason",
+    "Reviewed dev incident",
+  ];
+  await import("../../scripts/sponsorship-budget");
+  await vi.waitFor(() => expect(mocks.closeAllRedisClients).toHaveBeenCalledOnce());
+}
+
+describe("sponsorship operator CLI", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    process.exitCode = 0;
+    mocks.setPolicyEnabled.mockResolvedValue(policy);
+  });
+  afterEach(() => {
+    process.argv = originalArgv;
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  it("resumes the global policy without changing limits and closes both clients", async () => {
+    await run();
+    expect(mocks.setPolicyEnabled).toHaveBeenCalledWith({
+      network: "devnet",
+      scopeType: "global",
+      scopeId: null,
+      enabled: true,
+      operator: "github:operator",
+      reason: "Reviewed dev incident",
+    });
+    expect(mocks.syncPolicy).toHaveBeenCalledWith(policy);
+    expect(mocks.closeDatabasePools).toHaveBeenCalledOnce();
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("repairs Redis on an idempotent resume without a second database revision", async () => {
+    mocks.setPolicyEnabled.mockResolvedValue(null);
+    mocks.listPolicies.mockResolvedValue([policy]);
+    await run();
+    expect(mocks.syncPolicy).toHaveBeenCalledWith(policy);
+    expect(mocks.setPolicyEnabled).toHaveBeenCalledOnce();
+  });
+
+  it("fails and closes clients when Redis synchronization fails", async () => {
+    mocks.syncPolicy.mockRejectedValue(new Error("Redis unavailable"));
+    await run();
+    expect(process.exitCode).toBe(1);
+    expect(mocks.closeDatabasePools).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an invalid network before changing any policy", async () => {
+    await run("invalid");
+    expect(mocks.setPolicyEnabled).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Package the existing sponsorship operator CLI in the API image so an infra-managed, manual Cloud Run job can execute it inside the dev VPC. No endpoint, credentials, policy limits, or automatic enablement are added.

- Ship `sponsorship-budget.js` alongside the existing migration and job bundles.
- Close both Postgres and Redis clients on completion/error so one-shot jobs terminate.
- Repair Redis when an idempotent resume/kill finds Postgres already in the requested state. Previously a successful database write followed by failed Redis sync could not be repaired by retrying the command.
- Add CLI regression coverage for preserved limits/audit arguments, idempotent repair, Redis failure, and invalid-network rejection.

## Verification

- 19 focused tests passed (CLI plus existing operator validation), using an isolated Vitest config without the unrelated Docker database bootstrap. The CLI tests mock storage; they do not exercise dev.
- API typecheck passed.
- Full API bundle build passed; packaged CLI starts and exits with the expected missing-database configuration error without credentials.
- Biome checks and `git diff --check` passed.

## Rollout and risk

Companion infra runner: https://github.com/solana-foundation/sdp-infra/pull/157.

Deploy this image before dispatching the companion sdp-infra sponsorship operator workflow. Neither merging nor deploying this change enables sponsorship. The reviewed operator action must still explicitly resume devnet; existing budgets remain unchanged. Mainnet is not part of this rollout.

Context: [dev sponsorship breaker incident and operator approval](https://solana-foundation.slack.com/archives/C0A8Q74B9KP/p1788968411827089).
