### PR TITLE
ci(api): shard the unit-test job 4 ways with a merged coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,20 +207,25 @@ jobs:
           fi
 
   test:
-    name: Unit Tests
+    name: Unit Tests (api ${{ matrix.shard }}/4)
     needs: unit_test_scope
     if: needs.unit_test_scope.outputs.api == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 20
     permissions:
       contents: read
       id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     env:
       TURBO_CACHE_DIR: ${{ github.workspace }}/.turbo-ci-cache
       CI_HAS_DOPPLER_TOKEN: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       TEST_WORKSPACE_SPLIT: api
       TEST_CHANGED_SINCE: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || '' }}
-      DOPPLER_PRESERVE_ENV: TEST_CHANGED_SINCE,TEST_WORKSPACE_SPLIT
+      TEST_SHARD: ${{ matrix.shard }}/4
+      DOPPLER_PRESERVE_ENV: TEST_CHANGED_SINCE,TEST_WORKSPACE_SPLIT,TEST_SHARD
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -242,9 +247,9 @@ jobs:
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .turbo-ci-cache
-          key: turbo-${{ github.job }}-${{ runner.os }}-${{ github.sha }}
+          key: turbo-${{ github.job }}-shard${{ matrix.shard }}-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
-            turbo-${{ github.job }}-${{ runner.os }}-
+            turbo-${{ github.job }}-shard${{ matrix.shard }}-${{ runner.os }}-
 
       - name: Install
         run: pnpm install --frozen-lockfile
@@ -279,13 +284,80 @@ jobs:
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .turbo-ci-cache
-          key: turbo-${{ github.job }}-${{ runner.os }}-${{ github.sha }}
+          key: turbo-${{ github.job }}-shard${{ matrix.shard }}-${{ runner.os }}-${{ github.sha }}
 
       - name: Unit tests (fork-safe)
         if: env.CI_IS_FORK_PULL_REQUEST == 'true' && env.CI_HAS_DOPPLER_TOKEN != 'true'
         run: |
           echo "::notice title=Fork-safe unit tests::Doppler OIDC authentication is unavailable to forked pull requests, so unit tests are running with local defaults instead of Doppler dev_ci secrets."
           node scripts/run-workspace-tests.mjs unit
+
+      - name: Upload vitest shard artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: vitest-api-shard-${{ matrix.shard }}
+          path: apps/sdp-api/.vitest-reports/blob-${{ matrix.shard }}-4.json
+          include-hidden-files: true
+          if-no-files-found: error
+
+  test_merge:
+    name: Unit Tests
+    needs: [unit_test_scope, test]
+    if: always() && needs.unit_test_scope.outputs.api == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Report shard results
+        env:
+          SHARD_RESULT: ${{ needs.test.result }}
+        run: |
+          if [ "${SHARD_RESULT}" != "success" ]; then
+            echo "One or more Unit Tests (api) shards finished with ${SHARD_RESULT}." >&2
+            exit 1
+          fi
+          echo "All Unit Tests (api) shards passed."
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
+        with:
+          version: 10.16.0
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Download shard artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: vitest-api-shard-*
+          path: shard-artifacts
+
+      - name: Verify and assemble shard blobs
+        run: |
+          set -euo pipefail
+          mkdir -p apps/sdp-api/.vitest-reports
+          for shard in 1 2 3 4; do
+            blob="shard-artifacts/vitest-api-shard-${shard}/blob-${shard}-4.json"
+            if [ ! -f "${blob}" ]; then
+              echo "Missing blob report for shard ${shard} (expected ${blob})." >&2
+              exit 1
+            fi
+            cp "${blob}" apps/sdp-api/.vitest-reports/
+          done
+          echo "Assembled $(find apps/sdp-api/.vitest-reports -type f | wc -l | tr -d ' ') blob files."
+
+      - name: Merge coverage and enforce thresholds
+        working-directory: apps/sdp-api
+        run: pnpm exec vitest run --merge-reports --coverage
 
   test_packages:
     name: Unit Tests (packages)

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ infra/self-hosted/default.env.example
 
 # Test coverage
 coverage/
+.vitest-reports/
 apps/sdp-web/playwright/.clerk/
 apps/sdp-web/playwright/.fixtures/
 apps/sdp-web/playwright-report/

--- a/apps/sdp-api/vitest.config.ts
+++ b/apps/sdp-api/vitest.config.ts
@@ -2,7 +2,9 @@ import path from "node:path";
 import { defineConfig } from "vitest/config";
 import { TEST_WORKER_COUNT } from "./src/test/worker-count";
 
-const isShardedRun = process.env.TEST_SHARD !== undefined;
+// Matches parseTestShard in scripts/run-workspace-tests.mjs: an unset or
+// blank TEST_SHARD means an unsharded run, which must keep thresholds.
+const isShardedRun = process.env.TEST_SHARD !== undefined && process.env.TEST_SHARD.trim() !== "";
 const isCiRun = process.env.CI !== undefined;
 
 export default defineConfig({

--- a/apps/sdp-api/vitest.config.ts
+++ b/apps/sdp-api/vitest.config.ts
@@ -2,6 +2,9 @@ import path from "node:path";
 import { defineConfig } from "vitest/config";
 import { TEST_WORKER_COUNT } from "./src/test/worker-count";
 
+const isShardedRun = process.env.TEST_SHARD !== undefined;
+const isCiRun = process.env.CI !== undefined;
+
 export default defineConfig({
   resolve: {
     alias: {
@@ -39,13 +42,21 @@ export default defineConfig({
       reportsDirectory: "./coverage/node",
       include: ["src/**/*.ts"],
       exclude: ["src/**/*.test.ts", "src/**/*.spec.ts", "src/types/**", "src/db/migrations/**"],
-      thresholds: {
-        statements: 78.1,
-        branches: 68.7,
-        functions: 84.3,
-        lines: 78.5,
-        autoUpdate: true,
-      },
+      // Per-shard runs exclude thresholds: each shard only sees a fraction of
+      // the suite, so threshold enforcement happens once in the CI merge job
+      // over the blob-merged coverage of all shards. The merge run leaves
+      // TEST_SHARD unset, so it enforces the thresholds defined here.
+      ...(isShardedRun
+        ? {}
+        : {
+            thresholds: {
+              statements: 78.1,
+              branches: 68.7,
+              functions: 84.3,
+              lines: 78.5,
+              autoUpdate: !isCiRun,
+            },
+          }),
     },
     testTimeout: 30_000,
     hookTimeout: 60_000,

--- a/scripts/run-workspace-tests.mjs
+++ b/scripts/run-workspace-tests.mjs
@@ -83,6 +83,38 @@ function run(command, args, options = {}) {
   });
 }
 
+const TEST_SHARD_PATTERN = /^[1-9]\d*\/[1-9]\d*$/;
+
+/**
+ * Parses the `TEST_SHARD` environment variable (`<index>/<count>`, e.g. `2/4`).
+ * An unset or empty value means "run the whole suite unsharded" and yields
+ * `undefined`; any other malformed value is a hard error so a typo in CI can
+ * never silently run the full suite or an overlapping subset.
+ *
+ * @param {string | undefined} raw Value of `process.env.TEST_SHARD`.
+ * @returns {string | undefined} The validated `<index>/<count>` string, or `undefined` when unset.
+ * @throws {Error} When the value is set but does not match `<positive-index>/<positive-count>`.
+ */
+function parseTestShard(raw) {
+  const trimmed = raw?.trim();
+  if (trimmed === undefined || trimmed === "") {
+    return undefined;
+  }
+
+  if (!TEST_SHARD_PATTERN.test(trimmed)) {
+    throw new Error(
+      `TEST_SHARD must be formatted as <index>/<count> with positive integers (e.g. "1/4"), received: ${trimmed}`
+    );
+  }
+
+  const [index, count] = trimmed.split("/");
+  if (Number(index) > Number(count)) {
+    throw new Error(`TEST_SHARD index must not exceed count, received: ${trimmed}`);
+  }
+
+  return trimmed;
+}
+
 try {
   if (mode === "integration") {
     await configureIntegrationSolanaRpc(resolvedEnv);
@@ -104,6 +136,7 @@ try {
   } else {
     const changedSince = mode === "unit" ? process.env.TEST_CHANGED_SINCE?.trim() : undefined;
     const split = mode === "unit" ? process.env.TEST_WORKSPACE_SPLIT?.trim() : undefined;
+    const testShard = mode === "unit" ? parseTestShard(process.env.TEST_SHARD) : undefined;
     const filters =
       mode === "integration"
         ? ["--filter=@sdp/api-integration"]
@@ -121,6 +154,13 @@ try {
               ? [`--filter=...[${changedSince}]`, "--filter=!@sdp/api-integration"]
               : ["--filter=!@sdp/api-integration"];
     const cacheDir = process.env.TURBO_CACHE_DIR?.trim();
+    const vitestShardArgs = testShard
+      ? [`--shard=${testShard}`, "--reporter=blob", "--reporter=default"]
+      : [];
+    const passthroughArgs =
+      forwardedArgs.length > 0 || vitestShardArgs.length > 0
+        ? ["--", ...forwardedArgs, ...vitestShardArgs]
+        : [];
     await run("pnpm", [
       "exec",
       "turbo",
@@ -128,7 +168,7 @@ try {
       "test",
       ...(cacheDir ? [`--cache-dir=${cacheDir}`] : []),
       ...filters,
-      ...(forwardedArgs.length > 0 ? ["--", ...forwardedArgs] : []),
+      ...passthroughArgs,
     ]);
   }
 } catch (error) {

--- a/turbo.json
+++ b/turbo.json
@@ -210,7 +210,8 @@
     },
     "test": {
       "dependsOn": ["^build"],
-      "outputs": ["coverage/**"]
+      "env": ["TEST_SHARD"],
+      "outputs": ["coverage/**", ".vitest-reports/**"]
     },
     "test:coverage": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
- The `Unit Tests` (@sdp/api) job was the CI critical path: ~17 min wall on a 4-vCPU runner (vitest: 948s duration, 2848s overlapped test time across 367 files, 651s import cost), while every other job finished by ~6.5 min.
- Splits it into a `shard: [1..4]` matrix; each shard runs `vitest --shard=N/4` with the blob reporter and uploads `blob-N-4.json` as an artifact.
- A fail-closed gate job keeps the required check name **`Unit Tests`**: it fails unless all shard jobs succeeded and all 4 blobs are present, then runs `vitest run --merge-reports --coverage` to enforce the existing thresholds once on the merged coverage.
- Per-shard threshold enforcement is off (vitest 4.1.11 has no shard special-casing in its coverage provider, so each shard would fail thresholds on partial coverage); `thresholds.autoUpdate` is disabled in CI so shards never mutate the config.
- `TEST_SHARD` is validated loudly in `run-workspace-tests.mjs` (malformed values error, never silently run unsharded) and is declared in turbo's `test` task `env` so shard identity is part of the task hash; turbo `test` outputs now include `.vitest-reports/**` so a cache hit still restores the blob the gate needs.

**before** — single `Unit Tests` job:

1. One `ubuntu-latest` job runs the full 367-file suite with `--coverage`, thresholds enforced inline.
2. ~17 min wall; total CI wall clock 15–18 min with this job as the sole critical path.
3. Coverage `autoUpdate: true` mutated the config in CI and discarded it.

**after** — 4 shards + merge gate:

1. Four matrix jobs each run `--shard=N/4 --reporter=blob --reporter=default --coverage` (thresholds off), upload their blob (`if-no-files-found: error`).
2. Gate job `Unit Tests` (same required-check name): fails immediately if any shard did not succeed, verifies all 4 blobs exist, assembles them, runs `--merge-reports --coverage`.
3. Thresholds enforced exactly once on the merged coverage map; a missing/failed/skipped shard fails the gate — it can never silently pass on partial results.

## How the shard plumbing works

```
ci.yml matrix (TEST_SHARD=N/4, in DOPPLER_PRESERVE_ENV)
  → doppler run → run-workspace-tests.mjs (validates N/4, appends passthrough args)
  → turbo run test --filter=@sdp/api -- --shard=N/4 --reporter=blob --reporter=default
  → vitest writes apps/sdp-api/.vitest-reports/blob-N-4.json (thresholds omitted when TEST_SHARD set)
gate: download 4 artifacts → assemble .vitest-reports/ → vitest run --merge-reports --coverage
  (TEST_SHARD unset → thresholds defined → enforced on merged map; no globalSetup/DB runs during merge)
```

**Verification**

- Shard completeness: union of `vitest list --shard=N/4` for N=1..4 equals the full inventory exactly (5130 = 5130 test entries, 0 cross-shard duplicates); shard file counts 1252/1247/1419/1212.
- Merge mechanics (local, Testcontainers): two small shards (`1/40`, `2/40`) produced blobs with no per-shard threshold errors; merge replayed 205 tests, produced merged coverage, and threshold enforcement fired on the partial coverage with exit 1 — proving the gate enforces on merged data.
- Fail-closed: missing-blob case exits 1; malformed `TEST_SHARD` (`1of4`, `5/4`, `0/4`) errors loudly.
- `pnpm --filter @sdp/api typecheck` clean; biome on changed files clean (4 pre-existing `noUndeclaredEnvVars` warnings identical to baseline); actionlint (repo-pinned 1.7.12 image) clean except the pre-existing L171 SC2086 info; `pnpm test:scripts` 133 pass.
- Expected result: api gate ≈ 6–8 min, total CI wall ≈ 6.5–8 min. This PR's own checks are the live measurement — compare against the ~17 min baseline.

Known gaps
- Shard count 4 is hardcoded across the matrix, blob filenames, and the assembly loop — changing it means editing them together.
- If branch protection pins a check identity beyond the job name `Unit Tests`, it needs a one-time update (the gate deliberately reuses the exact old name to avoid this).
- Per-shard coverage still writes text/json/html reports nobody reads; left as-is because trimming reporters has an unverified interaction with blob coverage capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8CAHVqa8xEUL6DDxXHgmq