### PR TITLE
fix(smoke): wait long enough for Clerk to activate the organization

### DIFF
--- a/apps/sdp-web/playwright/tests/auth.global.setup.ts
+++ b/apps/sdp-web/playwright/tests/auth.global.setup.ts
@@ -6,6 +6,9 @@ import { getE2EEnv } from "../env";
 import { authStatePath } from "../support/auth-state";
 import { resolveClerkTestIdentity, withTransientClerkRetry } from "../support/clerk-admin";
 
+/** `setActive` returns before Clerk has refreshed the session token. */
+const CLERK_ORGANIZATION_ACTIVATION_TIMEOUT_MS = 30_000;
+
 setup("authenticate admin test user and save auth state", async ({ page, browser }) => {
   setup.setTimeout(360_000);
   const env = getE2EEnv();
@@ -81,14 +84,18 @@ setup("authenticate admin test user and save auth state", async ({ page, browser
   );
 
   await expect
-    .poll(() =>
-      target.evaluate(() => {
-        return (
-          window as unknown as {
-            Clerk?: { organization?: { id?: string } };
-          }
-        ).Clerk?.organization?.id;
-      })
+    .poll(
+      () =>
+        target.evaluate(() => {
+          return (
+            window as unknown as {
+              Clerk?: { organization?: { id?: string } };
+            }
+          ).Clerk?.organization?.id;
+        }),
+      // expect.poll does not inherit the test timeout; its own default is 5s,
+      // which a warm run clears and a cold CI runner does not.
+      { timeout: CLERK_ORGANIZATION_ACTIVATION_TIMEOUT_MS }
     )
     .toBe(identity.organizationId);
 

--- a/apps/sdp-web/playwright/tests/auth.global.setup.ts
+++ b/apps/sdp-web/playwright/tests/auth.global.setup.ts
@@ -6,7 +6,6 @@ import { getE2EEnv } from "../env";
 import { authStatePath } from "../support/auth-state";
 import { resolveClerkTestIdentity, withTransientClerkRetry } from "../support/clerk-admin";
 
-/** `setActive` returns before Clerk has refreshed the session token. */
 const CLERK_ORGANIZATION_ACTIVATION_TIMEOUT_MS = 30_000;
 
 setup("authenticate admin test user and save auth state", async ({ page, browser }) => {
@@ -93,8 +92,6 @@ setup("authenticate admin test user and save auth state", async ({ page, browser
             }
           ).Clerk?.organization?.id;
         }),
-      // expect.poll does not inherit the test timeout; its own default is 5s,
-      // which a warm run clears and a cold CI runner does not.
       { timeout: CLERK_ORGANIZATION_ACTIVATION_TIMEOUT_MS }
     )
     .toBe(identity.organizationId);


### PR DESCRIPTION
The stage smoke has failed on the same assertion since 08:16Z today, blocking the 0.75.0 gate. The org-id mismatch reported in the failure is a symptom; the line under it is the cause:

```
Expected: "org_3IVBeDF5wyW8X1cjAWfJZcQKKwz"
Received: undefined
  - Timeout 5000ms exceeded while waiting on the predicate
```

`expect.poll` does not inherit the test timeout — `setup.setTimeout(360_000)` covers the test body, not the assertion — and `playwright.config.ts` declares no `expect` block, so the poll ran on Playwright's 5s default. What it waits for is a round trip to Clerk: `setActive` resolves before the session token carries the new organization, so `Clerk.organization` stays undefined until Clerk answers. A warm run clears five seconds; a cold CI runner does not. With `retries: 0` that aborts the whole gate.

The poll now carries a 30s bound. The assertion, the `setActive` call, and the identity resolution are untouched.

## Why this is not #1721 and not Clerk

#1721 is present in every failing run, and the smoke on its own merge commit (`da01ed1f9`) passed at 07:17Z. The failures begin with the next deploy at 08:16Z and continue through the 16:54Z run, all with the same 5000ms line. The first commit after the green run (`ad1942c73`, #1443) touches only `packages/sdp-custody` and `packages/sdp-redaction` — no web, no Playwright, no Clerk — so the correlation with that deploy is coincidental.

Clerk-side membership is ruled out by the test itself. For the external smoke, `resolveClerkTestIdentity` takes the read-only path, which throws when the user is not an `org:admin` member of `E2E_CLERK_ORG_ID`. The failure is at line 93, well past that check, so Clerk had already confirmed the membership on the run that failed.

## What this deliberately does not change

No blanket `retries` on CI. A retry would have hidden this failure rather than surfacing it, and this suite is a release gate — a silent second attempt is the wrong default for the one check that decides whether prod ships. If we want retries for genuinely flaky external dependencies, that is worth deciding on its own rather than as a side effect of this fix.

No global `expect.timeout` either. Only this assertion waits on an external service; raising the bound everywhere would slow every real failure in the suite to the same ceiling.

## Verification

- `biome check` and `tsc --noEmit` on `sdp-web` — clean.
- The smoke itself runs against deployed stage and cannot be exercised from a branch; the CI run on this PR is the check.
