### PR TITLE
feat(wallets): use exact custody wallets for signer checks

### DIFF
--- a/apps/sdp-api/src/openapi/paths/custody.ts
+++ b/apps/sdp-api/src/openapi/paths/custody.ts
@@ -312,7 +312,7 @@ export function registerCustodyPaths(registry: OpenAPIRegistry) {
         description: "Signer check verified in simulation",
         content: jsonContent(custodySignerCheckResponse),
       },
-      ...errorResponses(errorResponseSchema, [400, 401, 403, 429, 500, 502]),
+      ...errorResponses(errorResponseSchema, [400, 401, 403, 404, 409, 429, 500, 502]),
     },
   });
 

--- a/apps/sdp-api/src/openapi/schemas/custody.ts
+++ b/apps/sdp-api/src/openapi/schemas/custody.ts
@@ -30,7 +30,7 @@ export const switchSigningRequestSchema = withOpenApi(switchSigningSchemaBase, {
 
 export const signerCheckRequestSchema = withOpenApi(signerCheckSchemaBase, {
   description:
-    "Signer-check wallet selection. walletId is optional for an API key with one bound signing wallet and required for session-authenticated dashboard requests.",
+    "walletId is a Provider wallet ID. When omitted for an API key, its authenticated signing-wallet selection is used: the configured preference, otherwise the first resolved binding. Session-authenticated dashboard requests must provide walletId. Ambiguous Provider IDs are rejected; the check uses the resolved exact custody wallet record.",
   example: { walletId: "privy_wallet_123" },
 });
 

--- a/apps/sdp-api/src/openapi/spec.test.ts
+++ b/apps/sdp-api/src/openapi/spec.test.ts
@@ -26,6 +26,16 @@ function getWalletListItemSchema(value: unknown): TestJsonSchema {
 }
 
 describe("OpenAPI spec", () => {
+  it("documents exact signer-check runtime failures without changing its Provider-ID request", () => {
+    const operation = createPublicOpenApiDocument().paths?.["/v1/wallets/signer-check"]?.post;
+    expect(operation?.responses).toHaveProperty("403");
+    expect(operation?.responses).toHaveProperty("404");
+    expect(operation?.responses).toHaveProperty("409");
+    const request = getJsonSchema(operation?.requestBody);
+    expect(request.properties).toEqual({ walletId: expect.any(Object) });
+    expect(request.required).toBeUndefined();
+  });
+
   it("documents path-based versioning policy", () => {
     const doc = createOpenApiDocument();
 

--- a/apps/sdp-api/src/routes/custody-wallet-scope.test.ts
+++ b/apps/sdp-api/src/routes/custody-wallet-scope.test.ts
@@ -1,7 +1,7 @@
 import { hashString } from "@sdp/payments/hash";
 import * as rpcRelay from "@sdp/rpc/relay";
 import * as solanaRpc from "@sdp/rpc/solana";
-import type { CachedApiKey } from "@sdp/types";
+import type { CachedApiKey, SignerCheckRequest } from "@sdp/types";
 import { address, blockhash, generateKeyPairSigner, signature } from "@solana/kit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
@@ -9,6 +9,7 @@ import { getDb } from "@/db";
 import app from "@/index";
 import { clearWalletCaches } from "@/routes/custody/handlers/wallets";
 import * as tokenAccounts from "@/routes/payments/token-accounts";
+import { upsertApiKeyWalletBinding } from "@/services/api-key-wallets.service";
 import * as signingServiceModule from "@/services/domain/signing.service";
 import { TEST_SOLANA_ADDRESSES } from "@/test/fixtures/tokens";
 import { env } from "@/test/helpers/env";
@@ -17,6 +18,7 @@ import { clearKVStores, seedCachedApiKey } from "@/test/mocks/kv";
 
 const signerCheckMocks = vi.hoisted(() => ({
   createOrgSigner: vi.fn(),
+  createExactSigner: vi.fn(),
   createSponsorship: vi.fn(),
   signAndSend: vi.fn(),
 }));
@@ -24,6 +26,7 @@ const signerCheckMocks = vi.hoisted(() => ({
 vi.mock("@/services/solana", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/services/solana")>()),
   createOrgSigner: signerCheckMocks.createOrgSigner,
+  createOrgSignerForCustodyWallet: signerCheckMocks.createExactSigner,
 }));
 
 vi.mock("@/services/sponsorship.service", async (importOriginal) => ({
@@ -33,6 +36,7 @@ vi.mock("@/services/sponsorship.service", async (importOriginal) => ({
 
 const actualCreateSigningService = signingServiceModule.createSigningService;
 const createRpcMock = vi.spyOn(solanaRpc, "createRpc");
+const createRpcFromTransportSpy = vi.spyOn(solanaRpc, "createRpcFromTransport");
 const getAccountInfoMock = vi.spyOn(solanaRpc, "getAccountInfo");
 const getSplTokenBalancesMock = vi.spyOn(tokenAccounts, "getSplTokenBalances");
 const createSigningServiceMock = vi.spyOn(signingServiceModule, "createSigningService");
@@ -307,8 +311,32 @@ async function seedActiveConnectionWallet(
   ]);
 }
 
+function requestSignerCheck(body: SignerCheckRequest, actor: "api_key" | "session") {
+  const headers = new Headers({
+    "Content-Type": "application/json",
+    "x-project-id": TEST_PROJECT.id,
+  });
+  if (actor === "api_key") {
+    headers.set("Authorization", `Bearer ${TEST_API_KEY.raw}`);
+  } else {
+    headers.set("Cookie", `sdp_session=${TEST_SESSION_ID}`);
+  }
+  return app.request(
+    "/v1/wallets/signer-check",
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    },
+    env
+  );
+}
+
 describe("Custody wallet scope routes", () => {
+  let originalPrivyByokEnabled: string | undefined;
+
   beforeEach(async () => {
+    originalPrivyByokEnabled = env.PRIVY_BYOK_ENABLED;
     vi.clearAllMocks();
 
     createRpcMock.mockReturnValue({} as ReturnType<typeof solanaRpc.createRpc>);
@@ -349,7 +377,9 @@ describe("Custody wallet scope routes", () => {
       unitsConsumed: null,
       error: null,
     });
-    signerCheckMocks.createOrgSigner.mockResolvedValue(await generateKeyPairSigner());
+    const signer = await generateKeyPairSigner();
+    signerCheckMocks.createOrgSigner.mockResolvedValue(signer);
+    signerCheckMocks.createExactSigner.mockResolvedValue(signer);
     signerCheckMocks.signAndSend.mockResolvedValue(TEST_SIGNATURE);
     signerCheckMocks.createSponsorship.mockReturnValue({
       providerId: "test",
@@ -357,8 +387,8 @@ describe("Custody wallet scope routes", () => {
       signAsFeePayer: vi.fn(),
       signAndSend: signerCheckMocks.signAndSend,
     });
-    createSigningServiceMock.mockImplementation((envArg) => {
-      const service = actualCreateSigningService(envArg);
+    createSigningServiceMock.mockImplementation((envArg, scope) => {
+      const service = actualCreateSigningService(envArg, scope);
       service.getPublicKey = vi.fn(async (_organizationId, _projectId, walletId) => {
         if (walletId === "para_wallet_a") {
           return address(TEST_SOLANA_ADDRESSES.wallet2);
@@ -376,13 +406,205 @@ describe("Custody wallet scope routes", () => {
   });
 
   afterEach(async () => {
+    env.PRIVY_BYOK_ENABLED = originalPrivyByokEnabled;
     await clearKVStores(env);
     createSigningServiceMock.mockReset();
     getAccountInfoMock.mockReset();
     getSplTokenBalancesMock.mockReset();
   });
 
+  it.each([
+    { state: "paused", status: 403, reason: "runtime_execution_paused" },
+    { state: "unavailable", status: 409, reason: "runtime_execution_unavailable" },
+  ])(
+    "refuses a $state signer check before signer, fee payer, or RPC access",
+    async ({ state, status, reason }) => {
+      await seedActiveConnectionWallet(
+        "signer_check",
+        "privy_check",
+        TEST_SOLANA_ADDRESSES.wallet1
+      );
+      env.PRIVY_BYOK_ENABLED = state === "paused" ? "false" : "true";
+      if (state === "unavailable") {
+        await getDb(env)
+          .prepare(
+            "UPDATE provider_credentials SET status = 'retired' WHERE id = 'pcred_scope_signer_check'"
+          )
+          .run();
+      }
+      const response = await requestSignerCheck({ walletId: "privy_check" }, "session");
+
+      expect(response.status).toBe(status);
+      expect(await response.json()).toMatchObject({
+        error: { details: { reason } },
+      });
+      expect(signerCheckMocks.createOrgSigner).not.toHaveBeenCalled();
+      expect(signerCheckMocks.createExactSigner).not.toHaveBeenCalled();
+      expect(signerCheckMocks.createSponsorship).not.toHaveBeenCalled();
+      expect(resolveRpcTargetMock).not.toHaveBeenCalled();
+      expect(createRpcFromTransportSpy).not.toHaveBeenCalled();
+      expect(simulateTransactionMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it("checks the exact Connection wallet even if the default changes after admission", async () => {
+    const signer = await generateKeyPairSigner();
+    await seedActiveConnectionWallet("signer_check", "privy_check", signer.address);
+    env.PRIVY_BYOK_ENABLED = "true";
+    signerCheckMocks.createExactSigner.mockResolvedValue(signer);
+    createSigningServiceMock.mockImplementation((envArg, scope) => {
+      const service = actualCreateSigningService(envArg, scope);
+      const admit = service.admitRuntimeExecution.bind(service);
+      service.admitRuntimeExecution = async (...args) => {
+        await admit(...args);
+        await getDb(env)
+          .prepare(
+            "UPDATE custody_scope_defaults SET default_custody_config_id = ? WHERE id = 'csd_scope_org_default'"
+          )
+          .bind(PARA_CONFIG_ID)
+          .run();
+      };
+      return service;
+    });
+
+    const response = await requestSignerCheck({ walletId: "privy_check" }, "session");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      data: { walletId: "privy_check", walletAddress: signer.address, simulated: true },
+    });
+    expect(signerCheckMocks.createExactSigner).toHaveBeenCalledWith(
+      env,
+      TEST_ORG.id,
+      TEST_PROJECT.id,
+      "cwlt_scope_signer_check"
+    );
+    expect(signerCheckMocks.createOrgSigner).not.toHaveBeenCalled();
+    expect(signerCheckMocks.signAndSend).not.toHaveBeenCalled();
+    expect(createRpcFromTransportSpy).toHaveBeenCalledOnce();
+  });
+
+  it.each(["session", "api_key"] as const)(
+    "refuses ambiguous signer-check Provider IDs for %s callers",
+    async (actor) => {
+      await upsertApiKeyWalletBinding(getDb(env), TEST_API_KEY.id, {
+        walletId: "privy_wallet_a",
+        permissions: ["wallets:write"],
+      });
+      await seedCachedKey({
+        signingWalletId: "privy_wallet_a",
+        walletBindings: [{ walletId: "privy_wallet_a", permissions: ["wallets:write"] }],
+      });
+      // The cache still names the original row when another owner introduces a duplicate.
+      await seedActiveConnectionWallet(
+        "duplicate",
+        "privy_wallet_a",
+        TEST_SOLANA_ADDRESSES.wallet2
+      );
+      env.PRIVY_BYOK_ENABLED = "true";
+
+      const response = await requestSignerCheck({ walletId: "privy_wallet_a" }, actor);
+
+      expect(response.status).toBe(actor === "session" ? 409 : 403);
+      expect(signerCheckMocks.createExactSigner).not.toHaveBeenCalled();
+      expect(signerCheckMocks.createOrgSigner).not.toHaveBeenCalled();
+      expect(signerCheckMocks.createSponsorship).not.toHaveBeenCalled();
+      expect(resolveRpcTargetMock).not.toHaveBeenCalled();
+      expect(simulateTransactionMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(["read-only", "revoked", "expired"])(
+    "refuses %s signer-check authorization despite a cached write grant",
+    async (state) => {
+      await upsertApiKeyWalletBinding(getDb(env), TEST_API_KEY.id, {
+        walletId: "privy_wallet_a",
+        permissions: ["wallets:write"],
+      });
+      await seedCachedKey({
+        signingWalletId: "privy_wallet_a",
+        walletBindings: [{ walletId: "privy_wallet_a", permissions: ["wallets:write"] }],
+      });
+      if (state === "read-only") {
+        await upsertApiKeyWalletBinding(getDb(env), TEST_API_KEY.id, {
+          walletId: "privy_wallet_a",
+          permissions: ["wallets:read"],
+        });
+      } else if (state === "revoked") {
+        await getDb(env)
+          .prepare("UPDATE api_keys SET status = 'revoked' WHERE id = ?")
+          .bind(TEST_API_KEY.id)
+          .run();
+      } else {
+        await getDb(env)
+          .prepare("UPDATE api_keys SET expires_at = '2000-01-01T00:00:00.000Z' WHERE id = ?")
+          .bind(TEST_API_KEY.id)
+          .run();
+      }
+
+      const response = await requestSignerCheck({ walletId: "privy_wallet_a" }, "api_key");
+
+      expect(response.status).toBe(403);
+      expect(signerCheckMocks.createExactSigner).not.toHaveBeenCalled();
+      expect(signerCheckMocks.createSponsorship).not.toHaveBeenCalled();
+      expect(resolveRpcTargetMock).not.toHaveBeenCalled();
+      expect(simulateTransactionMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(["privy_missing", "cwlt_scope_privy_a"])(
+    "preserves the missing-wallet error for signer-check selector %s",
+    async (walletId) => {
+      const response = await requestSignerCheck({ walletId }, "session");
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({
+        error: { code: "BAD_REQUEST", message: "Custody wallet not found" },
+      });
+      expect(signerCheckMocks.createExactSigner).not.toHaveBeenCalled();
+      expect(signerCheckMocks.createSponsorship).not.toHaveBeenCalled();
+      expect(resolveRpcTargetMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it("does not resolve a signer-check wallet belonging to another project", async () => {
+    await getDb(env).batch([
+      getDb(env)
+        .prepare(
+          `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES ('prj_check_other', ?, 'Other', 'check-other', 'sandbox', 'active', ?)`
+        )
+        .bind(TEST_ORG.id, TEST_USER.id),
+      getDb(env)
+        .prepare(
+          `INSERT INTO custody_configs (id, organization_id, project_id, provider, config_encrypted, status)
+         VALUES ('cfg_check_other', ?, 'prj_check_other', 'privy', 'not-read', 'active')`
+        )
+        .bind(TEST_ORG.id),
+      getDb(env)
+        .prepare(
+          `INSERT INTO custody_wallets (id, custody_config_id, wallet_id, public_key, status)
+         VALUES ('cwlt_check_other', 'cfg_check_other', 'privy_check_other', ?, 'active')`
+        )
+        .bind(TEST_SOLANA_ADDRESSES.wallet2),
+    ]);
+
+    const response = await requestSignerCheck({ walletId: "privy_check_other" }, "session");
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { code: "BAD_REQUEST", message: "Custody wallet not found" },
+    });
+    expect(signerCheckMocks.createExactSigner).not.toHaveBeenCalled();
+    expect(signerCheckMocks.createSponsorship).not.toHaveBeenCalled();
+    expect(resolveRpcTargetMock).not.toHaveBeenCalled();
+  });
+
   it("resolves the API key's bound wallet when walletId is omitted", async () => {
+    await upsertApiKeyWalletBinding(getDb(env), TEST_API_KEY.id, {
+      walletId: "privy_wallet_a",
+      permissions: ["wallets:write"],
+    });
     await seedCachedKey({
       signingWalletId: "privy_wallet_a",
       walletBindings: [{ walletId: "privy_wallet_a", permissions: ["wallets:write"] }],
@@ -412,17 +634,88 @@ describe("Custody wallet scope routes", () => {
       })
       .parse(await response.json());
     expect(body.data.walletId).toBe("privy_wallet_a");
-    expect(signerCheckMocks.createOrgSigner).toHaveBeenCalledWith(
+    expect(signerCheckMocks.createExactSigner).toHaveBeenCalledWith(
       env,
       TEST_ORG.id,
       TEST_PROJECT.id,
-      "privy_wallet_a"
+      "cwlt_scope_privy_a"
     );
     // The signature is the wallet's own, verified locally and in simulation —
     // never broadcast, and never paid for by sponsorship.
     expect(simulateTransactionMock).toHaveBeenCalledOnce();
     expect(signerCheckMocks.signAndSend).not.toHaveBeenCalled();
   });
+
+  it.each([
+    {
+      label: "single binding",
+      walletIds: ["privy_wallet_b"],
+      preferred: null,
+      status: 200,
+      walletId: "privy_wallet_b",
+      recordId: "cwlt_scope_privy_b",
+    },
+    {
+      label: "preferred binding",
+      walletIds: ["privy_wallet_a", "privy_wallet_b"],
+      preferred: "privy_wallet_b",
+      status: 200,
+      walletId: "privy_wallet_b",
+      recordId: "cwlt_scope_privy_b",
+    },
+    {
+      label: "the auth layer's first-binding fallback",
+      walletIds: ["privy_wallet_a", "privy_wallet_b"],
+      preferred: null,
+      status: 200,
+      walletId: "privy_wallet_a",
+      recordId: "cwlt_scope_privy_a",
+    },
+    {
+      label: "no bindings",
+      walletIds: [],
+      preferred: null,
+      status: 400,
+      walletId: null,
+      recordId: null,
+    },
+  ])(
+    "preserves signer-check selection with $label and no walletId",
+    async ({ walletIds, preferred, status, walletId, recordId }) => {
+      const bindings: NonNullable<CachedApiKey["walletBindings"]> = walletIds.map((walletId) => ({
+        walletId,
+        permissions: ["wallets:write"],
+      }));
+      for (const binding of bindings) {
+        await upsertApiKeyWalletBinding(getDb(env), TEST_API_KEY.id, binding);
+      }
+      await getDb(env)
+        .prepare("UPDATE api_keys SET signing_wallet_id = ? WHERE id = ?")
+        .bind(preferred, TEST_API_KEY.id)
+        .run();
+      await seedCachedKey({ signingWalletId: preferred, walletBindings: bindings });
+
+      const response = await requestSignerCheck({}, "api_key");
+
+      expect(response.status).toBe(status);
+      if (status === 200) {
+        expect(await response.json()).toMatchObject({
+          data: { walletId, simulated: true },
+        });
+        expect(signerCheckMocks.createExactSigner).toHaveBeenCalledWith(
+          env,
+          TEST_ORG.id,
+          TEST_PROJECT.id,
+          recordId
+        );
+      } else {
+        expect(signerCheckMocks.createExactSigner).not.toHaveBeenCalled();
+        expect(signerCheckMocks.createSponsorship).not.toHaveBeenCalled();
+        expect(resolveRpcTargetMock).not.toHaveBeenCalled();
+      }
+      expect(signerCheckMocks.createOrgSigner).not.toHaveBeenCalled();
+    }
+  );
 
   it("requires walletId for a session-authenticated signer check", async () => {
     const response = await app.request(
@@ -447,6 +740,7 @@ describe("Custody wallet scope routes", () => {
       },
     });
     expect(signerCheckMocks.createOrgSigner).not.toHaveBeenCalled();
+    expect(signerCheckMocks.createExactSigner).not.toHaveBeenCalled();
   });
 
   it("generates the memo for a session request and strips a caller memo", async () => {
@@ -474,16 +768,20 @@ describe("Custody wallet scope routes", () => {
       /^SDP signer check [0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
     );
     expect(body.data.memo).not.toBe(callerMemo);
-    expect(signerCheckMocks.createOrgSigner).toHaveBeenCalledWith(
+    expect(signerCheckMocks.createExactSigner).toHaveBeenCalledWith(
       env,
       TEST_ORG.id,
       TEST_PROJECT.id,
-      "privy_wallet_a"
+      "cwlt_scope_privy_a"
     );
     expect(signerCheckMocks.createSponsorship).toHaveBeenCalledOnce();
   });
 
   it("executes signer check without consulting a denying wallet policy", async () => {
+    await upsertApiKeyWalletBinding(getDb(env), TEST_API_KEY.id, {
+      walletId: "privy_wallet_a",
+      permissions: ["wallets:write"],
+    });
     await seedCachedKey({
       signingWalletId: "privy_wallet_a",
       walletBindings: [{ walletId: "privy_wallet_a", permissions: ["wallets:write"] }],
@@ -533,6 +831,10 @@ describe("Custody wallet scope routes", () => {
   });
 
   it("rate-limits the third signer check by the same actor", async () => {
+    await upsertApiKeyWalletBinding(getDb(env), TEST_API_KEY.id, {
+      walletId: "privy_wallet_a",
+      permissions: ["wallets:write"],
+    });
     await seedCachedKey({
       signingWalletId: "privy_wallet_a",
       walletBindings: [{ walletId: "privy_wallet_a", permissions: ["wallets:write"] }],

--- a/apps/sdp-api/src/routes/custody-wallet-scope.test.ts
+++ b/apps/sdp-api/src/routes/custody-wallet-scope.test.ts
@@ -514,6 +514,100 @@ describe("Custody wallet scope routes", () => {
     }
   );
 
+  it.each([
+    { actor: "session", connectionStatus: "active", configScope: "project" },
+    { actor: "api_key", connectionStatus: "active", configScope: "project" },
+    { actor: "selected_key", connectionStatus: "active", configScope: "project" },
+    { actor: "session", connectionStatus: "deactivated", configScope: "project" },
+    { actor: "session", connectionStatus: "active", configScope: "organization" },
+  ])(
+    "refuses a signer check for $actor with a $configScope Config and inactive duplicate in a $connectionStatus Connection",
+    async ({ actor, connectionStatus, configScope }) => {
+      if (configScope === "project") {
+        await getDb(env)
+          .prepare("UPDATE custody_configs SET project_id = ? WHERE id = ?")
+          .bind(TEST_PROJECT.id, PRIVY_CONFIG_ID)
+          .run();
+      }
+      await seedActiveConnectionWallet(
+        "inactive_duplicate",
+        "privy_wallet_a",
+        TEST_SOLANA_ADDRESSES.wallet2
+      );
+      await getDb(env)
+        .prepare("UPDATE custody_wallets SET status = 'inactive' WHERE id = ?")
+        .bind("cwlt_scope_inactive_duplicate")
+        .run();
+      if (connectionStatus === "deactivated") {
+        await getDb(env)
+          .prepare(
+            "UPDATE custody_connections SET status = 'deactivated', deactivated_at = sdp_iso_now() WHERE id = ?"
+          )
+          .bind("cconn_scope_inactive_duplicate")
+          .run();
+      }
+      if (actor === "selected_key") {
+        await upsertApiKeyWalletBinding(getDb(env), TEST_API_KEY.id, {
+          walletId: "privy_wallet_a",
+          permissions: ["wallets:write"],
+        });
+        await seedCachedKey({
+          signingWalletId: "privy_wallet_a",
+          walletBindings: [
+            {
+              walletId: "privy_wallet_a",
+              custodyWalletId: "cwlt_scope_privy_a",
+              permissions: ["wallets:write"],
+            },
+          ],
+        });
+      }
+      env.PRIVY_BYOK_ENABLED = "true";
+
+      const response = await requestSignerCheck(
+        { walletId: "privy_wallet_a" },
+        actor === "session" ? "session" : "api_key"
+      );
+
+      expect(response.status).toBe(409);
+      expect(await response.json()).toMatchObject({
+        error: { code: "CONFLICT", message: "Custody wallet ownership is ambiguous" },
+      });
+      expect(signerCheckMocks.createExactSigner).not.toHaveBeenCalled();
+      expect(signerCheckMocks.createOrgSigner).not.toHaveBeenCalled();
+      expect(signerCheckMocks.createSponsorship).not.toHaveBeenCalled();
+      expect(resolveRpcTargetMock).not.toHaveBeenCalled();
+      expect(simulateTransactionMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it("keeps signer-check Config selection when an inactive Config has the same Provider ID", async () => {
+    await getDb(env).batch([
+      getDb(env)
+        .prepare(
+          `INSERT INTO custody_configs (id, organization_id, project_id, provider, config_encrypted, status)
+           VALUES ('cfg_signer_retired', ?, ?, 'privy', 'not-read', 'inactive')`
+        )
+        .bind(TEST_ORG.id, TEST_PROJECT.id),
+      getDb(env)
+        .prepare(
+          `INSERT INTO custody_wallets (id, custody_config_id, wallet_id, public_key, status)
+           VALUES ('cwlt_signer_retired', 'cfg_signer_retired', 'privy_wallet_a', ?, 'inactive')`
+        )
+        .bind(TEST_SOLANA_ADDRESSES.wallet2),
+    ]);
+
+    const response = await requestSignerCheck({ walletId: "privy_wallet_a" }, "session");
+
+    expect(response.status).toBe(200);
+    expect(signerCheckMocks.createExactSigner).toHaveBeenCalledWith(
+      env,
+      TEST_ORG.id,
+      TEST_PROJECT.id,
+      "cwlt_scope_privy_a"
+    );
+  });
+
   it.each(["read-only", "revoked", "expired"])(
     "refuses %s signer-check authorization despite a cached write grant",
     async (state) => {

--- a/apps/sdp-api/src/routes/custody/handlers/signer-check.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/signer-check.ts
@@ -20,13 +20,19 @@ import { getDb } from "@/db";
 import { getAuth } from "@/lib/auth";
 import { AppError, badRequest } from "@/lib/errors";
 import { success } from "@/lib/response";
+import { getRequestTenantScope } from "@/lib/tenant-scope";
 import type { ValidatedBodyContext } from "@/middleware/validate";
-import { resolveApiKeySigningWalletId } from "@/services/api-key-scope.service";
+import {
+  assertFreshApiKeyCustodyWalletAccess,
+  resolveApiKeySigningWalletId,
+} from "@/services/api-key-scope.service";
+import { createSigningService } from "@/services/domain/signing.service";
 import { FeePaymentError } from "@/services/ports";
 import { createRpcTransportForTarget } from "@/services/rpc-egress";
-import { createOrgSigner } from "@/services/solana";
+import { createOrgSignerForCustodyWallet } from "@/services/solana";
 import { createAuthenticatedSponsorshipFeePayment } from "@/services/sponsorship.service";
 import type { SignerCheckResponse, signerCheckSchema } from "../schemas";
+import { findAuthorizedOperationalWallet } from "./wallets";
 
 // biome-ignore lint/security/noSecrets: Solana Memo program id constant, not a secret.
 const MEMO_PROGRAM_ADDRESS = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr" as Address;
@@ -68,6 +74,19 @@ export const signerCheck = async (c: ValidatedBodyContext<typeof signerCheckSche
   const memo = `SDP signer check ${crypto.randomUUID()}`;
 
   try {
+    const wallet = await findAuthorizedOperationalWallet(c, resolvedWalletId, ["wallets:write"]);
+    if (!wallet) {
+      throw new SigningError("Custody wallet not found", "WALLET_NOT_FOUND");
+    }
+    await assertFreshApiKeyCustodyWalletAccess(getDb(c.env), auth, wallet.id, ["wallets:write"]);
+    // Resolve once to an exact row, then admit before any signer, Kora, or RPC work.
+    // The exact signer repeats its runtime guard; a default change cannot select another wallet.
+    await createSigningService(c.env, getRequestTenantScope(c)).admitRuntimeExecution(
+      auth.organizationId,
+      auth.projectId ?? undefined,
+      wallet.id
+    );
+
     // The sponsorship port supplies only the fee payer ADDRESS, so the
     // simulated message has a funded payer. The check never calls signAndSend:
     // a signer check is diagnostics, and diagnostics must not be able to spend
@@ -75,7 +94,7 @@ export const signerCheck = async (c: ValidatedBodyContext<typeof signerCheckSche
     // simulation, and is never broadcast.
     const feePayment = createAuthenticatedSponsorshipFeePayment(c);
     const [signer, feePayer, rpcTarget] = await Promise.all([
-      createOrgSigner(c.env, auth.organizationId, auth.projectId, resolvedWalletId),
+      createOrgSignerForCustodyWallet(c.env, auth.organizationId, auth.projectId, wallet.id),
       feePayment.getFeePayer(),
       resolveRpcTarget({
         env: c.env,

--- a/apps/sdp-api/src/routes/custody/handlers/signer-check.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/signer-check.ts
@@ -18,7 +18,7 @@ import {
 import { partiallySignTransactionMessageWithSigners } from "@solana/signers";
 import { getDb } from "@/db";
 import { getAuth } from "@/lib/auth";
-import { AppError, badRequest } from "@/lib/errors";
+import { AppError, badRequest, conflict } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { getRequestTenantScope } from "@/lib/tenant-scope";
 import type { ValidatedBodyContext } from "@/middleware/validate";
@@ -26,6 +26,7 @@ import {
   assertFreshApiKeyCustodyWalletAccess,
   resolveApiKeySigningWalletId,
 } from "@/services/api-key-scope.service";
+import { CustodyRuntimeTargets } from "@/services/domain/signing/custody-runtime-target";
 import { createSigningService } from "@/services/domain/signing.service";
 import { FeePaymentError } from "@/services/ports";
 import { createRpcTransportForTarget } from "@/services/rpc-egress";
@@ -79,6 +80,17 @@ export const signerCheck = async (c: ValidatedBodyContext<typeof signerCheckSche
       throw new SigningError("Custody wallet not found", "WALLET_NOT_FOUND");
     }
     await assertFreshApiKeyCustodyWalletAccess(getDb(c.env), auth, wallet.id, ["wallets:write"]);
+    // Keep the legacy selector's retained-Connection checks; inventory hides inactive rows.
+    const target = await new CustodyRuntimeTargets(getDb(c.env), c.env, new Map()).resolve({
+      kind: "wallet",
+      organizationId: auth.organizationId,
+      projectId: auth.projectId ?? undefined,
+      walletId: resolvedWalletId,
+    });
+    // A retained project Connection must not disappear into the org-Config inventory fallback.
+    if (target?.kind === "connection" && target.connectionId !== wallet.custodyConnectionId) {
+      throw conflict("Custody wallet ownership is ambiguous");
+    }
     // Resolve once to an exact row, then admit before any signer, Kora, or RPC work.
     // The exact signer repeats its runtime guard; a default change cannot select another wallet.
     await createSigningService(c.env, getRequestTenantScope(c)).admitRuntimeExecution(

--- a/apps/sdp-api/src/routes/custody/handlers/wallets.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/wallets.ts
@@ -125,7 +125,7 @@ async function queryWalletSummaries(
     : wallets.filter((wallet) => allowedWalletIds.includes(wallet.id));
 }
 
-async function findAuthorizedOperationalWallet(
+export async function findAuthorizedOperationalWallet(
   c: AppContext,
   walletId: string,
   permissions: Parameters<typeof resolveApiKeyCustodyWalletId>[2],

--- a/apps/sdp-web/src/lib/api-playground-catalog.generated.json
+++ b/apps/sdp-web/src/lib/api-playground-catalog.generated.json
@@ -477,7 +477,7 @@
       {
         "id": "check-wallet-signer",
         "operationId": "checkWalletSigner",
-        "title": "Check signer via memo transaction",
+        "title": "Check signer via simulated memo transaction",
         "method": "POST",
         "path": "/v1/wallets/signer-check",
         "pathFields": [],
@@ -499,8 +499,8 @@
             "feePayer": "So11111111111111111111111111111111111111112",
             "memo": "SDP signer check 123e4567-e89b-42d3-a456-426614174000",
             "signature": "sig_example",
-            "slot": 123456789,
-            "blockTime": "2026-02-20T00:00:00.000Z"
+            "simulated": true,
+            "checkedAt": "2026-02-20T00:00:00.000Z"
           },
           "meta": {
             "requestId": "req_example",
@@ -8303,7 +8303,7 @@
             "description": "Generated from this operation's public OpenAPI request schema.",
             "kind": "textarea",
             "valueType": "json",
-            "defaultValue": "{\n  \"name\": \"Example Token Updated\",\n  \"description\": \"Updated token description.\",\n  \"uri\": \"https://example.com/metadata.json\",\n  \"imageUrl\": \"https://example.com/token.png\",\n  \"status\": \"active\",\n  \"requiresAllowlist\": true,\n  \"maxSupply\": \"1000000\"\n}",
+            "defaultValue": "{\n  \"name\": \"Example Token Updated\",\n  \"description\": \"Updated token description.\",\n  \"uri\": \"https://example.com/metadata.json\",\n  \"imageUrl\": \"https://example.com/token.png\",\n  \"requiresAllowlist\": true,\n  \"maxSupply\": \"1000000\"\n}",
             "required": true
           }
         ],


### PR DESCRIPTION
## What changed

- Resolve signer-check’s existing `walletId` to one exact custody wallet record, revalidate selected API-key permissions, and run runtime admission before signer, Kora, or RPC work.
- Sign through that same record. Preserve retained Connection ambiguity checks so inactive duplicates cannot silently redirect the check to a Config wallet.
- Document additional runtime errors and refresh generated playground examples.

## Why

This prepares signer-check for BYOK by keeping wallet authorization, credentials, and execution tied to the same custody record.

It reuses the shared execution safeguards without enabling BYOK or changing the public wallet selector.

## Impact

- Request and success-response formats remain unchanged: `walletId` is still a Provider wallet ID.
- Existing API-key selection when `walletId` is omitted is preserved.
- No migrations, backfill, new dependencies, feature-flag changes, or Dashboard component changes.
- Invalid selected-key permissions and runtime denials stop the check before external work.

## Pre/post release actions

- Pre: require green CI. No configuration or database changes are needed.
- Post: run **Wallet → Actions → Prove ownership** on an existing wallet; verify Connection-backed execution separately where enabled.
- Rollback: redeploy the previous API image. No database rollback is required; reverting the code also removes these additional checks.

## Result Validation

- After rebasing onto `main`: **95/95 targeted tests passed**, including wallet scope, inactive duplicates, Config compatibility, tenant boundaries, RPC egress/parity, and OpenAPI.
- API typecheck, Biome, module-boundary checks, and playground drift checks passed.
- Local Chrome smoke: **Prove ownership** on an existing Privy wallet showed **“Signer check passed”** and **“Nothing was sent on-chain.”**
- Full API suite before rebase: **5079 passed, 2 failed, 14 skipped**; coverage thresholds passed. Both failures were in unchanged quota tests, which passed **7/7** in isolation. The full suite was not rerun after rebase.

## Does it affect current flows & behavior and how

```text
Before:
walletId → Provider-ID signer lookup alongside Kora/RPC setup
         → sign and simulate

After:
walletId → exact wallet + fresh selected-key permissions
         → ambiguity check → runtime admission
         → same exact signer + Kora/RPC setup
         → sign and simulate
```

The server still creates the memo, verifies the signature, and only simulates the transaction. Nothing is broadcast and no sponsorship is spent. Existing quotas remain unchanged.

## Known gaps

- Connection/BYOK execution has automated coverage but was not exercised in the local live smoke.
- The public Provider-ID selector cannot explicitly choose between duplicate custody records.
- A standalone inactive Connection wallet can return `400 — Custody wallet not found` instead of its former runtime denial.
- Admission checks local eligibility, not provider health or guaranteed signing success.

## Notes

- No policy/Approval flow or durable wallet pin is added to this diagnostic endpoint.
- The guarded RPC transport from `main` is preserved.
- Generated playground changes also refresh pre-existing examples; Issuance runtime behavior is unchanged.