### PR TITLE
fix(docs): stop the link check failing on ngrok's dashboard

### DIFF
--- a/apps/sdp-docs/scripts/link-check.config.json
+++ b/apps/sdp-docs/scripts/link-check.config.json
@@ -1,9 +1,10 @@
 {
   "ignoredExternalHosts": [],
   "ignoredExternalUrls": [
-    "https://api.solana.com/openapi.json",
     "https://api.solana.com/llms.txt",
-    "https://www.sec.gov/newsroom/speeches-statements/corp-fin-statement-tokenized-securities-012826-statement-tokenized-securities",
-    "https://www.anchorage.com/platform/stablecoin-issuance"
+    "https://api.solana.com/openapi.json",
+    "https://dashboard.ngrok.com/domains",
+    "https://www.anchorage.com/platform/stablecoin-issuance",
+    "https://www.sec.gov/newsroom/speeches-statements/corp-fin-statement-tokenized-securities-012826-statement-tokenized-securities"
   ]
 }


### PR DESCRIPTION
Docs Integrity is failing on `main` and on every open PR:

```
Docs link integrity failed:
- External URL check failed for https://dashboard.ngrok.com/domains (fetch failed)
  referenced at apps/sdp-docs/content/docs/self-hosting/first-devnet-deployment.mdx:56
```

`fetch failed` is a network error, not a bad link. The URL answers `302` to its login page from an ordinary client, and two consecutive CI runs failed with the identical message, so ngrok is refusing the runner's requests rather than the page having moved. Rerunning does not clear it.

Added to `ignoredExternalUrls` — the escape hatch already carrying `sec.gov` and `anchorage.com`, which refuse CI probes the same way. The link stays in the self-hosting guide, since it is correct and useful to a human reader.

## The larger point, not fixed here

The check treats a transport failure and an HTTP 404 as the same finding, so any third-party site that throttles or blocks datacenter IPs can block merges repo-wide. This is the second external service to break CI today — the other took down the release gate through an apt mirror. Worth separating the two cases: fail on 4xx/5xx, warn on network errors, or move external probing to a scheduled run and keep PRs to internal links. Left out of this change so it stays a one-line unblock.

## Verification

Ran locally in the same order as CI (`generate:api`, `generate:ai`, then `check:links`):

```
Docs link integrity passed: 55 pages, 268 markdown links, 27 external URLs checked.
```
