### PR TITLE
feat(earn): PRO-1873 address-free positions summary via includeOwnerAddresses=false

### DIFF
--- a/apps/sdp-api/src/openapi/paths/earn.ts
+++ b/apps/sdp-api/src/openapi/paths/earn.ts
@@ -4,6 +4,7 @@ import {
   earnExternalWalletEarningsQuerySchema,
   earnExternalWalletMovementParamsSchema,
   earnExternalWalletMovementsQuerySchema,
+  earnExternalWalletPositionSummaryQuerySchema,
   earnExternalWalletPositionsQuerySchema,
   earnStrategyIdParamsSchema,
   listEarnStrategiesQuerySchema,
@@ -199,7 +200,7 @@ function registerEarnExternalWalletPaths(
       "grouped by strategy and token. The service pages every stored claim before hydration. " +
       "A total is omitted when any contributing live value is unavailable, never reported as zero or partial.",
     security,
-    request: { headers: projectScopeHeaders },
+    request: { headers: projectScopeHeaders, query: earnExternalWalletPositionSummaryQuerySchema },
     responses: {
       200: {
         description: "Complete external-wallet position aggregate",

--- a/apps/sdp-api/src/openapi/schemas/earn.ts
+++ b/apps/sdp-api/src/openapi/schemas/earn.ts
@@ -685,9 +685,15 @@ const earnExternalWalletStrategyTotalSchema = z.object({
     example: "7uib8xGAwkaPz4ZGCA6t8sSEid5Yp9ty13PHUweTypx",
   }),
   label: z.string().openapi({ example: "Allez USDC" }),
-  ownerAddresses: z.array(earnOwnerAddressSchema).openapi({
-    description: "The exact project-scoped owners contributing to this strategy total.",
-  }),
+  ownerAddresses: z
+    .array(earnOwnerAddressSchema)
+    .optional()
+    .openapi({
+      description:
+        "The exact project-scoped owners contributing to this strategy total. Present by default; " +
+        "absent when the request passed `includeOwnerAddresses=false`. This list is the project's " +
+        "end-user address book, so keys that only need totals should opt out.",
+    }),
   walletCount: z.number().int().nonnegative(),
   positionCount: z.number().int().nonnegative(),
   totalsByToken: z.array(earnExternalWalletTokenTotalSchema),

--- a/apps/sdp-api/src/routes/earn.external-wallet-positions.test.ts
+++ b/apps/sdp-api/src/routes/earn.external-wallet-positions.test.ts
@@ -272,6 +272,48 @@ describe("external-wallet position reads", () => {
     expect(summary.data.summary.totalsByToken[0]).not.toHaveProperty("tokenValue");
   });
 
+  it("summary omits every owner address when the caller asks for totals only (EARN-028, PRO-1873)", async () => {
+    await seedPosition({
+      ownerAddress: OWNER_A,
+      vaultAddress: "vault-usdc",
+      tokenMint: USDC,
+      label: "USDC vault",
+    });
+    await seedPosition({
+      ownerAddress: OWNER_B,
+      vaultAddress: "vault-usdc",
+      tokenMint: USDC,
+      label: "USDC vault",
+    });
+
+    const response = await get(
+      "/v1/earn/external-wallet/positions/summary?includeOwnerAddresses=false"
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      data: { summary: { walletCount: number; totalsByStrategy: Array<Record<string, unknown>> } };
+    };
+
+    // Totals survive; the address book does not. Omitted rather than emptied,
+    // so "not requested" can never read as "no owners".
+    expect(body.data.summary.walletCount).toBe(2);
+    expect(body.data.summary.totalsByStrategy).toHaveLength(1);
+    expect(body.data.summary.totalsByStrategy[0]).toMatchObject({
+      walletCount: 2,
+      positionCount: 2,
+    });
+    expect(body.data.summary.totalsByStrategy[0]).not.toHaveProperty("ownerAddresses");
+    expect(JSON.stringify(body)).not.toContain(OWNER_A);
+    expect(JSON.stringify(body)).not.toContain(OWNER_B);
+  });
+
+  it("summary rejects a malformed includeOwnerAddresses rather than guessing", async () => {
+    const response = await get(
+      "/v1/earn/external-wallet/positions/summary?includeOwnerAddresses=maybe"
+    );
+    expect(response.status).toBe(400);
+  });
+
   it("summary excludes a sibling project's positions and never leaks their owner addresses (EARN-028)", async () => {
     // The summary is project-wide, and totalsByStrategy.ownerAddresses returns
     // raw end-user addresses to any earn:read key in the project. Its only

--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -1001,6 +1001,15 @@ owner-signed row can never satisfy
 (`idx_earn_movements_external_wallet_owner`, migration 0073, serves all
 three).
 
+`GET /external-wallet/positions/summary` is the one read on this surface that
+is project-wide rather than per-owner, and its `totalsByStrategy[].ownerAddresses`
+is the project's entire end-user address book (threat model EARN-028): any
+`earn:read` key becomes PII-bearing by calling it. `?includeOwnerAddresses=false`
+omits the list (omitted, never emptied, so "not requested" cannot read as "no
+owners") and keeps `walletCount`; the default stays address-bearing because the
+dashboard drives its per-owner reads off that list (PRO-1873). Partner docs
+steer analytics keys to the opt-out.
+
 The owner is a REQUIRED `?ownerAddress=` query filter on EVERY per-owner read
 (movements, positions, earnings) — one addressing style for one concept, no
 literal segment (`positions/summary`) can collide with a path parameter, and

--- a/apps/sdp-api/src/routes/earn/handlers/external-wallet.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/external-wallet.ts
@@ -132,7 +132,10 @@ const EXTERNAL_POSITION_PAGE_SIZE = 100;
  * plausible-looking partial total.
  */
 export async function getEarnExternalWalletPositionSummary(c: AppContext) {
-  parseQuery(c, earnExternalWalletPositionSummaryQuerySchema);
+  const { includeOwnerAddresses = true } = parseQuery(
+    c,
+    earnExternalWalletPositionSummaryQuerySchema
+  );
   const environment = resolveSdpEnvironment(c);
   const auth = getAuth(c);
   const projectId = requireProjectId(c);
@@ -149,7 +152,7 @@ export async function getEarnExternalWalletPositionSummary(c: AppContext) {
   );
   const holdings = rows.map((row) => requireExternalWalletHolding(row, projectId));
   const live = await hydrateVaultPositions(c, environment, holdings.map(toHydratableHolding));
-  const summary = summarizeExternalWalletPositions(holdings, live);
+  const summary = summarizeExternalWalletPositions(holdings, live, { includeOwnerAddresses });
   if (summary.unavailablePositionCount > 0) {
     getLogger().warn(
       {
@@ -1061,7 +1064,8 @@ interface MutableStrategyTotal {
 
 function summarizeExternalWalletPositions(
   holdings: readonly ExternalWalletHolding[],
-  live: ReadonlyMap<string, HydratedVaultPositionValue>
+  live: ReadonlyMap<string, HydratedVaultPositionValue>,
+  options: { includeOwnerAddresses: boolean } = { includeOwnerAddresses: true }
 ): EarnExternalWalletPositionSummary {
   const owners = new Set<string>();
   const strategies = new Map<string, MutableStrategyTotal>();
@@ -1103,7 +1107,12 @@ function summarizeExternalWalletPositions(
         provider: strategy.provider,
         providerReference: strategy.providerReference,
         label: strategy.label,
-        ownerAddresses: [...strategy.owners].sort(compareWireStrings),
+        // The address list is the PII-bearing half of this read (EARN-028):
+        // omitted, not emptied, when the caller asked for totals only, so a
+        // consumer cannot mistake "not requested" for "no owners".
+        ...(options.includeOwnerAddresses
+          ? { ownerAddresses: [...strategy.owners].sort(compareWireStrings) }
+          : {}),
         walletCount: strategy.owners.size,
         positionCount: strategy.positionCount,
         totalsByToken: [...strategy.tokens.values()].map(finalizeTokenTotal).sort(tokenTotalOrder),

--- a/apps/sdp-api/src/routes/earn/schemas.ts
+++ b/apps/sdp-api/src/routes/earn/schemas.ts
@@ -534,7 +534,21 @@ export const earnExternalWalletPositionsQuerySchema = z
   })
   .strict();
 
-export const earnExternalWalletPositionSummaryQuerySchema = z.object({}).strict();
+/**
+ * `includeOwnerAddresses=false` drops `totalsByStrategy[].ownerAddresses`
+ * (PRO-1873, threat model EARN-028). The default keeps them because the
+ * dashboard drives its per-owner reads off that list; analytics consumers that
+ * need totals should never carry the project's entire end-user address book on
+ * an `earn:read` key.
+ */
+export const earnExternalWalletPositionSummaryQuerySchema = z
+  .object({
+    includeOwnerAddresses: z
+      .enum(["true", "false"])
+      .transform((value) => value === "true")
+      .optional(),
+  })
+  .strict();
 
 /**
  * One external wallet's activity, newest first (PRO-1772). The owner is a

--- a/apps/sdp-docs/content/docs/guides/embedded-yield.mdx
+++ b/apps/sdp-docs/content/docs/guides/embedded-yield.mdx
@@ -200,7 +200,7 @@ The Treasury surface uses SDP's configured paymaster when Earn sponsorship is en
 - `GET /v1/earn/external-wallet/earnings?ownerAddress=…` returns balance and total earned per deposit token. `earned` is stated only when exact; otherwise it is absent with a named `earnedUnavailableReason`. Render a dash for an absent figure, never $0.
 - `GET /v1/earn/external-wallet/movements?ownerAddress=…` is the customer's activity feed, newest first, keyset-paged via `before`.
 - `GET /v1/earn/external-wallet/positions?ownerAddress=…` lists live positions. Page it to completion; a silently short list hides withdrawable money. Read `id` and `withdrawableShares` here to drive withdrawals. If live RPC hydration fails, `shares`, `withdrawableShares`, and `tokenValue` are absent, never zero. Show an unavailable state and disable withdrawal until a fresh read returns the ceiling.
-- `GET /v1/earn/external-wallet/positions/summary` aggregates your whole project across customers, by strategy and token.
+- `GET /v1/earn/external-wallet/positions/summary` aggregates your whole project across customers, by strategy and token. By default each strategy total carries `ownerAddresses`, the full list of your customers' wallet addresses, which makes any `earn:read` key that can call it a holder of personal data. A key that only needs totals should pass `includeOwnerAddresses=false`, which omits the list and leaves `walletCount`; reserve the default for the surface that actually drives per-customer reads.
 
 ## 5. Withdraw
 

--- a/apps/sdp-docs/public/llms-full.txt
+++ b/apps/sdp-docs/public/llms-full.txt
@@ -1090,7 +1090,7 @@ The Treasury surface uses SDP's configured paymaster when Earn sponsorship is en
 - `GET /v1/earn/external-wallet/earnings?ownerAddress=…` returns balance and total earned per deposit token. `earned` is stated only when exact; otherwise it is absent with a named `earnedUnavailableReason`. Render a dash for an absent figure, never $0.
 - `GET /v1/earn/external-wallet/movements?ownerAddress=…` is the customer's activity feed, newest first, keyset-paged via `before`.
 - `GET /v1/earn/external-wallet/positions?ownerAddress=…` lists live positions. Page it to completion; a silently short list hides withdrawable money. Read `id` and `withdrawableShares` here to drive withdrawals. If live RPC hydration fails, `shares`, `withdrawableShares`, and `tokenValue` are absent, never zero. Show an unavailable state and disable withdrawal until a fresh read returns the ceiling.
-- `GET /v1/earn/external-wallet/positions/summary` aggregates your whole project across customers, by strategy and token.
+- `GET /v1/earn/external-wallet/positions/summary` aggregates your whole project across customers, by strategy and token. By default each strategy total carries `ownerAddresses`, the full list of your customers' wallet addresses, which makes any `earn:read` key that can call it a holder of personal data. A key that only needs totals should pass `includeOwnerAddresses=false`, which omits the list and leaves `walletCount`; reserve the default for the surface that actually drives per-customer reads.
 
 ## 5. Withdraw
 

--- a/apps/sdp-web/src/app/dashboard/markets/earn/embedded-yield-dashboard.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/embedded-yield-dashboard.tsx
@@ -136,7 +136,7 @@ function StrategyWalletDrawer({
       refreshing = true;
       try {
         const pages = await Promise.all(
-          currentStrategy.ownerAddresses.map(fetchEarnExternalWalletPositions)
+          (currentStrategy.ownerAddresses ?? []).map(fetchEarnExternalWalletPositions)
         );
         if (!active) return;
         setPositions(

--- a/packages/sdp-types/src/earn.ts
+++ b/packages/sdp-types/src/earn.ts
@@ -356,8 +356,13 @@ export interface EarnExternalWalletStrategyTotal {
   provider: string;
   providerReference: string;
   label: string;
-  /** Exact project-scoped owners contributing to this strategy total. */
-  ownerAddresses: string[];
+  /**
+   * Exact project-scoped owners contributing to this strategy total. Present by
+   * default; ABSENT when the caller passed `includeOwnerAddresses=false`
+   * (PRO-1873). This is the end-user address book of the whole project, so an
+   * analytics consumer that only needs totals should opt out and never hold it.
+   */
+  ownerAddresses?: string[];
   walletCount: number;
   positionCount: number;
   totalsByToken: EarnExternalWalletTokenTotal[];


### PR DESCRIPTION
`GET /v1/earn/external-wallet/positions/summary` hands every end-user wallet address in the project to any `earn:read` key through `totalsByStrategy[].ownerAddresses`, with no wallet-binding narrowing possible on that path. A leaked read-only key enumerates a partner's whole user base ([PRO-1873](https://linear.app/solana-fndn/issue/PRO-1873/threat-model-add-an-address-free-positions-summary-variant), threat model EARN-028). Analytics consumers need totals, not addresses.

**before**: the summary always carried the address list; the only way to get totals was to also hold the address book.

**after**: `?includeOwnerAddresses=false` omits `ownerAddresses` from every strategy total and keeps `walletCount`; a malformed value is a 400, not a guess.

## Reviewer notes

- **Default stays address-bearing, deliberately.** The dashboard drives its per-owner position reads off that list (`embedded-yield-dashboard.tsx`), so flipping the default would break it and every partner already consuming the field. The opt-out is where analytics keys are steered in the partner docs.
- **Omitted, never emptied.** An empty array would read as "no owners"; absence reads as "not requested". The wire type marks the field optional and the one dashboard call site is null-safe.
- Query flag rather than a sibling route: same auth, same scoping, same OpenAPI operation, one new documented parameter.
- Docs artifacts regenerated in the Docs Integrity order (`generate:api` then `generate:ai`).

**Verification**

- 2 new route tests: totals-only response contains neither owner address anywhere in the body, and the malformed flag is rejected
- earn external-wallet route suites and the dashboard unit suite green; `tsc` clean in sdp-api and sdp-web; biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)