### PR TITLE
docs(earn): state how the audit actor is sourced per direction

### DIFF
--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -1093,8 +1093,12 @@ whose second test exhausts both counters and asserts the payout still lands.
 
 Every earn money write also lands a hash-chained `audit_logs` event: action
 `deposit`/`withdraw`, resourceType `earn_movement`, resourceId the movement id,
-actor identical to the movement's `created_by`/`initiated_by_key_id` (passed
-explicitly, so the two records cannot disagree). Helpers live in
+actor matching the movement's `created_by`/`initiated_by_key_id`. The actor is
+sourced by direction: withdrawals read it off the movement row (post-effect,
+the row exists); deposits are admitted before any row exists, so their intent
+carries the request's own auth, the same values the service writes into the
+row. Passed explicitly in both cases so `log()` never falls back to a context
+naming someone else. Helpers live in
 `handlers/movement-audit.ts`; the five seams are the two custody vault routes,
 the two external-wallet submits, and the program withdrawal.
 

--- a/apps/sdp-api/src/routes/earn/handlers/movement-audit.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/movement-audit.ts
@@ -64,8 +64,9 @@ function earnMovementEntry(
 ): AuditLogEntry {
   return {
     organizationId: actor.organizationId,
-    // `log()` falls back to the request context for absent actor fields; the
-    // movement's own values are passed so a mismatch is unrepresentable.
+    // `log()` falls back to the request context for absent actor fields. The
+    // caller passes the actor explicitly (the row's values on a withdrawal, the
+    // request's auth on a deposit, see the header) so that fallback never runs.
     userId: actor.userId ?? undefined,
     apiKeyId: actor.apiKeyId ?? undefined,
     action,

--- a/apps/sdp-api/src/routes/earn/handlers/movement-audit.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/movement-audit.ts
@@ -64,9 +64,12 @@ function earnMovementEntry(
 ): AuditLogEntry {
   return {
     organizationId: actor.organizationId,
-    // `log()` falls back to the request context for absent actor fields. The
-    // caller passes the actor explicitly (the row's values on a withdrawal, the
-    // request's auth on a deposit, see the header) so that fallback never runs.
+    // `log()` falls back to the request context for absent actor fields, and a
+    // null here becomes `undefined`, so that fallback DOES evaluate for a null
+    // user or key. It cannot pick a different actor: the caller passes the
+    // actor explicitly (the row's values on a withdrawal, the request's auth on
+    // a deposit, see the header), and the request contexts are mutually
+    // exclusive, so whatever the fallback finds is the same principal.
     userId: actor.userId ?? undefined,
     apiKeyId: actor.apiKeyId ?? undefined,
     action,

--- a/apps/sdp-api/src/routes/earn/handlers/movement-audit.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/movement-audit.ts
@@ -8,10 +8,16 @@ import type { AppContext } from "../context";
 /**
  * Audit-ledger parity for earn money movements (PRO-1866).
  *
- * Every earn money write lands one hash-chained audit event whose actor is
- * the movement row's own attribution (`created_by`/`initiated_by_key_id`),
- * passed explicitly so the two records cannot disagree: the audit feed and
- * the wire-level movement must name the same key or user.
+ * Every earn money write lands one hash-chained audit event naming the same
+ * actor as its movement row, reached two different ways. WITHDRAWALS read the
+ * actor off the row itself (`created_by`/`initiated_by_key_id`), because the
+ * row exists by the time the post-effect audit is written. DEPOSITS are
+ * admitted BEFORE any movement row exists, so their intent carries the
+ * request's own auth (`auth.userId`/`auth.apiKeyId`), which is exactly what
+ * the service then writes into the row: same source, so the two agree, but
+ * the audit is not copied FROM the row on that path. Passing the values
+ * explicitly in both cases keeps `log()` from falling back to a context that
+ * could name a different actor.
  *
  * The two directions deliberately take different failure postures, the same
  * asymmetry the metered quotas follow (routes/earn/CLAUDE.md):


### PR DESCRIPTION
Docs-only correction to the PRO-1866 audit-ledger prose, found by an adversarial audit of that PR's claims after it merged.

The header of `handlers/movement-audit.ts` and the routes/earn/CLAUDE.md audit section said the actor is "the movement row's own attribution, passed explicitly so the two records cannot disagree" on every seam. That is true for withdrawals and false for deposits: a deposit's intent is written by `beginCritical` before any movement row exists, so it carries the request's `auth.userId`/`auth.apiKeyId`. Those are the same values the service then writes into the row, so the records do agree in practice, but the documented mechanism was wrong, and a reader trusting it would look for a row read that is not there.

No behavior change. Both sites now state the per-direction source and why the values still match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)