### PR TITLE
ci(workflows): 8 API shards, parallel issuance E2E, path-scoped docker/e2e, compose layer cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,10 +208,10 @@ jobs:
               echo "$1=false" >> "$GITHUB_OUTPUT"
             fi
           }
-          detect api '^(apps/sdp-api/|packages/|package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|patches/|turbo\.json|scripts/run-workspace-tests\.mjs|scripts/doppler/|\.github/workflows/ci\.yml)'
-          detect rest '^(apps/|packages/|package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|patches/|turbo\.json|scripts/|\.github/workflows/ci\.yml)'
-          detect e2e '^(apps/sdp-api/|apps/sdp-web/|packages/|package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|patches/|turbo\.json|scripts/|\.github/workflows/ci\.yml)'
-          detect docker '^(apps/|packages/|package\.json|tsconfig\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|patches/|docker-compose(\.ci)?\.yml|\.dockerignore|\.github/workflows/ci\.yml)'
+          detect api '^(apps/sdp-api/|packages/|package\.json|\.npmrc|pnpm-lock\.yaml|pnpm-workspace\.yaml|patches/|turbo\.json|scripts/run-workspace-tests\.mjs|scripts/doppler/|\.github/workflows/ci\.yml)'
+          detect rest '^(apps/|packages/|package\.json|\.npmrc|pnpm-lock\.yaml|pnpm-workspace\.yaml|patches/|turbo\.json|scripts/|\.github/workflows/ci\.yml)'
+          detect e2e '^(apps/sdp-api/|apps/sdp-web/|packages/|package\.json|\.npmrc|pnpm-lock\.yaml|pnpm-workspace\.yaml|patches/|turbo\.json|scripts/|\.github/workflows/ci\.yml)'
+          detect docker '^(apps/|packages/|package\.json|\.npmrc|tsconfig\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|patches/|docker-compose(\.ci)?\.yml|\.dockerignore|\.github/workflows/ci\.yml)'
 
   test:
     name: Unit Tests (api ${{ matrix.shard }}/8)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -897,9 +897,26 @@ jobs:
           - name: Dashboard E2E (Transactions / Surfpool Local)
             test_script: test:e2e:dashboard-transactions
             artifact_suffix: dashboard-transactions-surfpool
-          - name: Issuance E2E (Surfpool Shards)
+          - name: Issuance E2E (basics)
             test_script: kora:surfpool:e2e:issuance
-            artifact_suffix: issuance
+            issuance_group: basics
+            artifact_suffix: issuance-basics
+          - name: Issuance E2E (authority and supply)
+            test_script: kora:surfpool:e2e:issuance
+            issuance_group: authority-and-supply
+            artifact_suffix: issuance-authority-and-supply
+          - name: Issuance E2E (freeze controls)
+            test_script: kora:surfpool:e2e:issuance
+            issuance_group: freeze-controls
+            artifact_suffix: issuance-freeze-controls
+          - name: Issuance E2E (pause controls)
+            test_script: kora:surfpool:e2e:issuance
+            issuance_group: pause-controls
+            artifact_suffix: issuance-pause-controls
+          - name: Issuance E2E (allowlist)
+            test_script: kora:surfpool:e2e:issuance
+            issuance_group: allowlist
+            artifact_suffix: issuance-allowlist
     env:
       CI_HAS_DOPPLER_TOKEN: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       DATABASE_URL: postgresql://sdp:sdp@127.0.0.1:5432/sdp
@@ -1036,7 +1053,7 @@ jobs:
           SOLANA_RPC_CI_PREFERRED_PROVIDER: quicknode
         run: |
           if [ "${{ matrix.test_script }}" = "kora:surfpool:e2e:issuance" ]; then
-            scripts/doppler/run-with-config.sh pnpm ${{ matrix.test_script }}
+            scripts/doppler/run-with-config.sh pnpm ${{ matrix.test_script }} -- ${{ matrix.issuance_group }}
           else
             scripts/doppler/run-with-config.sh pnpm kora:surfpool:run -- pnpm --filter sdp-web run ${{ matrix.test_script }}
           fi
@@ -1055,3 +1072,20 @@ jobs:
             apps/sdp-web/playwright-report
             apps/sdp-web/test-results
           if-no-files-found: ignore
+
+  issuance_e2e:
+    name: Issuance E2E (Surfpool Shards)
+    runs-on: ubuntu-latest
+    needs: [unit_test_scope, browser_e2e]
+    if: always() && needs.unit_test_scope.outputs.e2e == 'true'
+    timeout-minutes: 5
+    steps:
+      - name: Report browser e2e results
+        env:
+          E2E_RESULT: ${{ needs.browser_e2e.result }}
+        run: |
+          if [ "${E2E_RESULT}" != "success" ]; then
+            echo "One or more browser e2e jobs finished with ${E2E_RESULT}." >&2
+            exit 1
+          fi
+          echo "All browser e2e jobs passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1048,7 +1048,7 @@ jobs:
           SOLANA_RPC_CI_PREFERRED_PROVIDER: quicknode
         run: |
           if [ -n "${{ matrix.issuance_group }}" ]; then
-            scripts/doppler/run-with-config.sh pnpm kora:surfpool:e2e:issuance -- ${{ matrix.issuance_group }}
+            scripts/doppler/run-with-config.sh pnpm kora:surfpool:e2e:issuance ${{ matrix.issuance_group }}
           else
             scripts/doppler/run-with-config.sh pnpm kora:surfpool:run -- pnpm --filter sdp-web run ${{ matrix.test_script }}
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1074,13 +1074,20 @@ jobs:
     needs: [unit_test_scope, browser_e2e]
     if: always() && needs.unit_test_scope.outputs.e2e == 'true'
     timeout-minutes: 5
+    permissions:
+      actions: read
     steps:
-      - name: Report browser e2e results
+      - name: Require all five issuance groups green
         env:
-          E2E_RESULT: ${{ needs.browser_e2e.result }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if [ "${E2E_RESULT}" != "success" ]; then
-            echo "One or more browser e2e jobs finished with ${E2E_RESULT}." >&2
+          set -euo pipefail
+          conclusions=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100" \
+            --jq '[.jobs[] | select(.name | test("^Issuance E2E \\((basics|authority and supply|freeze controls|pause controls|allowlist)\\)$")) | .conclusion]')
+          count=$(jq 'length' <<<"${conclusions}")
+          green=$(jq '[.[] | select(. == "success")] | length' <<<"${conclusions}")
+          if [ "${count}" -ne 5 ] || [ "${green}" -ne 5 ]; then
+            echo "Expected 5 successful issuance e2e jobs, found ${green}/${count}: ${conclusions}" >&2
             exit 1
           fi
-          echo "All browser e2e jobs passed."
+          echo "All 5 issuance e2e groups passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,8 @@ jobs:
     outputs:
       api: ${{ steps.detect.outputs.api }}
       rest: ${{ steps.detect.outputs.rest }}
+      e2e: ${{ steps.detect.outputs.e2e }}
+      docker: ${{ steps.detect.outputs.docker }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -194,23 +196,25 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "api=true" >> "$GITHUB_OUTPUT"; echo "rest=true" >> "$GITHUB_OUTPUT"; exit 0
+            for scope in api rest e2e docker; do echo "${scope}=true" >> "$GITHUB_OUTPUT"; done
+            exit 0
           fi
           changed=$(git diff --name-only "origin/${BASE_REF}...HEAD")
           printf '%s\n' "$changed"
-          if printf '%s\n' "$changed" | grep -qE '^(apps/sdp-api/|packages/|pnpm-lock\.yaml|pnpm-workspace\.yaml|turbo\.json|scripts/run-workspace-tests\.mjs|scripts/doppler/|\.github/workflows/ci\.yml)'; then
-            echo "api=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "api=false" >> "$GITHUB_OUTPUT"
-          fi
-          if printf '%s\n' "$changed" | grep -qE '^(apps/|packages/|pnpm-lock\.yaml|pnpm-workspace\.yaml|turbo\.json|scripts/|\.github/workflows/ci\.yml)'; then
-            echo "rest=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "rest=false" >> "$GITHUB_OUTPUT"
-          fi
+          detect() {
+            if printf '%s\n' "$changed" | grep -qE "$2"; then
+              echo "$1=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "$1=false" >> "$GITHUB_OUTPUT"
+            fi
+          }
+          detect api '^(apps/sdp-api/|packages/|package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|patches/|turbo\.json|scripts/run-workspace-tests\.mjs|scripts/doppler/|\.github/workflows/ci\.yml)'
+          detect rest '^(apps/|packages/|package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|patches/|turbo\.json|scripts/|\.github/workflows/ci\.yml)'
+          detect e2e '^(apps/sdp-api/|apps/sdp-web/|packages/|package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|patches/|turbo\.json|scripts/|\.github/workflows/ci\.yml)'
+          detect docker '^(apps/|packages/|package\.json|tsconfig\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|patches/|docker-compose(\.ci)?\.yml|\.dockerignore|\.github/workflows/ci\.yml)'
 
   test:
-    name: Unit Tests (api ${{ matrix.shard }}/4)
+    name: Unit Tests (api ${{ matrix.shard }}/8)
     needs: unit_test_scope
     if: needs.unit_test_scope.outputs.api == 'true'
     runs-on: ubuntu-latest
@@ -221,13 +225,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     env:
       TURBO_CACHE_DIR: ${{ github.workspace }}/.turbo-ci-cache
       CI_HAS_DOPPLER_TOKEN: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       TEST_WORKSPACE_SPLIT: api
       TEST_CHANGED_SINCE: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || '' }}
-      TEST_SHARD: ${{ matrix.shard }}/4
+      TEST_SHARD: ${{ matrix.shard }}/8
       DOPPLER_PRESERVE_ENV: TEST_CHANGED_SINCE,TEST_WORKSPACE_SPLIT,TEST_SHARD
     steps:
       - name: Checkout
@@ -300,7 +304,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:
           name: vitest-api-shard-${{ matrix.shard }}
-          path: apps/sdp-api/.vitest-reports/blob-${{ matrix.shard }}-4.json
+          path: apps/sdp-api/.vitest-reports/blob-${{ matrix.shard }}-8.json
           include-hidden-files: true
           if-no-files-found: error
 
@@ -348,8 +352,8 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p apps/sdp-api/.vitest-reports
-          for shard in 1 2 3 4; do
-            blob="shard-artifacts/vitest-api-shard-${shard}/blob-${shard}-4.json"
+          for shard in 1 2 3 4 5 6 7 8; do
+            blob="shard-artifacts/vitest-api-shard-${shard}/blob-${shard}-8.json"
             if [ ! -f "${blob}" ]; then
               echo "Missing blob report for shard ${shard} (expected ${blob})." >&2
               exit 1
@@ -485,6 +489,8 @@ jobs:
 
   docker_build_api:
     name: Docker Build API
+    needs: unit_test_scope
+    if: needs.unit_test_scope.outputs.docker == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -511,6 +517,8 @@ jobs:
 
   docker_build_docs:
     name: Docker Build Docs
+    needs: unit_test_scope
+    if: needs.unit_test_scope.outputs.docker == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -537,6 +545,8 @@ jobs:
 
   docker_build_web:
     name: Docker Build Web
+    needs: unit_test_scope
+    if: needs.unit_test_scope.outputs.docker == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -565,17 +575,23 @@ jobs:
 
   docker_compose_smoke:
     name: Docker Compose Smoke
+    needs: unit_test_scope
+    if: needs.unit_test_scope.outputs.docker == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_c21va2UubG9jYWwuY2xlcmsuZGV2JA
       CLERK_SECRET_KEY: sk_test_dummy_smoke_for_ci_only
+      COMPOSE_FILE: docker-compose.yml:docker-compose.ci.yml
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Expose GitHub Actions cache to BuildKit
+        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
 
       - name: Build compose stack
         run: docker compose build
@@ -864,6 +880,8 @@ jobs:
 
   browser_e2e:
     name: ${{ matrix.name }}
+    needs: unit_test_scope
+    if: needs.unit_test_scope.outputs.e2e == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -898,23 +898,18 @@ jobs:
             test_script: test:e2e:dashboard-transactions
             artifact_suffix: dashboard-transactions-surfpool
           - name: Issuance E2E (basics)
-            test_script: kora:surfpool:e2e:issuance
             issuance_group: basics
             artifact_suffix: issuance-basics
           - name: Issuance E2E (authority and supply)
-            test_script: kora:surfpool:e2e:issuance
             issuance_group: authority-and-supply
             artifact_suffix: issuance-authority-and-supply
           - name: Issuance E2E (freeze controls)
-            test_script: kora:surfpool:e2e:issuance
             issuance_group: freeze-controls
             artifact_suffix: issuance-freeze-controls
           - name: Issuance E2E (pause controls)
-            test_script: kora:surfpool:e2e:issuance
             issuance_group: pause-controls
             artifact_suffix: issuance-pause-controls
           - name: Issuance E2E (allowlist)
-            test_script: kora:surfpool:e2e:issuance
             issuance_group: allowlist
             artifact_suffix: issuance-allowlist
     env:
@@ -1052,8 +1047,8 @@ jobs:
           DOPPLER_CONFIG: dev_ci
           SOLANA_RPC_CI_PREFERRED_PROVIDER: quicknode
         run: |
-          if [ "${{ matrix.test_script }}" = "kora:surfpool:e2e:issuance" ]; then
-            scripts/doppler/run-with-config.sh pnpm ${{ matrix.test_script }} -- ${{ matrix.issuance_group }}
+          if [ -n "${{ matrix.issuance_group }}" ]; then
+            scripts/doppler/run-with-config.sh pnpm kora:surfpool:e2e:issuance -- ${{ matrix.issuance_group }}
           else
             scripts/doppler/run-with-config.sh pnpm kora:surfpool:run -- pnpm --filter sdp-web run ${{ matrix.test_script }}
           fi

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,19 @@
+# CI-only overlay: share BuildKit layers through the GitHub Actions cache.
+# Requires a docker-container builder and the Actions runtime env (see ci.yml).
+services:
+  sdp-migrate:
+    build:
+      cache_from: [type=gha,scope=sdp-api]
+      cache_to: [type=gha,scope=sdp-api,mode=max]
+  sdp-api:
+    build:
+      cache_from: [type=gha,scope=sdp-api]
+      cache_to: [type=gha,scope=sdp-api,mode=max]
+  sdp-web:
+    build:
+      cache_from: [type=gha,scope=sdp-web]
+      cache_to: [type=gha,scope=sdp-web,mode=max]
+  sdp-docs:
+    build:
+      cache_from: [type=gha,scope=sdp-docs]
+      cache_to: [type=gha,scope=sdp-docs,mode=max]

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -3,17 +3,17 @@
 services:
   sdp-migrate:
     build:
-      cache_from: [type=gha,scope=sdp-api]
-      cache_to: [type=gha,scope=sdp-api,mode=max]
+      cache_from: ["type=gha,scope=sdp-api"]
+      cache_to: ["type=gha,scope=sdp-api,mode=max"]
   sdp-api:
     build:
-      cache_from: [type=gha,scope=sdp-api]
-      cache_to: [type=gha,scope=sdp-api,mode=max]
+      cache_from: ["type=gha,scope=sdp-api"]
+      cache_to: ["type=gha,scope=sdp-api,mode=max"]
   sdp-web:
     build:
-      cache_from: [type=gha,scope=sdp-web]
-      cache_to: [type=gha,scope=sdp-web,mode=max]
+      cache_from: ["type=gha,scope=sdp-web"]
+      cache_to: ["type=gha,scope=sdp-web,mode=max"]
   sdp-docs:
     build:
-      cache_from: [type=gha,scope=sdp-docs]
-      cache_to: [type=gha,scope=sdp-docs,mode=max]
+      cache_from: ["type=gha,scope=sdp-docs"]
+      cache_to: ["type=gha,scope=sdp-docs,mode=max"]

--- a/scripts/kora-surfpool/e2e-issuance.sh
+++ b/scripts/kora-surfpool/e2e-issuance.sh
@@ -1,11 +1,29 @@
 #!/usr/bin/env bash
+# Usage: e2e-issuance.sh [group]  — one group key, or every group in order when omitted.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ALL_GROUPS="basics authority-and-supply freeze-controls pause-controls allowlist"
+
+group_pattern() {
+  case "$1" in
+    basics) echo "\\b(1|2|3|4|5)\\. user" ;;
+    authority-and-supply) echo "\\b(7|9)\\. user" ;;
+    freeze-controls) echo "\\b(8|10|11|12)\\. user" ;;
+    pause-controls) echo "\\b13\\. user" ;;
+    allowlist) echo "\\b6\\. user" ;;
+    *)
+      echo "Unknown issuance E2E group: $1" >&2
+      echo "Valid groups: ${ALL_GROUPS}" >&2
+      exit 2
+      ;;
+  esac
+}
 
 run_shard() {
   local name="$1"
-  local grep="$2"
+  local grep
+  grep="$(group_pattern "${name}")"
 
   echo "Running issuance E2E Surfpool shard: ${name}"
   (
@@ -19,8 +37,8 @@ run_shard() {
   )
 }
 
-run_shard "basics" "\\b(1|2|3|4|5)\\. user"
-run_shard "authority and supply" "\\b(7|9)\\. user"
-run_shard "freeze controls" "\\b(8|10|11|12)\\. user"
-run_shard "pause controls" "\\b13\\. user"
-run_shard "allowlist" "\\b6\\. user"
+if [ "$#" -eq 0 ]; then
+  for group in ${ALL_GROUPS}; do run_shard "${group}"; done
+else
+  run_shard "$1"
+fi


### PR DESCRIPTION
Cuts PR wall time by attacking the three critical paths measured over the last 40 CI runs: the slowest API unit shard (6–11.5 min), the sequential issuance browser E2E job (~5 min), and Docker jobs that rebuilt every image from scratch on every PR.

**Changes**

- **API unit tests: 4 → 8 shards.** Measured 4-shard max was 360–695 s against a ~200 s min; the slow shard moves between runs, so it is runner noise plus file-level split, not one heavy file. Halving the per-shard floor also halves the tail. Same blob-report merge gate, same thresholds enforced once on merged coverage.
- **Issuance browser E2E: 1 job → 5 matrix groups.** `scripts/kora-surfpool/e2e-issuance.sh` takes an optional group key (`basics`, `authority-and-supply`, `freeze-controls`, `pause-controls`, `allowlist`); no arg runs all five in the original order (local behaviour unchanged); unknown key exits 2. A gate job keeps the required check name `Issuance E2E (Surfpool Shards)`.
- **Path scoping for Docker and E2E jobs.** `unit_test_scope` gains `e2e` and `docker` outputs; Docker Build ×3, Docker Compose Smoke and `browser_e2e` are gated on them. Docs-only / workflow-only / `.github` PRs no longer build three images and run five browser suites. Root `package.json`, `.npmrc`, `patches/` added to every pattern (they were missing from the existing `api`/`rest` ones).
- **Compose Smoke uses the GHA layer cache.** `docker-compose.ci.yml` overlay adds `cache_from`/`cache_to type=gha` with the same `scope=sdp-{api,web,docs}` the standalone Docker Build jobs already write; `crazy-max/ghaction-github-runtime` (SHA-pinned) exposes the cache endpoint to BuildKit. Dependency layers hit; only source layers rebuild.

**before** — every PR:

1. 4 API shards; wall = slowest shard, 6–11.5 min.
2. Issuance E2E starts Surfpool + API five times in one job, ~5 min.
3. `docker compose build` rebuilds api/web/docs with no cache (~4.5–5.5 min) while three parallel jobs build the same images with cache.
4. Docs-only PR still waits ~5.5 min for Docker + E2E.

**after**:

1. 8 API shards; expected slowest shard ~3.5–4 min + 0.7 min merge.
2. Five issuance jobs in parallel, each one Surfpool boot + one group; heaviest (`basics`, 5 tests) ~2.5–3 min. Gate job reports the required name.
3. Compose Smoke restores layers from the cache warmed by main pushes and the standalone jobs.
4. Scope job skips Docker + E2E when no `apps/`, `packages/`, lockfile, `patches/`, root config, `scripts/`, Dockerfile or compose input changed; skipped required checks satisfy branch rules exactly as `Unit Tests` already does for non-API PRs.

**Measured on this PR (run 34434001166, worst case: `ci.yml` + compose changed so every job ran)**

| | before (last 40 runs) | after |
|---|---|---|
| wall, PR touching API | 7–12 min | 6.0 min (all jobs forced) |
| slowest API shard | 360–695 s | 275 s |
| issuance E2E | 282–337 s (1 job) | 165–193 s (5 jobs) |
| Docker Compose Smoke | 244–333 s | 250 s (cache warm-up run) |
| compute | 71 min | 70 min (41 jobs) |

Docs-only / workflow-only PRs skip Docker + E2E entirely (~2 min wall, ~15 compute-min).

**Verification**

- `actionlint .github/workflows/ci.yml` — only finding is pre-existing SC2086 in the Typecheck job (line 174), untouched here.
- `docker compose -f docker-compose.yml -f docker-compose.ci.yml config` — merged config carries `cache_from`/`cache_to` on all four build services.
- `scripts/kora-surfpool/e2e-issuance.sh bogus` — exits 2 with the valid-group list; grep patterns byte-identical to `main` (diffed).
- CI on this PR is the real test: it changes `ci.yml` and the compose overlay, so every scoped job runs, including all 8 shards, the merge gate, Compose Smoke with cache, and all 5 issuance groups plus the gate.

**Known gaps / not done**

- The three standalone Docker Build jobs are now redundant with Compose Smoke but are kept: they are required checks in the live ruleset (`SDP required CI checks`), and removing a required check needs an admin ruleset edit. Follow-up once someone with admin edits the ruleset.
- Integration test shards are not path-scoped (not on the critical path; their gate job would need the same skipped-upstream handling).
- Web-touching PRs are now bounded by `next build` inside the Docker image (~4 min). Only a larger runner or moving the smoke to main-only shortens that

