### PR TITLE
feat(payments): one sponsored transaction per payment request per blockhash window

### DIFF
--- a/apps/sdp-api/src/db/migrations/postgres/0092_payment_request_sponsored_signature_cap.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0092_payment_request_sponsored_signature_cap.sql
@@ -1,0 +1,5 @@
+-- Lifetime cap support for sponsored signatures built from the public
+-- Solana Pay endpoint. Authoritative in Postgres deliberately: a Redis-side
+-- counter would reset with the shared Memorystore and silently lift the cap.
+ALTER TABLE payment_requests
+  ADD COLUMN IF NOT EXISTS sponsored_signature_count integer NOT NULL DEFAULT 0;

--- a/apps/sdp-api/src/db/migrations/postgres/0092_payment_request_sponsored_signature_cap.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0092_payment_request_sponsored_signature_cap.sql
@@ -1,5 +1,0 @@
--- Lifetime cap support for sponsored signatures built from the public
--- Solana Pay endpoint. Authoritative in Postgres deliberately: a Redis-side
--- counter would reset with the shared Memorystore and silently lift the cap.
-ALTER TABLE payment_requests
-  ADD COLUMN IF NOT EXISTS sponsored_signature_count integer NOT NULL DEFAULT 0;

--- a/apps/sdp-api/src/db/migrations/postgres/0092_payment_request_sponsored_tx_window.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0092_payment_request_sponsored_tx_window.sql
@@ -1,0 +1,21 @@
+-- One sponsored transaction per payment request per blockhash window, held on
+-- the request row so the claim survives a Redis reset and every instance sees
+-- the same candidate. The claimed account, the unsigned and signed transaction
+-- bytes, and the height the claim expires at travel together: a claim exists
+-- only with an account and an expiry, and signed bytes only for a claim.
+ALTER TABLE payment_requests
+  ADD COLUMN IF NOT EXISTS sponsored_tx_account TEXT,
+  ADD COLUMN IF NOT EXISTS sponsored_tx_unsigned TEXT,
+  ADD COLUMN IF NOT EXISTS sponsored_tx_signed TEXT,
+  ADD COLUMN IF NOT EXISTS sponsored_tx_last_valid_block_height BIGINT,
+  ADD CONSTRAINT payment_requests_sponsored_tx_claim_shape CHECK (
+    (
+      (sponsored_tx_account IS NULL)
+        = (sponsored_tx_unsigned IS NULL)
+    )
+    AND (
+      (sponsored_tx_account IS NULL)
+        = (sponsored_tx_last_valid_block_height IS NULL)
+    )
+    AND (sponsored_tx_signed IS NULL OR sponsored_tx_account IS NOT NULL)
+  );

--- a/apps/sdp-api/src/db/repositories/payment-requests.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/payment-requests.repository.postgres.ts
@@ -163,30 +163,71 @@ export function createPostgresPaymentRequestsRepository(db: AppDb): PaymentReque
       return row ? mapPaymentRequestRow(row) : null;
     },
 
-    async reserveSponsoredSignature(params) {
+    async claimSponsoredTransactionWindow(params) {
       const row = await db
         .prepare(
           `UPDATE payment_requests
-             SET sponsored_signature_count = sponsored_signature_count + 1,
+             SET sponsored_tx_account = ?,
+                 sponsored_tx_unsigned = ?,
+                 sponsored_tx_signed = NULL,
+                 sponsored_tx_last_valid_block_height = ?,
                  updated_at = sdp_iso_now()
            WHERE id = ?
-             AND sponsored_signature_count < ?
+             AND status = 'awaiting_payment'
+             AND (
+               sponsored_tx_last_valid_block_height IS NULL
+               OR sponsored_tx_last_valid_block_height < ?
+             )
            RETURNING id`
         )
-        .bind(params.requestId, params.cap)
+        .bind(
+          params.account,
+          params.unsignedTransaction,
+          params.lastValidBlockHeight.toString(),
+          params.requestId,
+          params.currentBlockHeight.toString()
+        )
         .first<{ id: string }>();
       return row !== null;
     },
 
-    async releaseSponsoredSignature(requestId) {
+    async getSponsoredTransactionClaim(requestId) {
+      const row = await db
+        .prepare(
+          `SELECT sponsored_tx_account, sponsored_tx_unsigned, sponsored_tx_signed,
+                  sponsored_tx_last_valid_block_height
+             FROM payment_requests
+            WHERE id = ?`
+        )
+        .bind(requestId)
+        .first<{
+          sponsored_tx_account: string | null;
+          sponsored_tx_unsigned: string | null;
+          sponsored_tx_signed: string | null;
+          sponsored_tx_last_valid_block_height: string | number | null;
+        }>();
+      if (!row || row.sponsored_tx_account === null) {
+        return null;
+      }
+      if (row.sponsored_tx_unsigned === null || row.sponsored_tx_last_valid_block_height === null) {
+        throw internalError("payment_requests sponsored claim row is missing claim fields");
+      }
+      return {
+        account: row.sponsored_tx_account,
+        unsignedTransaction: row.sponsored_tx_unsigned,
+        signedTransaction: row.sponsored_tx_signed,
+        lastValidBlockHeight: BigInt(row.sponsored_tx_last_valid_block_height),
+      };
+    },
+
+    async storeSponsoredTransactionSignature(params) {
       await db
         .prepare(
           `UPDATE payment_requests
-             SET sponsored_signature_count = GREATEST(sponsored_signature_count - 1, 0),
-                 updated_at = sdp_iso_now()
-           WHERE id = ?`
+             SET sponsored_tx_signed = ?, updated_at = sdp_iso_now()
+           WHERE id = ? AND sponsored_tx_account = ?`
         )
-        .bind(requestId)
+        .bind(params.signedTransaction, params.requestId, params.account)
         .run();
     },
 

--- a/apps/sdp-api/src/db/repositories/payment-requests.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/payment-requests.repository.postgres.ts
@@ -163,6 +163,21 @@ export function createPostgresPaymentRequestsRepository(db: AppDb): PaymentReque
       return row ? mapPaymentRequestRow(row) : null;
     },
 
+    async reserveSponsoredSignature(params) {
+      const row = await db
+        .prepare(
+          `UPDATE payment_requests
+             SET sponsored_signature_count = sponsored_signature_count + 1,
+                 updated_at = sdp_iso_now()
+           WHERE id = ?
+             AND sponsored_signature_count < ?
+           RETURNING id`
+        )
+        .bind(params.requestId, params.cap)
+        .first<{ id: string }>();
+      return row !== null;
+    },
+
     async getPaymentRequestByPublicToken(publicToken) {
       const row = await db
         .prepare(`SELECT * FROM payment_requests WHERE public_token = ?`)

--- a/apps/sdp-api/src/db/repositories/payment-requests.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/payment-requests.repository.postgres.ts
@@ -178,6 +178,18 @@ export function createPostgresPaymentRequestsRepository(db: AppDb): PaymentReque
       return row !== null;
     },
 
+    async releaseSponsoredSignature(requestId) {
+      await db
+        .prepare(
+          `UPDATE payment_requests
+             SET sponsored_signature_count = GREATEST(sponsored_signature_count - 1, 0),
+                 updated_at = sdp_iso_now()
+           WHERE id = ?`
+        )
+        .bind(requestId)
+        .run();
+    },
+
     async getPaymentRequestByPublicToken(publicToken) {
       const row = await db
         .prepare(`SELECT * FROM payment_requests WHERE public_token = ?`)

--- a/apps/sdp-api/src/db/repositories/payment-requests.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/payment-requests.repository.test.ts
@@ -408,29 +408,116 @@ describe("PaymentRequestsRepository (postgres)", () => {
     });
   });
 
-  describe("reserveSponsoredSignature", () => {
-    it("admits up to the cap and refuses after", async () => {
+  describe("sponsored transaction window", () => {
+    const ACCOUNT_A = "9wVmMF2GpxZMsJLxCv2xXWjDWVv8HtqTmKqnZxNKkYTz";
+    const ACCOUNT_B = "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJfhRhPkV";
+
+    it("admits exactly one of two concurrent claims", async () => {
       const request = await repo.createPaymentRequest(createInput());
-
-      expect(await repo.reserveSponsoredSignature({ requestId: request.id, cap: 2 })).toBe(true);
-      expect(await repo.reserveSponsoredSignature({ requestId: request.id, cap: 2 })).toBe(true);
-      expect(await repo.reserveSponsoredSignature({ requestId: request.id, cap: 2 })).toBe(false);
-    });
-
-    it("admits exactly one of two concurrent reservations at cap 1", async () => {
-      const request = await repo.createPaymentRequest(createInput());
-
       const results = await Promise.all([
-        repo.reserveSponsoredSignature({ requestId: request.id, cap: 1 }),
-        repo.reserveSponsoredSignature({ requestId: request.id, cap: 1 }),
+        repo.claimSponsoredTransactionWindow({
+          requestId: request.id,
+          account: ACCOUNT_A,
+          unsignedTransaction: "dHhB",
+          lastValidBlockHeight: 1_000n,
+          currentBlockHeight: 900n,
+        }),
+        repo.claimSponsoredTransactionWindow({
+          requestId: request.id,
+          account: ACCOUNT_B,
+          unsignedTransaction: "dHhC",
+          lastValidBlockHeight: 1_000n,
+          currentBlockHeight: 900n,
+        }),
       ]);
       expect(results.filter(Boolean)).toHaveLength(1);
+
+      const claim = await repo.getSponsoredTransactionClaim(request.id);
+      expect(claim).not.toBeNull();
+      expect([ACCOUNT_A, ACCOUNT_B]).toContain(claim?.account);
+      expect(claim?.signedTransaction).toBeNull();
+      expect(claim?.lastValidBlockHeight).toBe(1_000n);
     });
 
-    it("returns false for an unknown request id", async () => {
-      expect(await repo.reserveSponsoredSignature({ requestId: "preq_missing", cap: 5 })).toBe(
-        false
+    it("refuses a reclaim while the window is live and admits one after expiry", async () => {
+      const request = await repo.createPaymentRequest(createInput());
+      expect(
+        await repo.claimSponsoredTransactionWindow({
+          requestId: request.id,
+          account: ACCOUNT_A,
+          unsignedTransaction: "dHhB",
+          lastValidBlockHeight: 1_000n,
+          currentBlockHeight: 900n,
+        })
+      ).toBe(true);
+      expect(
+        await repo.claimSponsoredTransactionWindow({
+          requestId: request.id,
+          account: ACCOUNT_B,
+          unsignedTransaction: "dHhC",
+          lastValidBlockHeight: 1_100n,
+          currentBlockHeight: 950n,
+        })
+      ).toBe(false);
+      expect(
+        await repo.claimSponsoredTransactionWindow({
+          requestId: request.id,
+          account: ACCOUNT_B,
+          unsignedTransaction: "dHhC",
+          lastValidBlockHeight: 1_200n,
+          currentBlockHeight: 1_001n,
+        })
+      ).toBe(true);
+      const claim = await repo.getSponsoredTransactionClaim(request.id);
+      expect(claim?.account).toBe(ACCOUNT_B);
+      expect(claim?.signedTransaction).toBeNull();
+    });
+
+    it("stores the signature for the claiming account only", async () => {
+      const request = await repo.createPaymentRequest(createInput());
+      await repo.claimSponsoredTransactionWindow({
+        requestId: request.id,
+        account: ACCOUNT_A,
+        unsignedTransaction: "dHhB",
+        lastValidBlockHeight: 1_000n,
+        currentBlockHeight: 900n,
+      });
+      await repo.storeSponsoredTransactionSignature({
+        requestId: request.id,
+        account: ACCOUNT_B,
+        signedTransaction: "c2lnQg==",
+      });
+      expect((await repo.getSponsoredTransactionClaim(request.id))?.signedTransaction).toBeNull();
+
+      await repo.storeSponsoredTransactionSignature({
+        requestId: request.id,
+        account: ACCOUNT_A,
+        signedTransaction: "c2lnQQ==",
+      });
+      expect((await repo.getSponsoredTransactionClaim(request.id))?.signedTransaction).toBe(
+        "c2lnQQ=="
       );
+    });
+
+    it("refuses a claim on a request that is not awaiting payment", async () => {
+      const request = await repo.createPaymentRequest(createInput());
+      await repo.markPaymentRequest({
+        requestId: request.id,
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        status: "canceled",
+        fulfilledByTransferId: null,
+        canceledBy: TEST_USER.id,
+      });
+      expect(
+        await repo.claimSponsoredTransactionWindow({
+          requestId: request.id,
+          account: ACCOUNT_A,
+          unsignedTransaction: "dHhB",
+          lastValidBlockHeight: 1_000n,
+          currentBlockHeight: 900n,
+        })
+      ).toBe(false);
     });
   });
 });

--- a/apps/sdp-api/src/db/repositories/payment-requests.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/payment-requests.repository.test.ts
@@ -407,4 +407,30 @@ describe("PaymentRequestsRepository (postgres)", () => {
       expect(result).toBeNull();
     });
   });
+
+  describe("reserveSponsoredSignature", () => {
+    it("admits up to the cap and refuses after", async () => {
+      const request = await repo.createPaymentRequest(createInput());
+
+      expect(await repo.reserveSponsoredSignature({ requestId: request.id, cap: 2 })).toBe(true);
+      expect(await repo.reserveSponsoredSignature({ requestId: request.id, cap: 2 })).toBe(true);
+      expect(await repo.reserveSponsoredSignature({ requestId: request.id, cap: 2 })).toBe(false);
+    });
+
+    it("admits exactly one of two concurrent reservations at cap 1", async () => {
+      const request = await repo.createPaymentRequest(createInput());
+
+      const results = await Promise.all([
+        repo.reserveSponsoredSignature({ requestId: request.id, cap: 1 }),
+        repo.reserveSponsoredSignature({ requestId: request.id, cap: 1 }),
+      ]);
+      expect(results.filter(Boolean)).toHaveLength(1);
+    });
+
+    it("returns false for an unknown request id", async () => {
+      expect(await repo.reserveSponsoredSignature({ requestId: "preq_missing", cap: 5 })).toBe(
+        false
+      );
+    });
+  });
 });

--- a/apps/sdp-api/src/db/repositories/payment-requests.repository.ts
+++ b/apps/sdp-api/src/db/repositories/payment-requests.repository.ts
@@ -85,5 +85,6 @@ export interface PaymentRequestsRepository {
     projectId: string;
   }): Promise<PaymentRequestRow | null>;
   getPaymentRequestByPublicToken(publicToken: string): Promise<PaymentRequestRow | null>;
+  reserveSponsoredSignature(params: { requestId: string; cap: number }): Promise<boolean>;
   listPaymentRequests(params: ListPaymentRequestsInput): Promise<ListPaymentRequestsResult>;
 }

--- a/apps/sdp-api/src/db/repositories/payment-requests.repository.ts
+++ b/apps/sdp-api/src/db/repositories/payment-requests.repository.ts
@@ -76,6 +76,13 @@ export interface ListPaymentRequestsResult {
   total: number;
 }
 
+export interface SponsoredTransactionClaim {
+  account: string;
+  unsignedTransaction: string;
+  signedTransaction: string | null;
+  lastValidBlockHeight: bigint;
+}
+
 export interface PaymentRequestsRepository {
   createPaymentRequest(input: CreatePaymentRequestInput): Promise<PaymentRequestRow>;
   markPaymentRequest(input: MarkPaymentRequestInput): Promise<PaymentRequestRow | null>;
@@ -85,7 +92,18 @@ export interface PaymentRequestsRepository {
     projectId: string;
   }): Promise<PaymentRequestRow | null>;
   getPaymentRequestByPublicToken(publicToken: string): Promise<PaymentRequestRow | null>;
-  reserveSponsoredSignature(params: { requestId: string; cap: number }): Promise<boolean>;
-  releaseSponsoredSignature(requestId: string): Promise<void>;
+  claimSponsoredTransactionWindow(params: {
+    requestId: string;
+    account: string;
+    unsignedTransaction: string;
+    lastValidBlockHeight: bigint;
+    currentBlockHeight: bigint;
+  }): Promise<boolean>;
+  getSponsoredTransactionClaim(requestId: string): Promise<SponsoredTransactionClaim | null>;
+  storeSponsoredTransactionSignature(params: {
+    requestId: string;
+    account: string;
+    signedTransaction: string;
+  }): Promise<void>;
   listPaymentRequests(params: ListPaymentRequestsInput): Promise<ListPaymentRequestsResult>;
 }

--- a/apps/sdp-api/src/db/repositories/payment-requests.repository.ts
+++ b/apps/sdp-api/src/db/repositories/payment-requests.repository.ts
@@ -86,5 +86,6 @@ export interface PaymentRequestsRepository {
   }): Promise<PaymentRequestRow | null>;
   getPaymentRequestByPublicToken(publicToken: string): Promise<PaymentRequestRow | null>;
   reserveSponsoredSignature(params: { requestId: string; cap: number }): Promise<boolean>;
+  releaseSponsoredSignature(requestId: string): Promise<void>;
   listPaymentRequests(params: ListPaymentRequestsInput): Promise<ListPaymentRequestsResult>;
 }

--- a/apps/sdp-api/src/db/repositories/repository-factory.ts
+++ b/apps/sdp-api/src/db/repositories/repository-factory.ts
@@ -132,7 +132,12 @@ export function createPaymentRequestsRepository(
     createPostgresPaymentRequestsRepository(getDb(env)),
     scope,
     "PaymentRequestsRepository",
-    ["getPaymentRequestByPublicToken", "reserveSponsoredSignature"]
+    [
+      "getPaymentRequestByPublicToken",
+      "claimSponsoredTransactionWindow",
+      "getSponsoredTransactionClaim",
+      "storeSponsoredTransactionSignature",
+    ]
   );
 }
 

--- a/apps/sdp-api/src/db/repositories/repository-factory.ts
+++ b/apps/sdp-api/src/db/repositories/repository-factory.ts
@@ -132,7 +132,7 @@ export function createPaymentRequestsRepository(
     createPostgresPaymentRequestsRepository(getDb(env)),
     scope,
     "PaymentRequestsRepository",
-    ["getPaymentRequestByPublicToken"]
+    ["getPaymentRequestByPublicToken", "reserveSponsoredSignature"]
   );
 }
 

--- a/apps/sdp-api/src/routes/pay.test.ts
+++ b/apps/sdp-api/src/routes/pay.test.ts
@@ -134,13 +134,13 @@ describe("Public payment request routes", () => {
       expect(sponsorship).toHaveBeenCalledTimes(5);
     });
 
-    it("does not return the counter slot when signing fails", async () => {
+    it("returns the counter slot when no sponsored signature was produced", async () => {
       const sponsorship = stubSponsorship();
       sponsorship.mockRejectedValueOnce(new Error("provider down"));
       const request = await createAwaitingPaymentRequest();
 
       expect((await postTransaction(request.public_token)).status).toBe(500);
-      for (let i = 0; i < 4; i++) {
+      for (let i = 0; i < 5; i++) {
         expect((await postTransaction(request.public_token)).status).toBe(200);
       }
       expect((await postTransaction(request.public_token)).status).toBe(429);

--- a/apps/sdp-api/src/routes/pay.test.ts
+++ b/apps/sdp-api/src/routes/pay.test.ts
@@ -157,6 +157,49 @@ describe("Public payment request routes", () => {
       expect((await postTransaction(request.public_token)).status).toBe(429);
     });
 
+    it("does not spend a sponsored slot on a payload it cannot build a transaction from", async () => {
+      const sponsorship = stubSponsorship();
+      const request = await createAwaitingPaymentRequest();
+
+      for (let i = 0; i < 5; i++) {
+        const malformed = await app.request(
+          `/pay/${request.public_token}/tx`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ account: "not-a-solana-address" }),
+          },
+          env
+        );
+        expect(malformed.status).toBe(400);
+      }
+      expect(sponsorship).not.toHaveBeenCalled();
+
+      // The payer still has the full budget.
+      expect((await postTransaction(request.public_token)).status).toBe(200);
+    });
+
+    it("does not spend a sponsored slot on a payload it cannot build a transaction from", async () => {
+      const sponsorship = stubSponsorship();
+      const request = await createAwaitingPaymentRequest();
+
+      for (let i = 0; i < 5; i++) {
+        const malformed = await app.request(
+          `/pay/${request.public_token}/tx`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ account: "not-a-solana-address" }),
+          },
+          env
+        );
+        expect(malformed.status).toBe(400);
+      }
+      expect(sponsorship).not.toHaveBeenCalled();
+
+      expect((await postTransaction(request.public_token)).status).toBe(200);
+    });
+
     it("rate limits per payment token before touching the database counter", async () => {
       const spy = vi.spyOn(rateLimit, "enforceRateLimit");
       stubSponsorship();

--- a/apps/sdp-api/src/routes/pay.test.ts
+++ b/apps/sdp-api/src/routes/pay.test.ts
@@ -115,97 +115,105 @@ describe("Public payment request routes", () => {
     expect(getRecentBlockhashMock).not.toHaveBeenCalled();
   });
 
-  describe("sponsored signature cap", () => {
+  describe("sponsored transaction window", () => {
     beforeEach(() => {
       createRpcMock.mockReturnValue({
         getSignaturesForAddress: () => ({ send: async () => [] }),
+        getBlockHeight: () => ({ send: async () => 900n }),
       } as unknown as ReturnType<typeof solanaRpc.createRpc>);
     });
-    it("serves the cap then returns 429 and stops calling the sponsorship service", async () => {
+
+    it("signs once per window and replays the stored transaction for the same account", async () => {
       const sponsorship = stubSponsorship();
       const request = await createAwaitingPaymentRequest();
 
-      for (let i = 0; i < 5; i++) {
-        expect((await postTransaction(request.public_token)).status).toBe(200);
-      }
-      const refused = await postTransaction(request.public_token);
-      expect(refused.status).toBe(429);
-      await expect(refused.json()).resolves.toMatchObject({ error: { code: "RATE_LIMITED" } });
-      expect(sponsorship).toHaveBeenCalledTimes(5);
+      const first = await postTransaction(request.public_token);
+      expect(first.status).toBe(200);
+      const firstBody = (await first.json()) as { transaction: string };
+
+      const second = await postTransaction(request.public_token);
+      expect(second.status).toBe(200);
+      const secondBody = (await second.json()) as { transaction: string };
+
+      expect(secondBody.transaction).toBe(firstBody.transaction);
+      expect(sponsorship).toHaveBeenCalledTimes(1);
     });
 
-    it("keeps the slot spent when signing may have produced a signature", async () => {
+    it("answers a different account with 429 and Retry-After while the claim is live", async () => {
+      stubSponsorship();
       const request = await createAwaitingPaymentRequest();
-      vi.spyOn(sponsorshipService, "createProjectSponsorshipFeePayment").mockImplementation(
-        async () => ({
-          providerId: "test",
-          getFeePayer: async () => address(TEST_KORA_FEE_PAYER),
-          signAsFeePayer: () => Promise.reject(new Error("signing timed out")),
-          signAndSend: () => Promise.reject(new Error("not used")),
-          prepareOwnedSubmission: () => Promise.reject(new Error("not used")),
-        })
+      expect((await postTransaction(request.public_token)).status).toBe(200);
+
+      const other = await app.request(
+        `/pay/${request.public_token}/tx`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ account: TEST_SOLANA_ADDRESSES.wallet3 }),
+        },
+        env
       );
-
-      expect((await postTransaction(request.public_token)).status).toBe(500);
-
-      stubSponsorship();
-      for (let i = 0; i < 4; i++) {
-        expect((await postTransaction(request.public_token)).status).toBe(200);
-      }
-      expect((await postTransaction(request.public_token)).status).toBe(429);
+      expect(other.status).toBe(429);
+      expect(Number(other.headers.get("Retry-After"))).toBeGreaterThan(0);
     });
 
-    it("returns the counter slot when the request fails before signing", async () => {
-      const sponsorship = stubSponsorship();
-      sponsorship.mockRejectedValueOnce(new Error("provider down"));
-      const request = await createAwaitingPaymentRequest();
-
-      expect((await postTransaction(request.public_token)).status).toBe(500);
-      for (let i = 0; i < 5; i++) {
-        expect((await postTransaction(request.public_token)).status).toBe(200);
-      }
-      expect((await postTransaction(request.public_token)).status).toBe(429);
-    });
-
-    it("enforces the cap when the rate-limit store admits everything", async () => {
-      vi.spyOn(rateLimit, "enforceRateLimit").mockResolvedValue();
-      stubSponsorship();
-      const request = await createAwaitingPaymentRequest();
-
-      for (let i = 0; i < 5; i++) {
-        expect((await postTransaction(request.public_token)).status).toBe(200);
-      }
-      expect((await postTransaction(request.public_token)).status).toBe(429);
-    });
-
-    it("does not spend a sponsored slot on a payload it cannot build a transaction from", async () => {
+    it("lets a new account claim after the window expires", async () => {
       const sponsorship = stubSponsorship();
       const request = await createAwaitingPaymentRequest();
+      expect((await postTransaction(request.public_token)).status).toBe(200);
 
-      for (let i = 0; i < 5; i++) {
-        const malformed = await app.request(
-          `/pay/${request.public_token}/tx`,
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ account: "not-a-solana-address" }),
-          },
-          env
-        );
-        expect(malformed.status).toBe(400);
-      }
+      createRpcMock.mockReturnValue({
+        getSignaturesForAddress: () => ({ send: async () => [] }),
+        getBlockHeight: () => ({ send: async () => 2_000n }),
+      } as unknown as ReturnType<typeof solanaRpc.createRpc>);
+
+      const other = await app.request(
+        `/pay/${request.public_token}/tx`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ account: TEST_SOLANA_ADDRESSES.wallet3 }),
+        },
+        env
+      );
+      expect(other.status).toBe(200);
+      expect(sponsorship).toHaveBeenCalledTimes(2);
+    });
+
+    it("keeps the claim when signing fails and signs the stored bytes on retry", async () => {
+      const sponsorship = stubSponsorship();
+      sponsorship.mockImplementationOnce(async () => ({
+        providerId: "test",
+        getFeePayer: async () => address(TEST_KORA_FEE_PAYER),
+        signAsFeePayer: () => Promise.reject(new Error("signing timed out")),
+        signAndSend: () => Promise.reject(new Error("not used")),
+        prepareOwnedSubmission: () => Promise.reject(new Error("not used")),
+      }));
+      const request = await createAwaitingPaymentRequest();
+
+      expect((await postTransaction(request.public_token)).status).toBe(500);
+      const retried = await postTransaction(request.public_token);
+      expect(retried.status).toBe(200);
+      expect(sponsorship).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not open a claim for a payload it cannot build a transaction from", async () => {
+      const sponsorship = stubSponsorship();
+      const request = await createAwaitingPaymentRequest();
+
+      const malformed = await app.request(
+        `/pay/${request.public_token}/tx`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ account: "not-a-solana-address" }),
+        },
+        env
+      );
+      expect(malformed.status).toBe(400);
       expect(sponsorship).not.toHaveBeenCalled();
 
       expect((await postTransaction(request.public_token)).status).toBe(200);
-    });
-
-    it("rate limits per payment token before touching the database counter", async () => {
-      const spy = vi.spyOn(rateLimit, "enforceRateLimit");
-      stubSponsorship();
-      const request = await createAwaitingPaymentRequest();
-
-      await postTransaction(request.public_token);
-      expect(spy).toHaveBeenCalledWith(expect.anything(), `pay-tx:${request.public_token}`, 10);
     });
   });
 });

--- a/apps/sdp-api/src/routes/pay.test.ts
+++ b/apps/sdp-api/src/routes/pay.test.ts
@@ -175,28 +175,6 @@ describe("Public payment request routes", () => {
       }
       expect(sponsorship).not.toHaveBeenCalled();
 
-      // The payer still has the full budget.
-      expect((await postTransaction(request.public_token)).status).toBe(200);
-    });
-
-    it("does not spend a sponsored slot on a payload it cannot build a transaction from", async () => {
-      const sponsorship = stubSponsorship();
-      const request = await createAwaitingPaymentRequest();
-
-      for (let i = 0; i < 5; i++) {
-        const malformed = await app.request(
-          `/pay/${request.public_token}/tx`,
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ account: "not-a-solana-address" }),
-          },
-          env
-        );
-        expect(malformed.status).toBe(400);
-      }
-      expect(sponsorship).not.toHaveBeenCalled();
-
       expect((await postTransaction(request.public_token)).status).toBe(200);
     });
 

--- a/apps/sdp-api/src/routes/pay.test.ts
+++ b/apps/sdp-api/src/routes/pay.test.ts
@@ -134,7 +134,28 @@ describe("Public payment request routes", () => {
       expect(sponsorship).toHaveBeenCalledTimes(5);
     });
 
-    it("returns the counter slot when no sponsored signature was produced", async () => {
+    it("keeps the slot spent when signing may have produced a signature", async () => {
+      const request = await createAwaitingPaymentRequest();
+      vi.spyOn(sponsorshipService, "createProjectSponsorshipFeePayment").mockImplementation(
+        async () => ({
+          providerId: "test",
+          getFeePayer: async () => address(TEST_KORA_FEE_PAYER),
+          signAsFeePayer: () => Promise.reject(new Error("signing timed out")),
+          signAndSend: () => Promise.reject(new Error("not used")),
+          prepareOwnedSubmission: () => Promise.reject(new Error("not used")),
+        })
+      );
+
+      expect((await postTransaction(request.public_token)).status).toBe(500);
+
+      stubSponsorship();
+      for (let i = 0; i < 4; i++) {
+        expect((await postTransaction(request.public_token)).status).toBe(200);
+      }
+      expect((await postTransaction(request.public_token)).status).toBe(429);
+    });
+
+    it("returns the counter slot when the request fails before signing", async () => {
       const sponsorship = stubSponsorship();
       sponsorship.mockRejectedValueOnce(new Error("provider down"));
       const request = await createAwaitingPaymentRequest();

--- a/apps/sdp-api/src/routes/pay.test.ts
+++ b/apps/sdp-api/src/routes/pay.test.ts
@@ -1,16 +1,22 @@
+import type * as solanaRpc from "@sdp/rpc/solana";
 import { SOL_MINT } from "@sdp/types";
-import { describe, expect, it } from "vitest";
+import { address } from "@solana/kit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
 import { createPaymentRequestsRepository } from "@/db/repositories/repository-factory";
 import app from "@/index";
 import { createTenantScope } from "@/lib/tenant-scope";
+import * as rateLimit from "@/middleware/rate-limit";
+import * as sponsorshipService from "@/services/sponsorship.service";
 import { TEST_SOLANA_ADDRESSES } from "@/test/fixtures/tokens";
 import { env } from "@/test/helpers/env";
 import {
   createFeePaymentAdapterMock,
+  createRpcMock,
   getRecentBlockhashMock,
   installPaymentsRouteTestHooks,
   TEST_CUSTODY_WALLET_ID,
+  TEST_KORA_FEE_PAYER,
   TEST_ORG,
   TEST_PROJECT,
   TEST_USER,
@@ -19,6 +25,48 @@ import {
 
 describe("Public payment request routes", () => {
   installPaymentsRouteTestHooks();
+
+  function createAwaitingPaymentRequest() {
+    return createPaymentRequestsRepository(
+      env,
+      createTenantScope({ organizationId: TEST_ORG.id, projectId: TEST_PROJECT.id })
+    ).createPaymentRequest({
+      organizationId: TEST_ORG.id,
+      projectId: TEST_PROJECT.id,
+      counterpartyId: null,
+      custodyWalletId: TEST_CUSTODY_WALLET_ID,
+      walletId: TEST_WALLET_ID,
+      destinationAddress: TEST_SOLANA_ADDRESSES.wallet1,
+      token: SOL_MINT,
+      amount: "1.5",
+      expiresAt: null,
+      createdBy: TEST_USER.id,
+    });
+  }
+
+  function postTransaction(publicToken: string) {
+    return app.request(
+      `/pay/${publicToken}/tx`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ account: TEST_SOLANA_ADDRESSES.wallet2 }),
+      },
+      env
+    );
+  }
+
+  function stubSponsorship() {
+    return vi
+      .spyOn(sponsorshipService, "createProjectSponsorshipFeePayment")
+      .mockImplementation(async () => ({
+        providerId: "test",
+        getFeePayer: async () => address(TEST_KORA_FEE_PAYER),
+        signAsFeePayer: async (transaction: Uint8Array) => transaction,
+        signAndSend: () => Promise.reject(new Error("not used")),
+        prepareOwnedSubmission: () => Promise.reject(new Error("not used")),
+      }));
+  }
 
   it("keeps an unresolved legacy request readable but refuses to build its transaction", async () => {
     const request = await createPaymentRequestsRepository(
@@ -65,5 +113,57 @@ describe("Public payment request routes", () => {
     });
     expect(createFeePaymentAdapterMock).not.toHaveBeenCalled();
     expect(getRecentBlockhashMock).not.toHaveBeenCalled();
+  });
+
+  describe("sponsored signature cap", () => {
+    beforeEach(() => {
+      createRpcMock.mockReturnValue({
+        getSignaturesForAddress: () => ({ send: async () => [] }),
+      } as unknown as ReturnType<typeof solanaRpc.createRpc>);
+    });
+    it("serves the cap then returns 429 and stops calling the sponsorship service", async () => {
+      const sponsorship = stubSponsorship();
+      const request = await createAwaitingPaymentRequest();
+
+      for (let i = 0; i < 5; i++) {
+        expect((await postTransaction(request.public_token)).status).toBe(200);
+      }
+      const refused = await postTransaction(request.public_token);
+      expect(refused.status).toBe(429);
+      await expect(refused.json()).resolves.toMatchObject({ error: { code: "RATE_LIMITED" } });
+      expect(sponsorship).toHaveBeenCalledTimes(5);
+    });
+
+    it("does not return the counter slot when signing fails", async () => {
+      const sponsorship = stubSponsorship();
+      sponsorship.mockRejectedValueOnce(new Error("provider down"));
+      const request = await createAwaitingPaymentRequest();
+
+      expect((await postTransaction(request.public_token)).status).toBe(500);
+      for (let i = 0; i < 4; i++) {
+        expect((await postTransaction(request.public_token)).status).toBe(200);
+      }
+      expect((await postTransaction(request.public_token)).status).toBe(429);
+    });
+
+    it("enforces the cap when the rate-limit store admits everything", async () => {
+      vi.spyOn(rateLimit, "enforceRateLimit").mockResolvedValue();
+      stubSponsorship();
+      const request = await createAwaitingPaymentRequest();
+
+      for (let i = 0; i < 5; i++) {
+        expect((await postTransaction(request.public_token)).status).toBe(200);
+      }
+      expect((await postTransaction(request.public_token)).status).toBe(429);
+    });
+
+    it("rate limits per payment token before touching the database counter", async () => {
+      const spy = vi.spyOn(rateLimit, "enforceRateLimit");
+      stubSponsorship();
+      const request = await createAwaitingPaymentRequest();
+
+      await postTransaction(request.public_token);
+      expect(spy).toHaveBeenCalledWith(expect.anything(), `pay-tx:${request.public_token}`, 10);
+    });
   });
 });

--- a/apps/sdp-api/src/routes/pay.test.ts
+++ b/apps/sdp-api/src/routes/pay.test.ts
@@ -6,7 +6,6 @@ import { getDb } from "@/db";
 import { createPaymentRequestsRepository } from "@/db/repositories/repository-factory";
 import app from "@/index";
 import { createTenantScope } from "@/lib/tenant-scope";
-import * as rateLimit from "@/middleware/rate-limit";
 import * as sponsorshipService from "@/services/sponsorship.service";
 import { TEST_SOLANA_ADDRESSES } from "@/test/fixtures/tokens";
 import { env } from "@/test/helpers/env";

--- a/apps/sdp-api/src/routes/pay.ts
+++ b/apps/sdp-api/src/routes/pay.ts
@@ -22,7 +22,8 @@ import { getTransferSolInstruction } from "@solana-program/system";
 import { Hono } from "hono";
 import { z } from "zod";
 import { createSystemPaymentRequestsRepository } from "@/db/repositories/repository-factory";
-import { badRequest, notFound } from "@/lib/errors";
+import { badRequest, notFound, rateLimited } from "@/lib/errors";
+import { enforceRateLimit } from "@/middleware/rate-limit";
 import { type ValidatedBodyContext, validateBody } from "@/middleware/validate";
 import {
   isPaymentRequestExpired,
@@ -38,6 +39,12 @@ import {
 
 const REQUEST_LABEL = "Solana Developer Platform";
 const REQUEST_ICON = `${getSdpDocsOrigin()}/icon.svg`;
+
+// Lifetime signature budget per payment request: room for legitimate wallet
+// retries (expired blockhash, re-scanned QR) while keeping the sponsored
+// spend behind one payment link bounded.
+const SPONSORED_SIGNATURES_PER_REQUEST = 5;
+const PAY_TX_TOKEN_MAX_REQUESTS = 10;
 
 const transactionRequestBodySchema = z.object({ account: z.string() });
 
@@ -85,15 +92,24 @@ pay.post(
   validateBody(transactionRequestBodySchema),
   async (c: ValidatedBodyContext<typeof transactionRequestBodySchema>) => {
     const { token } = c.req.param();
-    const existing = await createSystemPaymentRequestsRepository(
-      c.env
-    ).getPaymentRequestByPublicToken(token);
+    await enforceRateLimit(c, `pay-tx:${token}`, PAY_TX_TOKEN_MAX_REQUESTS);
+
+    const repository = createSystemPaymentRequestsRepository(c.env);
+    const existing = await repository.getPaymentRequestByPublicToken(token);
     if (!existing) {
       throw notFound("Payment request");
     }
     const request = await reconcilePaymentRequest(c.env, existing, { bestEffort: false });
     if (request.status !== "awaiting_payment" || isPaymentRequestExpired(request.expires_at)) {
       throw badRequest("Payment request is no longer payable");
+    }
+
+    const admitted = await repository.reserveSponsoredSignature({
+      requestId: request.id,
+      cap: SPONSORED_SIGNATURES_PER_REQUEST,
+    });
+    if (!admitted) {
+      throw rateLimited("Payment request has exhausted its sponsored transaction attempts");
     }
 
     const payer = assertValidAddress(c.req.valid("json").account, "account");

--- a/apps/sdp-api/src/routes/pay.ts
+++ b/apps/sdp-api/src/routes/pay.ts
@@ -114,63 +114,67 @@ pay.post(
       throw rateLimited("Payment request has exhausted its sponsored transaction attempts");
     }
 
-    const withReference = (instruction: Instruction & { accounts: readonly AccountMeta[] }) => ({
-      ...instruction,
-      accounts: [...instruction.accounts, { address: reference, role: AccountRole.READONLY }],
-    });
-
-    const payerSigner = createNoopSigner(payer);
-    const rpc = solanaRpc.createRpc(c.env);
-    if (!request.project_id) {
-      throw badRequest("Payment request is not eligible for sponsored fees");
-    }
-    const feePayment = await createProjectSponsorshipFeePayment(c.env, {
-      organizationId: request.organization_id,
-      projectId: request.project_id,
-      actor: { type: "wallet", id: request.wallet_id },
-    });
-    const [feePayer, { blockhash, lastValidBlockHeight }] = await Promise.all([
-      feePayment.getFeePayer(),
-      solanaRpc.getRecentBlockhash(rpc, "confirmed"),
-    ]);
-
-    let instructions: Instruction[];
-    if (request.token === SOL_MINT) {
-      const lamports = parseDecimalAmount(request.amount, SOL_DECIMALS);
-      if (lamports <= 0n) {
-        throw badRequest("Transfer amount must be greater than zero");
-      }
-      const transferInstruction = getTransferSolInstruction({
-        source: payerSigner,
-        destination: recipient,
-        amount: lamports,
+    try {
+      const withReference = (instruction: Instruction & { accounts: readonly AccountMeta[] }) => ({
+        ...instruction,
+        accounts: [...instruction.accounts, { address: reference, role: AccountRole.READONLY }],
       });
-      instructions = [withReference(transferInstruction)];
-    } else {
-      const { createDestinationAtaInstruction, transferInstruction } =
-        await buildSplTransferInstructions(rpc, {
-          authority: payerSigner,
+
+      const payerSigner = createNoopSigner(payer);
+      const rpc = solanaRpc.createRpc(c.env);
+      if (!request.project_id) {
+        throw badRequest("Payment request is not eligible for sponsored fees");
+      }
+      const feePayment = await createProjectSponsorshipFeePayment(c.env, {
+        organizationId: request.organization_id,
+        projectId: request.project_id,
+        actor: { type: "wallet", id: request.wallet_id },
+      });
+      const [feePayer, { blockhash, lastValidBlockHeight }] = await Promise.all([
+        feePayment.getFeePayer(),
+        solanaRpc.getRecentBlockhash(rpc, "confirmed"),
+      ]);
+
+      let instructions: Instruction[];
+      if (request.token === SOL_MINT) {
+        const lamports = parseDecimalAmount(request.amount, SOL_DECIMALS);
+        if (lamports <= 0n) {
+          throw badRequest("Transfer amount must be greater than zero");
+        }
+        const transferInstruction = getTransferSolInstruction({
+          source: payerSigner,
           destination: recipient,
-          mint: assertValidAddress(request.token, "token"),
-          amount: request.amount,
-          ataRentPayer: feePayer,
+          amount: lamports,
         });
-      instructions = [createDestinationAtaInstruction, withReference(transferInstruction)];
+        instructions = [withReference(transferInstruction)];
+      } else {
+        const { createDestinationAtaInstruction, transferInstruction } =
+          await buildSplTransferInstructions(rpc, {
+            authority: payerSigner,
+            destination: recipient,
+            mint: assertValidAddress(request.token, "token"),
+            amount: request.amount,
+            ataRentPayer: feePayer,
+          });
+        instructions = [createDestinationAtaInstruction, withReference(transferInstruction)];
+      }
+
+      const message = pipe(
+        createTransactionMessage({ version: 0 }),
+        (m) => setTransactionMessageFeePayer(feePayer, m),
+        (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
+        (m) => appendTransactionMessageInstructions(instructions, m)
+      );
+      const txBytes = new Uint8Array(getTransactionEncoder().encode(compileTransaction(message)));
+      const sponsored = await feePayment.signAsFeePayer(txBytes);
+      return c.json({
+        transaction: getBase64Decoder().decode(sponsored),
+        message: `Pay ${request.amount} ${resolveTokenLabel(request.token)} to ${REQUEST_LABEL}`,
+      });
+    } catch (error) {
+      await repository.releaseSponsoredSignature(request.id);
+      throw error;
     }
-
-    const message = pipe(
-      createTransactionMessage({ version: 0 }),
-      (m) => setTransactionMessageFeePayer(feePayer, m),
-      (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
-      (m) => appendTransactionMessageInstructions(instructions, m)
-    );
-    const txBytes = new Uint8Array(getTransactionEncoder().encode(compileTransaction(message)));
-    const sponsored = await feePayment.signAsFeePayer(txBytes);
-
-    return c.json({
-      transaction: getBase64Decoder().decode(sponsored),
-      message: `Pay ${request.amount} ${resolveTokenLabel(request.token)} to ${REQUEST_LABEL}`,
-    });
   }
 );
 

--- a/apps/sdp-api/src/routes/pay.ts
+++ b/apps/sdp-api/src/routes/pay.ts
@@ -11,6 +11,7 @@ import {
   createNoopSigner,
   createTransactionMessage,
   getBase64Decoder,
+  getBase64Encoder,
   getTransactionEncoder,
   type Instruction,
   pipe,
@@ -23,7 +24,6 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { createSystemPaymentRequestsRepository } from "@/db/repositories/repository-factory";
 import { badRequest, notFound, rateLimited } from "@/lib/errors";
-import { enforceRateLimit } from "@/middleware/rate-limit";
 import { type ValidatedBodyContext, validateBody } from "@/middleware/validate";
 import {
   isPaymentRequestExpired,
@@ -40,9 +40,6 @@ import {
 
 const REQUEST_LABEL = "Solana Developer Platform";
 const REQUEST_ICON = `${getSdpDocsOrigin()}/icon.svg`;
-
-const SPONSORED_SIGNATURES_PER_REQUEST = 5;
-const PAY_TX_TOKEN_MAX_REQUESTS = 10;
 
 const transactionRequestBodySchema = z.object({ account: solanaAddressSchema("account") });
 
@@ -90,7 +87,6 @@ pay.post(
   validateBody(transactionRequestBodySchema),
   async (c: ValidatedBodyContext<typeof transactionRequestBodySchema>) => {
     const { token } = c.req.param();
-    await enforceRateLimit(c, `pay-tx:${token}`, PAY_TX_TOKEN_MAX_REQUESTS);
 
     const repository = createSystemPaymentRequestsRepository(c.env);
     const existing = await repository.getPaymentRequestByPublicToken(token);
@@ -101,86 +97,135 @@ pay.post(
     if (request.status !== "awaiting_payment" || isPaymentRequestExpired(request.expires_at)) {
       throw badRequest("Payment request is no longer payable");
     }
+    if (!request.project_id) {
+      throw badRequest("Payment request is not eligible for sponsored fees");
+    }
 
     const payer = assertValidAddress(c.req.valid("json").account, "account");
     const recipient = assertValidAddress(request.destination_address, "destinationAddress");
     const reference = assertValidAddress(request.reference, "reference");
 
-    const admitted = await repository.reserveSponsoredSignature({
-      requestId: request.id,
-      cap: SPONSORED_SIGNATURES_PER_REQUEST,
-    });
-    if (!admitted) {
-      throw rateLimited("Payment request has exhausted its sponsored transaction attempts");
-    }
+    const rpc = solanaRpc.createRpc(c.env);
+    const currentBlockHeight = await rpc.getBlockHeight({ commitment: "confirmed" }).send();
 
-    let signingAttempted = false;
-    try {
-      const withReference = (instruction: Instruction & { accounts: readonly AccountMeta[] }) => ({
-        ...instruction,
-        accounts: [...instruction.accounts, { address: reference, role: AccountRole.READONLY }],
-      });
-
-      const payerSigner = createNoopSigner(payer);
-      const rpc = solanaRpc.createRpc(c.env);
-      if (!request.project_id) {
-        throw badRequest("Payment request is not eligible for sponsored fees");
-      }
-      const feePayment = await createProjectSponsorshipFeePayment(c.env, {
-        organizationId: request.organization_id,
-        projectId: request.project_id,
-        actor: { type: "wallet", id: request.wallet_id },
-      });
-      const [feePayer, { blockhash, lastValidBlockHeight }] = await Promise.all([
-        feePayment.getFeePayer(),
-        solanaRpc.getRecentBlockhash(rpc, "confirmed"),
-      ]);
-
-      let instructions: Instruction[];
-      if (request.token === SOL_MINT) {
-        const lamports = parseDecimalAmount(request.amount, SOL_DECIMALS);
-        if (lamports <= 0n) {
-          throw badRequest("Transfer amount must be greater than zero");
-        }
-        const transferInstruction = getTransferSolInstruction({
-          source: payerSigner,
-          destination: recipient,
-          amount: lamports,
-        });
-        instructions = [withReference(transferInstruction)];
-      } else {
-        const { createDestinationAtaInstruction, transferInstruction } =
-          await buildSplTransferInstructions(rpc, {
-            authority: payerSigner,
-            destination: recipient,
-            mint: assertValidAddress(request.token, "token"),
-            amount: request.amount,
-            ataRentPayer: feePayer,
-          });
-        instructions = [createDestinationAtaInstruction, withReference(transferInstruction)];
-      }
-
-      const message = pipe(
-        createTransactionMessage({ version: 0 }),
-        (m) => setTransactionMessageFeePayer(feePayer, m),
-        (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
-        (m) => appendTransactionMessageInstructions(instructions, m)
-      );
-      const txBytes = new Uint8Array(getTransactionEncoder().encode(compileTransaction(message)));
-      // Past this line a signature may exist even when the call throws: a Kora
-      // timeout is recorded as charged_unknown, so the slot stays spent.
-      signingAttempted = true;
-      const sponsored = await feePayment.signAsFeePayer(txBytes);
-      return c.json({
-        transaction: getBase64Decoder().decode(sponsored),
+    // One sponsored transaction per blockhash window, claimed on the request
+    // row. Everyone who scans while a claim is live gets the claimed payer's
+    // candidate back, or a Retry-After; a claim is never released early
+    // because a signed transaction is a bearer instrument until its blockhash
+    // expires, and two live ones would double the sponsor's exposure.
+    const respondWithClaim = async (signedTransaction: string) =>
+      c.json({
+        transaction: signedTransaction,
         message: `Pay ${request.amount} ${resolveTokenLabel(request.token)} to ${REQUEST_LABEL}`,
       });
-    } catch (error) {
-      if (!signingAttempted) {
-        await repository.releaseSponsoredSignature(request.id);
+
+    const serveLiveClaim = async () => {
+      const claim = await repository.getSponsoredTransactionClaim(request.id);
+      if (claim === null || claim.lastValidBlockHeight < currentBlockHeight) {
+        return null;
       }
-      throw error;
+      if (claim.account !== payer) {
+        const retryAfterSeconds = Math.ceil(
+          Number(claim.lastValidBlockHeight - currentBlockHeight) * 0.4
+        );
+        c.header("Retry-After", String(Math.max(retryAfterSeconds, 1)));
+        throw rateLimited("Another payer holds this payment request's sponsored transaction");
+      }
+      if (claim.signedTransaction !== null) {
+        return respondWithClaim(claim.signedTransaction);
+      }
+      return signAndStore(claim.unsignedTransaction);
+    };
+
+    let feePaymentInstance: Awaited<ReturnType<typeof createProjectSponsorshipFeePayment>> | null =
+      null;
+    const getFeePayment = async () => {
+      feePaymentInstance ??= await createProjectSponsorshipFeePayment(c.env, {
+        organizationId: request.organization_id,
+        projectId: request.project_id as string,
+        actor: { type: "wallet", id: request.wallet_id },
+      });
+      return feePaymentInstance;
+    };
+
+    const signAndStore = async (unsignedBase64: string) => {
+      const feePayment = await getFeePayment();
+      const unsignedBytes = new Uint8Array(getBase64Encoder().encode(unsignedBase64));
+      const sponsored = await feePayment.signAsFeePayer(unsignedBytes);
+      const signedBase64 = getBase64Decoder().decode(sponsored);
+      await repository.storeSponsoredTransactionSignature({
+        requestId: request.id,
+        account: payer,
+        signedTransaction: signedBase64,
+      });
+      return respondWithClaim(signedBase64);
+    };
+
+    const served = await serveLiveClaim();
+    if (served) {
+      return served;
     }
+
+    const withReference = (instruction: Instruction & { accounts: readonly AccountMeta[] }) => ({
+      ...instruction,
+      accounts: [...instruction.accounts, { address: reference, role: AccountRole.READONLY }],
+    });
+    const payerSigner = createNoopSigner(payer);
+    const feePayment = await getFeePayment();
+    const [feePayer, { blockhash, lastValidBlockHeight }] = await Promise.all([
+      feePayment.getFeePayer(),
+      solanaRpc.getRecentBlockhash(rpc, "confirmed"),
+    ]);
+
+    let instructions: Instruction[];
+    if (request.token === SOL_MINT) {
+      const lamports = parseDecimalAmount(request.amount, SOL_DECIMALS);
+      if (lamports <= 0n) {
+        throw badRequest("Transfer amount must be greater than zero");
+      }
+      const transferInstruction = getTransferSolInstruction({
+        source: payerSigner,
+        destination: recipient,
+        amount: lamports,
+      });
+      instructions = [withReference(transferInstruction)];
+    } else {
+      const { createDestinationAtaInstruction, transferInstruction } =
+        await buildSplTransferInstructions(rpc, {
+          authority: payerSigner,
+          destination: recipient,
+          mint: assertValidAddress(request.token, "token"),
+          amount: request.amount,
+          ataRentPayer: feePayer,
+        });
+      instructions = [createDestinationAtaInstruction, withReference(transferInstruction)];
+    }
+
+    const message = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayer(feePayer, m),
+      (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
+      (m) => appendTransactionMessageInstructions(instructions, m)
+    );
+    const txBytes = new Uint8Array(getTransactionEncoder().encode(compileTransaction(message)));
+    const unsignedBase64 = getBase64Decoder().decode(txBytes);
+
+    const claimed = await repository.claimSponsoredTransactionWindow({
+      requestId: request.id,
+      account: payer,
+      unsignedTransaction: unsignedBase64,
+      lastValidBlockHeight,
+      currentBlockHeight,
+    });
+    if (!claimed) {
+      const winner = await serveLiveClaim();
+      if (winner) {
+        return winner;
+      }
+      throw rateLimited("Another payer holds this payment request's sponsored transaction");
+    }
+
+    return signAndStore(unsignedBase64);
   }
 );
 

--- a/apps/sdp-api/src/routes/pay.ts
+++ b/apps/sdp-api/src/routes/pay.ts
@@ -31,6 +31,7 @@ import {
 } from "@/services/payments/payment-requests";
 import { createProjectSponsorshipFeePayment } from "@/services/sponsorship.service";
 import type { Env } from "@/types/env";
+import { solanaAddressSchema } from "./payments/schemas";
 import {
   buildSplTransferInstructions,
   resolveTokenLabel,
@@ -40,13 +41,10 @@ import {
 const REQUEST_LABEL = "Solana Developer Platform";
 const REQUEST_ICON = `${getSdpDocsOrigin()}/icon.svg`;
 
-// Lifetime signature budget per payment request: room for legitimate wallet
-// retries (expired blockhash, re-scanned QR) while keeping the sponsored
-// spend behind one payment link bounded.
 const SPONSORED_SIGNATURES_PER_REQUEST = 5;
 const PAY_TX_TOKEN_MAX_REQUESTS = 10;
 
-const transactionRequestBodySchema = z.object({ account: z.string() });
+const transactionRequestBodySchema = z.object({ account: solanaAddressSchema("account") });
 
 const pay = new Hono<{ Bindings: Env }>();
 
@@ -104,6 +102,10 @@ pay.post(
       throw badRequest("Payment request is no longer payable");
     }
 
+    const payer = assertValidAddress(c.req.valid("json").account, "account");
+    const recipient = assertValidAddress(request.destination_address, "destinationAddress");
+    const reference = assertValidAddress(request.reference, "reference");
+
     const admitted = await repository.reserveSponsoredSignature({
       requestId: request.id,
       cap: SPONSORED_SIGNATURES_PER_REQUEST,
@@ -112,9 +114,6 @@ pay.post(
       throw rateLimited("Payment request has exhausted its sponsored transaction attempts");
     }
 
-    const payer = assertValidAddress(c.req.valid("json").account, "account");
-    const recipient = assertValidAddress(request.destination_address, "destinationAddress");
-    const reference = assertValidAddress(request.reference, "reference");
     const withReference = (instruction: Instruction & { accounts: readonly AccountMeta[] }) => ({
       ...instruction,
       accounts: [...instruction.accounts, { address: reference, role: AccountRole.READONLY }],

--- a/apps/sdp-api/src/routes/pay.ts
+++ b/apps/sdp-api/src/routes/pay.ts
@@ -114,6 +114,7 @@ pay.post(
       throw rateLimited("Payment request has exhausted its sponsored transaction attempts");
     }
 
+    let signingAttempted = false;
     try {
       const withReference = (instruction: Instruction & { accounts: readonly AccountMeta[] }) => ({
         ...instruction,
@@ -166,13 +167,18 @@ pay.post(
         (m) => appendTransactionMessageInstructions(instructions, m)
       );
       const txBytes = new Uint8Array(getTransactionEncoder().encode(compileTransaction(message)));
+      // Past this line a signature may exist even when the call throws: a Kora
+      // timeout is recorded as charged_unknown, so the slot stays spent.
+      signingAttempted = true;
       const sponsored = await feePayment.signAsFeePayer(txBytes);
       return c.json({
         transaction: getBase64Decoder().decode(sponsored),
         message: `Pay ${request.amount} ${resolveTokenLabel(request.token)} to ${REQUEST_LABEL}`,
       });
     } catch (error) {
-      await repository.releaseSponsoredSignature(request.id);
+      if (!signingAttempted) {
+        await repository.releaseSponsoredSignature(request.id);
+      }
       throw error;
     }
   }


### PR DESCRIPTION
The public Solana Pay transaction endpoint built a fee-sponsored transaction for every POST from anyone holding a payment link, so a leaked or replayed link could draw down the organization's sponsorship budget without bound.

Each payment request now carries at most one live sponsored transaction per blockhash window, claimed on the request row itself: the claimed payer account, the unsigned and signed transaction bytes, and the block height the claim expires at travel together under a database CHECK, and a compare-and-swap admits a claim only while the request is awaiting payment and no live claim exists.

The same account asking again receives the stored signed transaction without another signer call, and a retry after a failed signing passes the stored unsigned bytes back, where the budget layer's message-digest reservation dedupes the charge. A different account is answered 429 with a Retry-After derived from the remaining block window. Claims are never released early, because a signed transaction is a bearer instrument until its blockhash expires and a second live one would double the sponsor's exposure; expiry is judged by block height rather than wall time.

Sponsor cost per payment request is one signature per blockhash window regardless of how many parties scan the link. The payer account field is validated at the schema boundary so a malformed payload cannot open a claim.

A follow-up (separate PR) will teach the sponsorship reconciler to release reservations whose blockhash expired without the transaction landing, instead of recording them as charged-unknown.

Tests cover concurrent claim races admitting exactly one winner, same-account replay without a signer call, 429 with Retry-After for a competing account, reclaim after window expiry, retry after a failed signing, and malformed payloads opening no claim.