### PR TITLE
feat(issuance): extend wallet-operation policy coverage to seize, force-burn, and burn

### DIFF
--- a/apps/sdp-api/src/routes/issuance.test.ts
+++ b/apps/sdp-api/src/routes/issuance.test.ts
@@ -852,6 +852,46 @@ describe("Issuance Routes", () => {
       }
     });
 
+    it("refuses to mint when the signer no longer matches the wallet policy judged", async () => {
+      const wallet = await seedIssuanceActivityWallet(
+        "wal_issuance_mint_signer_drift",
+        policyMintAuthority
+      );
+      const token = await seedIssuedToken({
+        id: "tok_issuance_mint_signer_drift",
+        signingWalletId: wallet.walletId,
+        mintAuthority: policyMintAuthority,
+      });
+      // Policy judged the seeded wallet; custody hands back a different one.
+      const createOrgSignerSpy = vi
+        .spyOn(SolanaServices, "createOrgSigner")
+        .mockResolvedValue(createNoopSigner(address(TEST_SOLANA_ADDRESSES.wallet2)));
+      const mintToSpy = vi.spyOn(MosaicService.prototype, "mintTo");
+
+      try {
+        const response = await app.request(
+          `/v1/issuance/tokens/${token.id}/mint`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+            },
+            body: JSON.stringify({
+              mint: { destination: TEST_SOLANA_ADDRESSES.wallet2, amount: "1" },
+            }),
+          },
+          env
+        );
+
+        expect(response.status).toBe(409);
+        expect(mintToSpy).not.toHaveBeenCalled();
+      } finally {
+        createOrgSignerSpy.mockRestore();
+        mintToSpy.mockRestore();
+      }
+    });
+
     it("does not cache a caller-supplied permanent delegate", async () => {
       const wallet = await seedIssuanceActivityWallet(
         "wal_issuance_seize_delegate",

--- a/apps/sdp-api/src/routes/issuance.test.ts
+++ b/apps/sdp-api/src/routes/issuance.test.ts
@@ -618,6 +618,240 @@ describe("Issuance Routes", () => {
       }
     });
 
+    it("stops a denied seize before signer and issuance side effects", async () => {
+      const wallet = await seedIssuanceActivityWallet(
+        "wal_issuance_seize_denied",
+        policyMintAuthority
+      );
+      const token = await seedIssuedToken({
+        id: "tok_issuance_seize_denied",
+        signingWalletId: wallet.walletId,
+        mintAuthority: policyMintAuthority,
+      });
+      const policyResponse = await app.request(
+        `/v1/payments/wallets/${wallet.walletId}/policies`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+          },
+          body: JSON.stringify({
+            defaultAction: "allow",
+            rules: [{ id: "deny-issuance-seize", kind: "always", action: "deny" }],
+          }),
+        },
+        env
+      );
+      expect(policyResponse.status).toBe(200);
+      const forceTransferSpy = vi.spyOn(MosaicService.prototype, "forceTransfer");
+
+      try {
+        const response = await app.request(
+          `/v1/issuance/tokens/${token.id}/seize`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+            },
+            body: JSON.stringify({
+              seize: {
+                source: TEST_SOLANA_ADDRESSES.wallet2,
+                destination: TEST_SOLANA_ADDRESSES.wallet1,
+                amount: "1",
+                delegateAuthority: policyMintAuthority,
+              },
+            }),
+          },
+          env
+        );
+
+        expect(response.status).toBe(403);
+        expect(forceTransferSpy).not.toHaveBeenCalled();
+        const transactionCount = await getDb(env)
+          .prepare("SELECT COUNT(*)::int AS count FROM issuance_transactions")
+          .first<{ count: number }>();
+        expect(transactionCount).toEqual({ count: 0 });
+        const operationCount = await getDb(env)
+          .prepare("SELECT COUNT(*)::int AS count FROM wallet_operations")
+          .first<{ count: number }>();
+        expect(operationCount).toEqual({ count: 1 });
+      } finally {
+        forceTransferSpy.mockRestore();
+      }
+    });
+
+    it("answers a seize dry-run without executing", async () => {
+      const wallet = await seedIssuanceActivityWallet(
+        "wal_issuance_seize_dry_run",
+        policyMintAuthority
+      );
+      const token = await seedIssuedToken({
+        id: "tok_issuance_seize_dry_run",
+        signingWalletId: wallet.walletId,
+        mintAuthority: policyMintAuthority,
+      });
+      const forceTransferSpy = vi.spyOn(MosaicService.prototype, "forceTransfer");
+
+      try {
+        const response = await app.request(
+          `/v1/issuance/tokens/${token.id}/seize`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+              "Dry-Run": "true",
+            },
+            body: JSON.stringify({
+              seize: {
+                source: TEST_SOLANA_ADDRESSES.wallet2,
+                destination: TEST_SOLANA_ADDRESSES.wallet1,
+                amount: "1",
+                delegateAuthority: policyMintAuthority,
+              },
+            }),
+          },
+          env
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toMatchObject({
+          data: { decision: "allow", criteria: [] },
+        });
+        expect(forceTransferSpy).not.toHaveBeenCalled();
+        const transactionCount = await getDb(env)
+          .prepare("SELECT COUNT(*)::int AS count FROM issuance_transactions")
+          .first<{ count: number }>();
+        expect(transactionCount).toEqual({ count: 0 });
+      } finally {
+        forceTransferSpy.mockRestore();
+      }
+    });
+
+    it("stops a denied force-burn before signer and issuance side effects", async () => {
+      const wallet = await seedIssuanceActivityWallet(
+        "wal_issuance_force_burn_denied",
+        policyMintAuthority
+      );
+      const token = await seedIssuedToken({
+        id: "tok_issuance_force_burn_denied",
+        signingWalletId: wallet.walletId,
+        mintAuthority: policyMintAuthority,
+      });
+      const policyResponse = await app.request(
+        `/v1/payments/wallets/${wallet.walletId}/policies`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+          },
+          body: JSON.stringify({
+            defaultAction: "allow",
+            rules: [{ id: "deny-issuance-force-burn", kind: "always", action: "deny" }],
+          }),
+        },
+        env
+      );
+      expect(policyResponse.status).toBe(200);
+      const forceBurnSpy = vi.spyOn(MosaicService.prototype, "forceBurn");
+
+      try {
+        const response = await app.request(
+          `/v1/issuance/tokens/${token.id}/force-burn`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+            },
+            body: JSON.stringify({
+              forceBurn: {
+                source: TEST_SOLANA_ADDRESSES.wallet2,
+                amount: "1",
+                delegateAuthority: policyMintAuthority,
+              },
+            }),
+          },
+          env
+        );
+
+        expect(response.status).toBe(403);
+        expect(forceBurnSpy).not.toHaveBeenCalled();
+        const transactionCount = await getDb(env)
+          .prepare("SELECT COUNT(*)::int AS count FROM issuance_transactions")
+          .first<{ count: number }>();
+        expect(transactionCount).toEqual({ count: 0 });
+        const operationCount = await getDb(env)
+          .prepare("SELECT COUNT(*)::int AS count FROM wallet_operations")
+          .first<{ count: number }>();
+        expect(operationCount).toEqual({ count: 1 });
+      } finally {
+        forceBurnSpy.mockRestore();
+      }
+    });
+
+    it("stops a denied burn before signer and issuance side effects", async () => {
+      const wallet = await seedIssuanceActivityWallet(
+        "wal_issuance_burn_denied",
+        policyMintAuthority
+      );
+      const token = await seedIssuedToken({
+        id: "tok_issuance_burn_denied",
+        signingWalletId: wallet.walletId,
+        mintAuthority: policyMintAuthority,
+      });
+      const policyResponse = await app.request(
+        `/v1/payments/wallets/${wallet.walletId}/policies`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+          },
+          body: JSON.stringify({
+            defaultAction: "allow",
+            rules: [{ id: "deny-issuance-burn", kind: "always", action: "deny" }],
+          }),
+        },
+        env
+      );
+      expect(policyResponse.status).toBe(200);
+      const createOrgSignerSpy = vi.spyOn(SolanaServices, "createOrgSigner");
+
+      try {
+        const response = await app.request(
+          `/v1/issuance/tokens/${token.id}/burn`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+            },
+            body: JSON.stringify({
+              burn: { source: TEST_SOLANA_ADDRESSES.wallet1, amount: "1" },
+            }),
+          },
+          env
+        );
+
+        expect(response.status).toBe(403);
+        expect(createOrgSignerSpy).not.toHaveBeenCalled();
+        const transactionCount = await getDb(env)
+          .prepare("SELECT COUNT(*)::int AS count FROM issuance_transactions")
+          .first<{ count: number }>();
+        expect(transactionCount).toEqual({ count: 0 });
+        const operationCount = await getDb(env)
+          .prepare("SELECT COUNT(*)::int AS count FROM wallet_operations")
+          .first<{ count: number }>();
+        expect(operationCount).toEqual({ count: 1 });
+      } finally {
+        createOrgSignerSpy.mockRestore();
+      }
+    });
+
     it("allows an ungoverned mint dry-run and executes without policy enforcement", async () => {
       const token = await seedIssuedToken({
         id: "tok_issuance_ungoverned_mint",

--- a/apps/sdp-api/src/routes/issuance.test.ts
+++ b/apps/sdp-api/src/routes/issuance.test.ts
@@ -852,6 +852,169 @@ describe("Issuance Routes", () => {
       }
     });
 
+    it("does not cache a caller-supplied permanent delegate", async () => {
+      const wallet = await seedIssuanceActivityWallet(
+        "wal_issuance_seize_delegate",
+        policyMintAuthority
+      );
+      const token = await seedIssuedToken({
+        id: "tok_issuance_seize_delegate",
+        signingWalletId: wallet.walletId,
+        mintAuthority: policyMintAuthority,
+      });
+      const updateAuthoritiesSpy = vi.spyOn(TokenService.prototype, "updateTokenAuthorities");
+      const forceTransferSpy = vi
+        .spyOn(MosaicService.prototype, "forceTransfer")
+        .mockResolvedValue({ signature: "sig_seize_delegate", slot: 654n });
+      const createOrgSignerSpy = vi
+        .spyOn(SolanaServices, "createOrgSigner")
+        .mockResolvedValue(createNoopSigner(address(policyMintAuthority)));
+
+      try {
+        const response = await app.request(
+          `/v1/issuance/tokens/${token.id}/seize`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+            },
+            body: JSON.stringify({
+              seize: {
+                source: TEST_SOLANA_ADDRESSES.wallet2,
+                destination: TEST_SOLANA_ADDRESSES.wallet1,
+                amount: "1",
+                delegateAuthority: policyMintAuthority,
+              },
+            }),
+          },
+          env
+        );
+
+        expect(response.status).toBe(200);
+        expect(forceTransferSpy).toHaveBeenCalledTimes(1);
+        expect(updateAuthoritiesSpy).not.toHaveBeenCalled();
+      } finally {
+        updateAuthoritiesSpy.mockRestore();
+        forceTransferSpy.mockRestore();
+        createOrgSignerSpy.mockRestore();
+      }
+    });
+
+    it("governs a burn that signs with the organization's effective custody wallet", async () => {
+      const wallet = await seedIssuanceActivityWallet(
+        "wal_issuance_burn_effective",
+        policyMintAuthority
+      );
+      const token = await seedIssuedToken({
+        id: "tok_issuance_burn_effective",
+        signingWalletId: null,
+        mintAuthority: policyMintAuthority,
+      });
+      const policyResponse = await app.request(
+        `/v1/payments/wallets/${wallet.walletId}/policies`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+          },
+          body: JSON.stringify({
+            defaultAction: "allow",
+            rules: [{ id: "deny-issuance-burn-effective", kind: "always", action: "deny" }],
+          }),
+        },
+        env
+      );
+      expect(policyResponse.status).toBe(200);
+      const createOrgSignerSpy = vi.spyOn(SolanaServices, "createOrgSigner");
+      const effectiveWalletSpy = vi
+        .spyOn(SolanaServices, "resolveEffectiveSigningWalletId")
+        .mockResolvedValue(wallet.walletId);
+
+      try {
+        const response = await app.request(
+          `/v1/issuance/tokens/${token.id}/burn`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+            },
+            body: JSON.stringify({
+              burn: { source: TEST_SOLANA_ADDRESSES.wallet1, amount: "1" },
+            }),
+          },
+          env
+        );
+
+        expect(response.status).toBe(403);
+        expect(createOrgSignerSpy).not.toHaveBeenCalled();
+        const operationCount = await getDb(env)
+          .prepare("SELECT COUNT(*)::int AS count FROM wallet_operations")
+          .first<{ count: number }>();
+        expect(operationCount).toEqual({ count: 1 });
+      } finally {
+        createOrgSignerSpy.mockRestore();
+        effectiveWalletSpy.mockRestore();
+      }
+    });
+
+    it("governs a mint that signs with the organization's effective custody wallet", async () => {
+      const wallet = await seedIssuanceActivityWallet(
+        "wal_issuance_mint_effective",
+        policyMintAuthority
+      );
+      const token = await seedIssuedToken({
+        id: "tok_issuance_mint_effective",
+        signingWalletId: null,
+        mintAuthority: policyMintAuthority,
+      });
+      const policyResponse = await app.request(
+        `/v1/payments/wallets/${wallet.walletId}/policies`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+          },
+          body: JSON.stringify({
+            defaultAction: "allow",
+            rules: [{ id: "deny-issuance-mint-effective", kind: "always", action: "deny" }],
+          }),
+        },
+        env
+      );
+      expect(policyResponse.status).toBe(200);
+      const createOrgSignerSpy = vi.spyOn(SolanaServices, "createOrgSigner");
+      const effectiveWalletSpy = vi
+        .spyOn(SolanaServices, "resolveEffectiveSigningWalletId")
+        .mockResolvedValue(wallet.walletId);
+
+      try {
+        const response = await app.request(
+          `/v1/issuance/tokens/${token.id}/mint`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+            },
+            body: JSON.stringify({
+              mint: { destination: TEST_SOLANA_ADDRESSES.wallet2, amount: "1" },
+            }),
+          },
+          env
+        );
+
+        expect(response.status).toBe(403);
+        expect(createOrgSignerSpy).not.toHaveBeenCalled();
+      } finally {
+        createOrgSignerSpy.mockRestore();
+        effectiveWalletSpy.mockRestore();
+      }
+    });
+
     it("allows an ungoverned mint dry-run and executes without policy enforcement", async () => {
       const token = await seedIssuedToken({
         id: "tok_issuance_ungoverned_mint",

--- a/apps/sdp-api/src/routes/issuance/handlers/authority-resolution.test.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/authority-resolution.test.ts
@@ -6,6 +6,7 @@ import { CustodyConfigStore } from "@/services/stores/custody-config.store";
 import { env as testEnv } from "@/test/helpers/env";
 import {
   getInitialPermanentDelegateAuthority,
+  persistDiscoveredPermanentDelegate,
   resolveAuthoritySigner,
   resolveAuthorityWallet,
   resolveMetadataAuthority,
@@ -100,6 +101,78 @@ describe("authority-resolution", () => {
 
     expect(delegate).toBe("AENLi9e2XHK7fnMmEqHbPCADPjRPV4n3DxuWbMcBbxK9");
     expect(fetchMock).toHaveBeenCalledOnce();
+    expect(tokenService.updateTokenAuthorities).toHaveBeenCalledWith("tok_test", {
+      permanentDelegate: "AENLi9e2XHK7fnMmEqHbPCADPjRPV4n3DxuWbMcBbxK9",
+    });
+  });
+
+  it("reads the on-chain permanent delegate without writing when discovery must not persist", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        result: {
+          value: {
+            data: {
+              parsed: {
+                info: {
+                  extensions: [
+                    {
+                      extension: "permanentDelegate",
+                      state: {
+                        delegate: "AENLi9e2XHK7fnMmEqHbPCADPjRPV4n3DxuWbMcBbxK9",
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tokenService = {
+      updateTokenAuthorities: vi.fn(),
+    } as unknown as {
+      updateTokenAuthorities: ReturnType<typeof vi.fn>;
+    };
+
+    const delegate = await resolvePermanentDelegateAuthority(
+      {
+        SOLANA_RPC_URL: "https://rpc.example.test",
+        SOLANA_NETWORK: "devnet",
+      } as never,
+      tokenService as never,
+      createToken(),
+      { persistDiscovery: false }
+    );
+
+    expect(delegate).toBe("AENLi9e2XHK7fnMmEqHbPCADPjRPV4n3DxuWbMcBbxK9");
+    expect(tokenService.updateTokenAuthorities).not.toHaveBeenCalled();
+  });
+
+  it("repairs the cached permanent delegate only when it differs", async () => {
+    const tokenService = {
+      updateTokenAuthorities: vi.fn(),
+    } as unknown as {
+      updateTokenAuthorities: ReturnType<typeof vi.fn>;
+    };
+
+    await persistDiscoveredPermanentDelegate(
+      tokenService as never,
+      "tok_test",
+      "AENLi9e2XHK7fnMmEqHbPCADPjRPV4n3DxuWbMcBbxK9",
+      "AENLi9e2XHK7fnMmEqHbPCADPjRPV4n3DxuWbMcBbxK9"
+    );
+    expect(tokenService.updateTokenAuthorities).not.toHaveBeenCalled();
+
+    await persistDiscoveredPermanentDelegate(
+      tokenService as never,
+      "tok_test",
+      null,
+      "AENLi9e2XHK7fnMmEqHbPCADPjRPV4n3DxuWbMcBbxK9"
+    );
     expect(tokenService.updateTokenAuthorities).toHaveBeenCalledWith("tok_test", {
       permanentDelegate: "AENLi9e2XHK7fnMmEqHbPCADPjRPV4n3DxuWbMcBbxK9",
     });

--- a/apps/sdp-api/src/routes/issuance/handlers/authority-resolution.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/authority-resolution.ts
@@ -121,7 +121,11 @@ async function fetchMintPermanentDelegate(
 export async function resolvePermanentDelegateAuthority(
   env: Env,
   tokenService: TokenService,
-  token: TokenRecord
+  token: TokenRecord,
+  // Policy extractors resolve the delegate before the gate decides, where a
+  // dry-run or a denied request must leave no trace. They pass false and hand
+  // the cache repair to the handler, which runs only once policy allows.
+  options: { persistDiscovery?: boolean } = {}
 ): Promise<string | null> {
   if (!token) {
     return null;
@@ -139,10 +143,13 @@ export async function resolvePermanentDelegateAuthority(
     const { rpcUrl } = getSolanaConfig(env);
     const { permanentDelegate } = await fetchMintPermanentDelegate(rpcUrl, token.mintAddress);
 
-    if (permanentDelegate && token.extensions?.permanentDelegate !== permanentDelegate) {
-      await tokenService.updateTokenAuthorities(token.id, {
-        permanentDelegate,
-      });
+    if ((options.persistDiscovery ?? true) && permanentDelegate) {
+      await persistDiscoveredPermanentDelegate(
+        tokenService,
+        token.id,
+        token.extensions?.permanentDelegate ?? null,
+        permanentDelegate
+      );
     }
 
     return permanentDelegate;
@@ -152,6 +159,19 @@ export async function resolvePermanentDelegateAuthority(
       error instanceof Error ? error.message : "Failed to resolve permanent delegate authority"
     );
   }
+}
+
+export async function persistDiscoveredPermanentDelegate(
+  tokenService: TokenService,
+  tokenId: string,
+  cachedPermanentDelegate: string | null,
+  permanentDelegate: string
+): Promise<void> {
+  if (cachedPermanentDelegate === permanentDelegate) {
+    return;
+  }
+
+  await tokenService.updateTokenAuthorities(tokenId, { permanentDelegate });
 }
 
 export async function resolveMetadataAuthority(

--- a/apps/sdp-api/src/routes/issuance/handlers/burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/burn.ts
@@ -1,12 +1,18 @@
+import type { WalletOperationPolicyEnforcement } from "@sdp/policy";
 import { createRpcForSdk } from "@sdp/rpc/solana";
 import { type Address, assertValidAddress } from "@sdp/solana/address";
 import { resolveTokenAccount } from "@solana/mosaic-sdk";
+import { z } from "zod";
 import { getDb } from "@/db";
+import type { ApiKeyContext } from "@/lib/auth";
 import { AppError, notFound } from "@/lib/errors";
+import { getPolicyGateContext, type PolicyGateExtraction } from "@/middleware/policy-gate";
 import { success } from "@/lib/response";
 import type { ValidatedBodyContext } from "@/middleware/validate";
 import { resolveApiKeySigningWalletId } from "@/services/api-key-scope.service";
 import { AuditService } from "@/services/audit.service";
+import { resolvePolicyCustodyWallet } from "@/services/policy/enforcement.service";
+import type { TokenService } from "@/services/token.service";
 import { createOrgSigner } from "@/services/solana";
 import {
   assertTokenAllowsOperation,
@@ -22,6 +28,7 @@ import {
 } from "../helpers";
 import type { burnSchema } from "../schemas";
 import { buildIdempotencyMetadata } from "./idempotency";
+import { buildIssuancePolicyCandidate } from "./policy";
 import {
   persistSettledTransactionThenOutcome,
   recoverSettledTransactionReplay,
@@ -231,10 +238,27 @@ export const prepareBurn = async (c: ValidatedBodyContext<typeof burnSchema>) =>
   });
 };
 
-export const executeBurn = async (c: ValidatedBodyContext<typeof burnSchema>) => {
+type BurnBody = z.output<typeof burnSchema>;
+
+interface BurnPolicyResolved {
+  tokenId: string;
+  auth: ApiKeyContext;
+  projectId: string;
+  tokenService: TokenService;
+  tokenSymbol: string;
+  supplyBaselineUpdatedAt: string | null;
+  signingWalletId: string | null;
+  mintAddress: ReturnType<typeof assertValidAddress>;
+  source: ReturnType<typeof assertValidAddress>;
+  amountBaseUnits: bigint;
+  mosaicAmount: number;
+}
+
+export async function extractBurnPolicyCandidate(
+  c: ValidatedBodyContext<typeof burnSchema>
+): Promise<PolicyGateExtraction> {
   const { tokenId } = c.req.param();
   const { auth, projectId, orgId } = requireProjectScope(c);
-
   const body = c.req.valid("json");
 
   const tokenService = getTenantTokenService(c);
@@ -243,7 +267,6 @@ export const executeBurn = async (c: ValidatedBodyContext<typeof burnSchema>) =>
     organizationId: orgId,
     projectId,
   });
-
   if (!token) {
     throw notFound("Token");
   }
@@ -262,6 +285,67 @@ export const executeBurn = async (c: ValidatedBodyContext<typeof burnSchema>) =>
     body.burn.amount,
     token.decimals
   );
+  const policyWallet =
+    signingWalletId === null ? null : await resolvePolicyCustodyWallet(c.env, auth, signingWalletId);
+
+  return {
+    candidate:
+      signingWalletId === null
+        ? null
+        : buildIssuancePolicyCandidate({
+            auth,
+            token,
+            custodyWalletId: policyWallet === null ? null : policyWallet.id,
+            walletId: signingWalletId,
+            operationType: "issuance_burn_execute",
+            amount: body.burn.amount,
+            destination: null,
+          }),
+    legs: [],
+    body,
+    resolved: {
+      tokenId,
+      auth,
+      projectId,
+      tokenService,
+      tokenSymbol: token.symbol,
+      supplyBaselineUpdatedAt: token.totalSupplyUpdatedAt ?? null,
+      signingWalletId,
+      mintAddress,
+      source,
+      amountBaseUnits,
+      mosaicAmount,
+    } satisfies BurnPolicyResolved,
+    rawPayload: {
+      tokenId: token.id,
+      mintAddress: token.mintAddress,
+      action: "burn",
+      source: body.burn.source,
+      amount: body.burn.amount,
+    },
+    idempotencyKey: null,
+  };
+}
+
+export const executeBurn = async (c: ValidatedBodyContext<typeof burnSchema>) => {
+  const {
+    body,
+    resolved: {
+      tokenId,
+      auth,
+      projectId,
+      tokenService,
+      tokenSymbol,
+      supplyBaselineUpdatedAt,
+      signingWalletId,
+      mintAddress,
+      source,
+      amountBaseUnits,
+      mosaicAmount,
+    },
+  } = getPolicyGateContext<BurnBody, BurnPolicyResolved, WalletOperationPolicyEnforcement | null>(
+    c
+  );
 
   const idempotencyMetadata = buildIdempotencyMetadata(c.req.header("Idempotency-Key"), {
     tokenId,
@@ -279,7 +363,7 @@ export const executeBurn = async (c: ValidatedBodyContext<typeof burnSchema>) =>
       source: body.burn.source,
       amount: body.burn.amount,
       memo: body.burn.memo,
-      supplyBaselineUpdatedAt: token.totalSupplyUpdatedAt ?? null,
+      supplyBaselineUpdatedAt,
     },
     initiatedByKeyId: auth.id,
     idempotencyKey: idempotencyMetadata.idempotencyKey,
@@ -325,7 +409,7 @@ export const executeBurn = async (c: ValidatedBodyContext<typeof burnSchema>) =>
       source,
       mintAddress,
       amountBaseUnits,
-      token.symbol
+      tokenSymbol
     );
 
     // Execute burn on Solana
@@ -361,7 +445,7 @@ export const executeBurn = async (c: ValidatedBodyContext<typeof burnSchema>) =>
     await tokenService.applySettledBurnSupply(tx.id, tokenId, body.burn.amount);
 
     emitTokenOperationCompleted(c, {
-      organizationId: orgId,
+      organizationId: auth.organizationId,
       projectId,
       tokenId,
       operation: "burn",

--- a/apps/sdp-api/src/routes/issuance/handlers/burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/burn.ts
@@ -12,7 +12,7 @@ import type { ValidatedBodyContext } from "@/middleware/validate";
 import { resolveApiKeySigningWalletId } from "@/services/api-key-scope.service";
 import { AuditService } from "@/services/audit.service";
 import { resolvePolicyCustodyWallet } from "@/services/policy/enforcement.service";
-import { createOrgSigner } from "@/services/solana";
+import { createOrgSigner, resolveEffectiveSigningWalletId } from "@/services/solana";
 import type { TokenService } from "@/services/token.service";
 import {
   assertTokenAllowsOperation,
@@ -285,20 +285,25 @@ export async function extractBurnPolicyCandidate(
     body.burn.amount,
     token.decimals
   );
+  // The handler signs through `createOrgSigner`, which falls back to the
+  // organization's effective custody wallet when no wallet is named. Naming it
+  // here keeps the wallet policy judges the wallet that signs; only a target
+  // that carries no wallet at all leaves the operation ungoverned.
+  const policyWalletId =
+    signingWalletId ??
+    (await resolveEffectiveSigningWalletId(c.env, auth.organizationId, auth.projectId));
   const policyWallet =
-    signingWalletId === null
-      ? null
-      : await resolvePolicyCustodyWallet(c.env, auth, signingWalletId);
+    policyWalletId === null ? null : await resolvePolicyCustodyWallet(c.env, auth, policyWalletId);
 
   return {
     candidate:
-      signingWalletId === null
+      policyWalletId === null
         ? null
         : buildIssuancePolicyCandidate({
             auth,
             token,
             custodyWalletId: policyWallet === null ? null : policyWallet.id,
-            walletId: signingWalletId,
+            walletId: policyWalletId,
             operationType: "issuance_burn_execute",
             amount: body.burn.amount,
             destination: null,

--- a/apps/sdp-api/src/routes/issuance/handlers/burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/burn.ts
@@ -2,18 +2,18 @@ import type { WalletOperationPolicyEnforcement } from "@sdp/policy";
 import { createRpcForSdk } from "@sdp/rpc/solana";
 import { type Address, assertValidAddress } from "@sdp/solana/address";
 import { resolveTokenAccount } from "@solana/mosaic-sdk";
-import { z } from "zod";
+import type { z } from "zod";
 import { getDb } from "@/db";
 import type { ApiKeyContext } from "@/lib/auth";
 import { AppError, notFound } from "@/lib/errors";
-import { getPolicyGateContext, type PolicyGateExtraction } from "@/middleware/policy-gate";
 import { success } from "@/lib/response";
+import { getPolicyGateContext, type PolicyGateExtraction } from "@/middleware/policy-gate";
 import type { ValidatedBodyContext } from "@/middleware/validate";
 import { resolveApiKeySigningWalletId } from "@/services/api-key-scope.service";
 import { AuditService } from "@/services/audit.service";
 import { resolvePolicyCustodyWallet } from "@/services/policy/enforcement.service";
-import type { TokenService } from "@/services/token.service";
 import { createOrgSigner } from "@/services/solana";
+import type { TokenService } from "@/services/token.service";
 import {
   assertTokenAllowsOperation,
   assertTokenIsDeployed,
@@ -286,7 +286,9 @@ export async function extractBurnPolicyCandidate(
     token.decimals
   );
   const policyWallet =
-    signingWalletId === null ? null : await resolvePolicyCustodyWallet(c.env, auth, signingWalletId);
+    signingWalletId === null
+      ? null
+      : await resolvePolicyCustodyWallet(c.env, auth, signingWalletId);
 
   return {
     candidate:

--- a/apps/sdp-api/src/routes/issuance/handlers/burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/burn.ts
@@ -28,7 +28,7 @@ import {
 } from "../helpers";
 import type { burnSchema } from "../schemas";
 import { buildIdempotencyMetadata } from "./idempotency";
-import { buildIssuancePolicyCandidate } from "./policy";
+import { assertSignerMatchesJudgedWallet, buildIssuancePolicyCandidate } from "./policy";
 import {
   persistSettledTransactionThenOutcome,
   recoverSettledTransactionReplay,
@@ -248,6 +248,7 @@ interface BurnPolicyResolved {
   tokenSymbol: string;
   supplyBaselineUpdatedAt: string | null;
   signingWalletId: string | null;
+  judgedWalletPublicKey: string | null;
   mintAddress: ReturnType<typeof assertValidAddress>;
   source: ReturnType<typeof assertValidAddress>;
   amountBaseUnits: bigint;
@@ -318,6 +319,7 @@ export async function extractBurnPolicyCandidate(
       tokenSymbol: token.symbol,
       supplyBaselineUpdatedAt: token.totalSupplyUpdatedAt ?? null,
       signingWalletId,
+      judgedWalletPublicKey: policyWallet === null ? null : policyWallet.publicKey,
       mintAddress,
       source,
       amountBaseUnits,
@@ -345,6 +347,7 @@ export const executeBurn = async (c: ValidatedBodyContext<typeof burnSchema>) =>
       tokenSymbol,
       supplyBaselineUpdatedAt,
       signingWalletId,
+      judgedWalletPublicKey,
       mintAddress,
       source,
       amountBaseUnits,
@@ -410,6 +413,7 @@ export const executeBurn = async (c: ValidatedBodyContext<typeof burnSchema>) =>
       auth.projectId,
       signingWalletId
     );
+    assertSignerMatchesJudgedWallet(signer, judgedWalletPublicKey);
     const normalizedSource = await resolveValidatedBurnSource(
       c.env,
       signer.address,

--- a/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
@@ -143,6 +143,7 @@ interface ForceBurnPolicyResolved {
   supplyBaselineUpdatedAt: string | null;
   mosaicAmount: number;
   permanentDelegateRaw: string;
+  discoveredPermanentDelegate: string | null;
   cachedPermanentDelegate: string | null;
   walletId: string;
   mintAddress: ReturnType<typeof assertValidAddress>;
@@ -171,11 +172,16 @@ export async function extractForceBurnPolicyCandidate(
 
   const { mosaicAmount } = parsePositiveTokenAmount(body.forceBurn.amount, token.decimals);
 
-  const permanentDelegateRaw =
-    body.forceBurn.delegateAuthority ??
-    (await resolvePermanentDelegateAuthority(c.env, tokenService, token, {
-      persistDiscovery: false,
-    }));
+  // Only a delegate read off the mint is worth caching. A caller-supplied one
+  // is an assertion about the chain, not an observation of it, so it never
+  // reaches the token record.
+  const discoveredPermanentDelegate =
+    body.forceBurn.delegateAuthority === undefined || body.forceBurn.delegateAuthority === null
+      ? await resolvePermanentDelegateAuthority(c.env, tokenService, token, {
+          persistDiscovery: false,
+        })
+      : null;
+  const permanentDelegateRaw = body.forceBurn.delegateAuthority ?? discoveredPermanentDelegate;
   if (!permanentDelegateRaw) {
     throw badRequest("Permanent delegate is not configured for this token");
   }
@@ -211,6 +217,7 @@ export async function extractForceBurnPolicyCandidate(
       supplyBaselineUpdatedAt: token.totalSupplyUpdatedAt ?? null,
       mosaicAmount,
       permanentDelegateRaw,
+      discoveredPermanentDelegate,
       cachedPermanentDelegate: token.extensions?.permanentDelegate ?? null,
       walletId,
       mintAddress,
@@ -238,6 +245,7 @@ export const executeForceBurn = async (c: ValidatedBodyContext<typeof forceBurnS
       supplyBaselineUpdatedAt,
       mosaicAmount,
       permanentDelegateRaw,
+      discoveredPermanentDelegate,
       cachedPermanentDelegate,
       walletId,
       mintAddress,
@@ -256,12 +264,14 @@ export const executeForceBurn = async (c: ValidatedBodyContext<typeof forceBurnS
     currentAuthority: permanentDelegateRaw,
   });
 
-  await persistDiscoveredPermanentDelegate(
-    tokenService,
-    tokenId,
-    cachedPermanentDelegate,
-    permanentDelegateRaw
-  );
+  if (discoveredPermanentDelegate !== null) {
+    await persistDiscoveredPermanentDelegate(
+      tokenService,
+      tokenId,
+      cachedPermanentDelegate,
+      discoveredPermanentDelegate
+    );
+  }
 
   const idempotencyMetadata = buildIdempotencyMetadata(c.req.header("Idempotency-Key"), {
     tokenId,

--- a/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
@@ -1,12 +1,12 @@
 import type { WalletOperationPolicyEnforcement } from "@sdp/policy";
 import { createRpc, simulateTransaction } from "@sdp/rpc/solana";
 import { assertValidAddress } from "@sdp/solana/address";
-import { z } from "zod";
+import type { z } from "zod";
 import { getDb } from "@/db";
 import type { ApiKeyContext } from "@/lib/auth";
 import { badRequest, notFound } from "@/lib/errors";
-import { getPolicyGateContext, type PolicyGateExtraction } from "@/middleware/policy-gate";
 import { success } from "@/lib/response";
+import { getPolicyGateContext, type PolicyGateExtraction } from "@/middleware/policy-gate";
 import type { ValidatedBodyContext } from "@/middleware/validate";
 import { AuditService } from "@/services/audit.service";
 import { resolvePolicyCustodyWallet } from "@/services/policy/enforcement.service";
@@ -26,11 +26,11 @@ import type { forceBurnSchema } from "../schemas";
 import {
   createResolvedAuthoritySigner,
   resolveAuthoritySigner,
-  resolvePermanentDelegateAuthority,
   resolveAuthorityWallet,
+  resolvePermanentDelegateAuthority,
 } from "./authority-resolution";
-import { buildIssuancePolicyCandidate } from "./policy";
 import { buildIdempotencyMetadata } from "./idempotency";
+import { buildIssuancePolicyCandidate } from "./policy";
 import {
   persistSettledTransactionThenOutcome,
   recoverSettledTransactionReplay,

--- a/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
@@ -1,10 +1,16 @@
+import type { WalletOperationPolicyEnforcement } from "@sdp/policy";
 import { createRpc, simulateTransaction } from "@sdp/rpc/solana";
 import { assertValidAddress } from "@sdp/solana/address";
+import { z } from "zod";
 import { getDb } from "@/db";
+import type { ApiKeyContext } from "@/lib/auth";
 import { badRequest, notFound } from "@/lib/errors";
+import { getPolicyGateContext, type PolicyGateExtraction } from "@/middleware/policy-gate";
 import { success } from "@/lib/response";
 import type { ValidatedBodyContext } from "@/middleware/validate";
 import { AuditService } from "@/services/audit.service";
+import { resolvePolicyCustodyWallet } from "@/services/policy/enforcement.service";
+import type { TokenService } from "@/services/token.service";
 import {
   assertTokenAllowsOperation,
   assertTokenIsDeployed,
@@ -17,7 +23,13 @@ import {
   requireProjectScope,
 } from "../helpers";
 import type { forceBurnSchema } from "../schemas";
-import { resolveAuthoritySigner, resolvePermanentDelegateAuthority } from "./authority-resolution";
+import {
+  createResolvedAuthoritySigner,
+  resolveAuthoritySigner,
+  resolvePermanentDelegateAuthority,
+  resolveAuthorityWallet,
+} from "./authority-resolution";
+import { buildIssuancePolicyCandidate } from "./policy";
 import { buildIdempotencyMetadata } from "./idempotency";
 import {
   persistSettledTransactionThenOutcome,
@@ -120,10 +132,26 @@ export const prepareForceBurn = async (c: ValidatedBodyContext<typeof forceBurnS
   });
 };
 
-export const executeForceBurn = async (c: ValidatedBodyContext<typeof forceBurnSchema>) => {
+type ForceBurnBody = z.output<typeof forceBurnSchema>;
+
+interface ForceBurnPolicyResolved {
+  tokenId: string;
+  auth: ApiKeyContext;
+  projectId: string;
+  tokenService: TokenService;
+  supplyBaselineUpdatedAt: string | null;
+  mosaicAmount: number;
+  permanentDelegateRaw: string;
+  walletId: string;
+  mintAddress: ReturnType<typeof assertValidAddress>;
+  source: ReturnType<typeof assertValidAddress>;
+}
+
+export async function extractForceBurnPolicyCandidate(
+  c: ValidatedBodyContext<typeof forceBurnSchema>
+): Promise<PolicyGateExtraction> {
   const { tokenId } = c.req.param();
   const { auth, projectId, orgId } = requireProjectScope(c);
-
   const body = c.req.valid("json");
 
   const tokenService = getTenantTokenService(c);
@@ -132,7 +160,6 @@ export const executeForceBurn = async (c: ValidatedBodyContext<typeof forceBurnS
     organizationId: orgId,
     projectId,
   });
-
   if (!token) {
     throw notFound("Token");
   }
@@ -149,16 +176,79 @@ export const executeForceBurn = async (c: ValidatedBodyContext<typeof forceBurnS
     throw badRequest("Permanent delegate is not configured for this token");
   }
 
-  const { signer } = await resolveAuthoritySigner({
+  const { walletId } = await resolveAuthorityWallet({
     env: c.env,
     auth,
     token,
     requestedWalletId: body.signingWalletId,
     currentAuthority: permanentDelegateRaw,
   });
-
   const mintAddress = assertValidAddress(token.mintAddress, "mintAddress");
   const source = assertValidAddress(body.forceBurn.source, "source");
+  const policyWallet = await resolvePolicyCustodyWallet(c.env, auth, walletId);
+
+  return {
+    candidate: buildIssuancePolicyCandidate({
+      auth,
+      token,
+      custodyWalletId: policyWallet === null ? null : policyWallet.id,
+      walletId,
+      operationType: "issuance_force_burn_execute",
+      amount: body.forceBurn.amount,
+      destination: null,
+    }),
+    legs: [],
+    body,
+    resolved: {
+      tokenId,
+      auth,
+      projectId,
+      tokenService,
+      supplyBaselineUpdatedAt: token.totalSupplyUpdatedAt ?? null,
+      mosaicAmount,
+      permanentDelegateRaw,
+      walletId,
+      mintAddress,
+      source,
+    } satisfies ForceBurnPolicyResolved,
+    rawPayload: {
+      tokenId: token.id,
+      mintAddress: token.mintAddress,
+      action: "force_burn",
+      source: body.forceBurn.source,
+      amount: body.forceBurn.amount,
+    },
+    idempotencyKey: null,
+  };
+}
+
+export const executeForceBurn = async (c: ValidatedBodyContext<typeof forceBurnSchema>) => {
+  const {
+    body,
+    resolved: {
+      tokenId,
+      auth,
+      projectId,
+      tokenService,
+      supplyBaselineUpdatedAt,
+      mosaicAmount,
+      permanentDelegateRaw,
+      walletId,
+      mintAddress,
+      source,
+    },
+  } = getPolicyGateContext<
+    ForceBurnBody,
+    ForceBurnPolicyResolved,
+    WalletOperationPolicyEnforcement | null
+  >(c);
+
+  const signer = await createResolvedAuthoritySigner({
+    env: c.env,
+    auth,
+    walletId,
+    currentAuthority: permanentDelegateRaw,
+  });
 
   const idempotencyMetadata = buildIdempotencyMetadata(c.req.header("Idempotency-Key"), {
     tokenId,
@@ -176,7 +266,7 @@ export const executeForceBurn = async (c: ValidatedBodyContext<typeof forceBurnS
       amount: body.forceBurn.amount,
       delegateAuthority: permanentDelegateRaw,
       memo: body.forceBurn.memo,
-      supplyBaselineUpdatedAt: token.totalSupplyUpdatedAt ?? null,
+      supplyBaselineUpdatedAt,
     },
     idempotencyKey: idempotencyMetadata.idempotencyKey,
     idempotencyFingerprint: idempotencyMetadata.idempotencyFingerprint,
@@ -241,7 +331,7 @@ export const executeForceBurn = async (c: ValidatedBodyContext<typeof forceBurnS
     await tokenService.applySettledBurnSupply(tx.id, tokenId, body.forceBurn.amount);
 
     emitTokenOperationCompleted(c, {
-      organizationId: orgId,
+      organizationId: auth.organizationId,
       projectId,
       tokenId,
       operation: "force_burn",

--- a/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
@@ -25,6 +25,7 @@ import {
 import type { forceBurnSchema } from "../schemas";
 import {
   createResolvedAuthoritySigner,
+  persistDiscoveredPermanentDelegate,
   resolveAuthoritySigner,
   resolveAuthorityWallet,
   resolvePermanentDelegateAuthority,
@@ -142,6 +143,7 @@ interface ForceBurnPolicyResolved {
   supplyBaselineUpdatedAt: string | null;
   mosaicAmount: number;
   permanentDelegateRaw: string;
+  cachedPermanentDelegate: string | null;
   walletId: string;
   mintAddress: ReturnType<typeof assertValidAddress>;
   source: ReturnType<typeof assertValidAddress>;
@@ -171,7 +173,9 @@ export async function extractForceBurnPolicyCandidate(
 
   const permanentDelegateRaw =
     body.forceBurn.delegateAuthority ??
-    (await resolvePermanentDelegateAuthority(c.env, tokenService, token));
+    (await resolvePermanentDelegateAuthority(c.env, tokenService, token, {
+      persistDiscovery: false,
+    }));
   if (!permanentDelegateRaw) {
     throw badRequest("Permanent delegate is not configured for this token");
   }
@@ -207,6 +211,7 @@ export async function extractForceBurnPolicyCandidate(
       supplyBaselineUpdatedAt: token.totalSupplyUpdatedAt ?? null,
       mosaicAmount,
       permanentDelegateRaw,
+      cachedPermanentDelegate: token.extensions?.permanentDelegate ?? null,
       walletId,
       mintAddress,
       source,
@@ -233,6 +238,7 @@ export const executeForceBurn = async (c: ValidatedBodyContext<typeof forceBurnS
       supplyBaselineUpdatedAt,
       mosaicAmount,
       permanentDelegateRaw,
+      cachedPermanentDelegate,
       walletId,
       mintAddress,
       source,
@@ -249,6 +255,13 @@ export const executeForceBurn = async (c: ValidatedBodyContext<typeof forceBurnS
     walletId,
     currentAuthority: permanentDelegateRaw,
   });
+
+  await persistDiscoveredPermanentDelegate(
+    tokenService,
+    tokenId,
+    cachedPermanentDelegate,
+    permanentDelegateRaw
+  );
 
   const idempotencyMetadata = buildIdempotencyMetadata(c.req.header("Idempotency-Key"), {
     tokenId,

--- a/apps/sdp-api/src/routes/issuance/handlers/mint.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/mint.ts
@@ -35,7 +35,7 @@ import {
   getOnChainAllowlistMutationForMint,
 } from "./access-control";
 import { buildIdempotencyMetadata } from "./idempotency";
-import { buildIssuancePolicyCandidate } from "./policy";
+import { assertSignerMatchesJudgedWallet, buildIssuancePolicyCandidate } from "./policy";
 import {
   persistSettledTransaction,
   persistSettledTransactionThenOutcome,
@@ -57,6 +57,7 @@ interface MintPolicyResolved {
   amountBaseUnits: MintOperationAmount["amountBaseUnits"];
   ablListAddress: string | null;
   signingWalletId: string | null;
+  judgedWalletPublicKey: string | null;
 }
 
 interface SettledMintEvidence {
@@ -542,6 +543,7 @@ export async function extractMintPolicyCandidate(
       amountBaseUnits,
       ablListAddress,
       signingWalletId,
+      judgedWalletPublicKey: policyWallet === null ? null : policyWallet.publicKey,
     },
     rawPayload: {
       tokenId: token.id,
@@ -568,6 +570,7 @@ export const executeMint = async (c: AppContext) => {
       amountBaseUnits,
       ablListAddress,
       signingWalletId,
+      judgedWalletPublicKey,
     },
   } = getPolicyGateContext<MintBody, MintPolicyResolved, WalletOperationPolicyEnforcement | null>(
     c
@@ -583,6 +586,7 @@ export const executeMint = async (c: AppContext) => {
   // (`isWalletOnList` returns true) since the original call drove the
   // wallet on-chain.
   const signer = await createOrgSigner(c.env, auth.organizationId, auth.projectId, signingWalletId);
+  assertSignerMatchesJudgedWallet(signer, judgedWalletPublicKey);
   const mosaic = createIssuanceMosaicService(c, signer, "sponsored");
   const addedToAllowlist = ablListAddress
     ? await syncDestinationToOnChainAllowlist({

--- a/apps/sdp-api/src/routes/issuance/handlers/mint.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/mint.ts
@@ -19,7 +19,7 @@ import {
   reserveMintSupplyAtApprovedEffectBoundary,
 } from "@/services/policy/approved-operation-replay";
 import { resolvePolicyCustodyWallet } from "@/services/policy/enforcement.service";
-import { createOrgSigner } from "@/services/solana";
+import { createOrgSigner, resolveEffectiveSigningWalletId } from "@/services/solana";
 import type { TokenService } from "@/services/token.service";
 import { resolveMintOperationAmount } from "@/services/token-operation.service";
 import { emitTokenOperationCompleted } from "@/services/workflows/token-events";
@@ -507,20 +507,25 @@ export async function extractMintPolicyCandidate(
   ]);
   const mintAddress = assertValidAddress(mintAddressRaw, "mintAddress");
   const destination = assertValidAddress(input.mint.destination, "destination");
+  // The handler signs through `createOrgSigner`, which falls back to the
+  // organization's effective custody wallet when no wallet is named. Naming it
+  // here keeps the wallet policy judges the wallet that signs; only a target
+  // that carries no wallet at all leaves the operation ungoverned.
+  const policyWalletId =
+    signingWalletId ??
+    (await resolveEffectiveSigningWalletId(c.env, auth.organizationId, auth.projectId));
   const policyWallet =
-    signingWalletId === null
-      ? null
-      : await resolvePolicyCustodyWallet(c.env, auth, signingWalletId);
+    policyWalletId === null ? null : await resolvePolicyCustodyWallet(c.env, auth, policyWalletId);
 
   return {
     candidate:
-      signingWalletId === null
+      policyWalletId === null
         ? null
         : buildIssuancePolicyCandidate({
             auth,
             token,
             custodyWalletId: policyWallet === null ? null : policyWallet.id,
-            walletId: signingWalletId,
+            walletId: policyWalletId,
             operationType: "issuance_mint_execute",
             amount: input.mint.amount,
             destination: input.mint.destination,

--- a/apps/sdp-api/src/routes/issuance/handlers/policy.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/policy.ts
@@ -4,7 +4,11 @@ import { walletOperationActorFromAuth } from "@/services/policy/enforcement.serv
 
 type IssuancePolicyOperationType = Extract<
   WalletOperationType,
-  "issuance_mint_execute" | "issuance_update_authority_execute"
+  | "issuance_burn_execute"
+  | "issuance_force_burn_execute"
+  | "issuance_mint_execute"
+  | "issuance_seize_execute"
+  | "issuance_update_authority_execute"
 >;
 
 /**

--- a/apps/sdp-api/src/routes/issuance/handlers/policy.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/policy.ts
@@ -1,6 +1,25 @@
 import type { PolicyCandidate, Token, WalletOperationType } from "@sdp/types";
+import type { TransactionSigner } from "@solana/kit";
 import type { ApiKeyContext } from "@/lib/auth";
+import { conflict } from "@/lib/errors";
 import { walletOperationActorFromAuth } from "@/services/policy/enforcement.service";
+
+/**
+ * Refuse a signer the gate did not judge.
+ *
+ * An extractor names the wallet policy is evaluated against, but a handler that
+ * asks for its signer by anything less specific re-runs custody resolution, and
+ * the custody target can move in between. Comparing addresses turns that race
+ * into a refusal instead of a transaction signed by an unjudged wallet.
+ */
+export function assertSignerMatchesJudgedWallet(
+  signer: TransactionSigner,
+  judgedWalletPublicKey: string | null
+): void {
+  if (judgedWalletPublicKey !== null && signer.address !== judgedWalletPublicKey) {
+    throw conflict("Signing wallet changed after the operation was evaluated by policy");
+  }
+}
 
 type IssuancePolicyOperationType = Extract<
   WalletOperationType,

--- a/apps/sdp-api/src/routes/issuance/handlers/seize.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/seize.ts
@@ -1,12 +1,12 @@
 import type { WalletOperationPolicyEnforcement } from "@sdp/policy";
 import { createRpc, simulateTransaction } from "@sdp/rpc/solana";
 import { assertValidAddress } from "@sdp/solana/address";
-import { z } from "zod";
+import type { z } from "zod";
 import { getDb } from "@/db";
 import type { ApiKeyContext } from "@/lib/auth";
 import { badRequest, notFound } from "@/lib/errors";
-import { getPolicyGateContext, type PolicyGateExtraction } from "@/middleware/policy-gate";
 import { success } from "@/lib/response";
+import { getPolicyGateContext, type PolicyGateExtraction } from "@/middleware/policy-gate";
 import type { ValidatedBodyContext } from "@/middleware/validate";
 import { AuditService } from "@/services/audit.service";
 import { resolvePolicyCustodyWallet } from "@/services/policy/enforcement.service";
@@ -30,8 +30,8 @@ import {
   resolveAuthorityWallet,
   resolvePermanentDelegateAuthority,
 } from "./authority-resolution";
-import { buildIssuancePolicyCandidate } from "./policy";
 import { buildIdempotencyMetadata } from "./idempotency";
+import { buildIssuancePolicyCandidate } from "./policy";
 import {
   persistSettledTransactionThenOutcome,
   recoverSettledTransactionReplay,

--- a/apps/sdp-api/src/routes/issuance/handlers/seize.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/seize.ts
@@ -153,6 +153,7 @@ interface SeizePolicyResolved {
   tokenService: TokenService;
   mosaicAmount: number;
   permanentDelegateRaw: string;
+  discoveredPermanentDelegate: string | null;
   cachedPermanentDelegate: string | null;
   walletId: string;
   mintAddress: ReturnType<typeof assertValidAddress>;
@@ -189,11 +190,16 @@ export async function extractSeizePolicyCandidate(
     isOnControlList,
   });
 
-  const permanentDelegateRaw =
-    body.seize.delegateAuthority ??
-    (await resolvePermanentDelegateAuthority(c.env, tokenService, token, {
-      persistDiscovery: false,
-    }));
+  // Only a delegate read off the mint is worth caching. A caller-supplied one
+  // is an assertion about the chain, not an observation of it, so it never
+  // reaches the token record.
+  const discoveredPermanentDelegate =
+    body.seize.delegateAuthority === undefined || body.seize.delegateAuthority === null
+      ? await resolvePermanentDelegateAuthority(c.env, tokenService, token, {
+          persistDiscovery: false,
+        })
+      : null;
+  const permanentDelegateRaw = body.seize.delegateAuthority ?? discoveredPermanentDelegate;
   if (!permanentDelegateRaw) {
     throw badRequest("Permanent delegate is not configured for this token");
   }
@@ -229,6 +235,7 @@ export async function extractSeizePolicyCandidate(
       tokenService,
       mosaicAmount,
       permanentDelegateRaw,
+      discoveredPermanentDelegate,
       cachedPermanentDelegate: token.extensions?.permanentDelegate ?? null,
       walletId,
       mintAddress,
@@ -257,6 +264,7 @@ export const executeSeize = async (c: ValidatedBodyContext<typeof seizeSchema>) 
       tokenService,
       mosaicAmount,
       permanentDelegateRaw,
+      discoveredPermanentDelegate,
       cachedPermanentDelegate,
       walletId,
       mintAddress,
@@ -274,12 +282,14 @@ export const executeSeize = async (c: ValidatedBodyContext<typeof seizeSchema>) 
     currentAuthority: permanentDelegateRaw,
   });
 
-  await persistDiscoveredPermanentDelegate(
-    tokenService,
-    tokenId,
-    cachedPermanentDelegate,
-    permanentDelegateRaw
-  );
+  if (discoveredPermanentDelegate !== null) {
+    await persistDiscoveredPermanentDelegate(
+      tokenService,
+      tokenId,
+      cachedPermanentDelegate,
+      discoveredPermanentDelegate
+    );
+  }
 
   const idempotencyMetadata = buildIdempotencyMetadata(c.req.header("Idempotency-Key"), {
     tokenId,

--- a/apps/sdp-api/src/routes/issuance/handlers/seize.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/seize.ts
@@ -1,10 +1,16 @@
+import type { WalletOperationPolicyEnforcement } from "@sdp/policy";
 import { createRpc, simulateTransaction } from "@sdp/rpc/solana";
 import { assertValidAddress } from "@sdp/solana/address";
+import { z } from "zod";
 import { getDb } from "@/db";
+import type { ApiKeyContext } from "@/lib/auth";
 import { badRequest, notFound } from "@/lib/errors";
+import { getPolicyGateContext, type PolicyGateExtraction } from "@/middleware/policy-gate";
 import { success } from "@/lib/response";
 import type { ValidatedBodyContext } from "@/middleware/validate";
 import { AuditService } from "@/services/audit.service";
+import { resolvePolicyCustodyWallet } from "@/services/policy/enforcement.service";
+import type { TokenService } from "@/services/token.service";
 import {
   assertTokenAllowsOperation,
   assertTokenIsDeployed,
@@ -18,7 +24,13 @@ import {
 } from "../helpers";
 import type { seizeSchema } from "../schemas";
 import { assertDestinationAllowedByControlList } from "./access-control";
-import { resolveAuthoritySigner, resolvePermanentDelegateAuthority } from "./authority-resolution";
+import {
+  createResolvedAuthoritySigner,
+  resolveAuthoritySigner,
+  resolveAuthorityWallet,
+  resolvePermanentDelegateAuthority,
+} from "./authority-resolution";
+import { buildIssuancePolicyCandidate } from "./policy";
 import { buildIdempotencyMetadata } from "./idempotency";
 import {
   persistSettledTransactionThenOutcome,
@@ -131,10 +143,26 @@ export const prepareSeize = async (c: ValidatedBodyContext<typeof seizeSchema>) 
   });
 };
 
-export const executeSeize = async (c: ValidatedBodyContext<typeof seizeSchema>) => {
+type SeizeBody = z.output<typeof seizeSchema>;
+
+interface SeizePolicyResolved {
+  tokenId: string;
+  auth: ApiKeyContext;
+  projectId: string;
+  tokenService: TokenService;
+  mosaicAmount: number;
+  permanentDelegateRaw: string;
+  walletId: string;
+  mintAddress: ReturnType<typeof assertValidAddress>;
+  source: ReturnType<typeof assertValidAddress>;
+  destination: ReturnType<typeof assertValidAddress>;
+}
+
+export async function extractSeizePolicyCandidate(
+  c: ValidatedBodyContext<typeof seizeSchema>
+): Promise<PolicyGateExtraction> {
   const { tokenId } = c.req.param();
   const { auth, projectId, orgId } = requireProjectScope(c);
-
   const body = c.req.valid("json");
 
   const tokenService = getTenantTokenService(c);
@@ -143,7 +171,6 @@ export const executeSeize = async (c: ValidatedBodyContext<typeof seizeSchema>) 
     organizationId: orgId,
     projectId,
   });
-
   if (!token) {
     throw notFound("Token");
   }
@@ -167,17 +194,79 @@ export const executeSeize = async (c: ValidatedBodyContext<typeof seizeSchema>) 
     throw badRequest("Permanent delegate is not configured for this token");
   }
 
-  const { signer } = await resolveAuthoritySigner({
+  const { walletId } = await resolveAuthorityWallet({
     env: c.env,
     auth,
     token,
     requestedWalletId: body.signingWalletId,
     currentAuthority: permanentDelegateRaw,
   });
-
   const mintAddress = assertValidAddress(token.mintAddress, "mintAddress");
   const source = assertValidAddress(body.seize.source, "source");
   const destination = assertValidAddress(body.seize.destination, "destination");
+  const policyWallet = await resolvePolicyCustodyWallet(c.env, auth, walletId);
+
+  return {
+    candidate: buildIssuancePolicyCandidate({
+      auth,
+      token,
+      custodyWalletId: policyWallet === null ? null : policyWallet.id,
+      walletId,
+      operationType: "issuance_seize_execute",
+      amount: body.seize.amount,
+      destination: body.seize.destination,
+    }),
+    legs: [],
+    body,
+    resolved: {
+      tokenId,
+      auth,
+      projectId,
+      tokenService,
+      mosaicAmount,
+      permanentDelegateRaw,
+      walletId,
+      mintAddress,
+      source,
+      destination,
+    } satisfies SeizePolicyResolved,
+    rawPayload: {
+      tokenId: token.id,
+      mintAddress: token.mintAddress,
+      action: "seize",
+      source: body.seize.source,
+      destination: body.seize.destination,
+      amount: body.seize.amount,
+    },
+    idempotencyKey: null,
+  };
+}
+
+export const executeSeize = async (c: ValidatedBodyContext<typeof seizeSchema>) => {
+  const {
+    body,
+    resolved: {
+      tokenId,
+      auth,
+      projectId,
+      tokenService,
+      mosaicAmount,
+      permanentDelegateRaw,
+      walletId,
+      mintAddress,
+      source,
+      destination,
+    },
+  } = getPolicyGateContext<SeizeBody, SeizePolicyResolved, WalletOperationPolicyEnforcement | null>(
+    c
+  );
+
+  const signer = await createResolvedAuthoritySigner({
+    env: c.env,
+    auth,
+    walletId,
+    currentAuthority: permanentDelegateRaw,
+  });
 
   const idempotencyMetadata = buildIdempotencyMetadata(c.req.header("Idempotency-Key"), {
     tokenId,
@@ -257,7 +346,7 @@ export const executeSeize = async (c: ValidatedBodyContext<typeof seizeSchema>) 
     });
 
     emitTokenOperationCompleted(c, {
-      organizationId: orgId,
+      organizationId: auth.organizationId,
       projectId,
       tokenId,
       operation: "seize",

--- a/apps/sdp-api/src/routes/issuance/handlers/seize.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/seize.ts
@@ -26,6 +26,7 @@ import type { seizeSchema } from "../schemas";
 import { assertDestinationAllowedByControlList } from "./access-control";
 import {
   createResolvedAuthoritySigner,
+  persistDiscoveredPermanentDelegate,
   resolveAuthoritySigner,
   resolveAuthorityWallet,
   resolvePermanentDelegateAuthority,
@@ -152,6 +153,7 @@ interface SeizePolicyResolved {
   tokenService: TokenService;
   mosaicAmount: number;
   permanentDelegateRaw: string;
+  cachedPermanentDelegate: string | null;
   walletId: string;
   mintAddress: ReturnType<typeof assertValidAddress>;
   source: ReturnType<typeof assertValidAddress>;
@@ -189,7 +191,9 @@ export async function extractSeizePolicyCandidate(
 
   const permanentDelegateRaw =
     body.seize.delegateAuthority ??
-    (await resolvePermanentDelegateAuthority(c.env, tokenService, token));
+    (await resolvePermanentDelegateAuthority(c.env, tokenService, token, {
+      persistDiscovery: false,
+    }));
   if (!permanentDelegateRaw) {
     throw badRequest("Permanent delegate is not configured for this token");
   }
@@ -225,6 +229,7 @@ export async function extractSeizePolicyCandidate(
       tokenService,
       mosaicAmount,
       permanentDelegateRaw,
+      cachedPermanentDelegate: token.extensions?.permanentDelegate ?? null,
       walletId,
       mintAddress,
       source,
@@ -252,6 +257,7 @@ export const executeSeize = async (c: ValidatedBodyContext<typeof seizeSchema>) 
       tokenService,
       mosaicAmount,
       permanentDelegateRaw,
+      cachedPermanentDelegate,
       walletId,
       mintAddress,
       source,
@@ -267,6 +273,13 @@ export const executeSeize = async (c: ValidatedBodyContext<typeof seizeSchema>) 
     walletId,
     currentAuthority: permanentDelegateRaw,
   });
+
+  await persistDiscoveredPermanentDelegate(
+    tokenService,
+    tokenId,
+    cachedPermanentDelegate,
+    permanentDelegateRaw
+  );
 
   const idempotencyMetadata = buildIdempotencyMetadata(c.req.header("Idempotency-Key"), {
     tokenId,

--- a/apps/sdp-api/src/routes/issuance/index.ts
+++ b/apps/sdp-api/src/routes/issuance/index.ts
@@ -26,7 +26,11 @@ import {
   prepareDeploy,
   prepareDeployMetadata,
 } from "./handlers/deploy";
-import { executeForceBurn, extractForceBurnPolicyCandidate, prepareForceBurn } from "./handlers/force-burn";
+import {
+  executeForceBurn,
+  extractForceBurnPolicyCandidate,
+  prepareForceBurn,
+} from "./handlers/force-burn";
 import { freezeAccount, listFrozenAccounts, unfreezeAccount } from "./handlers/freeze";
 import { enrollHolder, enrollHolderSchema, listHolders } from "./handlers/holders";
 import { serveTokenMetadata } from "./handlers/metadata";

--- a/apps/sdp-api/src/routes/issuance/index.ts
+++ b/apps/sdp-api/src/routes/issuance/index.ts
@@ -19,7 +19,7 @@ import {
   extractUpdateAuthorityPolicyCandidate,
   prepareUpdateAuthority,
 } from "./handlers/authority";
-import { executeBurn, prepareBurn } from "./handlers/burn";
+import { executeBurn, extractBurnPolicyCandidate, prepareBurn } from "./handlers/burn";
 import {
   confirmDeploy,
   deployToken,
@@ -177,6 +177,7 @@ issuance.post(
   "/tokens/:tokenId/burn",
   requirePermissions("tokens:write"),
   validateBody(burnSchema),
+  policyGate({ extract: extractBurnPolicyCandidate }),
   executeBurn
 );
 

--- a/apps/sdp-api/src/routes/issuance/index.ts
+++ b/apps/sdp-api/src/routes/issuance/index.ts
@@ -26,7 +26,7 @@ import {
   prepareDeploy,
   prepareDeployMetadata,
 } from "./handlers/deploy";
-import { executeForceBurn, prepareForceBurn } from "./handlers/force-burn";
+import { executeForceBurn, extractForceBurnPolicyCandidate, prepareForceBurn } from "./handlers/force-burn";
 import { freezeAccount, listFrozenAccounts, unfreezeAccount } from "./handlers/freeze";
 import { enrollHolder, enrollHolderSchema, listHolders } from "./handlers/holders";
 import { serveTokenMetadata } from "./handlers/metadata";
@@ -206,6 +206,7 @@ issuance.post(
   "/tokens/:tokenId/force-burn",
   requirePermissions("tokens:admin"),
   validateBody(forceBurnSchema),
+  policyGate({ extract: extractForceBurnPolicyCandidate }),
   executeForceBurn
 );
 

--- a/apps/sdp-api/src/routes/issuance/index.ts
+++ b/apps/sdp-api/src/routes/issuance/index.ts
@@ -32,7 +32,7 @@ import { enrollHolder, enrollHolderSchema, listHolders } from "./handlers/holder
 import { serveTokenMetadata } from "./handlers/metadata";
 import { executeMint, extractMintPolicyCandidate, prepareMint } from "./handlers/mint";
 import { pauseToken, unpauseToken } from "./handlers/pause";
-import { executeSeize, prepareSeize } from "./handlers/seize";
+import { executeSeize, extractSeizePolicyCandidate, prepareSeize } from "./handlers/seize";
 import { refreshTokenSupply } from "./handlers/supply";
 import { getTokenTemplate, listTokenTemplates } from "./handlers/templates";
 import { createToken, getToken, listTokenFacets, listTokens, updateToken } from "./handlers/tokens";
@@ -191,6 +191,7 @@ issuance.post(
   "/tokens/:tokenId/seize",
   requirePermissions("tokens:admin"),
   validateBody(seizeSchema),
+  policyGate({ extract: extractSeizePolicyCandidate }),
   executeSeize
 );
 

--- a/apps/sdp-api/src/security/value-moving-conformance.node.test.ts
+++ b/apps/sdp-api/src/security/value-moving-conformance.node.test.ts
@@ -111,6 +111,66 @@ const contracts: ValueMovingContract[] = [
     ],
   },
   {
+    family: "issuance",
+    trustedContext: {
+      file: "apps/sdp-api/src/routes/issuance/handlers/seize.ts",
+      evidence: "const { auth, projectId, orgId } = requireProjectScope(c)",
+    },
+    authorization: {
+      file: "apps/sdp-api/src/routes/issuance/index.ts",
+      section: '"/tokens/:tokenId/seize",',
+      before: "policyGate({ extract: extractSeizePolicyCandidate })",
+      after: "executeSeize",
+    },
+    replay: [
+      {
+        mode: "idempotency_fingerprint",
+        file: "apps/sdp-api/src/routes/issuance/handlers/settled-transaction.test.ts",
+        evidence: "repairs a pending transaction from its durable successful outcome",
+      },
+    ],
+  },
+  {
+    family: "issuance",
+    trustedContext: {
+      file: "apps/sdp-api/src/routes/issuance/handlers/force-burn.ts",
+      evidence: "const { auth, projectId, orgId } = requireProjectScope(c)",
+    },
+    authorization: {
+      file: "apps/sdp-api/src/routes/issuance/index.ts",
+      section: '"/tokens/:tokenId/force-burn",',
+      before: "policyGate({ extract: extractForceBurnPolicyCandidate })",
+      after: "executeForceBurn",
+    },
+    replay: [
+      {
+        mode: "idempotency_fingerprint",
+        file: "apps/sdp-api/src/routes/issuance/handlers/settled-transaction.test.ts",
+        evidence: "repairs a pending transaction from its durable successful outcome",
+      },
+    ],
+  },
+  {
+    family: "issuance",
+    trustedContext: {
+      file: "apps/sdp-api/src/routes/issuance/handlers/burn.ts",
+      evidence: "const { auth, projectId, orgId } = requireProjectScope(c)",
+    },
+    authorization: {
+      file: "apps/sdp-api/src/routes/issuance/index.ts",
+      section: '"/tokens/:tokenId/burn",',
+      before: "policyGate({ extract: extractBurnPolicyCandidate })",
+      after: "executeBurn",
+    },
+    replay: [
+      {
+        mode: "idempotency_fingerprint",
+        file: "apps/sdp-api/src/routes/issuance/handlers/settled-transaction.test.ts",
+        evidence: "repairs a pending transaction from its durable successful outcome",
+      },
+    ],
+  },
+  {
     family: "payments",
     trustedContext: {
       file: "apps/sdp-api/src/routes/payments/context.ts",
@@ -378,13 +438,18 @@ describe("value-moving authorization and replay conformance", () => {
   it("covers every required value-moving family", () => {
     // `earn` appears twice: money-in (vault deposits) and money-out (vault
     // withdrawals) are separately gated routes, and each carries its own
-    // authorization boundary and replay evidence.
+    // authorization boundary and replay evidence. `issuance` appears four
+    // times for the same reason: authority updates, seize, force-burn, and
+    // burn are separately gated execute routes.
     expect(contracts.map((contract) => contract.family).sort()).toEqual([
       "batch",
       "custody",
       "dvp",
       "earn",
       "earn",
+      "issuance",
+      "issuance",
+      "issuance",
       "issuance",
       "payments",
       "ramps",

--- a/apps/sdp-api/src/services/domain/signing.service.ts
+++ b/apps/sdp-api/src/services/domain/signing.service.ts
@@ -1611,6 +1611,22 @@ export class SigningService {
     );
   }
 
+  /**
+   * Name the wallet a signer request without an explicit wallet would use,
+   * without loading signing material. Callers that must evaluate policy before
+   * they are allowed to sign resolve through the same effective target
+   * `getTransactionSigner` does, so the wallet policy judges is the wallet that
+   * signs. Null means the target carries no wallet.
+   */
+  async getEffectiveSigningWalletId(orgId: string, projectId?: string): Promise<string | null> {
+    const target = await this.runtimeTargets.resolve({
+      kind: "effective",
+      organizationId: orgId,
+      projectId,
+    });
+    return target?.wallet?.walletId ?? null;
+  }
+
   async admitRuntimeExecution(
     orgId: string,
     projectId: string | undefined,

--- a/apps/sdp-api/src/services/solana/index.ts
+++ b/apps/sdp-api/src/services/solana/index.ts
@@ -27,5 +27,6 @@ export {
   createSignerFromBase58,
   getSignerAddress,
   type KeyPairSigner,
+  resolveEffectiveSigningWalletId,
   signerControlsAddress,
 } from "./signer";

--- a/apps/sdp-api/src/services/solana/signer.ts
+++ b/apps/sdp-api/src/services/solana/signer.ts
@@ -115,6 +115,21 @@ export async function createOrgSigner(
   return signingService.getTransactionSigner(orgId, projectId ?? undefined, walletId ?? undefined);
 }
 
+/**
+ * Name the wallet `createOrgSigner` would use when the caller names none,
+ * without loading signing material. Policy extractors run before the gate
+ * decides, so they resolve the signer's identity this way rather than treating
+ * an absent wallet id as an ungoverned operation.
+ */
+export async function resolveEffectiveSigningWalletId(
+  env: Env,
+  orgId: string,
+  projectId?: string | null
+): Promise<string | null> {
+  const signingService = createSigningService(env);
+  return signingService.getEffectiveSigningWalletId(orgId, projectId ?? undefined);
+}
+
 /** Resolve the signer for one already-authorized custody-wallet database row. */
 export async function createOrgSignerForCustodyWallet(
   env: Env,


### PR DESCRIPTION
Mounts the wallet-operation policy gate on the three issuance execute routes that were not yet covered — seize, force-burn, and burn — using the operation types already declared in WALLET_OPERATION_TYPES.
Each route gets an extraction function mirroring the existing mint and authority pattern: token resolution, control checks, and signing-wallet resolution move into the extractor, the gate evaluates the policy candidate, and the handler consumes the resolved context without re-resolving; signing material is still loaded only inside the handler.
Deny and approval-required policy decisions now apply before a transaction record or signature exists, and Dry-Run requests answer with the policy verdict without executing; prepare routes are unchanged since they do not sign.
The value-moving conformance registry gains entries for the three newly gated routes.
Tests cover an always-deny policy stopping each operation before signer and issuance side effects, a seize dry-run with zero writes, and the conformance registry.