### PR TITLE
fix(earn): PRO-1904 submitted-movement expiry corroboration, PRO-1872 public OpenAPI gate, PRO-1871 sponsor key guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Public docs and AI artifacts should mirror the supported public surface only.
 
 - Public API families: `health`, `api-keys`, `wallets`, `projects`, `issuance`, `payments`, `policies`, `compliance`, `earn`
 - Hidden/internal families stay out of public AI resources unless product policy changes: `rpc`, `admin`, `onboarding`, `auth`, `organizations`, `members`
+- Promoting a route into the public OpenAPI document is a security-relevant scope change, not a docs edit: the PR needs a named security sign-off. For `earn` the pinned list in `apps/sdp-api/src/openapi/spec.test.ts` enforces this (see `apps/sdp-api/src/routes/earn/CLAUDE.md`, "Public OpenAPI promotion").
 
 ## Preferred checks
 

--- a/apps/sdp-api/src/db/migrations/postgres/0092_earn_movement_unknown_signature_observation.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0092_earn_movement_unknown_signature_observation.sql
@@ -1,0 +1,41 @@
+-- Solana Earn: corroborate before expiring a SUBMITTED vault movement whose
+-- signature the RPC does not know (PRO-1904, threat model EARN-006).
+--
+-- ── The asymmetry this closes ──────────────────────────────────────────────
+-- The reconciliation sweep treats a null `getSignatureStatuses` answer two
+-- ways. A `confirmed` row is left alone: the transaction demonstrably landed
+-- and RPC history simply forgot it. A `submitted` row was expired to `failed`
+-- the moment the chain height passed its `last_valid_block_height`, on ONE
+-- null observation, with no corroboration. RPC history is not complete (that
+-- is exactly why the `confirmed` guard exists), so a submitted movement that
+-- landed and aged out of history before the sweep ever saw it `confirmed`
+-- became a false `failed`: the ledger said the money did not move while the
+-- shares sat in the vault, and `failed` is terminal, so nothing repaired it.
+--
+-- ── The evidence bar ───────────────────────────────────────────────────────
+-- Expiry of a `submitted` row now takes TWO null observations on separate
+-- sweep ticks, both past the blockhash window. This column is the first one.
+-- It is written only by the sweep (the interactive detail read never expires),
+-- only on a `submitted` row, and only once (COALESCE), so a burst of ticks
+-- cannot stack observations. A later tick that finds the signature moves the
+-- row forward and the column becomes inert history. `requested` rows keep the
+-- one-tick rule: an unbroadcast transaction past its blockhash cannot land.
+--
+-- A dedicated column rather than `provider_data`: that JSONB is the
+-- provider's payload, and a sweep bookkeeping mark hidden in it would be
+-- invisible to the constraint below and to anyone reading the row.
+
+ALTER TABLE earn_movements
+    ADD COLUMN IF NOT EXISTS unknown_signature_observed_at TEXT;
+
+COMMENT ON COLUMN earn_movements.unknown_signature_observed_at IS
+    'When the reconciliation sweep first saw this SUBMITTED movement''s signature unknown to RPC after its blockhash window closed. A second such observation on a later tick expires the row; NULL means never observed. Never written for requested or confirmed rows.';
+
+-- Only a broadcast movement can be observed unknown: a `requested` row has not
+-- been sent, and `confirmed` rows are never expired. Terminal rows keep the
+-- mark as history of how they got there.
+ALTER TABLE earn_movements
+    DROP CONSTRAINT IF EXISTS earn_movements_unknown_signature_observation_shape;
+ALTER TABLE earn_movements
+    ADD CONSTRAINT earn_movements_unknown_signature_observation_shape
+    CHECK (unknown_signature_observed_at IS NULL OR status <> 'requested');

--- a/apps/sdp-api/src/db/repositories/earn-movements.repository.ts
+++ b/apps/sdp-api/src/db/repositories/earn-movements.repository.ts
@@ -176,6 +176,12 @@ export interface EarnMovementRow {
   creates_share_account: boolean;
   /** Who this movement charged that rent to. Null means the custody wallet. */
   share_ata_rent_funder: string | null;
+  /**
+   * When the sweep first saw this SUBMITTED movement's signature unknown to
+   * RPC after its blockhash window closed (migration 0092, PRO-1904). One
+   * observation parks the row; a second on a later tick expires it.
+   */
+  unknown_signature_observed_at: string | null;
 }
 
 /**
@@ -535,6 +541,18 @@ export interface EarnMovementsRepository {
    */
   advanceVaultMovement(input: AdvanceVaultMovementInput): Promise<EarnMovementRow | null>;
   /**
+   * The sweep's first piece of evidence that a SUBMITTED vault movement did not
+   * land (PRO-1904): its signature came back unknown after the blockhash window
+   * closed. Idempotent (COALESCE) and status-guarded, so a burst of ticks
+   * records one observation and a row that has since moved on is untouched.
+   * Returns the row when the mark was written or already present, null when
+   * the row is no longer `submitted`.
+   */
+  recordUnknownSignatureObservation(input: {
+    movementId: string;
+    organizationId: string;
+  }): Promise<EarnMovementRow | null>;
+  /**
    * Insert-at-intent for a custodial movement: the row exists before the provider
    * accepts. Always returns the row — a missing holding heals then retries, and a
    * missing program wallet throws rather than letting money move unrecorded.
@@ -815,6 +833,7 @@ function mapMovementRow(row: Record<string, unknown>): EarnMovementRow {
     updated_at: row.updated_at as string,
     creates_share_account: row.creates_share_account === true,
     share_ata_rent_funder: row.share_ata_rent_funder as string | null,
+    unknown_signature_observed_at: row.unknown_signature_observed_at as string | null,
   };
 }
 
@@ -1752,6 +1771,23 @@ export function createPostgresEarnMovementsRepository(db: AppDb): EarnMovementsR
         }
         return movement;
       });
+    },
+
+    async recordUnknownSignatureObservation(input) {
+      const row = await db
+        .prepare(
+          `UPDATE earn_movements
+              SET unknown_signature_observed_at = COALESCE(unknown_signature_observed_at, sdp_iso_now()),
+                  updated_at = sdp_iso_now()
+            WHERE id = ?
+              AND organization_id = ?
+              AND execution_model = 'vault_direct'
+              AND status = 'submitted'
+            RETURNING *`
+        )
+        .bind(input.movementId, input.organizationId)
+        .first<Record<string, unknown>>();
+      return row ? mapMovementRow(row) : null;
     },
 
     async createCustodialMovement(input) {

--- a/apps/sdp-api/src/openapi/spec.test.ts
+++ b/apps/sdp-api/src/openapi/spec.test.ts
@@ -90,6 +90,51 @@ describe("OpenAPI spec", () => {
     }
     expect(publicDocument.components?.securitySchemes?.clerkBearerAuth).toBeUndefined();
 
+    // ── SECURITY REVIEW GATE (PRO-1872, threat model EARN-027) ──────────────
+    // The public/preview split is a PUBLICATION boundary, not an auth boundary:
+    // every /v1/earn route accepts every auth mode at runtime, so the public
+    // document is the whole partner-facing contract. Promoting a preview route
+    // into it is a security-relevant scope change and a threat-model revisit
+    // trigger. This list is the gate: a PR that grows it must carry security
+    // sign-off (routes/earn/CLAUDE.md, "Public OpenAPI promotion"). Do not
+    // widen the list to make a red test pass.
+    const publicEarnOperations = Object.entries(publicDocument.paths ?? {})
+      .filter(([path]) => path.startsWith("/v1/earn"))
+      .flatMap(([path, item]) =>
+        Object.keys(item ?? {})
+          .filter((method) => ["get", "post", "put", "patch", "delete"].includes(method))
+          .map((method) => `${method.toUpperCase()} ${path}`)
+      )
+      .sort();
+    expect(publicEarnOperations).toEqual(
+      [
+        "GET /v1/earn/strategies",
+        "GET /v1/earn/strategies/{strategyId}",
+        "POST /v1/earn/vault-deposit-previews",
+        "GET /v1/earn/external-wallet/positions/summary",
+        "GET /v1/earn/external-wallet/positions",
+        "GET /v1/earn/external-wallet/movements",
+        "GET /v1/earn/external-wallet/movements/{movementId}",
+        "GET /v1/earn/external-wallet/earnings",
+        "POST /v1/earn/external-wallet/deposit-transactions",
+        "POST /v1/earn/external-wallet/deposits",
+        "POST /v1/earn/external-wallet/withdrawal-previews",
+        "POST /v1/earn/external-wallet/withdrawal-transactions",
+        "POST /v1/earn/external-wallet/withdrawals",
+      ].sort()
+    );
+    // Coverage parity across the boundary: every published operation is the
+    // same registered route as its internal twin (same operationId), so the
+    // app-level request tracing and rate limiting that wrap `/v1/*` apply to
+    // both by construction; there is no public-only mount to fall outside them.
+    for (const operation of publicEarnOperations) {
+      const [method, path] = operation.split(" ") as [string, string];
+      const key = method.toLowerCase() as "get" | "post";
+      expect(internal.paths?.[path]?.[key]?.operationId).toBe(
+        publicDocument.paths?.[path]?.[key]?.operationId
+      );
+    }
+
     for (const path of [
       "/v1/earn/vault-deposit-previews",
       "/v1/earn/external-wallet/deposit-transactions",

--- a/apps/sdp-api/src/routes/earn.vault-withdrawals.test.ts
+++ b/apps/sdp-api/src/routes/earn.vault-withdrawals.test.ts
@@ -269,6 +269,7 @@ function movementRow(overrides: Partial<EarnMovementRow> = {}): EarnMovementRow 
     updated_at: new Date().toISOString(),
     creates_share_account: false,
     share_ata_rent_funder: null,
+    unknown_signature_observed_at: null,
     ...overrides,
   };
 }

--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -814,6 +814,30 @@ Pinned by the "sweep telemetry" describe in
 `../../services/jobs/reconcile-earn-vault-movements.test.ts`, whose
 `runWithCronRunEvent` test composes the real wrapper.
 
+**Expiring a `submitted` movement takes TWO unknown-signature observations**
+(PRO-1904, migration 0092). The evidence bar differs by status because the
+statuses carry different facts:
+
+- `requested` is unbroadcast. Past its blockhash it cannot land, so one null
+  status past the window expires it on that tick (the pre-existing rule).
+- `confirmed` demonstrably landed. A null status is RPC history forgetting, so
+  it is never expired (PRO-1716).
+- `submitted` was broadcast and MAY have landed. RPC history is not complete
+  (the `confirmed` rule exists for exactly that reason), so one null answer is
+  evidence, not proof, and a false `failed` is terminal with the shares still
+  in the vault. The first null observation past the window writes
+  `unknown_signature_observed_at` and returns `unchanged`; only a LATER tick
+  that sees the signature unknown again fails the row. A tick that finds the
+  signature in between advances it normally and the mark becomes inert.
+
+The mark is written only by the sweep (the interactive read-through passes no
+block height and can neither park nor expire), only on a `submitted` row, and
+only once (COALESCE), so a burst of ticks cannot count as two observations. An
+unavailable block-height read is not an observation either: the row is left for
+the next tick (ADR 0002 exit safety). Cost: a genuinely dead submitted
+movement fails one tick later than before. Pinned by the "expiring a SUBMITTED
+movement" describe in the same test file.
+
 ### Vault withdrawals — the exit half (PRO-1702)
 
 - `POST /vault-withdrawals` — **build + simulate + sign ALL legs + record ALL

--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -98,6 +98,19 @@ balance with a live one.
   integration guide is derived from the strategy catalogue and persists
   nothing.
 
+- **Public OpenAPI promotion is a security review gate** (PRO-1872, threat
+  model EARN-027). `registerPublicEarnPaths` decides what partners see, and
+  the public/preview split is a PUBLICATION boundary only: every `/v1/earn`
+  route accepts every auth mode at runtime, and both surfaces are the same
+  Hono router under the same `/v1/*` tracing and rate-limit middleware. So
+  moving a route into the public document changes the partner-facing scope
+  without changing any enforcement, which is why it needs a human gate. The
+  pinned operation list in `../../openapi/spec.test.ts` ("publishes the
+  caller-signed money routes") is that gate: growing it requires a security
+  sign-off named in the PR (who reviewed, and the threat-model row the route
+  lands under), and the threat model's revisit trigger fires. Never widen the
+  list just to make the test pass.
+
 - `GET /strategies[/:id]` — **DB** (synced catalogue), env-scoped. Rows are
   admitted only by the hourly sync cron; the 5-minute metrics refresh
   (`cron/earn-metrics-refresh.ts`) updates figures only and can never insert.

--- a/apps/sdp-api/src/services/earn/vault-movement-reconciliation.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-movement-reconciliation.service.ts
@@ -350,6 +350,23 @@ async function reconcileMovement(
     chain.currentBlockHeight !== null &&
     chain.currentBlockHeight > BigInt(lastValidBlockHeight)
   ) {
+    // A `requested` row was never broadcast, so past its blockhash it genuinely
+    // cannot land: expire it on the first observation. A `submitted` row is
+    // different (PRO-1904): RPC history is not complete, and the `confirmed`
+    // guard above exists for exactly that reason, so one null answer is not
+    // proof the transaction did not land. Expiring a landed movement is a
+    // terminal false `failed` with the shares sitting in the vault, so the
+    // sweep parks the row on the first null observation and expires it only
+    // when a LATER tick sees the signature unknown again. A tick that finds
+    // the signature in between moves the row forward through the branches
+    // above and the mark becomes inert.
+    if (movement.status === "submitted" && movement.unknown_signature_observed_at === null) {
+      await ledger.recordUnknownSignatureObservation({
+        movementId: movement.id,
+        organizationId: movement.organization_id,
+      });
+      return "unchanged";
+    }
     await failMovement(ledger, movement, "Transaction blockhash expired before confirmation");
     return "failed";
   }

--- a/apps/sdp-api/src/services/jobs/reconcile-earn-vault-movements.test.ts
+++ b/apps/sdp-api/src/services/jobs/reconcile-earn-vault-movements.test.ts
@@ -358,6 +358,74 @@ describe("reconcileEarnVaultMovements", () => {
     });
   });
 
+  describe("expiring a SUBMITTED movement takes two unknown-signature observations (PRO-1904)", () => {
+    async function seedSubmitted(lastValidBlockHeight = "100") {
+      const seeded = await seedMovement(lastValidBlockHeight);
+      await createPostgresEarnMovementsRepository(getDb(env)).advanceVaultMovement({
+        movementId: seeded.movement.id,
+        organizationId: ORG,
+        toStatus: "submitted",
+      });
+      return seeded;
+    }
+
+    it("parks the row on the first observation and expires it on the second", async () => {
+      const seeded = await seedSubmitted("100");
+      getSignatureStatuses.mockResolvedValue([null]);
+      getBlockHeight.mockResolvedValue(101n);
+
+      await reconcileEarnVaultMovements(env);
+
+      // One null answer past the window is evidence, not proof: the row stays
+      // submitted, remembers the observation, and is not rebroadcast (the
+      // blockhash is gone) nor failed.
+      const parked = await ledgerRow(seeded.movement.id);
+      expect(parked).toMatchObject({ status: "submitted", failure_reason: null });
+      expect(parked?.unknown_signature_observed_at).toEqual(expect.any(String));
+      expect(broadcastVaultTransaction).not.toHaveBeenCalled();
+
+      await reconcileEarnVaultMovements(env);
+
+      await expect(ledgerRow(seeded.movement.id)).resolves.toMatchObject({
+        status: "failed",
+        failure_reason: "Transaction blockhash expired before confirmation",
+      });
+    });
+
+    it("never fails a submitted movement whose signature was unknown once and then lands", async () => {
+      const seeded = await seedSubmitted("100");
+      getSignatureStatuses.mockResolvedValue([null]);
+      getBlockHeight.mockResolvedValue(101n);
+      await reconcileEarnVaultMovements(env);
+      await expect(ledgerRow(seeded.movement.id)).resolves.toMatchObject({ status: "submitted" });
+
+      // RPC history catches up: the transaction had landed all along.
+      getSignatureStatuses.mockResolvedValue([
+        { slot: 1n, confirmations: null, err: null, confirmationStatus: "finalized" },
+      ]);
+      await reconcileEarnVaultMovements(env);
+
+      await expect(ledgerRow(seeded.movement.id)).resolves.toMatchObject({
+        status: "finalized",
+        failure_reason: null,
+        amount_settled: "1",
+      });
+    });
+
+    it("leaves a parked row alone when the corroborating height read is unavailable", async () => {
+      const seeded = await seedSubmitted("100");
+      getSignatureStatuses.mockResolvedValue([null]);
+      getBlockHeight.mockResolvedValue(101n);
+      await reconcileEarnVaultMovements(env);
+
+      // Exit safety (ADR 0002): an unavailable read is not a second observation.
+      getBlockHeight.mockRejectedValue(new Error("rpc down"));
+      await expect(reconcileEarnVaultMovements(env)).rejects.toThrow();
+
+      await expect(ledgerRow(seeded.movement.id)).resolves.toMatchObject({ status: "submitted" });
+    });
+  });
+
   it("rebroadcasts the exact recorded bytes while the blockhash is valid", async () => {
     const seeded = await seedMovement("100");
     getSignatureStatuses.mockResolvedValue([null]);

--- a/apps/sdp-docs/content/docs/guides/embedded-yield.mdx
+++ b/apps/sdp-docs/content/docs/guides/embedded-yield.mdx
@@ -195,6 +195,18 @@ What to know when sponsoring:
 
 The Treasury surface uses SDP's configured paymaster when Earn sponsorship is enabled for the cluster. Otherwise the organization custody wallet pays its own fee and rent. This is separate from the partner-controlled `feePayer` on Embedded Yield builds.
 
+### Protect the sponsor key
+
+The sponsor is a hot key on your backend by design: it has to co-sign inside the blockhash window, so it cannot sit behind a manual approval. That makes it a target. Nothing SDP does limits what a stolen or abused sponsor key can spend, because the key never touches SDP; the controls are yours. Treat the following as the minimum before you sponsor on mainnet.
+
+- **Dedicated signer.** Use a keypair whose only job is co-signing SDP builds. Never reuse a treasury, deployer, or hot-wallet key: a compromise of the sponsor must cost you at most the sponsor's float.
+- **Programmatic co-sign only, and only of SDP builds.** Your co-signing code should sign transactions your own backend just received from `deposit-transactions`, `withdrawal-transactions`, or a split swap, for a customer session you authenticated, and nothing else. Do not expose a "sign this" endpoint that accepts arbitrary bytes, and do not let the key sign from a client. Verify the fee payer and the program IDs in the decoded message match what you asked SDP to build before signing.
+- **Bound the float.** Keep only what a day or two of expected sponsorship costs in the sponsor wallet, and top it up from a cold or multisig-controlled source on a schedule. A drained sponsor stops new deposits for a while; a drained treasury does not come back.
+- **Monitor spend and alert on it.** Track the sponsor's SOL balance and outflow per hour. Alert on the balance crossing your refill threshold, on outflow above your expected per-hour ceiling, and on any transfer from the sponsor that is not a fee or rent payment. Fee and rent griefing shows up first as a spend curve that does not match your deposit volume, so compare the two.
+- **Rate-limit sponsorship per customer.** A build costs you nothing until you co-sign, so decide per customer and per session how many sponsored transactions you will sign in a window, and refuse to co-sign past it. SDP will not do this for you: it does not know which of your customers a wallet belongs to.
+- **Plan rotation.** Keep the sponsor address in configuration, not code, so you can swap to a fresh keypair without a deploy. Rotate on any suspected exposure and on a fixed schedule. Rent refunds go to the funder recorded at deposit time, so a position sponsored by a retired key still refunds to that key on exit; keep retired sponsor keys retrievable until their positions are closed.
+- **Store the key like a secret.** A secrets manager or KMS-backed signer, never an environment variable in a repository or a file in an image. Log the sponsor's public key freely and its secret never.
+
 ## 4. Show balances and activity
 
 - `GET /v1/earn/external-wallet/earnings?ownerAddress=…` returns balance and total earned per deposit token. `earned` is stated only when exact; otherwise it is absent with a named `earnedUnavailableReason`. Render a dash for an absent figure, never $0.
@@ -237,7 +249,7 @@ Pass `sourceTokenMint` (USDC, USDG, PYUSD or USDT on your cluster) to accept a s
 
 If the composed transaction cannot fit one Solana packet, the response is `{ requiresSeparateSwap: true, swap, followUp }` instead: have the wallet sign `swap.transaction` and broadcast it yourself, then build again with the `followUp` body, which echoes your original `minSharesOut` and `feePayer` so the follow-up keeps the same protections.
 
-Recovery across that split is yours: persist the swap signature and the `followUp` body before broadcasting, and reconcile before you rebuild, because SDP records no movement for the standalone swap. SDP does record that it handed the swap out, and flags owners whose deposit-token balance rose by the swap's floor with no follow-up deposit after a grace period, so an integration that drops the follow-up will be noticed; it will not be repaired for you. Demonstrating split-swap recovery in sandbox is part of the production certification checklist.
+Recovery across that split is yours: persist the swap signature and the `followUp` body before broadcasting, and reconcile before you rebuild, because SDP records no movement for the standalone swap. SDP does record that it handed the swap out, and flags owners whose deposit-token balance rose by the swap's floor with no follow-up deposit after a grace period, so an integration that drops the follow-up will be noticed; it will not be repaired for you. Demonstrating split-swap recovery in sandbox is part of the [production checklist](#before-production).
 
 ## Idempotency, in one place
 
@@ -247,5 +259,15 @@ Recovery across that split is yours: persist the swap signature and the `followU
 | Submits | `Idempotency-Key` header required. Same key on retry returns the original movement (`replayed: true`); a different key against an already-consumed build is a 409. |
 
 A `400` means the request or current vault state must change before retrying. A `503 PROVIDER_UNAVAILABLE` means live provider or RPC state could not be read; retry the read-only preview or build with bounded backoff. For an uncertain submit response, retry the exact signed transaction with the same idempotency key.
+
+## Before production
+
+Work through this in sandbox before you go live. Each item is something SDP cannot check for you.
+
+- Your submit path retries an uncertain response with the same signed bytes and the same `Idempotency-Key`, and treats a `409` as "already consumed".
+- Your UI polls past `confirmed` and only treats `finalized` and `failed` as terminal.
+- Absent fields render as absent (a dash, never `$0`), and you handle every status in the vocabulary rather than collapsing unknown ones.
+- If you accept swap-funded deposits, you have demonstrated split-swap recovery in sandbox: a swap broadcast, a simulated crash, and the follow-up deposit rebuilt from persisted state.
+- If you sponsor fees, the sponsor key meets every point in [Protect the sponsor key](#protect-the-sponsor-key), and the spend alerts have fired at least once in a drill.
 
 Full request and response shapes: [Earn API reference](/docs/reference/api/earn).

--- a/apps/sdp-docs/public/llms-full.txt
+++ b/apps/sdp-docs/public/llms-full.txt
@@ -1085,6 +1085,18 @@ What to know when sponsoring:
 
 The Treasury surface uses SDP's configured paymaster when Earn sponsorship is enabled for the cluster. Otherwise the organization custody wallet pays its own fee and rent. This is separate from the partner-controlled `feePayer` on Embedded Yield builds.
 
+### Protect the sponsor key
+
+The sponsor is a hot key on your backend by design: it has to co-sign inside the blockhash window, so it cannot sit behind a manual approval. That makes it a target. Nothing SDP does limits what a stolen or abused sponsor key can spend, because the key never touches SDP; the controls are yours. Treat the following as the minimum before you sponsor on mainnet.
+
+- **Dedicated signer.** Use a keypair whose only job is co-signing SDP builds. Never reuse a treasury, deployer, or hot-wallet key: a compromise of the sponsor must cost you at most the sponsor's float.
+- **Programmatic co-sign only, and only of SDP builds.** Your co-signing code should sign transactions your own backend just received from `deposit-transactions`, `withdrawal-transactions`, or a split swap, for a customer session you authenticated, and nothing else. Do not expose a "sign this" endpoint that accepts arbitrary bytes, and do not let the key sign from a client. Verify the fee payer and the program IDs in the decoded message match what you asked SDP to build before signing.
+- **Bound the float.** Keep only what a day or two of expected sponsorship costs in the sponsor wallet, and top it up from a cold or multisig-controlled source on a schedule. A drained sponsor stops new deposits for a while; a drained treasury does not come back.
+- **Monitor spend and alert on it.** Track the sponsor's SOL balance and outflow per hour. Alert on the balance crossing your refill threshold, on outflow above your expected per-hour ceiling, and on any transfer from the sponsor that is not a fee or rent payment. Fee and rent griefing shows up first as a spend curve that does not match your deposit volume, so compare the two.
+- **Rate-limit sponsorship per customer.** A build costs you nothing until you co-sign, so decide per customer and per session how many sponsored transactions you will sign in a window, and refuse to co-sign past it. SDP will not do this for you: it does not know which of your customers a wallet belongs to.
+- **Plan rotation.** Keep the sponsor address in configuration, not code, so you can swap to a fresh keypair without a deploy. Rotate on any suspected exposure and on a fixed schedule. Rent refunds go to the funder recorded at deposit time, so a position sponsored by a retired key still refunds to that key on exit; keep retired sponsor keys retrievable until their positions are closed.
+- **Store the key like a secret.** A secrets manager or KMS-backed signer, never an environment variable in a repository or a file in an image. Log the sponsor's public key freely and its secret never.
+
 ## 4. Show balances and activity
 
 - `GET /v1/earn/external-wallet/earnings?ownerAddress=…` returns balance and total earned per deposit token. `earned` is stated only when exact; otherwise it is absent with a named `earnedUnavailableReason`. Render a dash for an absent figure, never $0.
@@ -1127,7 +1139,7 @@ Pass `sourceTokenMint` (USDC, USDG, PYUSD or USDT on your cluster) to accept a s
 
 If the composed transaction cannot fit one Solana packet, the response is `{ requiresSeparateSwap: true, swap, followUp }` instead: have the wallet sign `swap.transaction` and broadcast it yourself, then build again with the `followUp` body, which echoes your original `minSharesOut` and `feePayer` so the follow-up keeps the same protections.
 
-Recovery across that split is yours: persist the swap signature and the `followUp` body before broadcasting, and reconcile before you rebuild, because SDP records no movement for the standalone swap. SDP does record that it handed the swap out, and flags owners whose deposit-token balance rose by the swap's floor with no follow-up deposit after a grace period, so an integration that drops the follow-up will be noticed; it will not be repaired for you. Demonstrating split-swap recovery in sandbox is part of the production certification checklist.
+Recovery across that split is yours: persist the swap signature and the `followUp` body before broadcasting, and reconcile before you rebuild, because SDP records no movement for the standalone swap. SDP does record that it handed the swap out, and flags owners whose deposit-token balance rose by the swap's floor with no follow-up deposit after a grace period, so an integration that drops the follow-up will be noticed; it will not be repaired for you. Demonstrating split-swap recovery in sandbox is part of the [production checklist](#before-production).
 
 ## Idempotency, in one place
 
@@ -1137,6 +1149,16 @@ Recovery across that split is yours: persist the swap signature and the `followU
 | Submits | `Idempotency-Key` header required. Same key on retry returns the original movement (`replayed: true`); a different key against an already-consumed build is a 409. |
 
 A `400` means the request or current vault state must change before retrying. A `503 PROVIDER_UNAVAILABLE` means live provider or RPC state could not be read; retry the read-only preview or build with bounded backoff. For an uncertain submit response, retry the exact signed transaction with the same idempotency key.
+
+## Before production
+
+Work through this in sandbox before you go live. Each item is something SDP cannot check for you.
+
+- Your submit path retries an uncertain response with the same signed bytes and the same `Idempotency-Key`, and treats a `409` as "already consumed".
+- Your UI polls past `confirmed` and only treats `finalized` and `failed` as terminal.
+- Absent fields render as absent (a dash, never `$0`), and you handle every status in the vocabulary rather than collapsing unknown ones.
+- If you accept swap-funded deposits, you have demonstrated split-swap recovery in sandbox: a swap broadcast, a simulated crash, and the follow-up deposit rebuilt from persisted state.
+- If you sponsor fees, the sponsor key meets every point in [Protect the sponsor key](#protect-the-sponsor-key), and the spend alerts have fired at least once in a drill.
 
 Full request and response shapes: [Earn API reference](/docs/reference/api/earn).
 


### PR DESCRIPTION
Three small `[threat-model]` tickets from the Earn epic, bundled because none is large enough for its own PR. One commit each.

## What changed

| Ticket | Change |
| -- | -- |
| PRO-1904 | Migration 0092 adds `earn_movements.unknown_signature_observed_at`. The sweep parks a `submitted` movement on its first null-signature observation past the blockhash window and fails it only when a later tick sees it unknown again. `requested` rows keep the one-tick rule; `confirmed` rows are untouched. |
| PRO-1872 | `spec.test.ts` pins the exact public `/v1/earn` operation list (13 today) and asserts each shares its operationId with the internal twin. Growing the list requires named security sign-off (routes/earn/CLAUDE.md, AGENTS.md). |
| PRO-1871 | Embedded-yield guide gains "Protect the sponsor key" and a "Before production" checklist that links it and split-swap recovery. |

## Reviewer notes

- **PRO-1904 costs one extra tick.** A genuinely dead submitted movement now fails a minute later than before. That is the price of never turning a landed-but-forgotten transaction into a terminal false `failed`. Full rationale in the 0092 header and the CLAUDE.md "two unknown-signature observations" section.
- **The mark is sweep-only and write-once.** The interactive read-through passes no block height so it can neither park nor expire; COALESCE stops a burst of ticks counting as two observations; an unavailable height read is not an observation (ADR 0002 exit safety).
- **No PR template exists in this repo**, so the PRO-1872 "PR template note" lives in AGENTS.md and the earn CLAUDE.md instead of a new repo-wide template.
- **Parity is by construction.** Public and preview earn routes are the same Hono router under the same `/v1/*` tracing and rate-limit wildcards, so no gap tickets from PRO-1872.

## Verification

- Reconciliation job suite 31 pass (3 new), spec test 20 pass, withdrawals + repository + tenant-isolation + migration + authz-matrix + movements suites 161 pass.
- `tsc --noEmit` clean. The one biome warning and one docs link-check miss are pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
