### PR TITLE
feat(dvp): sponsor trade creation fee and rent through Kora

### DIFF
--- a/apps/sdp-api/src/db/repositories/dvp-trade.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/dvp-trade.repository.postgres.ts
@@ -1,5 +1,6 @@
 import { type Address, address, type Signature, signature } from "@solana/kit";
 import type { AppDb } from "@/db";
+import type { DatabaseExecutor } from "@/db/client";
 import type {
   DvpTradeInsert,
   DvpTradeListFilters,
@@ -140,11 +141,17 @@ function walletScopeClause(sdpWalletIds: string[] | null | undefined): {
 }
 
 export function createPostgresDvpTradeRepository(db: AppDb): DvpTradeRepository {
-  return {
-    async create(row: DvpTradeInsert) {
-      const inserted = await db
-        .prepare(
-          `INSERT INTO dvp_trades (
+  /**
+   * Inserts a DvP claim through either the client or its transaction executor.
+   *
+   * @param executor - Database executor owning the statement.
+   * @param row - Claim to insert.
+   * @returns The inserted claim.
+   */
+  async function insert(executor: DatabaseExecutor, row: DvpTradeInsert): Promise<DvpTradeRow> {
+    const inserted = await executor
+      .prepare(
+        `INSERT INTO dvp_trades (
               id, organization_id, project_id, swap_dvp,
               settlement_authority, user_a, user_b, mint_a, mint_b, nonce,
               token_program_a, token_program_b,
@@ -166,45 +173,85 @@ export function createPostgresDvpTradeRepository(db: AppDb): DvpTradeRepository 
               ?, ?
             )
             RETURNING ${SELECT_COLUMNS}`
+      )
+      .bind(
+        row.id,
+        row.organizationId,
+        row.projectId,
+        row.swapDvp,
+        row.settlementAuthority,
+        row.userA,
+        row.userB,
+        row.mintA,
+        row.mintB,
+        row.nonce,
+        row.tokenProgramA,
+        row.tokenProgramB,
+        row.decimalsA,
+        row.decimalsB,
+        row.symbolA,
+        row.symbolB,
+        row.amountA,
+        row.amountB,
+        row.expiryTimestamp,
+        row.earliestSettlementTimestamp,
+        row.userASettlementDestination,
+        row.userBSettlementDestination,
+        row.refString,
+        row.escrowA,
+        row.escrowB,
+        row.counterpartyAccountIdA,
+        row.counterpartyAccountIdB,
+        row.idempotencyKey,
+        row.idempotencyFingerprint,
+        row.createSignature,
+        row.createLastValidBlockHeight
+      )
+      .first<Record<string, unknown>>();
+    if (!inserted) {
+      throw new Error("DvP trade insert returned no row");
+    }
+    return mapDvpTradeRow(inserted);
+  }
+
+  return {
+    async create(row: DvpTradeInsert) {
+      return insert(db, row);
+    },
+
+    async claimWithKeyRelease(failedRowId: string | null, row: DvpTradeInsert) {
+      return db.transaction(async (executor) => {
+        if (failedRowId !== null) {
+          await executor
+            .prepare(
+              `UPDATE dvp_trades
+                  SET idempotency_key = NULL, updated_at = sdp_iso_now()
+                WHERE id = ? AND status = 'create_failed' AND idempotency_key IS NOT NULL`
+            )
+            .bind(failedRowId)
+            .run();
+        }
+        return insert(executor, row);
+      });
+    },
+
+    async attachCreateSignature(
+      id: string,
+      createSignature: Signature,
+      lastValidBlockHeight: string
+    ) {
+      const row = await db
+        .prepare(
+          `UPDATE dvp_trades
+              SET create_signature = ?,
+                  create_last_valid_block_height = ?,
+                  updated_at = sdp_iso_now()
+            WHERE id = ? AND status = 'creating' AND create_signature IS NULL
+            RETURNING ${SELECT_COLUMNS}`
         )
-        .bind(
-          row.id,
-          row.organizationId,
-          row.projectId,
-          row.swapDvp,
-          row.settlementAuthority,
-          row.userA,
-          row.userB,
-          row.mintA,
-          row.mintB,
-          row.nonce,
-          row.tokenProgramA,
-          row.tokenProgramB,
-          row.decimalsA,
-          row.decimalsB,
-          row.symbolA,
-          row.symbolB,
-          row.amountA,
-          row.amountB,
-          row.expiryTimestamp,
-          row.earliestSettlementTimestamp,
-          row.userASettlementDestination,
-          row.userBSettlementDestination,
-          row.refString,
-          row.escrowA,
-          row.escrowB,
-          row.counterpartyAccountIdA,
-          row.counterpartyAccountIdB,
-          row.idempotencyKey,
-          row.idempotencyFingerprint,
-          row.createSignature,
-          row.createLastValidBlockHeight
-        )
+        .bind(createSignature, lastValidBlockHeight, id)
         .first<Record<string, unknown>>();
-      if (!inserted) {
-        throw new Error("DvP trade insert returned no row");
-      }
-      return mapDvpTradeRow(inserted);
+      return row ? mapDvpTradeRow(row) : null;
     },
 
     async resolveCreate(id: string, status: "created" | "create_failed") {

--- a/apps/sdp-api/src/db/repositories/dvp-trade.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/dvp-trade.repository.test.ts
@@ -31,6 +31,9 @@ const WALLET_B_PUBKEY = "7WLcnnT1nnPuHiWaVnAY3Uz8Y2SgFy2VMg2t7GAoxnpg";
 const BIG_NONCE = "18446744073709551610";
 const BIG_AMOUNT = "18446744073709551615";
 const CLOSE_SIGNATURE = signature("1".repeat(64));
+const CREATE_SIGNATURE = signature(
+  "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy"
+);
 
 function tradeInsert(overrides: Partial<DvpTradeInsert> = {}): DvpTradeInsert {
   return {
@@ -151,6 +154,33 @@ describe("DvpTradeRepository (postgres)", () => {
     expect(created.counterpartyAccountIdA).toBeNull();
     expect(created.counterpartyAccountIdB).toBeNull();
     expect(created.createdAt).toBeTruthy();
+  });
+
+  it("attaches a create signature exactly once", async () => {
+    const created = await repo.create(tradeInsert());
+
+    const attached = await repo.attachCreateSignature(created.id, CREATE_SIGNATURE, "1500");
+    const second = await repo.attachCreateSignature(created.id, CREATE_SIGNATURE, "1500");
+
+    expect(attached).toMatchObject({
+      createSignature: CREATE_SIGNATURE,
+      createLastValidBlockHeight: "1500",
+    });
+    expect(second).toBeNull();
+  });
+
+  it("does not attach a signature to a failed claim", async () => {
+    const created = await repo.create(tradeInsert());
+    await repo.resolveCreate(created.id, "create_failed");
+
+    await expect(
+      repo.attachCreateSignature(created.id, CREATE_SIGNATURE, "1500")
+    ).resolves.toBeNull();
+    await expect(repo.getById(scope, created.id)).resolves.toMatchObject({
+      status: "create_failed",
+      createSignature: null,
+      createLastValidBlockHeight: null,
+    });
   });
 
   it("round-trips counterparty account attribution", async () => {

--- a/apps/sdp-api/src/db/repositories/dvp-trade.repository.ts
+++ b/apps/sdp-api/src/db/repositories/dvp-trade.repository.ts
@@ -157,6 +157,30 @@ export interface DvpTradeRepository {
   /** Writes the row at `creating`, before the create transaction is broadcast. */
   create(row: DvpTradeInsert): Promise<DvpTradeRow>;
   /**
+   * Atomically releases a failed attempt's key and inserts its replacement claim.
+   *
+   * @param failedRowId - Failed attempt to release, or null for a first claim.
+   * @param row - The replacement claim to insert.
+   * @returns The newly inserted claim.
+   */
+  claimWithKeyRelease(failedRowId: string | null, row: DvpTradeInsert): Promise<DvpTradeRow>;
+  /**
+   * Attaches the sponsored signature to a still-live create claim.
+   *
+   * The compare-and-swap prevents resurrecting a claim that the reconciler
+   * failed while this request was waiting for its sponsor.
+   *
+   * @param id - Claim identifier.
+   * @param signature - Sponsor-signed transaction signature.
+   * @param lastValidBlockHeight - Last block height at which the transaction can land.
+   * @returns The updated claim, or null when it is no longer live or already signed.
+   */
+  attachCreateSignature(
+    id: string,
+    signature: Signature,
+    lastValidBlockHeight: string
+  ): Promise<DvpTradeRow | null>;
+  /**
    * Resolves a `creating` row once the broadcast outcome is known.
    *
    * Compare-and-swap on `creating`, so a reconciler that already resolved the

--- a/apps/sdp-api/src/openapi/schemas/dvp.ts
+++ b/apps/sdp-api/src/openapi/schemas/dvp.ts
@@ -26,7 +26,7 @@ export const dvpTradeIdParamsSchema = dvpTradeIdParamsSchemaBase;
 
 export const createDvpTradeRequestSchema = withOpenApi(createDvpTradeSchemaBase, {
   description:
-    "Terms of the trade to create on chain. Creating a trade commits neither party: only the fee payer signs, and the trade is a proposal until an escrow is funded.",
+    "Terms of the trade to create on chain. Creating a trade commits neither party: only SDP's sponsored fee payer signs, and the trade is a proposal until an escrow is funded.",
 });
 
 export const listDvpTradesQuerySchema = listDvpTradesQuerySchemaBase

--- a/apps/sdp-api/src/routes/dvp/handlers.ts
+++ b/apps/sdp-api/src/routes/dvp/handlers.ts
@@ -376,14 +376,9 @@ export const createTrade = async (c: ValidatedBodyContext<typeof createDvpTradeS
   const projectId = requireProjectId(c);
   const body = c.req.valid("json");
 
-  // A wallet named here either spends fee+rent (the payer) or is staged for
-  // funding (a party slot), so the key's binding on it is re-read from the DB
-  // (never the hour-old auth snapshot). The DEFAULTED payer — the settlement
-  // wallet — is project infrastructure every trade uses and needs no per-key
-  // assertion; key/wallet bindings gate caller-chosen wallets only.
-  // Liveness first, for EVERY key: with a defaulted payer and pasted-address
-  // slots no wallet is named below, yet create provisions the settlement
-  // wallet and spends its rent — a revoked key must not get that far on a
+  // Liveness first, for EVERY key. Create provisions the settlement wallet and
+  // spends sponsored Kora budget on the project's behalf, even when both party
+  // slots are pasted addresses, so a revoked key must not get that far on a
   // stale snapshot.
   await assertFreshApiKeyActive(getDb(c.env), auth);
   // A wallet-scoped key only SEES trades its bound wallets are party to, and
@@ -404,7 +399,6 @@ export const createTrade = async (c: ValidatedBodyContext<typeof createDvpTradeS
     );
   }
   const assertedWalletIds = [
-    ...(body.payerWalletId ? [body.payerWalletId] : []),
     ...("walletId" in body.partyA ? [body.partyA.walletId] : []),
     ...("walletId" in body.partyB ? [body.partyB.walletId] : []),
   ];
@@ -417,8 +411,6 @@ export const createTrade = async (c: ValidatedBodyContext<typeof createDvpTradeS
     projectId,
     partyA: body.partyA,
     partyB: body.partyB,
-    payerWalletId:
-      body.payerWalletId === null || body.payerWalletId === undefined ? null : body.payerWalletId,
     mintA: body.mintA,
     tokenProgramA: body.tokenProgramA,
     mintB: body.mintB,

--- a/apps/sdp-api/src/routes/dvp/schemas.ts
+++ b/apps/sdp-api/src/routes/dvp/schemas.ts
@@ -90,16 +90,13 @@ const dvpTradeTermsShape = {
 /**
  * The create body: two symmetric party slots and the trade terms.
  *
- * `partyA` and `partyB` are {@link dvpPartySchema} slots; `payerWalletId` is the
- * fee/rent signer and is NOT a term of the trade. Omitted, the project's DvP
- * settlement wallet pays — and, closing every trade, later receives the rent
- * back.
+ * `partyA` and `partyB` are {@link dvpPartySchema} slots. Fee and rent are paid
+ * by SDP's sponsored fee payer; nothing about the payer is configurable or a
+ * term of the trade.
  */
 export const createDvpTradeSchema = z.object({
   partyA: dvpPartySchema,
   partyB: dvpPartySchema,
-  /** Fee/rent signer; omitted means the settlement wallet pays. Not a term of the trade. */
-  payerWalletId: z.string().min(1).nullish(),
   ...dvpTradeTermsShape,
 });
 

--- a/apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts
@@ -13,12 +13,12 @@ import { createPostgresPaymentsRepository } from "@/db/repositories/payments.rep
 import { internalError, transactionFailed } from "@/lib/errors";
 import { createTenantScope } from "@/lib/tenant-scope";
 import { logEvent } from "@/runtime/money-path-events";
-import {
-  createTransferSignedSubmissionStore,
-  isDefiniteSubmissionError,
-  submitSignedPaymentTransaction,
-} from "@/services/payments/signed-submission";
+import { createTransferSignedSubmissionStore } from "@/services/payments/signed-submission";
 import { beginApprovedWalletOperationEffect } from "@/services/policy/approved-operation-replay";
+import {
+  isDefiniteSubmissionError,
+  submitSponsoredTransaction,
+} from "@/services/sponsorship-submission";
 import { type AppContext, type getFeePayment, getPaymentsRepository } from "../../context";
 import type { TransactionChunk } from "./transaction";
 import type { ResolvedBatchRequest } from "./types";
@@ -220,7 +220,7 @@ export async function executeChunk(params: {
   await beginApprovedWalletOperationEffect(c);
   const submissionStore = createTransferSignedSubmissionStore(getPaymentsRepository(c), transfer);
   try {
-    await submitSignedPaymentTransaction({
+    await submitSponsoredTransaction({
       feePayment: params.feePayment,
       rpc: resolved.rpc,
       transaction: txBytes,

--- a/apps/sdp-api/src/routes/payments/handlers/transfers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfers.ts
@@ -78,12 +78,7 @@ import {
   type OutboundPaymentOperation,
   resolveOutboundPaymentOperation,
 } from "@/services/payment-operation.service";
-import {
-  createTransferSignedSubmissionStore,
-  isDefiniteSubmissionError,
-  type SignedSubmissionStore,
-  submitSignedPaymentTransaction,
-} from "@/services/payments/signed-submission";
+import { createTransferSignedSubmissionStore } from "@/services/payments/signed-submission";
 import {
   approvedWalletOperationId,
   assertApprovedWalletOperationCustodyWallet,
@@ -98,6 +93,11 @@ import {
   prepareMagicBlockPrivateTransfer,
 } from "@/services/private-transfers";
 import * as solanaServices from "@/services/solana";
+import {
+  isDefiniteSubmissionError,
+  type SignedSubmissionStore,
+  submitSponsoredTransaction,
+} from "@/services/sponsorship-submission";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import { type AppContext, getFeePayment, getPaymentsRepository } from "../context";
 import { mapTransferRow } from "../mappers";
@@ -719,7 +719,7 @@ async function executeSolTransfer(
   const txEncoder = getTransactionEncoder();
   const txBytes = new Uint8Array(txEncoder.encode(partiallySigned));
   await beginApprovedWalletOperationEffect(c);
-  const signature = await submitSignedPaymentTransaction({
+  const signature = await submitSponsoredTransaction({
     feePayment,
     rpc,
     transaction: txBytes,
@@ -1279,7 +1279,7 @@ async function executePreparedPrivateTransfer(
 
   await beginApprovedWalletOperationEffect(c);
   const rpc = solanaRpc.createRpc(c.env);
-  const signature = await submitSignedPaymentTransaction({
+  const signature = await submitSponsoredTransaction({
     feePayment,
     rpc,
     transaction: encodedSignedTransaction,
@@ -1351,7 +1351,7 @@ async function executeSplTransfer(
   const txEncoder = getTransactionEncoder();
   const txBytes = new Uint8Array(txEncoder.encode(partiallySigned));
   await beginApprovedWalletOperationEffect(c);
-  const signature = await submitSignedPaymentTransaction({
+  const signature = await submitSponsoredTransaction({
     feePayment,
     rpc,
     transaction: txBytes,

--- a/apps/sdp-api/src/security/value-moving-conformance.node.test.ts
+++ b/apps/sdp-api/src/security/value-moving-conformance.node.test.ts
@@ -349,11 +349,13 @@ const signingSinkInventory: Record<string, string[]> = {
     // Wallet-paid signing likewise returns fully signed bytes without sending.
     "signTransactionMessageWithSigners",
   ],
-  // DvP signs from the project's settlement-authority custody wallet. Both
-  // sinks return fully signed bytes without sending, so the signature is known
-  // before anything reaches the network — which is what lets create record the
-  // trade, and settle cross the approved-operation fence, before broadcasting.
-  "apps/sdp-api/src/services/dvp/create.ts": ["signTransactionMessageWithSigners"],
+  // DvP create is Kora-sponsored: the paymaster signs as fee payer and rent
+  // payer and returns bytes without sending, so the signature is known before
+  // the trade is recorded. Fund and settle still sign from the project's
+  // custody wallets; those sinks likewise return fully signed bytes without
+  // sending, which is what lets settle cross the approved-operation fence
+  // before broadcasting.
+  "apps/sdp-api/src/services/dvp/create.ts": ["signAsFeePayer"],
   "apps/sdp-api/src/services/dvp/fund.ts": ["signTransactionMessageWithSigners"],
   "apps/sdp-api/src/services/dvp/settle.ts": ["signTransactionMessageWithSigners"],
   "apps/sdp-api/src/routes/pay.ts": ["signAsFeePayer"],

--- a/apps/sdp-api/src/security/value-moving-conformance.node.test.ts
+++ b/apps/sdp-api/src/security/value-moving-conformance.node.test.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -349,17 +349,15 @@ const signingSinkInventory: Record<string, string[]> = {
     // Wallet-paid signing likewise returns fully signed bytes without sending.
     "signTransactionMessageWithSigners",
   ],
-  // DvP create is Kora-sponsored: the paymaster signs as fee payer and rent
-  // payer and returns bytes without sending, so the signature is known before
-  // the trade is recorded. Fund and settle still sign from the project's
+  // DvP create and payments share the owned sponsorship submission sink, which
+  // signs and persists before broadcasting. Fund and settle still sign from the project's
   // custody wallets; those sinks likewise return fully signed bytes without
   // sending, which is what lets settle cross the approved-operation fence
   // before broadcasting.
-  "apps/sdp-api/src/services/dvp/create.ts": ["signAsFeePayer"],
   "apps/sdp-api/src/services/dvp/fund.ts": ["signTransactionMessageWithSigners"],
   "apps/sdp-api/src/services/dvp/settle.ts": ["signTransactionMessageWithSigners"],
   "apps/sdp-api/src/routes/pay.ts": ["signAsFeePayer"],
-  "apps/sdp-api/src/services/payments/signed-submission.ts": ["prepareOwnedSubmission"],
+  "apps/sdp-api/src/services/sponsorship-submission.ts": ["prepareOwnedSubmission"],
   "apps/sdp-api/src/services/payments/recurring-payments/shared.ts": ["signAndSend"],
   "apps/sdp-api/src/services/private-channels/deposit.ts": ["signTransactionMessageWithSigners"],
   "apps/sdp-api/src/services/private-channels/transfer.ts": ["signTransactionMessageWithSigners"],
@@ -382,6 +380,7 @@ const valueMovingSourceRoots = [
   // DvP settles and cancels sign from the project's settlement-authority
   // custody wallet, so it is a money-moving sink like the ones above.
   "apps/sdp-api/src/services/dvp",
+  "apps/sdp-api/src/services/sponsorship-submission.ts",
   "packages/sdp-issuance/src",
   "packages/sdp-solana/src",
 ];
@@ -391,6 +390,11 @@ function readSource(relativePath: string): string {
 }
 
 function sourceFiles(directory: string): string[] {
+  // A root may name a single module: the owned sponsorship submission helper
+  // lives beside the sponsorship services rather than in a directory of its own.
+  if (statSync(directory).isFile()) {
+    return [directory];
+  }
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
     const entryPath = path.join(directory, entry.name);
     if (entry.isDirectory()) {

--- a/apps/sdp-api/src/services/dvp/create.test.ts
+++ b/apps/sdp-api/src/services/dvp/create.test.ts
@@ -32,6 +32,7 @@ import {
   setTransactionMessageFeePayer,
   setTransactionMessageLifetimeUsingBlockhash,
   signature,
+  signatureBytes,
 } from "@solana/kit";
 import { generateKeyPairSigner } from "@solana/signers";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -777,6 +778,33 @@ describe("createDvpTrade", () => {
     });
 
     await expect(createDvpTrade(env, tradeInput())).rejects.toThrow(/missing the sponsor/);
+    await expect(rowsInDb()).resolves.toMatchObject([{ status: "create_failed" }]);
+    expect(sendTransaction).not.toHaveBeenCalled();
+  });
+
+  // A filled slot is not a signature. Kora is trusted to sign, not to be
+  // infallible: bytes that fail Ed25519 against the sponsor's key must fail the
+  // claim here, not be persisted in flight for the RPC to reject later.
+  it("refuses a sponsor signature that does not verify", async () => {
+    prepareOwnedSubmission.mockImplementation(async (bytes: Uint8Array, lifecycle) => {
+      const transaction = getTransactionDecoder().decode(bytes);
+      const forged = {
+        ...transaction,
+        signatures: {
+          ...transaction.signatures,
+          [sponsor.address]: signatureBytes(new Uint8Array(64).fill(9)),
+        },
+      };
+      const submission = {
+        signedTransaction: new Uint8Array(getTransactionEncoder().encode(forged)),
+        signature: TEST_SIGNATURE,
+        releaseDefinitelyUnbroadcast,
+      };
+      await lifecycle.persistSigned(submission);
+      return submission;
+    });
+
+    await expect(createDvpTrade(env, tradeInput())).rejects.toThrow(/invalid sponsor/);
     await expect(rowsInDb()).resolves.toMatchObject([{ status: "create_failed" }]);
     expect(sendTransaction).not.toHaveBeenCalled();
   });

--- a/apps/sdp-api/src/services/dvp/create.test.ts
+++ b/apps/sdp-api/src/services/dvp/create.test.ts
@@ -31,17 +31,22 @@ import {
   SolanaError,
   setTransactionMessageFeePayer,
   setTransactionMessageLifetimeUsingBlockhash,
+  signature,
 } from "@solana/kit";
 import { generateKeyPairSigner } from "@solana/signers";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
+import type { DvpTradeRow } from "@/db/repositories";
+import type { AppError } from "@/lib/errors";
+import type { SponsorshipFeePayment } from "@/services/sponsorship.service";
 import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
 import { env } from "@/test/helpers/env";
 import { seedTestDatabase } from "@/test/mocks/db";
 
 const createProjectSponsorshipFeePayment = vi.hoisted(() => vi.fn());
 const getFeePayer = vi.hoisted(() => vi.fn());
-const signAsFeePayer = vi.hoisted(() => vi.fn());
+const prepareOwnedSubmission = vi.hoisted(() => vi.fn());
+const releaseDefinitelyUnbroadcast = vi.hoisted(() => vi.fn());
 const sendTransaction = vi.hoisted(() => vi.fn());
 // The mint pre-flight is verified separately against real devnet mints in
 // mints.test.ts; here it is stubbed so these tests stay about broadcast
@@ -62,6 +67,11 @@ vi.mock("@/services/sponsorship.service", async () => {
 vi.mock("./mints", () => ({ validateDvpMints }));
 vi.mock("./inspect-mint", () => ({ inspectDvpMint }));
 vi.mock("./settlement-wallet", () => ({ getOrCreateDvpSettlementWallet }));
+// The immediate chain read after a send is the reconciler's contract, tested in
+// observe-now.test.ts; here it is stubbed so these tests stay about the claim,
+// sign and send ordering. Null means "nothing observed yet".
+const observeDvpTradeNow = vi.hoisted(() => vi.fn());
+vi.mock("./observe-now", () => ({ observeDvpTradeNow }));
 vi.mock("@sdp/rpc/solana", () => ({
   createRpc: () => ({}),
   getRecentBlockhash: async () => ({
@@ -86,6 +96,20 @@ const COUNTERPARTY_ADDRESS = "7WLcnnT1nnPuHiWaVnAY3Uz8Y2SgFy2VMg2t7GAoxnpg";
 // expiry, so two tradeInput() calls straddling a second boundary would be
 // different requests and 409 a replay the test meant to be identical.
 const EXPIRY_TIMESTAMP = BigInt(Math.floor(Date.now() / 1000) + 3600);
+const TEST_SIGNATURE = signature(
+  "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy"
+);
+
+/**
+ * Configures RPC acceptance with the signature encoded in the submitted bytes.
+ *
+ * @returns Nothing.
+ */
+function acceptSend(): void {
+  sendTransaction.mockImplementation(async (_rpc: unknown, bytes: Uint8Array) =>
+    getSignatureFromTransaction(getTransactionDecoder().decode(bytes))
+  );
+}
 
 function tradeInput() {
   return {
@@ -118,11 +142,13 @@ async function rowsInDb(): Promise<
     nonce: string;
     counterparty_account_id_a: string | null;
     counterparty_account_id_b: string | null;
+    create_signature: string | null;
+    create_last_valid_block_height: string | null;
   }[]
 > {
   const result = await getDb(env)
     .prepare(
-      "SELECT id, status, nonce, counterparty_account_id_a, counterparty_account_id_b FROM dvp_trades"
+      "SELECT id, status, nonce, counterparty_account_id_a, counterparty_account_id_b, create_signature, create_last_valid_block_height FROM dvp_trades"
     )
     .all<{
       id: string;
@@ -130,6 +156,8 @@ async function rowsInDb(): Promise<
       nonce: string;
       counterparty_account_id_a: string | null;
       counterparty_account_id_b: string | null;
+      create_signature: string | null;
+      create_last_valid_block_height: string | null;
     }>();
   return result.results ?? [];
 }
@@ -159,16 +187,28 @@ describe("createDvpTrade", () => {
     });
     sponsor = await generateKeyPairSigner();
     getFeePayer.mockResolvedValue(sponsor.address);
-    signAsFeePayer.mockImplementation(async (bytes: Uint8Array) => {
-      const transaction = getTransactionDecoder().decode(bytes);
-      expect(transaction.signatures[sponsor.address]).toBeNull();
-      const signed = await partiallySignTransaction([sponsor.keyPair], transaction);
-      return new Uint8Array(getTransactionEncoder().encode(signed));
-    });
+    prepareOwnedSubmission.mockImplementation(
+      async (
+        bytes: Uint8Array,
+        lifecycle: Parameters<SponsorshipFeePayment["prepareOwnedSubmission"]>[1]
+      ) => {
+        const transaction = getTransactionDecoder().decode(bytes);
+        expect(transaction.signatures[sponsor.address]).toBeNull();
+        const signed = await partiallySignTransaction([sponsor.keyPair], transaction);
+        const signedTransaction = new Uint8Array(getTransactionEncoder().encode(signed));
+        const signature = getSignatureFromTransaction(signed);
+        const submission = { signedTransaction, signature, releaseDefinitelyUnbroadcast };
+        await lifecycle.persistSigned(submission);
+        await lifecycle.markStarted();
+        return submission;
+      }
+    );
+    observeDvpTradeNow.mockResolvedValue(null);
     createProjectSponsorshipFeePayment.mockResolvedValue({
       getFeePayer,
-      signAsFeePayer,
+      prepareOwnedSubmission,
     });
+    acceptSend();
     originalSettlementAuthority = env.DVP_SETTLEMENT_AUTHORITY;
     env.DVP_SETTLEMENT_AUTHORITY = SETTLEMENT_AUTHORITY;
 
@@ -232,9 +272,9 @@ describe("createDvpTrade", () => {
 
   it("has the trade durably recorded at `creating` before the bytes go out", async () => {
     let rowsAtSendTime: Awaited<ReturnType<typeof rowsInDb>> = [];
-    sendTransaction.mockImplementation(async () => {
+    sendTransaction.mockImplementation(async (_rpc: unknown, bytes: Uint8Array) => {
       rowsAtSendTime = await rowsInDb();
-      return "sig";
+      return getSignatureFromTransaction(getTransactionDecoder().decode(bytes));
     });
 
     const trade = await createDvpTrade(env, tradeInput());
@@ -247,14 +287,30 @@ describe("createDvpTrade", () => {
     expect(rowsAtSendTime[0].nonce).toBe(trade.nonce);
   });
 
-  it("advances the trade to created once the broadcast is accepted", async () => {
-    sendTransaction.mockResolvedValue("sig");
+  it("leaves the trade creating until chain observation confirms it", async () => {
+    acceptSend();
+
+    const trade = await createDvpTrade(env, tradeInput());
+
+    expect(trade.status).toBe("creating");
+    expect(trade.createSignature).toBeTruthy();
+    expect(observeDvpTradeNow).toHaveBeenCalledOnce();
+    await expect(rowsInDb()).resolves.toMatchObject([{ status: "creating" }]);
+  });
+
+  // RPC acceptance is not confirmation. Only a chain read may say `created`,
+  // and when the immediate read already sees the account the caller gets that
+  // row rather than a stale claim.
+  it("returns the observed row when the immediate chain read sees the trade", async () => {
+    acceptSend();
+    observeDvpTradeNow.mockImplementationOnce(async (_env: unknown, claimed: DvpTradeRow) => ({
+      ...claimed,
+      status: "created" as const,
+    }));
 
     const trade = await createDvpTrade(env, tradeInput());
 
     expect(trade.status).toBe("created");
-    expect(trade.createSignature).toBeTruthy();
-    await expect(rowsInDb()).resolves.toMatchObject([{ status: "created" }]);
   });
 
   // A preflight failure is the one send error the RPC guarantees never reached
@@ -280,11 +336,14 @@ describe("createDvpTrade", () => {
       })
     );
 
-    await expect(createDvpTrade(env, tradeInput())).rejects.toThrow();
+    await expect(createDvpTrade(env, tradeInput())).rejects.toMatchObject({
+      code: "TRANSACTION_FAILED",
+    } satisfies Partial<AppError>);
 
     const rows = await rowsInDb();
     expect(rows).toHaveLength(1);
     expect(rows[0].status).toBe("create_failed");
+    expect(releaseDefinitelyUnbroadcast).toHaveBeenCalledTimes(1);
   });
 
   // The dangerous case. A timeout does NOT mean the transaction failed — it may
@@ -298,6 +357,9 @@ describe("createDvpTrade", () => {
     const rows = await rowsInDb();
     expect(rows).toHaveLength(1);
     expect(rows[0].status).toBe("creating");
+    expect(rows[0].create_signature).not.toBeNull();
+    expect(rows[0].create_last_valid_block_height).toBe("100");
+    expect(releaseDefinitelyUnbroadcast).not.toHaveBeenCalled();
   });
 
   // The pre-flight has to run BEFORE anything is signed or written. A mint the
@@ -311,7 +373,7 @@ describe("createDvpTrade", () => {
     await expect(createDvpTrade(env, tradeInput())).rejects.toThrow(/ScaledUiAmountConfig/);
 
     expect(createProjectSponsorshipFeePayment).not.toHaveBeenCalled();
-    expect(signAsFeePayer).not.toHaveBeenCalled();
+    expect(prepareOwnedSubmission).not.toHaveBeenCalled();
     expect(sendTransaction).not.toHaveBeenCalled();
     await expect(rowsInDb()).resolves.toEqual([]);
   });
@@ -321,7 +383,7 @@ describe("createDvpTrade", () => {
   // different address and the first trade sits on chain with a published escrow
   // nobody is watching.
   it("returns the original trade when a keyed request is retried", async () => {
-    sendTransaction.mockResolvedValue("sig");
+    acceptSend();
     const input = { ...tradeInput(), idempotencyKey: "key-1" };
 
     const first = await createDvpTrade(env, input);
@@ -362,29 +424,29 @@ describe("createDvpTrade", () => {
 
     it("lets the same key create the trade on a retry", async () => {
       await failOnceWith("key-retry");
-      sendTransaction.mockResolvedValue("sig");
+      acceptSend();
 
       const retried = await createDvpTrade(env, { ...tradeInput(), idempotencyKey: "key-retry" });
 
-      expect(retried.status).toBe("created");
+      expect(retried.status).toBe("creating");
     });
 
     it("keeps the failed attempt on the record rather than deleting it", async () => {
       await failOnceWith("key-retry");
-      sendTransaction.mockResolvedValue("sig");
+      acceptSend();
 
       await createDvpTrade(env, { ...tradeInput(), idempotencyKey: "key-retry" });
 
       const rows = await rowsInDb();
       expect(rows).toHaveLength(2);
-      expect(rows.map((row) => row.status).sort()).toEqual(["create_failed", "created"]);
+      expect(rows.map((row) => row.status).sort()).toEqual(["create_failed", "creating"]);
     });
 
     // Freed on the dead row only. Leaving it there would let a second retry
     // replay the corpse again.
     it("frees the key from the failed row so only the live trade answers to it", async () => {
       await failOnceWith("key-retry");
-      sendTransaction.mockResolvedValue("sig");
+      acceptSend();
       const live = await createDvpTrade(env, { ...tradeInput(), idempotencyKey: "key-retry" });
 
       const replayed = await createDvpTrade(env, { ...tradeInput(), idempotencyKey: "key-retry" });
@@ -397,13 +459,18 @@ describe("createDvpTrade", () => {
   // An AMBIGUOUS failure is the opposite case: the transaction may still land,
   // so its key must keep answering or the retry would create a second trade at
   // a second address while the first sits on chain.
+  // An ambiguous send is one the submission helper neither classifies as a
+  // preflight rejection nor retries as transient: the transaction may be in
+  // flight, so the claim keeps its signature and stays `creating` for the chain
+  // reader. (A transient failure such as a hung socket is retried by the
+  // helper itself; that schedule is covered in sponsorship-submission's tests.)
   it("does not free the key of a trade still stuck at creating", async () => {
-    sendTransaction.mockRejectedValueOnce(new Error("socket hang up"));
+    sendTransaction.mockRejectedValueOnce(new Error("rpc returned an unreadable response"));
     await expect(
       createDvpTrade(env, { ...tradeInput(), idempotencyKey: "key-ambiguous" })
-    ).rejects.toThrow("socket hang up");
+    ).rejects.toThrow("rpc returned an unreadable response");
 
-    sendTransaction.mockResolvedValue("sig");
+    acceptSend();
     const retried = await createDvpTrade(env, {
       ...tradeInput(),
       idempotencyKey: "key-ambiguous",
@@ -417,7 +484,7 @@ describe("createDvpTrade", () => {
   // unique index rejects one, and without recovery that retry gets a 500 —
   // exactly the case the key exists to make safe.
   it("replays rather than failing when two keyed requests race", async () => {
-    sendTransaction.mockResolvedValue("sig");
+    acceptSend();
     const input = { ...tradeInput(), idempotencyKey: "key-race" };
 
     const [first, second] = await Promise.all([
@@ -429,10 +496,13 @@ describe("createDvpTrade", () => {
     await expect(rowsInDb()).resolves.toHaveLength(1);
     // The loser must not broadcast a second transaction for the same trade.
     expect(sendTransaction).toHaveBeenCalledTimes(1);
+    expect(createProjectSponsorshipFeePayment).toHaveBeenCalledTimes(1);
+    expect(getFeePayer).toHaveBeenCalledTimes(1);
+    expect(prepareOwnedSubmission).toHaveBeenCalledTimes(1);
   });
 
   it("creates separate trades for different keys", async () => {
-    sendTransaction.mockResolvedValue("sig");
+    acceptSend();
 
     const first = await createDvpTrade(env, { ...tradeInput(), idempotencyKey: "key-a" });
     const second = await createDvpTrade(env, { ...tradeInput(), idempotencyKey: "key-b" });
@@ -444,7 +514,7 @@ describe("createDvpTrade", () => {
   // Without a key there is nothing to replay against, so each call is a new
   // trade — which is exactly why the key matters on a retry.
   it("creates a new trade every time when no key is sent", async () => {
-    sendTransaction.mockResolvedValue("sig");
+    acceptSend();
 
     const first = await createDvpTrade(env, tradeInput());
     const second = await createDvpTrade(env, tradeInput());
@@ -461,7 +531,7 @@ describe("createDvpTrade", () => {
     ).rejects.toThrow(/settlementAuthority must not be/);
 
     expect(createProjectSponsorshipFeePayment).not.toHaveBeenCalled();
-    expect(signAsFeePayer).not.toHaveBeenCalled();
+    expect(prepareOwnedSubmission).not.toHaveBeenCalled();
     expect(sendTransaction).not.toHaveBeenCalled();
     await expect(rowsInDb()).resolves.toEqual([]);
   });
@@ -469,7 +539,7 @@ describe("createDvpTrade", () => {
   // A `{ walletId }` slot resolves to the wallet's address and stores NULL
   // attribution — fundability re-derives later, never from a stored column.
   it("resolves a walletId slot to the wallet's address and stores null attribution", async () => {
-    sendTransaction.mockResolvedValue("sig");
+    acceptSend();
 
     const trade = await createDvpTrade(env, tradeInput());
 
@@ -500,7 +570,7 @@ describe("createDvpTrade", () => {
       .bind(TEST_ORG.id, TEST_PROJECT_ID)
       .run();
 
-    sendTransaction.mockResolvedValue("sig");
+    acceptSend();
     const trade = await createDvpTrade(env, {
       ...tradeInput(),
       partyA: { counterpartyAccountId: "cpa_resolve" },
@@ -533,7 +603,7 @@ describe("createDvpTrade", () => {
       .bind(TEST_ORG.id, TEST_PROJECT_ID)
       .run();
 
-    sendTransaction.mockResolvedValue("sig");
+    acceptSend();
     await expect(
       createDvpTrade(env, {
         ...tradeInput(),
@@ -563,7 +633,7 @@ describe("createDvpTrade", () => {
       .bind(TEST_ORG.id, TEST_PROJECT_ID)
       .run();
 
-    sendTransaction.mockResolvedValue("sig");
+    acceptSend();
     await expect(
       createDvpTrade(env, {
         ...tradeInput(),
@@ -593,7 +663,7 @@ describe("createDvpTrade", () => {
       .bind(TEST_ORG.id, TEST_PROJECT_ID_OTHER)
       .run();
 
-    sendTransaction.mockResolvedValue("sig");
+    acceptSend();
     await expect(
       createDvpTrade(env, {
         ...tradeInput(),
@@ -605,7 +675,7 @@ describe("createDvpTrade", () => {
 
   // Unknown walletId — no active custody wallet with that row id in scope.
   it("refuses an unknown walletId", async () => {
-    sendTransaction.mockResolvedValue("sig");
+    acceptSend();
     await expect(
       createDvpTrade(env, {
         ...tradeInput(),
@@ -628,7 +698,7 @@ describe("createDvpTrade", () => {
       .bind(CUSTODY_CONFIG_ID, archivedSigner.address)
       .run();
 
-    sendTransaction.mockResolvedValue("sig");
+    acceptSend();
     await expect(
       createDvpTrade(env, {
         ...tradeInput(),
@@ -639,7 +709,7 @@ describe("createDvpTrade", () => {
   });
 
   it("uses the sponsor as fee payer and instruction payer in one signature slot", async () => {
-    sendTransaction.mockResolvedValue("sig");
+    acceptSend();
     const trade = await createDvpTrade(env, tradeInput());
 
     const [, bytes] = sendTransaction.mock.calls[0];
@@ -660,7 +730,7 @@ describe("createDvpTrade", () => {
   });
 
   it("refuses sponsor bytes over a different message", async () => {
-    signAsFeePayer.mockImplementation(async () => {
+    prepareOwnedSubmission.mockImplementation(async (_bytes: Uint8Array, lifecycle) => {
       const foreign = pipe(
         createTransactionMessage({ version: 0 }),
         (message) => setTransactionMessageFeePayer(sponsor.address, message),
@@ -680,28 +750,47 @@ describe("createDvpTrade", () => {
         compileTransaction
       );
       const signed = await partiallySignTransaction([sponsor.keyPair], foreign);
-      return new Uint8Array(getTransactionEncoder().encode(signed));
+      const signedTransaction = new Uint8Array(getTransactionEncoder().encode(signed));
+      const submission = {
+        signedTransaction,
+        signature: getSignatureFromTransaction(signed),
+        releaseDefinitelyUnbroadcast,
+      };
+      await lifecycle.persistSigned(submission);
+      return submission;
     });
 
     await expect(createDvpTrade(env, tradeInput())).rejects.toThrow(/different message/);
-    await expect(rowsInDb()).resolves.toEqual([]);
+    await expect(rowsInDb()).resolves.toMatchObject([{ status: "create_failed" }]);
     expect(sendTransaction).not.toHaveBeenCalled();
   });
 
   it("refuses bytes without the sponsor signature", async () => {
-    signAsFeePayer.mockImplementation(async (bytes: Uint8Array) => bytes);
+    prepareOwnedSubmission.mockImplementation(async (bytes: Uint8Array, lifecycle) => {
+      const submission = {
+        signedTransaction: bytes,
+        signature: TEST_SIGNATURE,
+        releaseDefinitelyUnbroadcast,
+      };
+      await lifecycle.persistSigned(submission);
+      return submission;
+    });
 
     await expect(createDvpTrade(env, tradeInput())).rejects.toThrow(/missing the sponsor/);
-    await expect(rowsInDb()).resolves.toEqual([]);
+    await expect(rowsInDb()).resolves.toMatchObject([{ status: "create_failed" }]);
     expect(sendTransaction).not.toHaveBeenCalled();
   });
 
-  it("writes nothing when Kora denies sponsorship", async () => {
+  it("fails the claim when Kora denies and frees the key on replay", async () => {
     const denial = new FeePaymentError("Kora rate limit", "RATE_LIMITED");
-    signAsFeePayer.mockRejectedValue(denial);
+    prepareOwnedSubmission.mockRejectedValueOnce(denial);
 
-    await expect(createDvpTrade(env, tradeInput())).rejects.toBe(denial);
-    await expect(rowsInDb()).resolves.toEqual([]);
-    expect(sendTransaction).not.toHaveBeenCalled();
+    const input = { ...tradeInput(), idempotencyKey: "key-kora-denial" };
+    await expect(createDvpTrade(env, input)).rejects.toBe(denial);
+    await expect(rowsInDb()).resolves.toMatchObject([{ status: "create_failed" }]);
+
+    const retried = await createDvpTrade(env, input);
+    expect(retried.status).toBe("creating");
+    await expect(rowsInDb()).resolves.toHaveLength(2);
   });
 });

--- a/apps/sdp-api/src/services/dvp/create.test.ts
+++ b/apps/sdp-api/src/services/dvp/create.test.ts
@@ -13,12 +13,24 @@
  * deposit that nobody can ever rescue (EXO-216/217).
  */
 
+import { FeePaymentError } from "@sdp/payments/fee-payment";
 import {
   address,
+  appendTransactionMessageInstructions,
   type Blockhash,
+  compileTransaction,
+  createTransactionMessage,
   getBase58Codec,
+  getCompiledTransactionMessageDecoder,
+  getSignatureFromTransaction,
+  getTransactionDecoder,
+  getTransactionEncoder,
+  partiallySignTransaction,
+  pipe,
   SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,
   SolanaError,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
 } from "@solana/kit";
 import { generateKeyPairSigner } from "@solana/signers";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -27,7 +39,9 @@ import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
 import { env } from "@/test/helpers/env";
 import { seedTestDatabase } from "@/test/mocks/db";
 
-const createOrgSignerForCustodyWallet = vi.hoisted(() => vi.fn());
+const createProjectSponsorshipFeePayment = vi.hoisted(() => vi.fn());
+const getFeePayer = vi.hoisted(() => vi.fn());
+const signAsFeePayer = vi.hoisted(() => vi.fn());
 const sendTransaction = vi.hoisted(() => vi.fn());
 // The mint pre-flight is verified separately against real devnet mints in
 // mints.test.ts; here it is stubbed so these tests stay about broadcast
@@ -39,7 +53,12 @@ const inspectDvpMint = vi.hoisted(() => vi.fn());
 // stubbed so these tests stay about broadcast ordering.
 const getOrCreateDvpSettlementWallet = vi.hoisted(() => vi.fn());
 
-vi.mock("@/services/solana/signer", () => ({ createOrgSignerForCustodyWallet }));
+vi.mock("@/services/sponsorship.service", async () => {
+  const actual = await vi.importActual<typeof import("@/services/sponsorship.service")>(
+    "@/services/sponsorship.service"
+  );
+  return { ...actual, createProjectSponsorshipFeePayment };
+});
 vi.mock("./mints", () => ({ validateDvpMints }));
 vi.mock("./inspect-mint", () => ({ inspectDvpMint }));
 vi.mock("./settlement-wallet", () => ({ getOrCreateDvpSettlementWallet }));
@@ -74,7 +93,6 @@ function tradeInput() {
     projectId: TEST_PROJECT_ID,
     partyA: { walletId: CUSTODY_WALLET_ID },
     partyB: { address: address(COUNTERPARTY_ADDRESS) },
-    payerWalletId: null,
     mintA: address("ns7Y4h26io6zGKiuvSx1jRBWANjDytnYyxEmVPfPAk1"),
     tokenProgramA: address("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"),
     mintB: address("AqTgvZaiZ18ykVvzaQhfB2KQ4SGDw4i1o5rQqBAMsZiE"),
@@ -118,6 +136,7 @@ async function rowsInDb(): Promise<
 
 describe("createDvpTrade", () => {
   let custodyWalletAddress: string;
+  let sponsor: Awaited<ReturnType<typeof generateKeyPairSigner>>;
   let originalSettlementAuthority: string | undefined;
 
   beforeAll(async () => {
@@ -137,6 +156,18 @@ describe("createDvpTrade", () => {
     getOrCreateDvpSettlementWallet.mockResolvedValue({
       custodyWalletId: "cwlt_settlement",
       address: SETTLEMENT_AUTHORITY,
+    });
+    sponsor = await generateKeyPairSigner();
+    getFeePayer.mockResolvedValue(sponsor.address);
+    signAsFeePayer.mockImplementation(async (bytes: Uint8Array) => {
+      const transaction = getTransactionDecoder().decode(bytes);
+      expect(transaction.signatures[sponsor.address]).toBeNull();
+      const signed = await partiallySignTransaction([sponsor.keyPair], transaction);
+      return new Uint8Array(getTransactionEncoder().encode(signed));
+    });
+    createProjectSponsorshipFeePayment.mockResolvedValue({
+      getFeePayer,
+      signAsFeePayer,
     });
     originalSettlementAuthority = env.DVP_SETTLEMENT_AUTHORITY;
     env.DVP_SETTLEMENT_AUTHORITY = SETTLEMENT_AUTHORITY;
@@ -183,11 +214,8 @@ describe("createDvpTrade", () => {
       .bind(CUSTODY_CONFIG_ID, TEST_ORG.id)
       .run();
 
-    // A real signer, so the transaction is really signed and the signature the
-    // row carries is the one the network would see.
     const signer = await generateKeyPairSigner();
     custodyWalletAddress = signer.address;
-    createOrgSignerForCustodyWallet.mockResolvedValue(signer);
 
     await db
       .prepare(
@@ -282,7 +310,8 @@ describe("createDvpTrade", () => {
 
     await expect(createDvpTrade(env, tradeInput())).rejects.toThrow(/ScaledUiAmountConfig/);
 
-    expect(createOrgSignerForCustodyWallet).not.toHaveBeenCalled();
+    expect(createProjectSponsorshipFeePayment).not.toHaveBeenCalled();
+    expect(signAsFeePayer).not.toHaveBeenCalled();
     expect(sendTransaction).not.toHaveBeenCalled();
     await expect(rowsInDb()).resolves.toEqual([]);
   });
@@ -423,7 +452,7 @@ describe("createDvpTrade", () => {
     expect(second.id).not.toBe(first.id);
   });
 
-  it("writes nothing when the terms are refused before signing", async () => {
+  it("resolves sponsorship after term validation", async () => {
     await expect(
       createDvpTrade(env, {
         ...tradeInput(),
@@ -431,6 +460,8 @@ describe("createDvpTrade", () => {
       })
     ).rejects.toThrow(/settlementAuthority must not be/);
 
+    expect(createProjectSponsorshipFeePayment).not.toHaveBeenCalled();
+    expect(signAsFeePayer).not.toHaveBeenCalled();
     expect(sendTransaction).not.toHaveBeenCalled();
     await expect(rowsInDb()).resolves.toEqual([]);
   });
@@ -607,34 +638,70 @@ describe("createDvpTrade", () => {
     await expect(rowsInDb()).resolves.toEqual([]);
   });
 
-  // An explicit payer signs with that wallet; an omitted payer signs with the
-  // settlement wallet.
-  it("signs with an explicit payer wallet when one is given", async () => {
+  it("uses the sponsor as fee payer and instruction payer in one signature slot", async () => {
     sendTransaction.mockResolvedValue("sig");
-    await createDvpTrade(env, {
-      ...tradeInput(),
-      partyA: { address: address(COUNTERPARTY_ADDRESS) },
-      partyB: { address: address("GjupWG8a4BXmduuUQt7vP7QxJ5Kq5YhwKZNkFYp5KPr") },
-      payerWalletId: CUSTODY_WALLET_ID,
-    });
+    const trade = await createDvpTrade(env, tradeInput());
 
-    expect(createOrgSignerForCustodyWallet).toHaveBeenCalledWith(
-      env,
-      TEST_ORG.id,
-      TEST_PROJECT_ID,
-      CUSTODY_WALLET_ID
-    );
+    const [, bytes] = sendTransaction.mock.calls[0];
+    const transaction = getTransactionDecoder().decode(bytes);
+    const message = getCompiledTransactionMessageDecoder().decode(transaction.messageBytes);
+    expect(Object.keys(transaction.signatures)).toEqual([sponsor.address]);
+    expect(message.staticAccounts[0]).toBe(sponsor.address);
+    expect(message).toMatchObject({
+      version: 0,
+      instructions: [{ accountIndices: expect.arrayContaining([0]) }],
+    });
+    expect(trade.createSignature).toBe(getSignatureFromTransaction(transaction));
+    expect(createProjectSponsorshipFeePayment).toHaveBeenCalledWith(env, {
+      organizationId: TEST_ORG.id,
+      projectId: TEST_PROJECT_ID,
+      actor: { type: "wallet", id: "cwlt_settlement" },
+    });
   });
 
-  it("signs with the settlement wallet when no payer is given", async () => {
-    sendTransaction.mockResolvedValue("sig");
-    await createDvpTrade(env, tradeInput());
+  it("refuses sponsor bytes over a different message", async () => {
+    signAsFeePayer.mockImplementation(async () => {
+      const foreign = pipe(
+        createTransactionMessage({ version: 0 }),
+        (message) => setTransactionMessageFeePayer(sponsor.address, message),
+        (message) =>
+          setTransactionMessageLifetimeUsingBlockhash(
+            {
+              blockhash: getBase58Codec().decode(new Uint8Array(32).fill(9)) as Blockhash,
+              lastValidBlockHeight: 100n,
+            },
+            message
+          ),
+        (message) =>
+          appendTransactionMessageInstructions(
+            [{ programAddress: address("11111111111111111111111111111111") }],
+            message
+          ),
+        compileTransaction
+      );
+      const signed = await partiallySignTransaction([sponsor.keyPair], foreign);
+      return new Uint8Array(getTransactionEncoder().encode(signed));
+    });
 
-    expect(createOrgSignerForCustodyWallet).toHaveBeenCalledWith(
-      env,
-      TEST_ORG.id,
-      TEST_PROJECT_ID,
-      "cwlt_settlement"
-    );
+    await expect(createDvpTrade(env, tradeInput())).rejects.toThrow(/different message/);
+    await expect(rowsInDb()).resolves.toEqual([]);
+    expect(sendTransaction).not.toHaveBeenCalled();
+  });
+
+  it("refuses bytes without the sponsor signature", async () => {
+    signAsFeePayer.mockImplementation(async (bytes: Uint8Array) => bytes);
+
+    await expect(createDvpTrade(env, tradeInput())).rejects.toThrow(/missing the sponsor/);
+    await expect(rowsInDb()).resolves.toEqual([]);
+    expect(sendTransaction).not.toHaveBeenCalled();
+  });
+
+  it("writes nothing when Kora denies sponsorship", async () => {
+    const denial = new FeePaymentError("Kora rate limit", "RATE_LIMITED");
+    signAsFeePayer.mockRejectedValue(denial);
+
+    await expect(createDvpTrade(env, tradeInput())).rejects.toBe(denial);
+    await expect(rowsInDb()).resolves.toEqual([]);
+    expect(sendTransaction).not.toHaveBeenCalled();
   });
 });

--- a/apps/sdp-api/src/services/dvp/create.ts
+++ b/apps/sdp-api/src/services/dvp/create.ts
@@ -501,7 +501,7 @@ export async function createDvpTrade(env: Env, input: CreateDvpTradeInput): Prom
       lastValidBlockHeight,
       store: {
         persistSigned: async ({ signature, signedTransaction, lastValidBlockHeight: height }) => {
-          assertSponsorSignedSameMessage({
+          await assertSponsorSignedSameMessage({
             unsignedOrPartiallySigned: compiled,
             sponsorSigned: new Uint8Array(getBase64Encoder().encode(signedTransaction)),
             sponsor,

--- a/apps/sdp-api/src/services/dvp/create.ts
+++ b/apps/sdp-api/src/services/dvp/create.ts
@@ -12,6 +12,11 @@
  * we hold no keys for. It also means the instruction creates no obligation: a
  * SwapDvp is a proposal until someone funds it.
  *
+ * The row is claimed before signing because sponsorship budget is consumed at
+ * sign time. Claim, sign, attach, send makes the idempotency race finish before
+ * either request can spend budget, while preserving the signed transaction as
+ * the durable marker before broadcast.
+ *
  * And because it is permissionless, a created trade is NOT proof of agreement.
  * Anyone can create one naming anyone, and the economic terms are not part of
  * the PDA seeds, so the address does not bind them. Whoever funds has to verify
@@ -29,13 +34,10 @@ import {
   compileTransaction,
   createNoopSigner,
   createTransactionMessage,
-  getSignatureFromTransaction,
+  getBase64Encoder,
   getTransactionEncoder,
-  isSolanaError,
   none,
   pipe,
-  type Signature,
-  SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,
   setTransactionMessageFeePayer,
   setTransactionMessageLifetimeUsingBlockhash,
   some,
@@ -55,12 +57,17 @@ import {
   assertSponsorSignedSameMessage,
   createProjectSponsorshipFeePayment,
 } from "@/services/sponsorship.service";
+import {
+  isDefiniteSubmissionError,
+  submitSponsoredTransaction,
+} from "@/services/sponsorship-submission";
 import type { Env } from "@/types/env";
 import { dvpCreateFingerprint, type ResolvedParty } from "./fingerprint";
 import { describeDvpDestinationProblem, findDvpDestinationProblem } from "./inspect-destination";
 import { inspectDvpMint } from "./inspect-mint";
 import { validateDvpMints } from "./mints";
 import { randomDvpNonce } from "./nonce";
+import { observeDvpTradeNow } from "./observe-now";
 import { getOrCreateDvpSettlementWallet } from "./settlement-wallet";
 import { validateDvpTerms } from "./validate";
 
@@ -128,12 +135,13 @@ function assertOwnReplay(trade: DvpTradeRow, fingerprint: string | null): DvpTra
  */
 async function insertOrReplay(
   repository: ReturnType<typeof createDvpTradeRepository>,
+  failedRowId: string | null,
   idempotencyKey: string | null,
   fingerprint: string | null,
   row: Parameters<ReturnType<typeof createDvpTradeRepository>["create"]>[0]
 ): Promise<DvpTradeRow> {
   try {
-    return await repository.create(row);
+    return await repository.claimWithKeyRelease(failedRowId, row);
   } catch (error) {
     if (!idempotencyKey) {
       throw error;
@@ -282,22 +290,13 @@ export async function createDvpTrade(env: Env, input: CreateDvpTradeInput): Prom
   const fingerprint = input.idempotencyKey
     ? dvpCreateFingerprint({ input, resolvedA, resolvedB })
     : null;
+  let failedRowId: string | null = null;
   if (input.idempotencyKey) {
     const replayed = await repository.getByIdempotencyKey(input.projectId, input.idempotencyKey);
     if (replayed) {
-      // A create that definitively failed left the request unmade, so its key
-      // has nothing to stand for. Replaying it would hand back a dead trade
-      // forever — and to a caller whose key is DERIVED from the payload, as
-      // the dashboard's is, "forever" is literal: there is no other key it can
-      // send for this trade, so one preflight rejection would retire those
-      // terms permanently. Freeing the key turns that into an ordinary retry.
-      //
-      // Only `create_failed`. `creating` may still land, and every other status
-      // means it already did; replaying those is the entire point of the key.
-      const freed =
-        replayed.status === "create_failed" &&
-        (await repository.releaseIdempotencyKey(replayed.id));
-      if (!freed) {
+      if (replayed.status === "create_failed") {
+        failedRowId = replayed.id;
+      } else {
         return assertOwnReplay(replayed, fingerprint);
       }
     }
@@ -380,17 +379,6 @@ export async function createDvpTrade(env: Env, input: CreateDvpTradeInput): Prom
     throw badRequest(`Invalid DvP terms: ${problems.join("; ")}`);
   }
 
-  // Kora pays the fee and ~6.63M lamports of rent per trade, while close
-  // refunds settlement_authority. That devnet subsidy is deliberate; mainnet
-  // pricing is a product decision tracked by PRO-1906. Resolved only after
-  // every local check above, so a 400 never costs a Kora round trip.
-  const feePayment = await createProjectSponsorshipFeePayment(env, {
-    organizationId: input.organizationId,
-    projectId: input.projectId,
-    actor: { type: "wallet", id: settlement.custodyWalletId },
-  });
-  const sponsor = await feePayment.getFeePayer();
-
   // Cryptographically random, and a bigint throughout. A predictable nonce lets
   // a third party squat the address before the real parties reach it.
   const nonce = randomDvpNonce();
@@ -409,131 +397,147 @@ export async function createDvpTrade(env: Env, input: CreateDvpTradeInput): Prom
     findAssociatedTokenPda({ owner: swapDvp, mint: mintB, tokenProgram: tokenProgramB }),
   ]);
 
-  const instruction = getCreateDvpInstruction({
-    payer: createNoopSigner(sponsor),
-    swapDvp,
-    nonceTombstone,
-    settlementAuthority,
-    userA,
-    userB,
-    mintA,
-    mintB,
-    dvpAtaA: escrowA,
-    dvpAtaB: escrowB,
-    tokenProgramA,
-    tokenProgramB,
-    amountA: input.amountA,
-    amountB: input.amountB,
-    expiryTimestamp: input.expiryTimestamp,
-    nonce,
-    refString: input.refString,
-    // Null when the caller named none, which the program records as the party's
-    // own address — the default every flow in PRO-1830 wants. An execution desk
-    // settling into an account other than the one it funded from passes them.
-    userASettlementDestination: input.userASettlementDestination,
-    userBSettlementDestination: input.userBSettlementDestination,
-    earliestSettlementTimestamp:
-      input.earliestSettlementTimestamp === null ? none() : some(input.earliestSettlementTimestamp),
-  });
-
-  const { blockhash, lastValidBlockHeight } = await solanaRpc.getRecentBlockhash(rpc, "confirmed");
-  const message = pipe(
-    createTransactionMessage({ version: 0 }),
-    (m) => setTransactionMessageFeePayer(sponsor, m),
-    (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
-    (m) => appendTransactionMessageInstructions([instruction], m)
+  const id = `dvp_${crypto.randomUUID().replace(/-/g, "")}`;
+  const recorded = await insertOrReplay(
+    repository,
+    failedRowId,
+    input.idempotencyKey,
+    fingerprint,
+    {
+      id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      swapDvp,
+      settlementAuthority,
+      userA,
+      userB,
+      mintA: input.mintA,
+      mintB: input.mintB,
+      nonce: nonce.toString(),
+      tokenProgramA: input.tokenProgramA,
+      tokenProgramB: input.tokenProgramB,
+      decimalsA: inspectedA?.decimals ?? null,
+      decimalsB: inspectedB?.decimals ?? null,
+      symbolA: inspectedA?.symbol ?? wellKnownSymbol(input.mintA),
+      symbolB: inspectedB?.symbol ?? wellKnownSymbol(input.mintB),
+      amountA: input.amountA.toString(),
+      amountB: input.amountB.toString(),
+      expiryTimestamp: input.expiryTimestamp.toString(),
+      earliestSettlementTimestamp: input.earliestSettlementTimestamp?.toString() ?? null,
+      userASettlementDestination: destinationA,
+      userBSettlementDestination: destinationB,
+      refString: input.refString,
+      escrowA,
+      escrowB,
+      counterpartyAccountIdA: resolvedA.counterpartyAccountId,
+      counterpartyAccountIdB: resolvedB.counterpartyAccountId,
+      idempotencyKey: input.idempotencyKey,
+      idempotencyFingerprint: fingerprint,
+      createSignature: null,
+      createLastValidBlockHeight: null,
+    }
   );
-  const compiled = compileTransaction(message);
-  const bytes = new Uint8Array(getTransactionEncoder().encode(compiled));
-  const sponsorSigned = assertSponsorSignedSameMessage({
-    unsignedOrPartiallySigned: compiled,
-    sponsorSigned: await feePayment.signAsFeePayer(bytes),
-    sponsor,
-  });
-  // Known from the signed bytes, so the row can carry it before anything is sent.
-  const signature: Signature = getSignatureFromTransaction(sponsorSigned);
 
-  // Recorded BEFORE broadcast, at status `creating`. The six seed values are the
-  // only durable copy of what RecoverDvp needs to rescue a deposit that lands
-  // once a trade has closed, and a retry cannot stand in for them: it draws a
-  // fresh nonce and derives a different address. So a crash between send and
-  // insert would strand a real on-chain trade permanently. Same safety order as
-  // the Earn vault services — build, sign, record, send.
-  const recorded = await insertOrReplay(repository, input.idempotencyKey, fingerprint, {
-    id: `dvp_${crypto.randomUUID().replace(/-/g, "")}`,
-    organizationId: input.organizationId,
-    projectId: input.projectId,
-    swapDvp,
-    settlementAuthority,
-    userA,
-    userB,
-    mintA: input.mintA,
-    mintB: input.mintB,
-    nonce: nonce.toString(),
-    tokenProgramA: input.tokenProgramA,
-    tokenProgramB: input.tokenProgramB,
-    decimalsA: inspectedA?.decimals ?? null,
-    decimalsB: inspectedB?.decimals ?? null,
-    // Metadata first, catalogue second. A Token-2022 mint carries its own name;
-    // USDC does not — it is legacy SPL with no metadata extension — so reading
-    // only the mint left the cash leg as a bare number on a screen showing two
-    // different tokens.
-    symbolA: inspectedA?.symbol ?? wellKnownSymbol(input.mintA),
-    symbolB: inspectedB?.symbol ?? wellKnownSymbol(input.mintB),
-    amountA: input.amountA.toString(),
-    amountB: input.amountB.toString(),
-    expiryTimestamp: input.expiryTimestamp.toString(),
-    earliestSettlementTimestamp: input.earliestSettlementTimestamp?.toString() ?? null,
-    // The program stores an omitted destination as the party's own address, so
-    // mirror that rather than storing null and having to branch on read.
-    userASettlementDestination: destinationA,
-    userBSettlementDestination: destinationB,
-    refString: input.refString,
-    escrowA,
-    escrowB,
-    // Org-scoped attribution; null for external addresses and wallets (fundability re-derives).
-    counterpartyAccountIdA: resolvedA.counterpartyAccountId,
-    counterpartyAccountIdB: resolvedB.counterpartyAccountId,
-    idempotencyKey: input.idempotencyKey,
-    idempotencyFingerprint: fingerprint,
-    createSignature: signature,
-    // Stored so the reconciler can tell a create that is still in flight from
-    // one that can never land, rather than inferring it from elapsed time.
-    createLastValidBlockHeight: lastValidBlockHeight.toString(),
-  });
-
-  // A concurrent keyed request won the insert, so the row we got back is theirs
-  // and their transaction is the one on the network. Broadcasting ours too
-  // would create the second trade this key exists to prevent.
-  if (recorded.createSignature !== signature) {
-    // The race loser has already reserved and signed sponsorship budget. The
-    // reconciler releases it after blockhash expiry once the signature remains
-    // absent for two passes; preflight-rejected broadcasts follow the same path.
+  if (recorded.id !== id) {
     return recorded;
   }
 
+  // Kora pays the fee and trade-account rent. Resolve sponsorship only after
+  // validation and after the durable claim has won the idempotency race.
+  let signed = false;
   try {
-    await solanaRpc.sendTransaction(
+    const feePayment = await createProjectSponsorshipFeePayment(env, {
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      actor: { type: "wallet", id: settlement.custodyWalletId },
+    });
+    const sponsor = await feePayment.getFeePayer();
+
+    const instruction = getCreateDvpInstruction({
+      payer: createNoopSigner(sponsor),
+      swapDvp,
+      nonceTombstone,
+      settlementAuthority,
+      userA,
+      userB,
+      mintA,
+      mintB,
+      dvpAtaA: escrowA,
+      dvpAtaB: escrowB,
+      tokenProgramA,
+      tokenProgramB,
+      amountA: input.amountA,
+      amountB: input.amountB,
+      expiryTimestamp: input.expiryTimestamp,
+      nonce,
+      refString: input.refString,
+      // Null when the caller named none, which the program records as the party's
+      // own address — the default every flow in PRO-1830 wants. An execution desk
+      // settling into an account other than the one it funded from passes them.
+      userASettlementDestination: input.userASettlementDestination,
+      userBSettlementDestination: input.userBSettlementDestination,
+      earliestSettlementTimestamp:
+        input.earliestSettlementTimestamp === null
+          ? none()
+          : some(input.earliestSettlementTimestamp),
+    });
+
+    const { blockhash, lastValidBlockHeight } = await solanaRpc.getRecentBlockhash(
       rpc,
-      new Uint8Array(getTransactionEncoder().encode(sponsorSigned))
+      "confirmed"
     );
+    const message = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayer(sponsor, m),
+      (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
+      (m) => appendTransactionMessageInstructions([instruction], m)
+    );
+    const compiled = compileTransaction(message);
+    const bytes = new Uint8Array(getTransactionEncoder().encode(compiled));
+    await submitSponsoredTransaction({
+      feePayment,
+      rpc,
+      transaction: bytes,
+      lastValidBlockHeight,
+      store: {
+        persistSigned: async ({ signature, signedTransaction, lastValidBlockHeight: height }) => {
+          assertSponsorSignedSameMessage({
+            unsignedOrPartiallySigned: compiled,
+            sponsorSigned: new Uint8Array(getBase64Encoder().encode(signedTransaction)),
+            sponsor,
+          });
+          const attached = await repository.attachCreateSignature(id, signature, height);
+          if (attached === null) {
+            throw new Error("claim was resolved before its signature could be attached");
+          }
+          signed = true;
+        },
+        // The attached signature is DvP's durable in-flight marker: the sweep
+        // treats `creating` + signature + height as possibly landed until the
+        // height expires. There is no second transition to record here.
+        markStarted: async () => {},
+        hasStarted: async () => {
+          const current = await repository.getById(
+            { organizationId: input.organizationId, projectId: input.projectId },
+            id
+          );
+          return current !== null && current.createSignature !== null;
+        },
+      },
+    });
   } catch (error) {
-    // A preflight failure is the one send error that is definitively terminal:
-    // the RPC rejected the bytes in simulation and never forwarded them, so
-    // nothing landed and nothing will. Every other failure — a timeout, a
-    // dropped socket — is ambiguous, and the transaction may still be in flight.
-    // Those rows stay `creating` for the chain to settle rather than being
-    // marked failed on a guess.
-    if (
-      isSolanaError(error, SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE)
-    ) {
-      await repository.resolveCreate(recorded.id, "create_failed");
+    if (!signed || isDefiniteSubmissionError(error)) {
+      await repository.resolveCreate(id, "create_failed");
     }
     throw error;
   }
-
-  // The RPC accepted it. `created` here means "broadcast accepted", not
-  // "confirmed" — confirmation is the reconciler's job, and until it runs the
-  // status is still only ever a cache of what we last observed.
-  return (await repository.resolveCreate(recorded.id, "created")) ?? recorded;
+  const claimed = await repository.getById(
+    { organizationId: input.organizationId, projectId: input.projectId },
+    id
+  );
+  if (claimed === null) {
+    throw new Error("DvP claim disappeared after sponsored submission");
+  }
+  const observed = await observeDvpTradeNow(env, claimed);
+  return observed === null ? claimed : observed;
 }

--- a/apps/sdp-api/src/services/dvp/create.ts
+++ b/apps/sdp-api/src/services/dvp/create.ts
@@ -6,9 +6,9 @@
  *
  * Two things about `CreateDvp` shape this whole function.
  *
- * Only the PAYER signs. `user_a`, `user_b` and `settlement_authority` are plain
- * accounts on the instruction, so the counterparty signs nothing here and needs
- * no integration with us. Verified on devnet by creating a trade with addresses
+ * Only the PAYER signs, and that payer is Kora's sponsor. `user_a`, `user_b`
+ * and `settlement_authority` are plain accounts on the instruction, so the
+ * counterparty signs nothing here and needs no integration with us. Verified on devnet by creating a trade with addresses
  * we hold no keys for. It also means the instruction creates no obligation: a
  * SwapDvp is a proposal until someone funds it.
  *
@@ -26,6 +26,8 @@ import {
   type Address,
   address,
   appendTransactionMessageInstructions,
+  compileTransaction,
+  createNoopSigner,
   createTransactionMessage,
   getSignatureFromTransaction,
   getTransactionEncoder,
@@ -34,11 +36,10 @@ import {
   pipe,
   type Signature,
   SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,
-  setTransactionMessageFeePayerSigner,
+  setTransactionMessageFeePayer,
   setTransactionMessageLifetimeUsingBlockhash,
   some,
 } from "@solana/kit";
-import { signTransactionMessageWithSigners } from "@solana/signers";
 import { findAssociatedTokenPda } from "@solana-program/token-2022";
 import { getDb } from "@/db";
 import {
@@ -50,7 +51,10 @@ import { badRequest, conflict } from "@/lib/errors";
 import { createTenantScope } from "@/lib/tenant-scope";
 import { CustodyRuntimeTargets } from "@/services/domain/signing/custody-runtime-target";
 import { readSolanaCryptoWalletAddress } from "@/services/payments/counterparty-account-resolution";
-import { createOrgSignerForCustodyWallet } from "@/services/solana/signer";
+import {
+  assertSponsorSignedSameMessage,
+  createProjectSponsorshipFeePayment,
+} from "@/services/sponsorship.service";
 import type { Env } from "@/types/env";
 import { dvpCreateFingerprint, type ResolvedParty } from "./fingerprint";
 import { describeDvpDestinationProblem, findDvpDestinationProblem } from "./inspect-destination";
@@ -76,8 +80,6 @@ export type CreateDvpTradeInput = {
   /** The two parties, each as the caller described them. */
   partyA: DvpPartyInput;
   partyB: DvpPartyInput;
-  /** Signs and pays fee + rent; null means the settlement wallet. NOT a term of the trade. */
-  payerWalletId: string | null;
   /** Asset leg mint and its token program. */
   mintA: Address;
   tokenProgramA: Address;
@@ -340,20 +342,6 @@ export async function createDvpTrade(env: Env, input: CreateDvpTradeInput): Prom
   });
   const settlementAuthority = settlement.address;
 
-  // The payer signs and pays fee + rent: explicit `payerWalletId`, else the
-  // settlement wallet already provisioned above (one provisioning call serves
-  // both roles). It is legal as payer for both trade shapes — the program
-  // refuses only `settlement_authority == user_a || user_b` — and rent refunds
-  // land on the wallet that closes, which is this same one.
-  const payerWalletId =
-    input.payerWalletId === null ? settlement.custodyWalletId : input.payerWalletId;
-  const signer = await createOrgSignerForCustodyWallet(
-    env,
-    input.organizationId,
-    input.projectId,
-    payerWalletId
-  );
-
   const userA = resolvedA.address;
   const userB = resolvedB.address;
 
@@ -392,6 +380,17 @@ export async function createDvpTrade(env: Env, input: CreateDvpTradeInput): Prom
     throw badRequest(`Invalid DvP terms: ${problems.join("; ")}`);
   }
 
+  // Kora pays the fee and ~6.63M lamports of rent per trade, while close
+  // refunds settlement_authority. That devnet subsidy is deliberate; mainnet
+  // pricing is a product decision tracked by PRO-1906. Resolved only after
+  // every local check above, so a 400 never costs a Kora round trip.
+  const feePayment = await createProjectSponsorshipFeePayment(env, {
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    actor: { type: "wallet", id: settlement.custodyWalletId },
+  });
+  const sponsor = await feePayment.getFeePayer();
+
   // Cryptographically random, and a bigint throughout. A predictable nonce lets
   // a third party squat the address before the real parties reach it.
   const nonce = randomDvpNonce();
@@ -411,7 +410,7 @@ export async function createDvpTrade(env: Env, input: CreateDvpTradeInput): Prom
   ]);
 
   const instruction = getCreateDvpInstruction({
-    payer: signer,
+    payer: createNoopSigner(sponsor),
     swapDvp,
     nonceTombstone,
     settlementAuthority,
@@ -440,13 +439,19 @@ export async function createDvpTrade(env: Env, input: CreateDvpTradeInput): Prom
   const { blockhash, lastValidBlockHeight } = await solanaRpc.getRecentBlockhash(rpc, "confirmed");
   const message = pipe(
     createTransactionMessage({ version: 0 }),
-    (m) => setTransactionMessageFeePayerSigner(signer, m),
+    (m) => setTransactionMessageFeePayer(sponsor, m),
     (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
     (m) => appendTransactionMessageInstructions([instruction], m)
   );
-  const signed = await signTransactionMessageWithSigners(message);
+  const compiled = compileTransaction(message);
+  const bytes = new Uint8Array(getTransactionEncoder().encode(compiled));
+  const sponsorSigned = assertSponsorSignedSameMessage({
+    unsignedOrPartiallySigned: compiled,
+    sponsorSigned: await feePayment.signAsFeePayer(bytes),
+    sponsor,
+  });
   // Known from the signed bytes, so the row can carry it before anything is sent.
-  const signature: Signature = getSignatureFromTransaction(signed);
+  const signature: Signature = getSignatureFromTransaction(sponsorSigned);
 
   // Recorded BEFORE broadcast, at status `creating`. The six seed values are the
   // only durable copy of what RecoverDvp needs to rescue a deposit that lands
@@ -501,11 +506,17 @@ export async function createDvpTrade(env: Env, input: CreateDvpTradeInput): Prom
   // and their transaction is the one on the network. Broadcasting ours too
   // would create the second trade this key exists to prevent.
   if (recorded.createSignature !== signature) {
+    // The race loser has already reserved and signed sponsorship budget. The
+    // reconciler releases it after blockhash expiry once the signature remains
+    // absent for two passes; preflight-rejected broadcasts follow the same path.
     return recorded;
   }
 
   try {
-    await solanaRpc.sendTransaction(rpc, new Uint8Array(getTransactionEncoder().encode(signed)));
+    await solanaRpc.sendTransaction(
+      rpc,
+      new Uint8Array(getTransactionEncoder().encode(sponsorSigned))
+    );
   } catch (error) {
     // A preflight failure is the one send error that is definitively terminal:
     // the RPC rejected the bytes in simulation and never forwarded them, so

--- a/apps/sdp-api/src/services/dvp/fingerprint.test.ts
+++ b/apps/sdp-api/src/services/dvp/fingerprint.test.ts
@@ -21,17 +21,12 @@ const MINT_B: Address = address("AqTgvZaiZ18ykVvzaQhfB2KQ4SGDw4i1o5rQqBAMsZiE");
 const TOKEN_A: Address = address("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
 const TOKEN_B: Address = address("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
 
-function baseInput(
-  partyA: DvpPartyInput,
-  partyB: DvpPartyInput,
-  payerWalletId: string | null
-): CreateDvpTradeInput {
+function baseInput(partyA: DvpPartyInput, partyB: DvpPartyInput): CreateDvpTradeInput {
   return {
     organizationId: "org_x",
     projectId: "prj_x",
     partyA,
     partyB,
-    payerWalletId,
     mintA: MINT_A,
     tokenProgramA: TOKEN_A,
     mintB: MINT_B,
@@ -53,7 +48,7 @@ function resolved(addr: Address, counterpartyAccountId: string | null): Resolved
 
 describe("dvpCreateFingerprint", () => {
   it("is deterministic: the same input hashes the same", () => {
-    const input = baseInput({ address: ADDR_A }, { address: ADDR_B }, null);
+    const input = baseInput({ address: ADDR_A }, { address: ADDR_B });
     const a = dvpCreateFingerprint({
       input,
       resolvedA: resolved(ADDR_A, null),
@@ -67,27 +62,9 @@ describe("dvpCreateFingerprint", () => {
     expect(a).toBe(b);
   });
 
-  it("keeps null and the empty string distinct (payerWalletId)", () => {
-    const addrInput = baseInput({ address: ADDR_A }, { address: ADDR_B }, null);
-    const strInput = baseInput({ address: ADDR_A }, { address: ADDR_B }, "");
-    // "" is not a valid wallet id in practice, but the point is that the
-    // encoding distinguishes the two rather than collapsing them.
-    const a = dvpCreateFingerprint({
-      input: addrInput,
-      resolvedA: resolved(ADDR_A, null),
-      resolvedB: resolved(ADDR_B, null),
-    });
-    const b = dvpCreateFingerprint({
-      input: strInput,
-      resolvedA: resolved(ADDR_A, null),
-      resolvedB: resolved(ADDR_B, null),
-    });
-    expect(a).not.toBe(b);
-  });
-
   it("treats the party slot reference kind as material (address vs walletId-resolving-to-the-same-address)", () => {
-    const asAddress = baseInput({ address: ADDR_A }, { address: ADDR_B }, null);
-    const asWallet = baseInput({ walletId: "wal_x" }, { address: ADDR_B }, null);
+    const asAddress = baseInput({ address: ADDR_A }, { address: ADDR_B });
+    const asWallet = baseInput({ walletId: "wal_x" }, { address: ADDR_B });
     const a = dvpCreateFingerprint({
       input: asAddress,
       resolvedA: resolved(ADDR_A, null),
@@ -102,8 +79,8 @@ describe("dvpCreateFingerprint", () => {
   });
 
   it("treats the party slot reference value as material (same kind, different id)", () => {
-    const cpa1 = baseInput({ counterpartyAccountId: "cpa_1" }, { address: ADDR_B }, null);
-    const cpa2 = baseInput({ counterpartyAccountId: "cpa_2" }, { address: ADDR_B }, null);
+    const cpa1 = baseInput({ counterpartyAccountId: "cpa_1" }, { address: ADDR_B });
+    const cpa2 = baseInput({ counterpartyAccountId: "cpa_2" }, { address: ADDR_B });
     const a = dvpCreateFingerprint({
       input: cpa1,
       resolvedA: resolved(ADDR_A, "cpa_1"),
@@ -118,7 +95,7 @@ describe("dvpCreateFingerprint", () => {
   });
 
   it("treats the resolved address as material (same reference id, re-pointed address)", () => {
-    const input = baseInput({ counterpartyAccountId: "cpa_1" }, { address: ADDR_B }, null);
+    const input = baseInput({ counterpartyAccountId: "cpa_1" }, { address: ADDR_B });
     const before = dvpCreateFingerprint({
       input,
       resolvedA: resolved(ADDR_A, "cpa_1"),
@@ -132,24 +109,8 @@ describe("dvpCreateFingerprint", () => {
     expect(before).not.toBe(after);
   });
 
-  it("treats payerWalletId as material when sent", () => {
-    const noPayer = baseInput({ address: ADDR_A }, { address: ADDR_B }, null);
-    const withPayer = baseInput({ address: ADDR_A }, { address: ADDR_B }, "wal_payer");
-    const a = dvpCreateFingerprint({
-      input: noPayer,
-      resolvedA: resolved(ADDR_A, null),
-      resolvedB: resolved(ADDR_B, null),
-    });
-    const b = dvpCreateFingerprint({
-      input: withPayer,
-      resolvedA: resolved(ADDR_A, null),
-      resolvedB: resolved(ADDR_B, null),
-    });
-    expect(a).not.toBe(b);
-  });
-
   it("treats amounts and mints as material", () => {
-    const base = baseInput({ address: ADDR_A }, { address: ADDR_B }, null);
+    const base = baseInput({ address: ADDR_A }, { address: ADDR_B });
     const diffAmount = { ...base, amountA: 999n };
     const diffMint = { ...base, mintB: MINT_A };
     const fp = dvpCreateFingerprint({

--- a/apps/sdp-api/src/services/dvp/fingerprint.ts
+++ b/apps/sdp-api/src/services/dvp/fingerprint.ts
@@ -2,8 +2,8 @@
  * The fingerprint of a keyed create request.
  *
  * A key is a claim, not a proof; the hash covers every field that defines the
- * trade — payer (as sent), both party slots (reference kind, value AND
- * resolved address), mints, token programs, amounts, timestamps, destinations
+ * trade — both party slots (reference kind, value AND resolved address),
+ * mints, token programs, amounts, timestamps, destinations
  * and refString — so a reuse with different terms (or a wallet-scoped caller
  * replaying someone else's key) 409s instead of handing escrows back. Hashed
  * AS SENT, so a retry replays even after settlement-wallet rotation. No v1
@@ -60,8 +60,6 @@ export function dvpCreateFingerprint({
   // Explicit, not derived from object iteration (reordering must never
   // invalidate stored fingerprints); JSON encoding keeps null and "" distinct.
   const material = [
-    // As sent; null when defaulted, so a retry replays across settlement-wallet rotation.
-    input.payerWalletId,
     ...partySlotMaterial(input.partyA, resolvedA),
     ...partySlotMaterial(input.partyB, resolvedB),
     input.mintA,

--- a/apps/sdp-api/src/services/dvp/observe.test.ts
+++ b/apps/sdp-api/src/services/dvp/observe.test.ts
@@ -26,6 +26,9 @@ function trade(overrides: Partial<DvpTradeExpectation> = {}): DvpTradeExpectatio
     amountB: "2000",
     expiryTimestamp: String(NOW_SECONDS + 3600),
     createLastValidBlockHeight: "1500",
+    createSignature:
+      "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy",
+    createdAt: new Date(NOW_MS - 1_000).toISOString(),
     ...overrides,
   };
 }

--- a/apps/sdp-api/src/services/dvp/observe.ts
+++ b/apps/sdp-api/src/services/dvp/observe.ts
@@ -44,6 +44,10 @@ export interface DvpTradeExpectation {
    * before this was recorded, which stay ambiguous rather than being guessed at.
    */
   createLastValidBlockHeight: string | null;
+  /** Signature attached when sponsorship completed, or null for an orphaned claim. */
+  createSignature: string | null;
+  /** Claim creation time used only to age unsigned orphaned claims. */
+  createdAt: string;
 }
 
 export interface DvpTradeDerivation {
@@ -60,6 +64,45 @@ const CLOSABLE: ReadonlySet<DvpTradeStatus> = new Set([
   "funded",
   "expired",
 ]);
+
+/** Grace period covering a request that is still waiting on Kora's timeout. */
+export const DVP_CREATE_CLAIM_GRACE_MS = 15 * 60 * 1_000;
+
+/**
+ * Derives a status when the SwapDvp account is absent from chain.
+ *
+ * @param observation - Chain reading carrying the current block height.
+ * @param trade - Stored claim and lifecycle state.
+ * @param nowMs - Current wall-clock time.
+ * @returns The status justified by the missing account.
+ */
+function deriveMissingTradeAccountStatus(
+  observation: DvpTradeObservation,
+  trade: DvpTradeExpectation,
+  nowMs: number
+): DvpTradeStatus {
+  // A decoded close beats every inference below: the transaction that closed
+  // the account says exactly which terminal path it took.
+  if (
+    observation.closeResolution !== null &&
+    (trade.status === "creating" || CLOSABLE.has(trade.status))
+  ) {
+    return observation.closeResolution.status;
+  }
+  if (trade.status === "creating") {
+    if (trade.createSignature === null && trade.createLastValidBlockHeight === null) {
+      // Nothing was signed, so nothing can be on chain. The grace period only
+      // protects a live request that is still waiting for Kora.
+      const orphaned = nowMs - Date.parse(trade.createdAt) >= DVP_CREATE_CLAIM_GRACE_MS;
+      return orphaned ? "create_failed" : "creating";
+    }
+    const expiry = trade.createLastValidBlockHeight;
+    return expiry !== null && observation.blockHeight > BigInt(expiry)
+      ? "create_failed"
+      : "creating";
+  }
+  return CLOSABLE.has(trade.status) ? "closed_unknown" : trade.status;
+}
 
 /**
  * Derives the status a trade should now hold.
@@ -98,31 +141,7 @@ export function deriveDvpTradeState(
   if (!observation.tradeAccountExists) {
     // Nothing at the address. Two very different reasons, and the row's own
     // status is what tells them apart.
-    if (
-      observation.closeResolution !== null &&
-      (trade.status === "creating" || CLOSABLE.has(trade.status))
-    ) {
-      return { status: observation.closeResolution.status, ...flags };
-    }
-    if (trade.status === "creating") {
-      // The create was signed and recorded but never seen to land. Whether it
-      // still CAN land is not a question about elapsed time — it is decided by
-      // the blockhash the transaction was signed against. Past that height the
-      // cluster can never accept it; before it, the transaction may yet appear.
-      //
-      // A row with no recorded height stays `creating` forever rather than
-      // being guessed at. That is deliberate: a wrong `create_failed` reports
-      // no escrow exists while its address sits on chain awaiting funds.
-      const expiry = trade.createLastValidBlockHeight;
-      const expired = expiry !== null && observation.blockHeight > BigInt(expiry);
-      return { status: expired ? "create_failed" : "creating", ...flags };
-    }
-    if (CLOSABLE.has(trade.status)) {
-      return { status: "closed_unknown", ...flags };
-    }
-    // Already terminal. A reconciler must never walk a trade backwards out of
-    // a state something better-informed put it in.
-    return { status: trade.status, ...flags };
+    return { status: deriveMissingTradeAccountStatus(observation, trade, nowMs), ...flags };
   }
 
   // The account is there, so whatever else is true, the create landed.

--- a/apps/sdp-api/src/services/earn/vault-execution.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-execution.service.ts
@@ -304,7 +304,7 @@ export async function signVaultPlan(
     signedBytes = await input.deadline.run("Signing the sponsored vault fee", () =>
       feePayment.signAsFeePayer(ownerSignedBytes)
     );
-    assertSponsorSignedSameMessage({
+    await assertSponsorSignedSameMessage({
       unsignedOrPartiallySigned: ownerSigned,
       sponsorSigned: signedBytes,
       sponsor: feePayer,

--- a/apps/sdp-api/src/services/earn/vault-execution.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-execution.service.ts
@@ -9,7 +9,6 @@ import {
   addSignersToTransactionMessage,
   appendTransactionMessageInstructions,
   type Blockhash,
-  bytesEqual,
   compileTransaction,
   compressTransactionMessageUsingAddressLookupTables,
   createTransactionMessage,
@@ -30,6 +29,7 @@ import {
   partiallySignTransactionMessageWithSigners,
   signTransactionMessageWithSigners,
 } from "@solana/signers";
+import { assertSponsorSignedSameMessage } from "@/services/sponsorship.service";
 import type { Env } from "@/types/env";
 import { assertClusterEndpoint } from "./execution-registry";
 import type { VaultDeadline } from "./vault-deadline";
@@ -304,29 +304,11 @@ export async function signVaultPlan(
     signedBytes = await input.deadline.run("Signing the sponsored vault fee", () =>
       feePayment.signAsFeePayer(ownerSignedBytes)
     );
-    // A paymaster returns BYTES, not a signature, so nothing about the call
-    // constrains it to return the message SDP just signed. Both checks belong
-    // HERE, before the bytes are persisted: past that point a sigverify
-    // rejection at broadcast is indistinguishable from a lost response, and the
-    // movement parks reconcilable until its blockhash expires.
-    //
-    // Message equality is the check that catches a swap, because the cheaper
-    // ones do not. The owner slot still carries a signature (over the OLD
-    // message), and a SUBSTITUTED fee payer still satisfies
-    // `getSignatureFromTransaction` below, which reads whatever sits in slot
-    // zero. It also means Kora may not rewrite the plan: a relayer that injects
-    // its own compute-budget or fee-transfer instruction fails here, loudly,
-    // rather than sending bytes that were never simulated or size-checked.
-    const sponsorSigned = getTransactionDecoder().decode(signedBytes);
-    if (!bytesEqual(sponsorSigned.messageBytes, ownerSigned.messageBytes)) {
-      throw new Error("Sponsored vault transaction came back over a different message");
-    }
-    if (
-      sponsorSigned.signatures[feePayer] === null ||
-      sponsorSigned.signatures[feePayer] === undefined
-    ) {
-      throw new Error("Vault transaction is missing the sponsor fee-payer signature");
-    }
+    assertSponsorSignedSameMessage({
+      unsignedOrPartiallySigned: ownerSigned,
+      sponsorSigned: signedBytes,
+      sponsor: feePayer,
+    });
   } else if (input.fee.kind === "caller-provided") {
     // Unreachable from the custody paths by construction; asserted so a new
     // caller cannot silently fall through to wallet-pays and sign the custody

--- a/apps/sdp-api/src/services/jobs/reconcile-dvp-trades.test.ts
+++ b/apps/sdp-api/src/services/jobs/reconcile-dvp-trades.test.ts
@@ -59,7 +59,16 @@ function swapDvpFor(id: string): string {
   return getBase58Decoder().decode(bytes);
 }
 
-async function seedTrade(id: string, status: string, overrides: Record<string, string> = {}) {
+async function seedTrade(
+  id: string,
+  status: string,
+  overrides: {
+    expiryTimestamp?: string;
+    createLastValidBlockHeight?: string | null;
+    createSignature?: string | null;
+    createdAt?: string;
+  } = {}
+) {
   await getDb(env)
     .prepare(
       `INSERT INTO dvp_trades (
@@ -69,7 +78,7 @@ async function seedTrade(id: string, status: string, overrides: Record<string, s
          amount_a, amount_b, expiry_timestamp,
          user_a_settlement_destination, user_b_settlement_destination,
          escrow_a, escrow_b, status,
-         create_last_valid_block_height
+         create_signature, create_last_valid_block_height
        ) VALUES (
          ?, ?, ?, ?,
          '9BvXsTHgFvS31NLpVN4hpAoHCTfwvVX1XkgFq7fJEZxY',
@@ -85,7 +94,7 @@ async function seedTrade(id: string, status: string, overrides: Record<string, s
          '7WLcnnT1nnPuHiWaVnAY3Uz8Y2SgFy2VMg2t7GAoxnpg',
          'FwQyjVB3o9UkWEEWZVLbvc3EizH3jhHp4g9HmpmuzGWU',
          '6yDKQfAMjjnQCgkHJvpDc1CVPx2vPDLhDkhZYQPw7w9y',
-         ?, ?
+         ?, ?, ?
        )`
     )
     .bind(
@@ -95,9 +104,18 @@ async function seedTrade(id: string, status: string, overrides: Record<string, s
       swapDvpFor(id),
       overrides.expiryTimestamp ?? String(Math.floor(Date.now() / 1000) + 3600),
       status,
-      overrides.createLastValidBlockHeight ?? "1500"
+      Object.hasOwn(overrides, "createSignature") ? overrides.createSignature : SIG,
+      Object.hasOwn(overrides, "createLastValidBlockHeight")
+        ? overrides.createLastValidBlockHeight
+        : "1500"
     )
     .run();
+  if (overrides.createdAt !== undefined) {
+    await getDb(env)
+      .prepare("UPDATE dvp_trades SET created_at = ? WHERE id = ?")
+      .bind(overrides.createdAt, id)
+      .run();
+  }
 }
 
 async function statusOf(id: string): Promise<Record<string, unknown> | null> {
@@ -208,6 +226,47 @@ describe("reconcileDvpTrades", () => {
     await reconcileDvpTrades(env);
 
     await expect(statusOf("dvp_live_create")).resolves.toMatchObject({ status: "creating" });
+  });
+
+  it("leaves an unsigned claim creating while it is younger than the grace period", async () => {
+    await seedTrade("dvp_young_claim", "creating", {
+      createSignature: null,
+      createLastValidBlockHeight: null,
+      createdAt: new Date(Date.now() - 14 * 60 * 1_000).toISOString(),
+    });
+    readDvpTradeObservation.mockResolvedValue(observation({ tradeAccountExists: false }));
+
+    await reconcileDvpTrades(env);
+
+    await expect(statusOf("dvp_young_claim")).resolves.toMatchObject({ status: "creating" });
+  });
+
+  it("fails an unsigned claim once it is older than the grace period", async () => {
+    await seedTrade("dvp_orphaned_claim", "creating", {
+      createSignature: null,
+      createLastValidBlockHeight: null,
+      createdAt: new Date(Date.now() - 16 * 60 * 1_000).toISOString(),
+    });
+    readDvpTradeObservation.mockResolvedValue(observation({ tradeAccountExists: false }));
+
+    await reconcileDvpTrades(env);
+
+    await expect(statusOf("dvp_orphaned_claim")).resolves.toMatchObject({
+      status: "create_failed",
+    });
+  });
+
+  it("uses block height rather than claim age after a signature is attached", async () => {
+    await seedTrade("dvp_signed_old_claim", "creating", {
+      createSignature: SIG,
+      createLastValidBlockHeight: "2000",
+      createdAt: new Date(Date.now() - 16 * 60 * 1_000).toISOString(),
+    });
+    readDvpTradeObservation.mockResolvedValue(observation({ tradeAccountExists: false }));
+
+    await reconcileDvpTrades(env);
+
+    await expect(statusOf("dvp_signed_old_claim")).resolves.toMatchObject({ status: "creating" });
   });
 
   it("records a frozen escrow, which balance alone cannot distinguish from unpaid", async () => {

--- a/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
@@ -42,11 +42,11 @@ import { logEvent } from "@/runtime/money-path-events";
 import { createSigningService } from "@/services/domain/signing.service";
 import {
   createTransferSignedSubmissionStore,
-  isDefiniteSubmissionError,
   type TransferSignedSubmissionStore,
 } from "@/services/payments/signed-submission";
 import * as solanaServices from "@/services/solana";
 import { createProjectSponsorshipFeePayment } from "@/services/sponsorship.service";
+import { isDefiniteSubmissionError } from "@/services/sponsorship-submission";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import { emitRecurringPaymentFailed } from "@/services/workflows/payment-events";
 import type { Env } from "@/types/env";

--- a/apps/sdp-api/src/services/payments/recurring-payments/shared.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/shared.ts
@@ -21,12 +21,12 @@ import type { PaymentRecurringPaymentRow } from "@/db/repositories/payment-recur
 import { AppError, badRequest } from "@/lib/errors";
 import { createTenantScope } from "@/lib/tenant-scope";
 import { isNativePaymentToken, normalizePaymentToken } from "@/services/payment-operation.service";
-import {
-  type SignedSubmissionStore,
-  submitSignedPaymentTransaction,
-} from "@/services/payments/signed-submission";
 import * as solanaServices from "@/services/solana";
 import { createProjectSponsorshipFeePayment } from "@/services/sponsorship.service";
+import {
+  type SignedSubmissionStore,
+  submitSponsoredTransaction,
+} from "@/services/sponsorship-submission";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import type { Env } from "@/types/env";
 
@@ -145,7 +145,7 @@ export async function sendSubscriptionInstructions(input: {
   const partiallySigned = await partiallySignTransactionMessageWithSigners(message);
   const txBytes = new Uint8Array(getTransactionEncoder().encode(partiallySigned));
   return input.submissionStore
-    ? submitSignedPaymentTransaction({
+    ? submitSponsoredTransaction({
         feePayment,
         rpc,
         transaction: txBytes,

--- a/apps/sdp-api/src/services/payments/signed-submission.test.ts
+++ b/apps/sdp-api/src/services/payments/signed-submission.test.ts
@@ -8,10 +8,8 @@ import {
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PaymentsRepository, PaymentTransferRow } from "@/db/repositories/payments.repository";
 import type { SponsorshipFeePayment } from "@/services/sponsorship.service";
-import {
-  createTransferSignedSubmissionStore,
-  submitSignedPaymentTransaction,
-} from "./signed-submission";
+import { submitSponsoredTransaction } from "../sponsorship-submission";
+import { createTransferSignedSubmissionStore } from "./signed-submission";
 
 const SIGNATURE =
   "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy" as Signature;
@@ -34,7 +32,7 @@ function preflightError(cause?: unknown) {
   });
 }
 
-describe("submitSignedPaymentTransaction", () => {
+describe("submitSponsoredTransaction", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
@@ -67,7 +65,7 @@ describe("submitSignedPaymentTransaction", () => {
     });
 
     await expect(
-      submitSignedPaymentTransaction({
+      submitSponsoredTransaction({
         feePayment,
         rpc: {} as solanaRpc.SolanaRpc,
         transaction: new Uint8Array([9]),
@@ -105,7 +103,7 @@ describe("submitSignedPaymentTransaction", () => {
       .mockRejectedValueOnce(new Error("fetch failed"))
       .mockResolvedValueOnce(SIGNATURE);
 
-    const result = submitSignedPaymentTransaction({
+    const result = submitSponsoredTransaction({
       feePayment,
       rpc: {} as solanaRpc.SolanaRpc,
       transaction: new Uint8Array([9]),
@@ -146,7 +144,7 @@ describe("submitSignedPaymentTransaction", () => {
     vi.spyOn(solanaRpc, "sendTransaction").mockRejectedValueOnce(error);
 
     await expect(
-      submitSignedPaymentTransaction({
+      submitSponsoredTransaction({
         feePayment,
         rpc: {} as solanaRpc.SolanaRpc,
         transaction: new Uint8Array([9]),
@@ -180,7 +178,7 @@ describe("submitSignedPaymentTransaction", () => {
     );
 
     await expect(
-      submitSignedPaymentTransaction({
+      submitSponsoredTransaction({
         feePayment,
         rpc: {} as solanaRpc.SolanaRpc,
         transaction: new Uint8Array([9]),
@@ -212,7 +210,7 @@ describe("submitSignedPaymentTransaction", () => {
       .mockRejectedValueOnce(deterministicError);
 
     const result = expect(
-      submitSignedPaymentTransaction({
+      submitSponsoredTransaction({
         feePayment,
         rpc: {} as solanaRpc.SolanaRpc,
         transaction: new Uint8Array([9]),
@@ -252,7 +250,7 @@ describe("submitSignedPaymentTransaction", () => {
       .mockRejectedValueOnce(finalError);
 
     const result = expect(
-      submitSignedPaymentTransaction({
+      submitSponsoredTransaction({
         feePayment,
         rpc: {} as solanaRpc.SolanaRpc,
         transaction: new Uint8Array([9]),

--- a/apps/sdp-api/src/services/payments/signed-submission.ts
+++ b/apps/sdp-api/src/services/payments/signed-submission.ts
@@ -1,50 +1,10 @@
-import { isTransientRpcError, withTransientRpcRetry } from "@sdp/rpc";
-import * as solanaRpc from "@sdp/rpc/solana";
-import {
-  getBase64Decoder,
-  isSolanaError,
-  type Signature,
-  SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM,
-  SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,
-  unwrapSimulationError,
-} from "@solana/kit";
 import type { PaymentsRepository, PaymentTransferRow } from "@/db/repositories/payments.repository";
-import { AppError, accountFrozen, transactionFailed } from "@/lib/errors";
-import type { SponsorshipFeePayment } from "@/services/sponsorship.service";
-
-export interface SignedSubmissionStore {
-  persistSigned(input: {
-    signature: Signature;
-    signedTransaction: string;
-    lastValidBlockHeight: string;
-  }): Promise<void>;
-  markStarted(): Promise<void>;
-  hasStarted(): Promise<boolean>;
-}
+import { AppError } from "@/lib/errors";
+import type { SignedSubmissionStore } from "@/services/sponsorship-submission";
 
 export type TransferSignedSubmissionStore = SignedSubmissionStore & {
   submittedRow(): Promise<PaymentTransferRow | null>;
 };
-
-export function isDefiniteSubmissionError(error: unknown): boolean {
-  return (
-    error instanceof AppError &&
-    (error.code === "TRANSACTION_FAILED" || error.code === "ACCOUNT_FROZEN")
-  );
-}
-
-function mapPreflightError(error: unknown): AppError | null {
-  if (
-    !isSolanaError(error, SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE)
-  ) {
-    return null;
-  }
-  const cause = unwrapSimulationError(error);
-  const message = cause instanceof Error ? cause.message : error.message;
-  return isSolanaError(cause, SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM) && cause.context.code === 17
-    ? accountFrozen(message)
-    : transactionFailed(message);
-}
 
 export function createTransferSignedSubmissionStore(
   repository: PaymentsRepository,
@@ -98,53 +58,4 @@ export function createTransferSignedSubmissionStore(
     },
     submittedRow: async () => (startState === "not_started" ? null : row),
   };
-}
-
-export async function submitSignedPaymentTransaction(input: {
-  feePayment: SponsorshipFeePayment;
-  rpc: solanaRpc.SolanaRpc;
-  transaction: Uint8Array;
-  lastValidBlockHeight: bigint;
-  store: SignedSubmissionStore;
-}): Promise<Signature> {
-  const submission = await input.feePayment.prepareOwnedSubmission(input.transaction, {
-    persistSigned: ({ signature, signedTransaction }) =>
-      input.store.persistSigned({
-        signature,
-        signedTransaction: getBase64Decoder().decode(signedTransaction),
-        lastValidBlockHeight: input.lastValidBlockHeight.toString(),
-      }),
-    markStarted: input.store.markStarted,
-    hasStarted: input.store.hasStarted,
-  });
-
-  let sawTransientFailure = false;
-  const submittedSignature = await withTransientRpcRetry(async () => {
-    try {
-      return await solanaRpc.sendTransaction(input.rpc, submission.signedTransaction);
-    } catch (error) {
-      const preflightError = sawTransientFailure ? null : mapPreflightError(error);
-      if (preflightError) {
-        try {
-          await submission.releaseDefinitelyUnbroadcast(error);
-        } catch {
-          // Managed sponsorship logs and trips its breaker; preserve the
-          // definitive chain verdict so the payment cannot remain processing.
-        }
-        throw preflightError;
-      }
-      const transient = isTransientRpcError(error);
-      if (sawTransientFailure && !transient) {
-        throw new Error("Solana RPC submission outcome is ambiguous after a transient failure", {
-          cause: error,
-        });
-      }
-      sawTransientFailure ||= transient;
-      throw error;
-    }
-  });
-  if (submittedSignature !== submission.signature) {
-    throw new Error("Solana RPC returned a different transaction signature");
-  }
-  return submission.signature;
 }

--- a/apps/sdp-api/src/services/sponsorship-submission.ts
+++ b/apps/sdp-api/src/services/sponsorship-submission.ts
@@ -1,0 +1,109 @@
+import { isTransientRpcError, withTransientRpcRetry } from "@sdp/rpc";
+import * as solanaRpc from "@sdp/rpc/solana";
+import {
+  getBase64Decoder,
+  isSolanaError,
+  type Signature,
+  SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM,
+  SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,
+  unwrapSimulationError,
+} from "@solana/kit";
+import { AppError, accountFrozen, transactionFailed } from "@/lib/errors";
+import type { SponsorshipFeePayment } from "@/services/sponsorship.service";
+
+export interface SignedSubmissionStore {
+  persistSigned(input: {
+    signature: Signature;
+    signedTransaction: string;
+    lastValidBlockHeight: string;
+  }): Promise<void>;
+  markStarted(): Promise<void>;
+  hasStarted(): Promise<boolean>;
+}
+
+/**
+ * Identifies a submission error that proves the transaction was not broadcast.
+ *
+ * @param error - The error returned by the sponsored submission path.
+ * @returns Whether the error is a definitive preflight rejection.
+ */
+export function isDefiniteSubmissionError(error: unknown): boolean {
+  return (
+    error instanceof AppError &&
+    (error.code === "TRANSACTION_FAILED" || error.code === "ACCOUNT_FROZEN")
+  );
+}
+
+/**
+ * Maps a Solana preflight rejection to the public money-path error contract.
+ *
+ * @param error - The RPC error to inspect.
+ * @returns The mapped application error, or null when the outcome is ambiguous.
+ */
+export function mapPreflightError(error: unknown): AppError | null {
+  if (
+    !isSolanaError(error, SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE)
+  ) {
+    return null;
+  }
+  const cause = unwrapSimulationError(error);
+  const message = cause instanceof Error ? cause.message : error.message;
+  return isSolanaError(cause, SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM) && cause.context.code === 17
+    ? accountFrozen(message)
+    : transactionFailed(message);
+}
+
+/**
+ * Signs, durably records, and submits an owned sponsored transaction for any money path.
+ *
+ * @param input - Sponsorship, RPC, transaction lifetime, and durable lifecycle store.
+ * @returns The signature of the submitted transaction.
+ */
+export async function submitSponsoredTransaction(input: {
+  feePayment: SponsorshipFeePayment;
+  rpc: solanaRpc.SolanaRpc;
+  transaction: Uint8Array;
+  lastValidBlockHeight: bigint;
+  store: SignedSubmissionStore;
+}): Promise<Signature> {
+  const submission = await input.feePayment.prepareOwnedSubmission(input.transaction, {
+    persistSigned: ({ signature, signedTransaction }) =>
+      input.store.persistSigned({
+        signature,
+        signedTransaction: getBase64Decoder().decode(signedTransaction),
+        lastValidBlockHeight: input.lastValidBlockHeight.toString(),
+      }),
+    markStarted: input.store.markStarted,
+    hasStarted: input.store.hasStarted,
+  });
+
+  let sawTransientFailure = false;
+  const submittedSignature = await withTransientRpcRetry(async () => {
+    try {
+      return await solanaRpc.sendTransaction(input.rpc, submission.signedTransaction);
+    } catch (error) {
+      const preflightError = sawTransientFailure ? null : mapPreflightError(error);
+      if (preflightError) {
+        try {
+          await submission.releaseDefinitelyUnbroadcast(error);
+        } catch {
+          // Managed sponsorship logs and trips its breaker; preserve the
+          // definitive chain verdict so the payment cannot remain processing.
+        }
+        throw preflightError;
+      }
+      const transient = isTransientRpcError(error);
+      if (sawTransientFailure && !transient) {
+        throw new Error("Solana RPC submission outcome is ambiguous after a transient failure", {
+          cause: error,
+        });
+      }
+      sawTransientFailure ||= transient;
+      throw error;
+    }
+  });
+  if (submittedSignature !== submission.signature) {
+    throw new Error("Solana RPC returned a different transaction signature");
+  }
+  return submission.signature;
+}

--- a/apps/sdp-api/src/services/sponsorship.service.ts
+++ b/apps/sdp-api/src/services/sponsorship.service.ts
@@ -6,7 +6,13 @@ import {
   type SponsorshipProviderConfiguration,
 } from "@sdp/payments/fee-payment";
 import type { ProjectEnvironment } from "@sdp/types";
-import type { Signature } from "@solana/kit";
+import {
+  type Address,
+  bytesEqual,
+  getTransactionDecoder,
+  type Signature,
+  type Transaction,
+} from "@solana/kit";
 import type { Context } from "hono";
 import { getDb } from "@/db";
 import { getAuth, requireProjectId } from "@/lib/auth";
@@ -43,6 +49,39 @@ export interface OwnedSubmissionLifecycle {
   persistSigned(submission: OwnedSignedSubmission): Promise<void>;
   markStarted(): Promise<void>;
   hasStarted(): Promise<boolean>;
+}
+
+/**
+ * Refuses paymaster bytes that are not the sponsor's signature over exactly
+ * the message SDP compiled.
+ *
+ * A paymaster returns bytes rather than a signature, so it could substitute a
+ * different message while still providing a valid fee-payer signature. This
+ * check also forbids relayers from injecting instructions after SDP simulated
+ * or size-checked the transaction.
+ *
+ * @param params - The compiled transaction, returned bytes, and expected sponsor.
+ * @param params.unsignedOrPartiallySigned - The transaction SDP handed to the sponsor.
+ * @param params.sponsorSigned - The bytes returned by the sponsor.
+ * @param params.sponsor - The address whose signature must be present.
+ * @returns The decoded sponsor-signed transaction.
+ */
+export function assertSponsorSignedSameMessage(params: {
+  unsignedOrPartiallySigned: Transaction;
+  sponsorSigned: Uint8Array;
+  sponsor: Address;
+}): Transaction {
+  const sponsorSigned = getTransactionDecoder().decode(params.sponsorSigned);
+  if (!bytesEqual(sponsorSigned.messageBytes, params.unsignedOrPartiallySigned.messageBytes)) {
+    throw new Error("Sponsored transaction came back over a different message");
+  }
+  if (
+    sponsorSigned.signatures[params.sponsor] === null ||
+    sponsorSigned.signatures[params.sponsor] === undefined
+  ) {
+    throw new Error("Sponsored transaction is missing the sponsor fee-payer signature");
+  }
+  return sponsorSigned;
 }
 
 /** App-local extension for SDP-owned submission flows. */

--- a/apps/sdp-api/src/services/sponsorship.service.ts
+++ b/apps/sdp-api/src/services/sponsorship.service.ts
@@ -9,9 +9,11 @@ import type { ProjectEnvironment } from "@sdp/types";
 import {
   type Address,
   bytesEqual,
+  getPublicKeyFromAddress,
   getTransactionDecoder,
   type Signature,
   type Transaction,
+  verifySignature,
 } from "@solana/kit";
 import type { Context } from "hono";
 import { getDb } from "@/db";
@@ -58,28 +60,32 @@ export interface OwnedSubmissionLifecycle {
  * A paymaster returns bytes rather than a signature, so it could substitute a
  * different message while still providing a valid fee-payer signature. This
  * check also forbids relayers from injecting instructions after SDP simulated
- * or size-checked the transaction.
+ * or size-checked the transaction. The sponsor's signature is then verified
+ * against its public key: a filled slot alone would let a corrupted response
+ * be persisted as an in-flight transaction that only the RPC could reject.
  *
  * @param params - The compiled transaction, returned bytes, and expected sponsor.
  * @param params.unsignedOrPartiallySigned - The transaction SDP handed to the sponsor.
  * @param params.sponsorSigned - The bytes returned by the sponsor.
- * @param params.sponsor - The address whose signature must be present.
+ * @param params.sponsor - The address whose signature must be present and valid.
  * @returns The decoded sponsor-signed transaction.
  */
-export function assertSponsorSignedSameMessage(params: {
+export async function assertSponsorSignedSameMessage(params: {
   unsignedOrPartiallySigned: Transaction;
   sponsorSigned: Uint8Array;
   sponsor: Address;
-}): Transaction {
+}): Promise<Transaction> {
   const sponsorSigned = getTransactionDecoder().decode(params.sponsorSigned);
   if (!bytesEqual(sponsorSigned.messageBytes, params.unsignedOrPartiallySigned.messageBytes)) {
     throw new Error("Sponsored transaction came back over a different message");
   }
-  if (
-    sponsorSigned.signatures[params.sponsor] === null ||
-    sponsorSigned.signatures[params.sponsor] === undefined
-  ) {
+  const sponsorSignature = sponsorSigned.signatures[params.sponsor];
+  if (sponsorSignature === null || sponsorSignature === undefined) {
     throw new Error("Sponsored transaction is missing the sponsor fee-payer signature");
+  }
+  const sponsorKey = await getPublicKeyFromAddress(params.sponsor);
+  if (!(await verifySignature(sponsorKey, sponsorSignature, sponsorSigned.messageBytes))) {
+    throw new Error("Sponsored transaction carries an invalid sponsor fee-payer signature");
   }
   return sponsorSigned;
 }

--- a/apps/sdp-api/src/test/integration-support.ts
+++ b/apps/sdp-api/src/test/integration-support.ts
@@ -3,6 +3,7 @@
  * Keep this facade intentionally small and integration-test specific.
  */
 
+import { DVP_SWAP_PROGRAM_PROGRAM_ADDRESS } from "@sdp/dvp";
 import { supportsVaultDirect } from "@sdp/earn/capabilities";
 import { createFeePaymentAdapter, KoraAdapter, KoraClient } from "@sdp/payments/fee-payment";
 import { hashString } from "@sdp/payments/hash";
@@ -60,6 +61,7 @@ export const apiTestSupport = {
   createVaultDeadline,
   depositIntoVault,
   CustodyConfigStore,
+  DVP_SWAP_PROGRAM_PROGRAM_ADDRESS,
   EARN_PROVIDERS,
   findAssociatedTokenPda,
   getCreateAssociatedTokenIdempotentInstruction,

--- a/apps/sdp-web/src/app/dashboard/markets/dvp/create/use-dvp-create-form.ts
+++ b/apps/sdp-web/src/app/dashboard/markets/dvp/create/use-dvp-create-form.ts
@@ -210,9 +210,6 @@ export function useDvpCreateForm(cluster: SolanaCluster, context: DvpCreateConte
       mintA: asset.mint,
       mintB: cash.mint,
       parties: parties.wire,
-      // Nobody configures a fee payer: the project settlement wallet signs
-      // and pays fee + rent until create is Kora-sponsored.
-      payerWalletId: null,
       refString: refString.trim(),
       tokenProgramA: asset.token?.tokenProgram ?? null,
       tokenProgramB: cash.token?.tokenProgram ?? null,

--- a/apps/sdp-web/src/app/dashboard/markets/dvp/create/use-dvp-create-submit.ts
+++ b/apps/sdp-web/src/app/dashboard/markets/dvp/create/use-dvp-create-submit.ts
@@ -61,7 +61,6 @@ function partyRefKind(ref: DvpPartyRef): string {
 
 function createIdempotencyKey(request: DvpCreateRequest): string {
   const material = JSON.stringify([
-    request.payerWalletId,
     // The party's address plus which reference kind named it: a wallet and a
     // registered counterparty resolving to the same address are different
     // attributions, and the fingerprint treats them as different parties.
@@ -92,12 +91,6 @@ function createIdempotencyKey(request: DvpCreateRequest): string {
 
 export interface DvpCreateRequest {
   parties: { a: DvpPartyWire; b: DvpPartyWire };
-  /**
-   * The wallet that pays the fee and the escrow rent, or null for the
-   * project's settlement wallet. Omitted from the request when null — the
-   * absence IS the default.
-   */
-  payerWalletId: string | null;
   amountA: string;
   amountB: string;
   /** The expiry as a local wall-clock datetime, "YYYY-MM-DDTHH:mm". */
@@ -144,9 +137,6 @@ export function useDvpCreateSubmit(): DvpCreateSubmit {
         body: JSON.stringify({
           partyA: request.parties.a.ref,
           partyB: request.parties.b.ref,
-          // Treated as the wire shape says: present only when the caller
-          // picked a payer; the project settlement wallet pays otherwise.
-          ...(request.payerWalletId ? { payerWalletId: request.payerWalletId } : {}),
           mintA: request.mintA,
           mintB: request.mintB,
           // A PASTED address is assumed Token-2022; if it is not, create

--- a/apps/sdp-web/src/app/dashboard/markets/dvp/create/use-dvp-create-submit.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/dvp/create/use-dvp-create-submit.unit.test.tsx
@@ -44,7 +44,6 @@ function request(overrides: Partial<DvpCreateRequest> = {}): DvpCreateRequest {
       a: { ref: { walletId: WALLET_A }, address: ADDRESS_A },
       b: { ref: { address: ADDRESS_B }, address: ADDRESS_B },
     },
-    payerWalletId: null,
     amountA: "1000",
     amountB: "2000",
     expiry: "2027-01-01T23:59",
@@ -107,18 +106,6 @@ describe("useDvpCreateSubmit wire shape", () => {
     expect(body.partyA).toEqual({ counterpartyAccountId: "cpa_1" });
   });
 
-  it("omits payerWalletId when the project settlement wallet pays", async () => {
-    const { body } = await requestFor({ payerWalletId: null });
-
-    expect(body).not.toHaveProperty("payerWalletId");
-  });
-
-  it("sends payerWalletId only when a wallet was picked", async () => {
-    const { body } = await requestFor({ payerWalletId: "cwlt_payer" });
-
-    expect(body.payerWalletId).toBe("cwlt_payer");
-  });
-
   it("omits empty settlement destinations rather than sending empty strings", async () => {
     const { body } = await requestFor();
 
@@ -164,7 +151,6 @@ describe("useDvpCreateSubmit idempotency key", () => {
           },
         },
       ],
-      ["the payer wallet", { payerWalletId: "cwlt_other" }],
       ["the asset token program", { tokenProgramA: LEGACY }],
       ["the cash token program", { tokenProgramB: LEGACY }],
       ["the reference", { refString: "invoice-42" }],

--- a/infra/kora/kora.toml
+++ b/infra/kora/kora.toml
@@ -43,6 +43,7 @@ allowed_programs = [
     "SPLxh1LVZzEkX99H6rqYizhytLWPZVV296zyYDPagv2",   # MagicBlock private transfer program
     "DELeGGvXpWV2fqJUhqcF5ZSYMS4JTLjteaAMARRSaeSh",   # MagicBlock delegation program
     "De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44",   # Subscriptions (recurring payments) program
+    "dvp34bdbcEm4f4FCUjGV4mDAkDshaQR4LkK8fdcsyZq",  # DvP swap program (devnet-only deploy)
     "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr",   # Memo Program
     "AddressLookupTab1e1111111111111111111111111",   # Address Lookup Table
     "ComputeBudget111111111111111111111111111111",   # Compute Budget

--- a/packages/sdp-api-integration/package.json
+++ b/packages/sdp-api-integration/package.json
@@ -12,6 +12,7 @@
     "typecheck": "vitest run --typecheck.enabled --typecheck.only --typecheck.include='src/**/*.test.ts' --passWithNoTests"
   },
   "dependencies": {
+    "@sdp/dvp": "workspace:*",
     "@sdp/private-channels": "workspace:*",
     "@sdp/rpc": "workspace:*",
     "@sdp/spc-escrow": "workspace:*",

--- a/packages/sdp-api-integration/package.json
+++ b/packages/sdp-api-integration/package.json
@@ -12,7 +12,6 @@
     "typecheck": "vitest run --typecheck.enabled --typecheck.only --typecheck.include='src/**/*.test.ts' --passWithNoTests"
   },
   "dependencies": {
-    "@sdp/dvp": "workspace:*",
     "@sdp/private-channels": "workspace:*",
     "@sdp/rpc": "workspace:*",
     "@sdp/spc-escrow": "workspace:*",

--- a/packages/sdp-api-integration/src/helpers/preflight.ts
+++ b/packages/sdp-api-integration/src/helpers/preflight.ts
@@ -1,4 +1,5 @@
 import { apiTestSupport } from "@sdp/api/test-support";
+import { DVP_SWAP_PROGRAM_PROGRAM_ADDRESS } from "@sdp/dvp";
 import { probeGatewayHealth } from "@sdp/private-channels";
 import { env } from "#env-impl";
 import { getIntegrationCustodyProvider } from "./custody-provider";
@@ -46,11 +47,9 @@ async function runPreflight(): Promise<void> {
   // existing Kora/on-chain shards keep working unchanged.
   const requested = getRequestedSuites();
   const koraInScope = requested ? requested.has("kora") : !!env.KORA_RPC_URL;
-  // DvP needs a cluster and a custody signer and nothing else — no Kora fee
-  // payer, no Private Channels gateway. Requiring either would make the suite
-  // unreachable without standing up a harness it never calls, which is the
-  // same reasoning that already keeps Kora and SPC independent of each other.
-  const dvpInScope = requested?.has("dvp") ?? false;
+  // DvP needs a cluster, custody signer, and Kora sponsorship. Private Channels
+  // remains independent because the DvP lane never calls its gateway.
+  const dvpInScope = requested === null ? false : requested.has("dvp");
   const spcInScope = requested
     ? requested.has("spc")
     : !env.KORA_RPC_URL && !!readEnv("PRIVATE_CHANNEL_GATEWAY_URL");
@@ -66,7 +65,7 @@ async function runPreflight(): Promise<void> {
   // Each scope validates only its own dependencies: an SPC-only run must not
   // require Kora, or the Private Channels suites are unreachable without standing
   // up a Kora harness they never call.
-  if (koraInScope) {
+  if (koraInScope || dvpInScope) {
     await preflightKoraSuite();
   }
   if (spcInScope) {
@@ -78,8 +77,8 @@ async function runPreflight(): Promise<void> {
 }
 
 /**
- * What a DvP run actually needs: a cluster, and a custody signer to be the
- * organization's side of a trade.
+ * What a DvP run actually needs: a cluster, Kora sponsorship, and a custody
+ * signer to be the organization's side of a trade.
  *
  * Deliberately short. Everything else DvP touches — the settlement authority,
  * the escrows, the policy rows — is created by the code under test, and a
@@ -90,6 +89,7 @@ async function preflightDvpSuite(): Promise<void> {
   const integrationCustodyProvider = getIntegrationCustodyProvider();
   const missing: string[] = [];
   if (!env.SOLANA_RPC_URL) missing.push("SOLANA_RPC_URL");
+  if (!env.KORA_RPC_URL) missing.push("KORA_RPC_URL");
   if (integrationCustodyProvider === "local" && !env.CUSTODY_PRIVATE_KEY) {
     missing.push("CUSTODY_PRIVATE_KEY");
   }
@@ -226,14 +226,19 @@ async function preflightKoraSuite(): Promise<void> {
 }
 
 function getRequiredKoraAllowedPrograms(): readonly string[] {
-  if (isKoraSurfpoolShim()) {
-    return REQUIRED_SURFPOOL_ALLOWED_PROGRAMS;
-  }
-
-  return REQUIRED_LIVE_KORA_ALLOWED_PROGRAMS;
+  const requested = getRequestedSuites();
+  const dvpRequired = requested === null ? false : requested.has("dvp");
+  const base = isKoraSurfpoolShim()
+    ? REQUIRED_SURFPOOL_ALLOWED_PROGRAMS
+    : REQUIRED_LIVE_KORA_ALLOWED_PROGRAMS;
+  return dvpRequired ? [...base, DVP_SWAP_PROGRAM_PROGRAM_ADDRESS] : base;
 }
 
 function getKoraPreflightScopeLabel(): string {
+  const requested = getRequestedSuites();
+  if (requested === null ? false : requested.has("dvp")) {
+    return "DvP";
+  }
   if (isKoraSurfpoolShim()) {
     return "Surfpool-backed SDP";
   }

--- a/packages/sdp-api-integration/src/helpers/preflight.ts
+++ b/packages/sdp-api-integration/src/helpers/preflight.ts
@@ -1,11 +1,10 @@
 import { apiTestSupport } from "@sdp/api/test-support";
-import { DVP_SWAP_PROGRAM_PROGRAM_ADDRESS } from "@sdp/dvp";
 import { probeGatewayHealth } from "@sdp/private-channels";
 import { env } from "#env-impl";
 import { getIntegrationCustodyProvider } from "./custody-provider";
 import { privateChannelProbeTransport } from "./private-channels";
 
-const { KoraClient } = apiTestSupport;
+const { DVP_SWAP_PROGRAM_PROGRAM_ADDRESS, KoraClient } = apiTestSupport;
 
 type SolanaRpcResponse<T> =
   | { jsonrpc: "2.0"; id: number; result: T }

--- a/packages/sdp-api-integration/src/tests/dvp-settlement.test.ts
+++ b/packages/sdp-api-integration/src/tests/dvp-settlement.test.ts
@@ -154,10 +154,8 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("DvP settlement", 
         mintAuthority: signer,
       });
 
-      // SDP is a party slot, the counterparty a bare external address. The
-      // payer is named explicitly: the default (the project's settlement
-      // wallet) is provisioned by the first create but not funded in this
-      // suite, so it cannot pay the create's rent.
+      // SDP is a party slot, the counterparty a bare external address. Kora
+      // pays create fee and rent; this wallet still needs SOL for settlement.
       const partyA = side === "a" ? { walletId: wallet.id } : { address: signer.address };
       const partyB = side === "a" ? { address: signer.address } : { walletId: wallet.id };
 
@@ -167,7 +165,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("DvP settlement", 
         body: JSON.stringify({
           partyA,
           partyB,
-          payerWalletId: wallet.id,
           mintA: asset.mint,
           tokenProgramA: "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
           mintB: cash.mint,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -518,9 +518,6 @@ importers:
 
   packages/sdp-api-integration:
     dependencies:
-      '@sdp/dvp':
-        specifier: workspace:*
-        version: link:../sdp-dvp
       '@sdp/private-channels':
         specifier: workspace:*
         version: link:../sdp-private-channels

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -518,6 +518,9 @@ importers:
 
   packages/sdp-api-integration:
     dependencies:
+      '@sdp/dvp':
+        specifier: workspace:*
+        version: link:../sdp-dvp
       '@sdp/private-channels':
         specifier: workspace:*
         version: link:../sdp-private-channels


### PR DESCRIPTION
- DvP trade creation is now sponsored end to end: Kora's signer is the transaction fee payer and the `payer` on `CreateDvp`, so it funds the trade account, nonce tombstone and both escrow ATAs. No project wallet spends SOL to create a trade.
- `payerWalletId` is removed from the create service, route schema, idempotency fingerprint, dashboard request and integration suite. Nothing about the payer is configurable or a term of the trade.
- Sponsorship goes through the owned boundary (`createProjectSponsorshipFeePayment`, actor = the project's settlement wallet id), so budget reservation and Kora usage identity apply exactly as for earn and payments.
- Paymaster bytes are verified before anything is persisted: the shared `assertSponsorSignedSameMessage` (extracted from earn, now used by both) refuses a different message or a missing sponsor signature.
- A Kora denial or verification failure writes no row. Build → sign → record → send order is unchanged, as is the preflight-failure → `create_failed` mapping.
- Local Kora policy (`infra/kora/kora.toml`) and the integration preflight now require the DvP program in `allowed_programs`; the deployed devnet policy change is sdp-infra #160.

**before** — the create payer was a project custody wallet:

1. Handler resolved `payerWalletId`, defaulting to the project's DvP settlement wallet, and asserted the key's binding on it.
2. `createOrgSignerForCustodyWallet` signed the transaction as fee payer and `CreateDvp.payer`.
3. That wallet paid the fee plus ~6.63M lamports of rent per trade, so a project's first trade failed until someone funded the settlement wallet by hand.

**after** — Kora is the only signer on create:

1. Handler validates the body (no payer field), settlement wallet is provisioned as before because `settlement_authority` is still an instruction account.
2. After every local 400 check, the service resolves the sponsor via `createProjectSponsorshipFeePayment` and builds the message with `createNoopSigner(sponsor)` as `payer` and the sponsor as fee payer.
3. `compileTransaction` → `feePayment.signAsFeePayer` → `assertSponsorSignedSameMessage` → insert row at `creating` → `sendTransaction`. Denial or a mismatched message throws before the insert.

## How Kora admits the transaction

Kora simulates the transaction to resolve inner instructions and validates all of them. `CreateDvp` CPIs `system.createAccount` ×2 (owner = DvP program) and `ata.createIdempotent` ×2, so the DvP program must be in `allowed_programs` both as an instruction program and as a CreateAccount owner. Devnet grants `system.allow_create_account`; measured outflow is 6,634,400 lamports + 5,000 fee against a 9.9M cap and a 10M per-transaction budget.

**API before/after**

`POST /v1/dvp/trades`

before (reconstructed): `payerWalletId` accepted and used; omitted → settlement wallet signed and paid; the key's binding on the named wallet was asserted.

after: `payerWalletId` is not in the schema and is ignored if sent. Devnet create `dvp_b6d0d2e2…`, signature `2hFtZyyS…qqscK`:

```text
signers:                 [HAoxp8p92zGSyvbqFZLdoqZKoaPVxus1sPUPM5b5wUVB]  (Kora signer, account 0)
fee payer balance delta: -6,634,400 lamports (fee 5,000)
settlement authority:    0
```

```json
{ "data": { "trade": { "id": "dvp_b6d0d2e2ea99475f83160a3a4a107ea2", "status": "created",
  "settlementAuthority": "8kUqsiksJjC7X4ozGaoTd344aU8vU5qfC4x3hDGhqJHN", "createSignature": "2hFtZyyS…qqscK" } } }
```

## Concurrency (after `1a0aa8d15`)

Budget is reserved at **sign** time (`BudgetedFeePayment.admit`, ceiling = fee + Kora `max_allowed_lamports`), and the sponsorship reconciler never refunds a signed-but-unbroadcast reservation (it ends `charged_unknown`). The first cut signed before inserting the row, so a race loser or a preflight rejection burned a full 9.9M ceiling. The flow is now **claim → sign → attach → send**:

1. Insert the row at `creating` with no signature. The unique `(project_id, idempotency_key)` index decides a race here, before any Kora call; the loser returns the winner's claim having spent nothing. A `create_failed` predecessor's key is released in the same transaction as the new claim.
2. Sign through `submitSponsoredTransaction` (`services/sponsorship-submission.ts`, the payments helper moved to a neutral module) → `prepareOwnedSubmission`. `persistSigned` verifies the sponsor bytes and attaches signature + last valid block height with a CAS on `status = 'creating' AND create_signature IS NULL`; a CAS miss throws before broadcast, so a claim the sweep already failed can never gain an on-chain trade.
3. Any failure before the signature is attached (Kora down, denied, verification) marks the claim `create_failed` immediately. A definitive preflight rejection releases the reservation (`releaseDefinitelyUnbroadcast`) and fails the claim; an ambiguous send leaves it `creating` with its signature for the chain reader.
4. RPC acceptance no longer marks `created` (the sweep treats `created` + no account as *closed*); the row stays `creating` until `observeDvpTradeNow` or the sweep sees the account. A signature-less claim older than 15 minutes is failed by the sweep, since nothing can be on chain for it.

| Interleaving | Row | Reservation | Budget |
|---|---|---|---|
| Two requests, same key, concurrent | loser returns winner's claim | loser never reserves | 0 |
| Same key, different payload | 409 before any spend | none | 0 |
| Kora down / denied / bad sponsor bytes | `create_failed`, key freed on retry | released or never taken | 0 |
| Preflight rejection at send | `create_failed` | `released` | 0 |
| Ambiguous send (timeout) | `creating` → sweep resolves by chain | `committed` or `charged_unknown` | actual or ceiling (conservative) |
| Crash between claim and sign | `creating` → `create_failed` after 15 min | none | 0 |
| Crash between attach and send | `creating` → `create_failed` at height expiry | `charged_unknown` (PRO-1910) | ceiling |

Full audit with Hermes cross-check: `docs/_devlog/PRO-1906/concurrency-audit.md` (local). Follow-ups: PRO-1910 (reconciler releases expired sign-only reservations), PRO-1911 (earn onto the same helper).

**Verification**

- `pnpm -C apps/sdp-api exec tsc --noEmit` — clean
- `pnpm -C apps/sdp-api exec vitest run src/services/dvp src/routes/dvp src/db/repositories/dvp-trade.repository.test.ts src/services/jobs src/routes/payments src/services/payments src/security src/services/earn/vault-execution.service.test.ts src/services/sponsorship*.node.test.ts` (isolated `TEST_DATABASE_URL`) — 57 files, 935 passed
- `pnpm -C packages/sdp-api-integration exec tsc --noEmit -p .` — clean
- `pnpm -C apps/sdp-web exec tsc --noEmit` and `vitest run src/app/dashboard/markets/dvp` — clean, 240 passed
- `biome check` on changed files — clean
- local app: created two trades through the dashboard and the API against local Kora (18080, devnet policy mirror + DvP allowlisted); Kora signed and paid on chain as shown above

**Known gaps**

- sdp-infra #160 (devnet Kora allowlist) must be deployed before this works against the shared devnet Kora; until then create fails with `Program dvp34bd… is not in the allowed list`.
- Settle/Cancel still charge the settlement wallet: PRO-1907.
- A crash after the signature is attached but before the send leaves the reservation `signed`; the sponsorship reconciler ends it as `charged_unknown` at blockhash expiry (a signed transaction was in flight, so conservative is right). PRO-1910 tracks releasing provably-expired sign-only reservations instead.
- Create is permissionless and sponsored, so a key with `payments:write` can burn ~6.6M lamports of Kora SOL per call. Bounded by the per-transaction/hourly/daily sponsorship budgets and Kora's usage limit; a pricing decision at mainnet.

