### PR TITLE
feat(issuance): enforce wallet-operation policy on seize, force-burn, and burn

### DIFF
--- a/apps/sdp-api/src/routes/issuance.test.ts
+++ b/apps/sdp-api/src/routes/issuance.test.ts
@@ -882,9 +882,6 @@ describe("Issuance Routes", () => {
           env
         );
 
-        if (response.status !== 403) {
-          console.log("DEBUG", response.status, await response.clone().text());
-        }
         expect(response.status).toBe(403);
         expect(signerSpy).not.toHaveBeenCalled();
         expect(effectSpy).not.toHaveBeenCalled();

--- a/apps/sdp-api/src/routes/issuance.test.ts
+++ b/apps/sdp-api/src/routes/issuance.test.ts
@@ -743,6 +743,10 @@ describe("Issuance Routes", () => {
         .prepare("SELECT COUNT(*)::int AS count FROM issuance_transactions")
         .first<{ count: number }>();
       expect(transactionCount).toEqual({ count: 0 });
+      const operationCount = await getDb(env)
+        .prepare("SELECT COUNT(*)::int AS count FROM wallet_operations")
+        .first<{ count: number }>();
+      expect(operationCount).toEqual({ count: 1 });
     });
 
     it("stops a denied seize before signer and issuance side effects", async () => {
@@ -1554,6 +1558,61 @@ describe("Issuance Routes", () => {
         expect(replay.status, JSON.stringify(await replay.clone().json())).toBe(200);
         expect(await replay.json()).toMatchObject({
           data: { transaction: { id: "ttx_direct_seize_replay", status: "finalized" } },
+        });
+        expect(authoritySpy).not.toHaveBeenCalled();
+        expect(admitSpy).not.toHaveBeenCalled();
+      } finally {
+        authoritySpy.mockRestore();
+        admitSpy.mockRestore();
+      }
+    });
+
+    it("replays force-burn without resolving the current permanent delegate", async () => {
+      const token = await seedIssuedToken({ id: "tok_direct_force_burn_replay" });
+      const idempotencyKey = "direct-force-burn-replay";
+      const body = {
+        forceBurn: {
+          source: TEST_SOLANA_ADDRESSES.wallet1,
+          amount: "1",
+        },
+      };
+      const idempotency = buildIdempotencyMetadata(idempotencyKey, {
+        tokenId: token.id,
+        operation: "force_burn",
+        mode: "execute",
+        params: {
+          ...body,
+          signingCustodyWalletId: DEFAULT_ISSUANCE_CUSTODY_WALLET_ID,
+        },
+      });
+      await seedIssuanceTransaction({
+        id: "ttx_direct_force_burn_replay",
+        tokenId: token.id,
+        type: "force_burn",
+        status: "finalized",
+        custodyWalletId: DEFAULT_ISSUANCE_CUSTODY_WALLET_ID,
+        idempotencyKey,
+        idempotencyFingerprint: idempotency.idempotencyFingerprint,
+        signature: "sig_direct_force_burn_replay",
+        slot: 12,
+        params: body.forceBurn,
+      });
+      const authoritySpy = vi
+        .spyOn(AuthorityResolution, "resolvePermanentDelegateAuthority")
+        .mockRejectedValue(new Error("authority unavailable"));
+      const admitSpy = vi
+        .spyOn(SigningService.prototype, "admitRuntimeExecution")
+        .mockRejectedValue(new Error("runtime unavailable"));
+
+      try {
+        const replay = await app.request(
+          `/v1/issuance/tokens/${token.id}/force-burn`,
+          { method: "POST", headers: headers(idempotencyKey), body: JSON.stringify(body) },
+          env
+        );
+        expect(replay.status, JSON.stringify(await replay.clone().json())).toBe(200);
+        expect(await replay.json()).toMatchObject({
+          data: { transaction: { id: "ttx_direct_force_burn_replay", status: "finalized" } },
         });
         expect(authoritySpy).not.toHaveBeenCalled();
         expect(admitSpy).not.toHaveBeenCalled();

--- a/apps/sdp-api/src/routes/issuance.test.ts
+++ b/apps/sdp-api/src/routes/issuance.test.ts
@@ -692,6 +692,216 @@ describe("Issuance Routes", () => {
       }
     });
 
+    it("stops a denied burn before signer and issuance side effects", async () => {
+      const wallet = await seedIssuanceActivityWallet(
+        "wal_issuance_burn_denied",
+        policyMintAuthority
+      );
+      const token = await seedIssuedToken({
+        id: "tok_issuance_burn_denied",
+        signingWalletId: wallet.walletId,
+        mintAuthority: policyMintAuthority,
+      });
+      const policyResponse = await app.request(
+        `/v1/payments/wallets/${wallet.walletId}/policies`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+          },
+          body: JSON.stringify({
+            defaultAction: "allow",
+            rules: [{ id: "deny-issuance-burn", kind: "always", action: "deny" }],
+          }),
+        },
+        env
+      );
+      expect(policyResponse.status).toBe(200);
+      const signerSpy = vi.mocked(SolanaServices.createOrgSignerForCustodyWallet);
+      signerSpy.mockClear();
+
+      const response = await app.request(
+        `/v1/issuance/tokens/${token.id}/burn`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+          },
+          body: JSON.stringify({
+            burn: { source: TEST_SOLANA_ADDRESSES.wallet1, amount: "1" },
+            signingCustodyWalletId: `cwlt_issuance_activity_${"wal_issuance_burn_denied"}`,
+          }),
+        },
+        env
+      );
+
+      expect(response.status).toBe(403);
+      expect(signerSpy).not.toHaveBeenCalled();
+      const transactionCount = await getDb(env)
+        .prepare("SELECT COUNT(*)::int AS count FROM issuance_transactions")
+        .first<{ count: number }>();
+      expect(transactionCount).toEqual({ count: 0 });
+    });
+
+    it("stops a denied seize before signer and issuance side effects", async () => {
+      const wallet = await seedIssuanceActivityWallet(
+        "wal_issuance_seize_denied",
+        policyMintAuthority
+      );
+      const token = await seedIssuedToken({
+        id: "tok_issuance_seize_denied",
+        signingWalletId: wallet.walletId,
+        mintAuthority: policyMintAuthority,
+        template: "arcade",
+      });
+      const mintRead = vi.spyOn(Token2022, "fetchMaybeMint").mockResolvedValue({
+        exists: true,
+        data: {
+          mintAuthority: { __option: "None" },
+          freezeAuthority: { __option: "None" },
+          extensions: {
+            __option: "Some",
+            value: [{ __kind: "PermanentDelegate", delegate: policyMintAuthority }],
+          },
+        },
+      } as never);
+      const policyResponse = await app.request(
+        `/v1/payments/wallets/${wallet.walletId}/policies`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+          },
+          body: JSON.stringify({
+            defaultAction: "allow",
+            rules: [{ id: "deny-issuance-seize", kind: "always", action: "deny" }],
+          }),
+        },
+        env
+      );
+      expect(policyResponse.status).toBe(200);
+      const signerSpy = vi.mocked(SolanaServices.createOrgSignerForCustodyWallet);
+      signerSpy.mockClear();
+      const effectSpy = vi.spyOn(MosaicService.prototype, "forceTransfer");
+
+      try {
+        const response = await app.request(
+          `/v1/issuance/tokens/${token.id}/seize`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+            },
+            body: JSON.stringify({
+              seize: {
+                source: TEST_SOLANA_ADDRESSES.wallet2,
+                destination: TEST_SOLANA_ADDRESSES.wallet1,
+                amount: "1",
+              },
+            }),
+          },
+          env
+        );
+
+        expect(response.status).toBe(403);
+        expect(signerSpy).not.toHaveBeenCalled();
+        expect(effectSpy).not.toHaveBeenCalled();
+        const transactionCount = await getDb(env)
+          .prepare("SELECT COUNT(*)::int AS count FROM issuance_transactions")
+          .first<{ count: number }>();
+        expect(transactionCount).toEqual({ count: 0 });
+        const operationCount = await getDb(env)
+          .prepare("SELECT COUNT(*)::int AS count FROM wallet_operations")
+          .first<{ count: number }>();
+        expect(operationCount).toEqual({ count: 1 });
+      } finally {
+        effectSpy.mockRestore();
+        mintRead.mockRestore();
+      }
+    });
+
+    it("stops a denied force-burn before signer and issuance side effects", async () => {
+      const wallet = await seedIssuanceActivityWallet(
+        "wal_issuance_force_burn_denied",
+        policyMintAuthority
+      );
+      const token = await seedIssuedToken({
+        id: "tok_issuance_force_burn_denied",
+        signingWalletId: wallet.walletId,
+        mintAuthority: policyMintAuthority,
+        template: "arcade",
+      });
+      const mintRead = vi.spyOn(Token2022, "fetchMaybeMint").mockResolvedValue({
+        exists: true,
+        data: {
+          mintAuthority: { __option: "None" },
+          freezeAuthority: { __option: "None" },
+          extensions: {
+            __option: "Some",
+            value: [{ __kind: "PermanentDelegate", delegate: policyMintAuthority }],
+          },
+        },
+      } as never);
+      const policyResponse = await app.request(
+        `/v1/payments/wallets/${wallet.walletId}/policies`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+          },
+          body: JSON.stringify({
+            defaultAction: "allow",
+            rules: [{ id: "deny-issuance-force-burn", kind: "always", action: "deny" }],
+          }),
+        },
+        env
+      );
+      expect(policyResponse.status).toBe(200);
+      const signerSpy = vi.mocked(SolanaServices.createOrgSignerForCustodyWallet);
+      signerSpy.mockClear();
+      const effectSpy = vi.spyOn(MosaicService.prototype, "forceBurn");
+
+      try {
+        const response = await app.request(
+          `/v1/issuance/tokens/${token.id}/force-burn`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+            },
+            body: JSON.stringify({
+              forceBurn: { source: TEST_SOLANA_ADDRESSES.wallet2, amount: "1" },
+            }),
+          },
+          env
+        );
+
+        if (response.status !== 403) {
+          console.log("DEBUG", response.status, await response.clone().text());
+        }
+        expect(response.status).toBe(403);
+        expect(signerSpy).not.toHaveBeenCalled();
+        expect(effectSpy).not.toHaveBeenCalled();
+        const transactionCount = await getDb(env)
+          .prepare("SELECT COUNT(*)::int AS count FROM issuance_transactions")
+          .first<{ count: number }>();
+        expect(transactionCount).toEqual({ count: 0 });
+        const operationCount = await getDb(env)
+          .prepare("SELECT COUNT(*)::int AS count FROM wallet_operations")
+          .first<{ count: number }>();
+        expect(operationCount).toEqual({ count: 1 });
+      } finally {
+        effectSpy.mockRestore();
+        mintRead.mockRestore();
+      }
+    });
+
     it("stops a denied mint before signer and issuance side effects", async () => {
       const wallet = await seedIssuanceActivityWallet(
         "wal_issuance_mint_denied",

--- a/apps/sdp-api/src/routes/issuance/handlers/burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/burn.ts
@@ -481,11 +481,11 @@ export async function extractBurnPolicyCandidate(
         tokenService,
         tokenId,
         type: "burn",
-        idempotencyKey: c.req.header("Idempotency-Key"),
+        idempotencyKey,
         requestedCustodyWalletId: body.signingCustodyWalletId,
         requiredWalletPermissions: ["tokens:write"],
         fingerprintForCustodyWalletId: (custodyWalletId) =>
-          buildIdempotencyMetadata(c.req.header("Idempotency-Key"), {
+          buildIdempotencyMetadata(idempotencyKey, {
             tokenId,
             operation: "burn",
             mode: "execute",
@@ -499,6 +499,8 @@ export async function extractBurnPolicyCandidate(
 
   assertTokenAllowsOperation(token, "burn");
   assertTokenIsDeployed(token);
+
+  parsePositiveTokenAmount(body.burn.amount, token.decimals);
 
   const wallet = await resolveIssuanceWallet({
     env: c.env,

--- a/apps/sdp-api/src/routes/issuance/handlers/burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/burn.ts
@@ -4,6 +4,7 @@ import { resolveTokenAccount } from "@solana/mosaic-sdk";
 import { getDb } from "@/db";
 import { AppError, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
+import type { PolicyGateExtraction } from "@/middleware/policy-gate";
 import type { ValidatedBodyContext } from "@/middleware/validate";
 import { AuditService } from "@/services/audit.service";
 import {
@@ -26,6 +27,7 @@ import {
   resolveIssuanceWallet,
 } from "./authority-resolution";
 import { buildIdempotencyMetadata } from "./idempotency";
+import { buildIssuancePolicyCandidate } from "./policy";
 import { toPublicTokenTransaction } from "./public-response";
 import {
   persistSettledTransactionThenOutcome,
@@ -444,3 +446,77 @@ export const executeBurn = async (c: ValidatedBodyContext<typeof burnSchema>) =>
     throw error;
   }
 };
+
+export async function extractBurnPolicyCandidate(
+  c: ValidatedBodyContext<typeof burnSchema>
+): Promise<PolicyGateExtraction> {
+  const { tokenId } = c.req.param();
+  const { auth, projectId, orgId } = requireProjectScope(c);
+  const body = c.req.valid("json");
+  const tokenService = getTenantTokenService(c);
+  const token = await tokenService.getToken({ tokenId, organizationId: orgId, projectId });
+  if (!token) {
+    throw notFound("Token");
+  }
+
+  const emptyExtraction = {
+    legs: [],
+    body,
+    resolved: {},
+    rawPayload: {
+      tokenId: token.id,
+      mintAddress: token.mintAddress,
+      action: "burn",
+      source: body.burn.source,
+      amount: body.burn.amount,
+    },
+    idempotencyKey: null,
+  };
+
+  const idempotencyKey = c.req.header("Idempotency-Key");
+  const replay = idempotencyKey
+    ? await resolveDirectIssuanceReplay({
+        env: c.env,
+        auth,
+        tokenService,
+        tokenId,
+        type: "burn",
+        idempotencyKey: c.req.header("Idempotency-Key"),
+        requestedCustodyWalletId: body.signingCustodyWalletId,
+        requiredWalletPermissions: ["tokens:write"],
+        fingerprintForCustodyWalletId: (custodyWalletId) =>
+          buildIdempotencyMetadata(c.req.header("Idempotency-Key"), {
+            tokenId,
+            operation: "burn",
+            mode: "execute",
+            params: { ...body, signingCustodyWalletId: custodyWalletId },
+          }).idempotencyFingerprint,
+      })
+    : null;
+  if (replay) {
+    return { ...emptyExtraction, candidate: null };
+  }
+
+  assertTokenAllowsOperation(token, "burn");
+  assertTokenIsDeployed(token);
+
+  const wallet = await resolveIssuanceWallet({
+    env: c.env,
+    auth,
+    custodyWalletId: body.signingCustodyWalletId,
+    requiredWalletPermissions: ["tokens:write"],
+  });
+
+  return {
+    ...emptyExtraction,
+    candidate: buildIssuancePolicyCandidate({
+      auth,
+      token,
+      custodyWalletId: wallet.custodyWalletId,
+      walletId: wallet.providerWalletId,
+      operationType: "issuance_burn_execute",
+      amount: body.burn.amount,
+      destination: null,
+    }),
+  };
+}

--- a/apps/sdp-api/src/routes/issuance/handlers/burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/burn.ts
@@ -32,7 +32,7 @@ import {
   resolveIssuanceWallet,
 } from "./authority-resolution";
 import { buildIdempotencyMetadata } from "./idempotency";
-import { buildIssuancePolicyCandidate } from "./policy";
+import { assertJudgedCustodyWallet, buildIssuancePolicyCandidate } from "./policy";
 import { toPublicTokenTransaction } from "./public-response";
 import {
   isSettledIssuanceTransaction,
@@ -319,6 +319,7 @@ export const executeBurn = async (c: ValidatedBodyContext<typeof burnSchema>) =>
     token.decimals
   );
 
+  assertJudgedCustodyWallet(c, wallet.custodyWalletId);
   await assertApprovedWalletOperationCustodyWallet(c, wallet.custodyWalletId);
 
   const idempotencyMetadata = idempotencyForWallet(wallet.custodyWalletId);
@@ -528,6 +529,7 @@ export async function extractBurnPolicyCandidate(
 
   return {
     ...emptyExtraction,
+    resolved: { judgedCustodyWalletId: wallet.custodyWalletId },
     candidate: buildIssuancePolicyCandidate({
       auth,
       token,

--- a/apps/sdp-api/src/routes/issuance/handlers/burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/burn.ts
@@ -293,6 +293,10 @@ export const executeBurn = async (c: ValidatedBodyContext<typeof burnSchema>) =>
       transaction: earlyReplay,
       action: "burn",
     });
+    if (approvedWalletOperationId(c) && !isSettledIssuanceTransaction(transaction)) {
+      await beginApprovedWalletOperationEffect(c);
+      throw conflict("Approved burn execution is incomplete and requires manual reconciliation");
+    }
     if (transaction.status === "confirmed") {
       await tokenService.applySettledBurnSupply(transaction.id, tokenId, body.burn.amount);
     }

--- a/apps/sdp-api/src/routes/issuance/handlers/burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/burn.ts
@@ -2,12 +2,16 @@ import { createRpcForSdk } from "@sdp/rpc/solana";
 import { type Address, assertValidAddress } from "@sdp/solana/address";
 import { resolveTokenAccount } from "@solana/mosaic-sdk";
 import { getDb } from "@/db";
-import { AppError, notFound } from "@/lib/errors";
+import { AppError, conflict, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
 import type { PolicyGateExtraction } from "@/middleware/policy-gate";
 import type { ValidatedBodyContext } from "@/middleware/validate";
 import { AuditService } from "@/services/audit.service";
-import { assertApprovedWalletOperationCustodyWallet } from "@/services/policy/approved-operation-replay";
+import {
+  approvedWalletOperationId,
+  assertApprovedWalletOperationCustodyWallet,
+  beginApprovedWalletOperationEffect,
+} from "@/services/policy/approved-operation-replay";
 import {
   assertTokenAllowsOperation,
   assertTokenIsDeployed,
@@ -31,6 +35,7 @@ import { buildIdempotencyMetadata } from "./idempotency";
 import { buildIssuancePolicyCandidate } from "./policy";
 import { toPublicTokenTransaction } from "./public-response";
 import {
+  isSettledIssuanceTransaction,
   persistSettledTransactionThenOutcome,
   recoverSettledTransactionReplay,
 } from "./settled-transaction";
@@ -347,6 +352,10 @@ export const executeBurn = async (c: ValidatedBodyContext<typeof burnSchema>) =>
       transaction: tx,
       action: "burn",
     });
+    if (approvedWalletOperationId(c) && !isSettledIssuanceTransaction(transaction)) {
+      await beginApprovedWalletOperationEffect(c);
+      throw conflict("Approved burn execution is incomplete and requires manual reconciliation");
+    }
     if (transaction.status === "confirmed") {
       await tokenService.applySettledBurnSupply(tx.id, tokenId, body.burn.amount);
     }
@@ -384,6 +393,7 @@ export const executeBurn = async (c: ValidatedBodyContext<typeof burnSchema>) =>
     // Execute burn on Solana
     const token2022 = createIssuanceToken2022Service(c, signer);
 
+    await beginApprovedWalletOperationEffect(c);
     const result = await token2022.burn({
       mint: mintAddress,
       source: normalizedSource,

--- a/apps/sdp-api/src/routes/issuance/handlers/burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/burn.ts
@@ -7,6 +7,7 @@ import { success } from "@/lib/response";
 import type { PolicyGateExtraction } from "@/middleware/policy-gate";
 import type { ValidatedBodyContext } from "@/middleware/validate";
 import { AuditService } from "@/services/audit.service";
+import { assertApprovedWalletOperationCustodyWallet } from "@/services/policy/approved-operation-replay";
 import {
   assertTokenAllowsOperation,
   assertTokenIsDeployed,
@@ -308,6 +309,8 @@ export const executeBurn = async (c: ValidatedBodyContext<typeof burnSchema>) =>
     body.burn.amount,
     token.decimals
   );
+
+  await assertApprovedWalletOperationCustodyWallet(c, wallet.custodyWalletId);
 
   const idempotencyMetadata = idempotencyForWallet(wallet.custodyWalletId);
 

--- a/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
@@ -32,7 +32,7 @@ import {
   resolvePermanentDelegateAuthority,
 } from "./authority-resolution";
 import { buildIdempotencyMetadata } from "./idempotency";
-import { buildIssuancePolicyCandidate } from "./policy";
+import { assertJudgedCustodyWallet, buildIssuancePolicyCandidate } from "./policy";
 import { toPublicTokenTransaction } from "./public-response";
 import {
   isSettledIssuanceTransaction,
@@ -224,6 +224,7 @@ export const executeForceBurn = async (c: ValidatedBodyContext<typeof forceBurnS
   const mintAddress = assertValidAddress(token.mintAddress, "mintAddress");
   const source = assertValidAddress(body.forceBurn.source, "source");
 
+  assertJudgedCustodyWallet(c, custodyWalletId);
   await assertApprovedWalletOperationCustodyWallet(c, custodyWalletId);
 
   const idempotencyMetadata = idempotencyForWallet(custodyWalletId);
@@ -427,6 +428,7 @@ export async function extractForceBurnPolicyCandidate(
 
   return {
     ...emptyExtraction,
+    resolved: { judgedCustodyWalletId: custodyWalletId },
     candidate: buildIssuancePolicyCandidate({
       auth,
       token,

--- a/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
@@ -1,12 +1,16 @@
 import { createRpc, simulateTransaction } from "@sdp/rpc/solana";
 import { assertValidAddress } from "@sdp/solana/address";
 import { getDb } from "@/db";
-import { badRequest, notFound } from "@/lib/errors";
+import { badRequest, conflict, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
 import type { PolicyGateExtraction } from "@/middleware/policy-gate";
 import type { ValidatedBodyContext } from "@/middleware/validate";
 import { AuditService } from "@/services/audit.service";
-import { assertApprovedWalletOperationCustodyWallet } from "@/services/policy/approved-operation-replay";
+import {
+  approvedWalletOperationId,
+  assertApprovedWalletOperationCustodyWallet,
+  beginApprovedWalletOperationEffect,
+} from "@/services/policy/approved-operation-replay";
 import {
   assertTokenAllowsOperation,
   assertTokenIsDeployed,
@@ -31,6 +35,7 @@ import { buildIdempotencyMetadata } from "./idempotency";
 import { buildIssuancePolicyCandidate } from "./policy";
 import { toPublicTokenTransaction } from "./public-response";
 import {
+  isSettledIssuanceTransaction,
   persistSettledTransactionThenOutcome,
   recoverSettledTransactionReplay,
 } from "./settled-transaction";
@@ -250,6 +255,12 @@ export const executeForceBurn = async (c: ValidatedBodyContext<typeof forceBurnS
       transaction: tx,
       action: "force_burn",
     });
+    if (approvedWalletOperationId(c) && !isSettledIssuanceTransaction(transaction)) {
+      await beginApprovedWalletOperationEffect(c);
+      throw conflict(
+        "Approved force-burn execution is incomplete and requires manual reconciliation"
+      );
+    }
     if (transaction.status === "confirmed") {
       await tokenService.applySettledBurnSupply(tx.id, tokenId, body.forceBurn.amount);
     }
@@ -281,6 +292,7 @@ export const executeForceBurn = async (c: ValidatedBodyContext<typeof forceBurnS
   let onChainEffectCompleted = false;
 
   try {
+    await beginApprovedWalletOperationEffect(c);
     const result = await mosaic.forceBurn({
       mint: mintAddress,
       source,

--- a/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
@@ -6,6 +6,7 @@ import { success } from "@/lib/response";
 import type { PolicyGateExtraction } from "@/middleware/policy-gate";
 import type { ValidatedBodyContext } from "@/middleware/validate";
 import { AuditService } from "@/services/audit.service";
+import { assertApprovedWalletOperationCustodyWallet } from "@/services/policy/approved-operation-replay";
 import {
   assertTokenAllowsOperation,
   assertTokenIsDeployed,
@@ -212,6 +213,8 @@ export const executeForceBurn = async (c: ValidatedBodyContext<typeof forceBurnS
   const mintAddress = assertValidAddress(token.mintAddress, "mintAddress");
   const source = assertValidAddress(body.forceBurn.source, "source");
 
+  await assertApprovedWalletOperationCustodyWallet(c, custodyWalletId);
+
   const idempotencyMetadata = idempotencyForWallet(custodyWalletId);
 
   await admitIssuanceRuntimeExecution({
@@ -389,6 +392,13 @@ export async function extractForceBurnPolicyCandidate(
   if (!permanentDelegateRaw) {
     throw badRequest("Permanent delegate is not configured for this token");
   }
+  if (
+    body.forceBurn.delegateAuthority !== undefined &&
+    body.forceBurn.delegateAuthority !== permanentDelegateRaw
+  ) {
+    throw badRequest("Provided delegate authority does not match the on-chain authority");
+  }
+
   const { custodyWalletId, providerWalletId } = await resolveAuthorityWallet({
     env: c.env,
     auth,

--- a/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
@@ -364,11 +364,11 @@ export async function extractForceBurnPolicyCandidate(
         tokenService,
         tokenId,
         type: "force_burn",
-        idempotencyKey: c.req.header("Idempotency-Key"),
+        idempotencyKey,
         requestedCustodyWalletId: body.signingCustodyWalletId,
         requiredWalletPermissions: ["tokens:admin"],
         fingerprintForCustodyWalletId: (custodyWalletId) =>
-          buildIdempotencyMetadata(c.req.header("Idempotency-Key"), {
+          buildIdempotencyMetadata(idempotencyKey, {
             tokenId,
             operation: "force_burn",
             mode: "execute",
@@ -382,6 +382,8 @@ export async function extractForceBurnPolicyCandidate(
 
   assertTokenAllowsOperation(token, "force_burn");
   assertTokenIsDeployed(token);
+
+  parsePositiveTokenAmount(body.forceBurn.amount, token.decimals);
 
   const permanentDelegateRaw = await resolvePermanentDelegateAuthority(c.env, tokenService, token);
   if (!permanentDelegateRaw) {

--- a/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
@@ -3,6 +3,7 @@ import { assertValidAddress } from "@sdp/solana/address";
 import { getDb } from "@/db";
 import { badRequest, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
+import type { PolicyGateExtraction } from "@/middleware/policy-gate";
 import type { ValidatedBodyContext } from "@/middleware/validate";
 import { AuditService } from "@/services/audit.service";
 import {
@@ -26,6 +27,7 @@ import {
   resolvePermanentDelegateAuthority,
 } from "./authority-resolution";
 import { buildIdempotencyMetadata } from "./idempotency";
+import { buildIssuancePolicyCandidate } from "./policy";
 import { toPublicTokenTransaction } from "./public-response";
 import {
   persistSettledTransactionThenOutcome,
@@ -327,3 +329,82 @@ export const executeForceBurn = async (c: ValidatedBodyContext<typeof forceBurnS
     throw error;
   }
 };
+
+export async function extractForceBurnPolicyCandidate(
+  c: ValidatedBodyContext<typeof forceBurnSchema>
+): Promise<PolicyGateExtraction> {
+  const { tokenId } = c.req.param();
+  const { auth, projectId, orgId } = requireProjectScope(c);
+  const body = c.req.valid("json");
+  const tokenService = getTenantTokenService(c);
+  const token = await tokenService.getToken({ tokenId, organizationId: orgId, projectId });
+  if (!token) {
+    throw notFound("Token");
+  }
+
+  const emptyExtraction = {
+    legs: [],
+    body,
+    resolved: {},
+    rawPayload: {
+      tokenId: token.id,
+      mintAddress: token.mintAddress,
+      action: "force_burn",
+      source: body.forceBurn.source,
+      amount: body.forceBurn.amount,
+    },
+    idempotencyKey: null,
+  };
+
+  const idempotencyKey = c.req.header("Idempotency-Key");
+  const replay = idempotencyKey
+    ? await resolveDirectIssuanceReplay({
+        env: c.env,
+        auth,
+        tokenService,
+        tokenId,
+        type: "force_burn",
+        idempotencyKey: c.req.header("Idempotency-Key"),
+        requestedCustodyWalletId: body.signingCustodyWalletId,
+        requiredWalletPermissions: ["tokens:admin"],
+        fingerprintForCustodyWalletId: (custodyWalletId) =>
+          buildIdempotencyMetadata(c.req.header("Idempotency-Key"), {
+            tokenId,
+            operation: "force_burn",
+            mode: "execute",
+            params: { ...body, signingCustodyWalletId: custodyWalletId },
+          }).idempotencyFingerprint,
+      })
+    : null;
+  if (replay) {
+    return { ...emptyExtraction, candidate: null };
+  }
+
+  assertTokenAllowsOperation(token, "force_burn");
+  assertTokenIsDeployed(token);
+
+  const permanentDelegateRaw = await resolvePermanentDelegateAuthority(c.env, tokenService, token);
+  if (!permanentDelegateRaw) {
+    throw badRequest("Permanent delegate is not configured for this token");
+  }
+  const { custodyWalletId, providerWalletId } = await resolveAuthorityWallet({
+    env: c.env,
+    auth,
+    requestedCustodyWalletId: body.signingCustodyWalletId,
+    currentAuthority: permanentDelegateRaw,
+    requiredWalletPermissions: ["tokens:admin"],
+  });
+
+  return {
+    ...emptyExtraction,
+    candidate: buildIssuancePolicyCandidate({
+      auth,
+      token,
+      custodyWalletId,
+      walletId: providerWalletId,
+      operationType: "issuance_force_burn_execute",
+      amount: body.forceBurn.amount,
+      destination: null,
+    }),
+  };
+}

--- a/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
@@ -185,6 +185,12 @@ export const executeForceBurn = async (c: ValidatedBodyContext<typeof forceBurnS
       transaction: earlyReplay,
       action: "force_burn",
     });
+    if (approvedWalletOperationId(c) && !isSettledIssuanceTransaction(transaction)) {
+      await beginApprovedWalletOperationEffect(c);
+      throw conflict(
+        "Approved force-burn execution is incomplete and requires manual reconciliation"
+      );
+    }
     if (transaction.status === "confirmed") {
       await tokenService.applySettledBurnSupply(transaction.id, tokenId, body.forceBurn.amount);
     }

--- a/apps/sdp-api/src/routes/issuance/handlers/policy.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/policy.ts
@@ -4,7 +4,11 @@ import { walletOperationActorFromAuth } from "@/services/policy/enforcement.serv
 
 type IssuancePolicyOperationType = Extract<
   WalletOperationType,
-  "issuance_mint_execute" | "issuance_update_authority_execute"
+  | "issuance_burn_execute"
+  | "issuance_force_burn_execute"
+  | "issuance_mint_execute"
+  | "issuance_seize_execute"
+  | "issuance_update_authority_execute"
 >;
 
 /**

--- a/apps/sdp-api/src/routes/issuance/handlers/policy.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/policy.ts
@@ -1,6 +1,26 @@
 import type { PolicyCandidate, Token, WalletOperationType } from "@sdp/types";
+import type { Context } from "hono";
 import type { ApiKeyContext } from "@/lib/auth";
+import { conflict } from "@/lib/errors";
+import { getPolicyGateContext } from "@/middleware/policy-gate";
 import { walletOperationActorFromAuth } from "@/services/policy/enforcement.service";
+import type { Env } from "@/types/env";
+
+/**
+ * Refuse a custody wallet the gate did not judge. A handler that resolves its
+ * signer a second time can land on a different wallet if the authority mapping
+ * moved in between, which would execute under a policy nobody evaluated.
+ */
+export function assertJudgedCustodyWallet(
+  c: Context<{ Bindings: Env }>,
+  custodyWalletId: string
+): void {
+  const judged = getPolicyGateContext<unknown, { judgedCustodyWalletId?: string }>(c).resolved
+    ?.judgedCustodyWalletId;
+  if (judged !== undefined && judged !== custodyWalletId) {
+    throw conflict("Signing wallet changed after the operation was evaluated by policy");
+  }
+}
 
 type IssuancePolicyOperationType = Extract<
   WalletOperationType,

--- a/apps/sdp-api/src/routes/issuance/handlers/seize.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/seize.ts
@@ -33,7 +33,7 @@ import {
   resolvePermanentDelegateAuthority,
 } from "./authority-resolution";
 import { buildIdempotencyMetadata } from "./idempotency";
-import { buildIssuancePolicyCandidate } from "./policy";
+import { assertJudgedCustodyWallet, buildIssuancePolicyCandidate } from "./policy";
 import { toPublicTokenTransaction } from "./public-response";
 import {
   isSettledIssuanceTransaction,
@@ -238,6 +238,7 @@ export const executeSeize = async (c: ValidatedBodyContext<typeof seizeSchema>) 
   const source = assertValidAddress(body.seize.source, "source");
   const destination = assertValidAddress(body.seize.destination, "destination");
 
+  assertJudgedCustodyWallet(c, custodyWalletId);
   await assertApprovedWalletOperationCustodyWallet(c, custodyWalletId);
 
   const idempotencyMetadata = idempotencyForWallet(custodyWalletId);
@@ -443,6 +444,7 @@ export async function extractSeizePolicyCandidate(
 
   return {
     ...emptyExtraction,
+    resolved: { judgedCustodyWalletId: custodyWalletId },
     candidate: buildIssuancePolicyCandidate({
       auth,
       token,

--- a/apps/sdp-api/src/routes/issuance/handlers/seize.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/seize.ts
@@ -6,6 +6,7 @@ import { success } from "@/lib/response";
 import type { PolicyGateExtraction } from "@/middleware/policy-gate";
 import type { ValidatedBodyContext } from "@/middleware/validate";
 import { AuditService } from "@/services/audit.service";
+import { assertApprovedWalletOperationCustodyWallet } from "@/services/policy/approved-operation-replay";
 import {
   assertTokenAllowsOperation,
   assertTokenIsDeployed,
@@ -228,6 +229,8 @@ export const executeSeize = async (c: ValidatedBodyContext<typeof seizeSchema>) 
   const source = assertValidAddress(body.seize.source, "source");
   const destination = assertValidAddress(body.seize.destination, "destination");
 
+  await assertApprovedWalletOperationCustodyWallet(c, custodyWalletId);
+
   const idempotencyMetadata = idempotencyForWallet(custodyWalletId);
 
   await admitIssuanceRuntimeExecution({
@@ -409,6 +412,13 @@ export async function extractSeizePolicyCandidate(
   if (!permanentDelegateRaw) {
     throw badRequest("Permanent delegate is not configured for this token");
   }
+  if (
+    body.seize.delegateAuthority !== undefined &&
+    body.seize.delegateAuthority !== permanentDelegateRaw
+  ) {
+    throw badRequest("Provided delegate authority does not match the on-chain authority");
+  }
+
   const { custodyWalletId, providerWalletId } = await resolveAuthorityWallet({
     env: c.env,
     auth,

--- a/apps/sdp-api/src/routes/issuance/handlers/seize.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/seize.ts
@@ -377,11 +377,11 @@ export async function extractSeizePolicyCandidate(
         tokenService,
         tokenId,
         type: "seize",
-        idempotencyKey: c.req.header("Idempotency-Key"),
+        idempotencyKey,
         requestedCustodyWalletId: body.signingCustodyWalletId,
         requiredWalletPermissions: ["tokens:admin"],
         fingerprintForCustodyWalletId: (custodyWalletId) =>
-          buildIdempotencyMetadata(c.req.header("Idempotency-Key"), {
+          buildIdempotencyMetadata(idempotencyKey, {
             tokenId,
             operation: "seize",
             mode: "execute",

--- a/apps/sdp-api/src/routes/issuance/handlers/seize.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/seize.ts
@@ -3,6 +3,7 @@ import { assertValidAddress } from "@sdp/solana/address";
 import { getDb } from "@/db";
 import { badRequest, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
+import type { PolicyGateExtraction } from "@/middleware/policy-gate";
 import type { ValidatedBodyContext } from "@/middleware/validate";
 import { AuditService } from "@/services/audit.service";
 import {
@@ -27,6 +28,7 @@ import {
   resolvePermanentDelegateAuthority,
 } from "./authority-resolution";
 import { buildIdempotencyMetadata } from "./idempotency";
+import { buildIssuancePolicyCandidate } from "./policy";
 import { toPublicTokenTransaction } from "./public-response";
 import {
   persistSettledTransactionThenOutcome,
@@ -339,3 +341,92 @@ export const executeSeize = async (c: ValidatedBodyContext<typeof seizeSchema>) 
     throw error;
   }
 };
+
+export async function extractSeizePolicyCandidate(
+  c: ValidatedBodyContext<typeof seizeSchema>
+): Promise<PolicyGateExtraction> {
+  const { tokenId } = c.req.param();
+  const { auth, projectId, orgId } = requireProjectScope(c);
+  const body = c.req.valid("json");
+  const tokenService = getTenantTokenService(c);
+  const token = await tokenService.getToken({ tokenId, organizationId: orgId, projectId });
+  if (!token) {
+    throw notFound("Token");
+  }
+
+  const emptyExtraction = {
+    legs: [],
+    body,
+    resolved: {},
+    rawPayload: {
+      tokenId: token.id,
+      mintAddress: token.mintAddress,
+      action: "seize",
+      source: body.seize.source,
+      destination: body.seize.destination,
+      amount: body.seize.amount,
+    },
+    idempotencyKey: null,
+  };
+
+  const idempotencyKey = c.req.header("Idempotency-Key");
+  const replay = idempotencyKey
+    ? await resolveDirectIssuanceReplay({
+        env: c.env,
+        auth,
+        tokenService,
+        tokenId,
+        type: "seize",
+        idempotencyKey: c.req.header("Idempotency-Key"),
+        requestedCustodyWalletId: body.signingCustodyWalletId,
+        requiredWalletPermissions: ["tokens:admin"],
+        fingerprintForCustodyWalletId: (custodyWalletId) =>
+          buildIdempotencyMetadata(c.req.header("Idempotency-Key"), {
+            tokenId,
+            operation: "seize",
+            mode: "execute",
+            params: { ...body, signingCustodyWalletId: custodyWalletId },
+          }).idempotencyFingerprint,
+      })
+    : null;
+  if (replay) {
+    return { ...emptyExtraction, candidate: null };
+  }
+
+  assertTokenAllowsOperation(token, "seize");
+  assertTokenIsDeployed(token);
+
+  parsePositiveTokenAmount(body.seize.amount, token.decimals);
+
+  const isOnControlList = await tokenService.isAddressAllowed(tokenId, body.seize.destination);
+  assertDestinationAllowedByControlList({
+    token,
+    destination: body.seize.destination,
+    isOnControlList,
+  });
+
+  const permanentDelegateRaw = await resolvePermanentDelegateAuthority(c.env, tokenService, token);
+  if (!permanentDelegateRaw) {
+    throw badRequest("Permanent delegate is not configured for this token");
+  }
+  const { custodyWalletId, providerWalletId } = await resolveAuthorityWallet({
+    env: c.env,
+    auth,
+    requestedCustodyWalletId: body.signingCustodyWalletId,
+    currentAuthority: permanentDelegateRaw,
+    requiredWalletPermissions: ["tokens:admin"],
+  });
+
+  return {
+    ...emptyExtraction,
+    candidate: buildIssuancePolicyCandidate({
+      auth,
+      token,
+      custodyWalletId,
+      walletId: providerWalletId,
+      operationType: "issuance_seize_execute",
+      amount: body.seize.amount,
+      destination: body.seize.destination,
+    }),
+  };
+}

--- a/apps/sdp-api/src/routes/issuance/handlers/seize.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/seize.ts
@@ -196,6 +196,10 @@ export const executeSeize = async (c: ValidatedBodyContext<typeof seizeSchema>) 
       transaction: earlyReplay,
       action: "seize",
     });
+    if (approvedWalletOperationId(c) && !isSettledIssuanceTransaction(transaction)) {
+      await beginApprovedWalletOperationEffect(c);
+      throw conflict("Approved seize execution is incomplete and requires manual reconciliation");
+    }
     return success(c, { transaction: toPublicTokenTransaction(transaction) });
   }
 

--- a/apps/sdp-api/src/routes/issuance/handlers/seize.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/seize.ts
@@ -1,12 +1,16 @@
 import { createRpc, simulateTransaction } from "@sdp/rpc/solana";
 import { assertValidAddress } from "@sdp/solana/address";
 import { getDb } from "@/db";
-import { badRequest, notFound } from "@/lib/errors";
+import { badRequest, conflict, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
 import type { PolicyGateExtraction } from "@/middleware/policy-gate";
 import type { ValidatedBodyContext } from "@/middleware/validate";
 import { AuditService } from "@/services/audit.service";
-import { assertApprovedWalletOperationCustodyWallet } from "@/services/policy/approved-operation-replay";
+import {
+  approvedWalletOperationId,
+  assertApprovedWalletOperationCustodyWallet,
+  beginApprovedWalletOperationEffect,
+} from "@/services/policy/approved-operation-replay";
 import {
   assertTokenAllowsOperation,
   assertTokenIsDeployed,
@@ -32,6 +36,7 @@ import { buildIdempotencyMetadata } from "./idempotency";
 import { buildIssuancePolicyCandidate } from "./policy";
 import { toPublicTokenTransaction } from "./public-response";
 import {
+  isSettledIssuanceTransaction,
   persistSettledTransactionThenOutcome,
   recoverSettledTransactionReplay,
 } from "./settled-transaction";
@@ -266,6 +271,10 @@ export const executeSeize = async (c: ValidatedBodyContext<typeof seizeSchema>) 
       transaction: tx,
       action: "seize",
     });
+    if (approvedWalletOperationId(c) && !isSettledIssuanceTransaction(transaction)) {
+      await beginApprovedWalletOperationEffect(c);
+      throw conflict("Approved seize execution is incomplete and requires manual reconciliation");
+    }
     return success(c, { transaction: toPublicTokenTransaction(transaction) });
   }
 
@@ -294,6 +303,7 @@ export const executeSeize = async (c: ValidatedBodyContext<typeof seizeSchema>) 
   let onChainEffectCompleted = false;
 
   try {
+    await beginApprovedWalletOperationEffect(c);
     const result = await mosaic.forceTransfer({
       mint: mintAddress,
       source,

--- a/apps/sdp-api/src/routes/issuance/handlers/settled-transaction.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/settled-transaction.ts
@@ -138,6 +138,16 @@ export async function persistSettledTransactionThenOutcome(options: {
   return settled.transaction;
 }
 
+export function isSettledIssuanceTransaction(transaction: {
+  status: string;
+  signature: string | null;
+}): boolean {
+  return (
+    (transaction.status === "confirmed" || transaction.status === "finalized") &&
+    transaction.signature !== null
+  );
+}
+
 export async function recoverSettledTransactionReplay(options: {
   auditService: AuditService;
   tokenService: TokenService;

--- a/apps/sdp-api/src/routes/issuance/index.ts
+++ b/apps/sdp-api/src/routes/issuance/index.ts
@@ -21,14 +21,18 @@ import {
   findUpdateAuthorityIdempotentKeyReplay,
   prepareUpdateAuthority,
 } from "./handlers/authority";
-import { executeBurn, prepareBurn } from "./handlers/burn";
+import { executeBurn, extractBurnPolicyCandidate, prepareBurn } from "./handlers/burn";
 import {
   confirmDeploy,
   deployToken,
   prepareDeploy,
   prepareDeployMetadata,
 } from "./handlers/deploy";
-import { executeForceBurn, prepareForceBurn } from "./handlers/force-burn";
+import {
+  executeForceBurn,
+  extractForceBurnPolicyCandidate,
+  prepareForceBurn,
+} from "./handlers/force-burn";
 import { freezeAccount, listFrozenAccounts, unfreezeAccount } from "./handlers/freeze";
 import { enrollHolder, enrollHolderSchema, listHolders } from "./handlers/holders";
 import { serveTokenMetadata } from "./handlers/metadata";
@@ -40,7 +44,7 @@ import {
   prepareMint,
 } from "./handlers/mint";
 import { pauseToken, unpauseToken } from "./handlers/pause";
-import { executeSeize, prepareSeize } from "./handlers/seize";
+import { executeSeize, extractSeizePolicyCandidate, prepareSeize } from "./handlers/seize";
 import { refreshTokenSupply } from "./handlers/supply";
 import { getTokenTemplate, listTokenTemplates } from "./handlers/templates";
 import { createToken, getToken, listTokenFacets, listTokens, updateToken } from "./handlers/tokens";
@@ -190,6 +194,7 @@ issuance.post(
   "/tokens/:tokenId/burn",
   requirePermissions("tokens:write"),
   validateBody(burnSchema),
+  policyGate({ extract: extractBurnPolicyCandidate }),
   executeBurn
 );
 
@@ -204,6 +209,7 @@ issuance.post(
   "/tokens/:tokenId/seize",
   requirePermissions("tokens:admin"),
   validateBody(seizeSchema),
+  policyGate({ extract: extractSeizePolicyCandidate }),
   executeSeize
 );
 
@@ -218,6 +224,7 @@ issuance.post(
   "/tokens/:tokenId/force-burn",
   requirePermissions("tokens:admin"),
   validateBody(forceBurnSchema),
+  policyGate({ extract: extractForceBurnPolicyCandidate }),
   executeForceBurn
 );
 

--- a/apps/sdp-api/src/security/value-moving-conformance.node.test.ts
+++ b/apps/sdp-api/src/security/value-moving-conformance.node.test.ts
@@ -111,6 +111,66 @@ const contracts: ValueMovingContract[] = [
     ],
   },
   {
+    family: "issuance",
+    trustedContext: {
+      file: "apps/sdp-api/src/routes/issuance/handlers/seize.ts",
+      evidence: "const { auth, projectId, orgId } = requireProjectScope(c)",
+    },
+    authorization: {
+      file: "apps/sdp-api/src/routes/issuance/index.ts",
+      section: '"/tokens/:tokenId/seize",',
+      before: "policyGate({ extract: extractSeizePolicyCandidate })",
+      after: "executeSeize",
+    },
+    replay: [
+      {
+        mode: "idempotency_fingerprint",
+        file: "apps/sdp-api/src/routes/issuance.test.ts",
+        evidence: "stops a denied seize before signer and issuance side effects",
+      },
+    ],
+  },
+  {
+    family: "issuance",
+    trustedContext: {
+      file: "apps/sdp-api/src/routes/issuance/handlers/force-burn.ts",
+      evidence: "const { auth, projectId, orgId } = requireProjectScope(c)",
+    },
+    authorization: {
+      file: "apps/sdp-api/src/routes/issuance/index.ts",
+      section: '"/tokens/:tokenId/force-burn",',
+      before: "policyGate({ extract: extractForceBurnPolicyCandidate })",
+      after: "executeForceBurn",
+    },
+    replay: [
+      {
+        mode: "idempotency_fingerprint",
+        file: "apps/sdp-api/src/routes/issuance.test.ts",
+        evidence: "stops a denied force-burn before signer and issuance side effects",
+      },
+    ],
+  },
+  {
+    family: "issuance",
+    trustedContext: {
+      file: "apps/sdp-api/src/routes/issuance/handlers/burn.ts",
+      evidence: "const { auth, projectId, orgId } = requireProjectScope(c)",
+    },
+    authorization: {
+      file: "apps/sdp-api/src/routes/issuance/index.ts",
+      section: '"/tokens/:tokenId/burn",',
+      before: "policyGate({ extract: extractBurnPolicyCandidate })",
+      after: "executeBurn",
+    },
+    replay: [
+      {
+        mode: "idempotency_fingerprint",
+        file: "apps/sdp-api/src/routes/issuance.test.ts",
+        evidence: "stops a denied burn before signer and issuance side effects",
+      },
+    ],
+  },
+  {
     family: "payments",
     trustedContext: {
       file: "apps/sdp-api/src/routes/payments/context.ts",
@@ -378,13 +438,18 @@ describe("value-moving authorization and replay conformance", () => {
   it("covers every required value-moving family", () => {
     // `earn` appears twice: money-in (vault deposits) and money-out (vault
     // withdrawals) are separately gated routes, and each carries its own
-    // authorization boundary and replay evidence.
+    // authorization boundary and replay evidence. `issuance` appears four
+    // times for the same reason: authority updates, seize, force-burn, and
+    // burn are separately gated execute routes.
     expect(contracts.map((contract) => contract.family).sort()).toEqual([
       "batch",
       "custody",
       "dvp",
       "earn",
       "earn",
+      "issuance",
+      "issuance",
+      "issuance",
       "issuance",
       "payments",
       "ramps",

--- a/apps/sdp-api/src/security/value-moving-conformance.node.test.ts
+++ b/apps/sdp-api/src/security/value-moving-conformance.node.test.ts
@@ -126,7 +126,7 @@ const contracts: ValueMovingContract[] = [
       {
         mode: "idempotency_fingerprint",
         file: "apps/sdp-api/src/routes/issuance.test.ts",
-        evidence: "stops a denied seize before signer and issuance side effects",
+        evidence: "replays seize without resolving the current permanent delegate",
       },
     ],
   },
@@ -146,7 +146,7 @@ const contracts: ValueMovingContract[] = [
       {
         mode: "idempotency_fingerprint",
         file: "apps/sdp-api/src/routes/issuance.test.ts",
-        evidence: "stops a denied force-burn before signer and issuance side effects",
+        evidence: "replays force-burn without resolving the current permanent delegate",
       },
     ],
   },
@@ -166,7 +166,7 @@ const contracts: ValueMovingContract[] = [
       {
         mode: "idempotency_fingerprint",
         file: "apps/sdp-api/src/routes/issuance.test.ts",
-        evidence: "stops a denied burn before signer and issuance side effects",
+        evidence: "replays burn before runtime checks and rejects a different exact wallet",
       },
     ],
   },


### PR DESCRIPTION
The three irreversible issuance execute routes signed and spent sponsored fees behind a permission check alone, so an organization's deny and approval policies never reached them. Each route now builds a policy candidate and passes it to the gate, using the operation types already declared in WALLET_OPERATION_TYPES.

Each extractor mirrors the existing mint extractor: it resolves the exact custody wallet the handler will sign with, through the same resolver the handler uses, and builds the candidate from that custody wallet id. The candidate is therefore always judged against the wallet that actually signs.

An idempotent replay is resolved only when the caller sent an Idempotency-Key, and returns no candidate, so a replay is served by the handler as before instead of opening a second governed operation.

Approval-required policies are fenced the way mint and authority already fence them: each handler asserts that an approved operation carries the custody wallet it is about to sign with, leases the approved attempt immediately before the on-chain submission, and refuses to serve an unsettled approved replay. The settled-transaction predicate moved beside the other replay helpers so all four routes share one implementation.

Prepare routes are unchanged, since they do not sign. The value-moving conformance registry gains an entry per newly gated route.

Tests cover a denied seize, force-burn and burn: each answers 403 before a signer is created, no on-chain effect is attempted, no issuance transaction is written, and the operation is recorded in the policy ledger.