### PR TITLE
fix(smoke): run the stage smoke against the deployed stage dashboard

### DIFF
--- a/.github/workflows/sdp-stage-smoke.yml
+++ b/.github/workflows/sdp-stage-smoke.yml
@@ -19,13 +19,14 @@ jobs:
     timeout-minutes: 20
     if: github.repository == 'solana-foundation/solana-developer-platform'
     env:
-      DOPPLER_PRESERVE_ENV: PLAYWRIGHT_API_URL,E2E_CLERK_TICKET_AUTH,PLAYWRIGHT_USE_EXTERNAL_API,PLAYWRIGHT_USE_NEXT_START,PLAYWRIGHT_NEXT_DIST_DIR,SDP_API_BASE_URL,NEXT_PUBLIC_SDP_API_BASE_URL,NEXT_PUBLIC_SENTRY_DSN,NODE_ENV,SENTRY_AUTH_TOKEN,VERCEL_ENV,SDP_FLAG_HOMEPAGE_OPEN_SIGNUP,CUSTODY_ENABLED,ISSUANCE_ENABLED,POLICIES_ENABLED,SDP_FLAG_PRIVY_BYOK,SDP_FLAG_ASSET_PROFILES,PRIVATE_CHANNELS_ENABLED,HELIUS_RINGS_ENABLED,PAYMENTS_ENABLED,MARKETS_ENABLED,EARN_ENABLED
+      DOPPLER_PRESERVE_ENV: PLAYWRIGHT_API_URL,PLAYWRIGHT_BASE_URL,E2E_CLERK_TICKET_AUTH,PLAYWRIGHT_USE_EXTERNAL_API,SDP_API_BASE_URL,NEXT_PUBLIC_SDP_API_BASE_URL,NEXT_PUBLIC_SENTRY_DSN,NODE_ENV,SENTRY_AUTH_TOKEN,VERCEL_ENV,SDP_FLAG_HOMEPAGE_OPEN_SIGNUP,CUSTODY_ENABLED,ISSUANCE_ENABLED,POLICIES_ENABLED,SDP_FLAG_PRIVY_BYOK,SDP_FLAG_ASSET_PROFILES,PRIVATE_CHANNELS_ENABLED,HELIUS_RINGS_ENABLED,PAYMENTS_ENABLED,MARKETS_ENABLED,EARN_ENABLED
       SMOKE_TARGET: stage
       E2E_CLERK_TICKET_AUTH: "1"
       PLAYWRIGHT_API_URL: https://api-preview.solana.com
+      # The deployed stage dashboard (same solana.com domain as the production Clerk cookie).
+      # A locally started dashboard on localhost can never finish the pk_live sign-in.
+      PLAYWRIGHT_BASE_URL: https://app-preview.solana.com
       PLAYWRIGHT_USE_EXTERNAL_API: "1"
-      PLAYWRIGHT_USE_NEXT_START: "1"
-      PLAYWRIGHT_NEXT_DIST_DIR: .next-playwright
       NEXT_PUBLIC_DISABLE_SENTRY: "1"
       NEXT_PUBLIC_SENTRY_DSN: ""
       PLAYWRIGHT_DISABLE_SENTRY: "1"
@@ -78,13 +79,12 @@ jobs:
       - name: Install Playwright browser
         run: pnpm --filter sdp-web exec playwright install chromium
 
-      - name: Build web app against the target API
-        env:
-          DOPPLER_CONFIG: stg_ci
-          SDP_API_BASE_URL: ${{ env.PLAYWRIGHT_API_URL }}
-          NEXT_PUBLIC_SDP_API_BASE_URL: ${{ env.PLAYWRIGHT_API_URL }}
-          SOLANA_RPC_CI_PREFERRED_PROVIDER: quicknode
-        run: scripts/doppler/run-with-config.sh node scripts/run-with-healthy-solana-rpc.mjs pnpm --filter sdp-web build
+      - name: Probe dashboard readiness
+        run: |
+          set -euo pipefail
+          STATUS=$(curl -sS -o /dev/null -m 15 -w '%{http_code}' "${PLAYWRIGHT_BASE_URL}/sign-in")
+          echo "GET ${PLAYWRIGHT_BASE_URL}/sign-in -> ${STATUS}"
+          [ "$STATUS" = "200" ]
 
       - name: Run GCP read-only smoke
         id: smoke

--- a/apps/sdp-web/playwright.config.ts
+++ b/apps/sdp-web/playwright.config.ts
@@ -53,22 +53,27 @@ export default defineConfig({
           },
         ]
       : []),
-    {
-      command: webCommand,
-      cwd: __dirname,
-      url: env.baseURL,
-      reuseExistingServer: false,
-      env: {
-        ...resolveProcessEnv(),
-        ...env.webServerEnv,
-        PLAYWRIGHT_NEXT_DIST_DIR: nextDistDir,
-        SDP_API_BASE_URL: apiBaseUrl,
-        NEXT_PUBLIC_SDP_API_BASE_URL: apiBaseUrl,
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-      timeout: 180_000,
-    },
+    // A deployed dashboard (stage smoke) is already serving; nothing to start locally.
+    ...(!env.deployedWeb
+      ? [
+          {
+            command: webCommand,
+            cwd: __dirname,
+            url: env.baseURL,
+            reuseExistingServer: false,
+            env: {
+              ...resolveProcessEnv(),
+              ...env.webServerEnv,
+              PLAYWRIGHT_NEXT_DIST_DIR: nextDistDir,
+              SDP_API_BASE_URL: apiBaseUrl,
+              NEXT_PUBLIC_SDP_API_BASE_URL: apiBaseUrl,
+            },
+            stdout: "pipe" as const,
+            stderr: "pipe" as const,
+            timeout: 180_000,
+          },
+        ]
+      : []),
   ],
   projects: [
     {

--- a/apps/sdp-web/playwright/env.ts
+++ b/apps/sdp-web/playwright/env.ts
@@ -4,6 +4,10 @@ import path from "node:path";
 const DEFAULT_CLERK_TEST_ORG_NAME = "Solana";
 const DEFAULT_CLERK_TEST_EMAIL = "e2e-smoke+sdp-web@example.com";
 const BASE_URL = "http://localhost:3100";
+// Deployed dashboards the external GCP smoke may target instead of a local `next start`.
+// The production Clerk instance scopes its client cookie to solana.com, so the page under
+// test must live there; a localhost or vercel.app page can never complete the sign-in.
+const GCP_DEPLOYED_WEB_URLS = ["https://app-preview.solana.com"];
 const GCP_EXTERNAL_API_URLS = [
   "https://api-dev.solana.com",
   "https://api-stage.solana.com",
@@ -19,6 +23,8 @@ type E2EEnvCommon = {
   clerkTestEmail: string;
   sdpApiBaseUrl: string;
   ticketAuth: boolean;
+  /** True when the run targets a deployed dashboard and must not start a local web server. */
+  deployedWeb: boolean;
   webServerEnv: Record<string, string>;
 };
 
@@ -118,8 +124,17 @@ export function getE2EEnv(): E2EEnv {
 
   const fallback = getFallbackEnv();
   const useExternalApi = process.env.PLAYWRIGHT_USE_EXTERNAL_API === "1";
-  if (useExternalApi && process.env.PLAYWRIGHT_USE_NEXT_START !== "1") {
-    throw new Error("External GCP smoke requires PLAYWRIGHT_USE_NEXT_START=1");
+  const deployedWebUrl = process.env.PLAYWRIGHT_BASE_URL?.trim().replace(/\/$/, "") || null;
+  if (useExternalApi && deployedWebUrl && !GCP_DEPLOYED_WEB_URLS.includes(deployedWebUrl)) {
+    throw new Error(
+      `External GCP smoke only accepts ${GCP_DEPLOYED_WEB_URLS.join(", ")} as PLAYWRIGHT_BASE_URL; received ${deployedWebUrl}`
+    );
+  }
+  const deployedWeb = useExternalApi && deployedWebUrl !== null;
+  if (useExternalApi && !deployedWeb && process.env.PLAYWRIGHT_USE_NEXT_START !== "1") {
+    throw new Error(
+      "External GCP smoke requires PLAYWRIGHT_USE_NEXT_START=1 or a deployed PLAYWRIGHT_BASE_URL"
+    );
   }
   if (useExternalApi && process.env.NODE_ENV !== "production") {
     throw new Error("External GCP smoke requires NODE_ENV=production");
@@ -175,13 +190,14 @@ export function getE2EEnv(): E2EEnv {
         useExternalApi: false as const,
       };
   cachedEnv = {
-    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? BASE_URL,
+    baseURL: deployedWebUrl ?? BASE_URL,
     clerkSecretKey,
     clerkPublishableKey,
     clerkOrgName: resolveEnvValue("E2E_CLERK_ORG_NAME", fallback, DEFAULT_CLERK_TEST_ORG_NAME),
     ...identityEnv,
     sdpApiBaseUrl,
     ticketAuth,
+    deployedWeb,
     webServerEnv: {
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: clerkPublishableKey,
       CLERK_SECRET_KEY: clerkSecretKey,


### PR DESCRIPTION
The stage smoke built and served the dashboard on `localhost:3100` while signing in to the production Clerk instance, whose client cookie is scoped to `solana.com`. The browser could never keep that cookie, so the sign-in never completed and every run since the gate was armed on 2026-09-08 failed at the organization check (Andrey's trace in the eng thread). Nikhil stood up `app-preview.solana.com` on Vercel (api-preview API, production Clerk keys, Clerk allowed origin added); DNS landed 2026-09-10 14:40Z. This points the smoke at it.

**What changes**
- `playwright/env.ts`: `PLAYWRIGHT_BASE_URL` selects a deployed dashboard for the external GCP smoke, allow-listed like the API URLs; a `deployedWeb` flag carries that decision. The local `next start` path stays for the CI dashboard E2E job.
- `playwright.config.ts`: no local web server when the run targets a deployed dashboard.
- `sdp-stage-smoke.yml`: sets `PLAYWRIGHT_BASE_URL`, drops the local build and the next-start flags, and probes `/sign-in` on the dashboard before the suite so a DNS or deployment problem fails with one clear line.

**before** — the smoke could never sign in:
1. Build the dashboard on the runner, serve it on localhost.
2. Ticket sign-in against the production Clerk instance succeeds server-side.
3. Cookie for `solana.com` is dropped by the browser; `/v1/client` answers 401; the page shows the sign-in form.
4. `Clerk.organization` stays undefined; the org-id poll times out whatever the bound (5s or 30s).

**after** — the smoke runs where the cookie is valid:
1. Probe `https://app-preview.solana.com/sign-in` answers 200.
2. Ticket sign-in on that page; the `solana.com` cookie is kept.
3. `setActive` makes the canary organization active; the org-id poll passes.
4. The read-only suite runs against the deployed stage dashboard and the stage API.

**Verification**
- `biome check` and `tsc --noEmit` on `sdp-web` — clean.
- Dry run of the env logic: with `PLAYWRIGHT_BASE_URL` set, `deployedWeb` is true and the Playwright `webServer` list is empty; a host outside the allow-list throws; without it, the local next-start path is unchanged (one web server).
- `https://app-preview.solana.com/sign-in` — 200, no deployment-protection redirect, checked 2026-09-10 14:42Z.
- The smoke itself cannot run from a branch (the Doppler identity is main-pinned): the post-merge run on main is the proof.

Known gaps
- The allow-list holds one host. A second stage dashboard means one more entry, on purpose.
