### PR TITLE
fix(smoke): accept a feature-disabled 403 on golden endpoint reads

### DIFF
--- a/apps/sdp-web/playwright/tests/gcp-read-only-z-api.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/gcp-read-only-z-api.e2e.spec.ts
@@ -8,6 +8,7 @@ interface GoldenEndpoint {
   path: string;
   scope: "org" | "project";
   query?: Record<string, string>;
+  allowDisabled?: boolean;
 }
 
 const FIRST_PAGE = { page: "1", pageSize: "20" };
@@ -30,7 +31,7 @@ const GOLDEN_ENDPOINTS: GoldenEndpoint[] = [
   },
   { domain: "payments-recurring", path: "/v1/payments/recurring-payments", scope: "project" },
   { domain: "policies", path: "/v1/policies", scope: "project" },
-  { domain: "earn-strategies", path: "/v1/earn/strategies", scope: "project" },
+  { domain: "earn-strategies", path: "/v1/earn/strategies", scope: "project", allowDisabled: true },
 ];
 
 test.describe("GCP dev API golden endpoints", () => {
@@ -61,7 +62,13 @@ test.describe("GCP dev API golden endpoints", () => {
       const path = endpoint.query
         ? `${endpoint.path}?${new URLSearchParams(endpoint.query)}`
         : endpoint.path;
-      await expect(api.get(path)).resolves.toBeDefined();
+      const read = api.get(path).catch((error: unknown) => {
+        if (endpoint.allowDisabled && /not enabled for this environment/i.test(String(error))) {
+          return "feature-disabled";
+        }
+        throw error;
+      });
+      await expect(read).resolves.toBeDefined();
     });
   }
 });

--- a/apps/sdp-web/playwright/tests/gcp-read-only-z-api.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/gcp-read-only-z-api.e2e.spec.ts
@@ -63,7 +63,12 @@ test.describe("GCP dev API golden endpoints", () => {
         ? `${endpoint.path}?${new URLSearchParams(endpoint.query)}`
         : endpoint.path;
       const read = api.get(path).catch((error: unknown) => {
-        if (endpoint.allowDisabled && /not enabled for this environment/i.test(String(error))) {
+        if (
+          endpoint.allowDisabled &&
+          /^Error: Local API request failed \(403\): \w+ is not enabled for this environment$/.test(
+            String(error)
+          )
+        ) {
           return "feature-disabled";
         }
         throw error;


### PR DESCRIPTION
- The z-api golden-endpoint smoke marks `earn-strategies` as `allowDisabled`; a 403 matching "not enabled for this environment" now resolves the read instead of failing it.
- Any other error on that endpoint, and any error on every other endpoint, still fails the test — the tolerance is opt-in per endpoint and matched on the exact disabled message.

**before** — stage smoke, earn flagged off on `api-preview`:

1. `GET /v1/earn/strategies` → 403 "Earn is not enabled for this environment"
2. `expect(api.get(path)).resolves` rejects → `earn-strategies responds to an authed read` fails
3. The stage gate stays red on a deliberate flag posture, not an API fault

**after** — same request:

1. The 403 is caught, matched against the disabled-feature message, and resolves as `feature-disabled`
2. The test passes: an authed, deliberate 403 still proves the API answered the read
3. Timeouts, 5xx, auth failures, and unexpected 403s on any endpoint still reject and fail the smoke

**Verification**

- `doppler run --config stg_ci -- playwright test --project=gcp-read-only gcp-read-only-z-api` against `https://app-preview.solana.com` / `api-preview` — 14/14 passed, including `earn-strategies` (the previously failing test)
- `pnpm exec biome check apps/sdp-web/playwright/tests/gcp-read-only-z-api.e2e.spec.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
