### PR TITLE
fix(smoke): only read earn strategies when the smoke posture enables earn

### DIFF
--- a/apps/sdp-web/playwright/tests/gcp-read-only-z-api.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/gcp-read-only-z-api.e2e.spec.ts
@@ -30,7 +30,11 @@ const GOLDEN_ENDPOINTS: GoldenEndpoint[] = [
   },
   { domain: "payments-recurring", path: "/v1/payments/recurring-payments", scope: "project" },
   { domain: "policies", path: "/v1/policies", scope: "project" },
-  { domain: "earn-strategies", path: "/v1/earn/strategies", scope: "project" },
+  // Earn answers 403 wherever EARN_ENABLED is off (stage and prod today); the smoke pins the
+  // flag off in smoke-flags.json, so the row is only meaningful when the posture turns it on.
+  ...(process.env.EARN_ENABLED === "true"
+    ? [{ domain: "earn-strategies", path: "/v1/earn/strategies", scope: "project" as const }]
+    : []),
 ];
 
 test.describe("GCP dev API golden endpoints", () => {


### PR DESCRIPTION
The first authenticated stage smoke (run 34492425668, after #1753) failed on the golden read of `/v1/earn/strategies` with `403 Earn is not enabled for this environment`. `EARN_ENABLED` is unset on the stage API, and `smoke-flags.json` pins earn off for the smoke itself, so the row asserts something the posture says is off. Prod answers the same 403.

**What changes**
- `gcp-read-only-z-api.e2e.spec.ts`: the earn-strategies row is included only when `EARN_ENABLED` is `true` in the smoke's environment. Every other golden endpoint is unchanged.

**before** — earn row always asserted:
1. Smoke posture pins `EARN_ENABLED=false`.
2. Golden read of `/v1/earn/strategies` runs anyway and gets 403.
3. The gate fails on a check that contradicts its own posture.

**after** — earn row follows the posture:
1. Posture off: the row is skipped, the other 12 golden reads still run.
2. Posture on: the row runs and must return 200.

**Verification**
- `biome check` and `tsc --noEmit` on `sdp-web` — clean.
- The smoke cannot run from a branch; the next main run is the proof. The other open failure on that run (no transfer in the canary project) is a stage data seed, separate from this change.
