### PR TITLE
feat(earn): PRO-1867 diff provider APY/TVL against the stored shelf and emit anomaly events

### DIFF
--- a/apps/sdp-api/src/cron/earn-catalogue-sync.node.test.ts
+++ b/apps/sdp-api/src/cron/earn-catalogue-sync.node.test.ts
@@ -25,9 +25,16 @@ const mocks = vi.hoisted(() => ({
   providerClients: {} as Record<string, EarnVaultProvider>,
   upsertStrategy: vi.fn(),
   deleteUnlistedStrategies: vi.fn(),
+  listStrategyFigures: vi.fn(),
+  logEvent: vi.fn(),
   get: vi.fn(),
   compareAndSet: vi.fn(),
   compareAndDelete: vi.fn(),
+}));
+
+vi.mock("@/runtime/money-path-events", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/runtime/money-path-events")>()),
+  logEvent: mocks.logEvent,
 }));
 
 vi.mock("@sdp/earn", async (importOriginal) => {
@@ -42,6 +49,7 @@ vi.mock("@/db/repositories", () => ({
   createEarnRepository: vi.fn(() => ({
     upsertStrategy: mocks.upsertStrategy,
     deleteUnlistedStrategies: mocks.deleteUnlistedStrategies,
+    listStrategyFigures: mocks.listStrategyFigures,
   })),
 }));
 
@@ -109,6 +117,8 @@ describe("runEarnCatalogueSyncIfDue", () => {
   beforeEach(() => {
     mocks.upsertStrategy.mockReset().mockResolvedValue(undefined);
     mocks.deleteUnlistedStrategies.mockReset().mockResolvedValue([]);
+    mocks.listStrategyFigures.mockReset().mockResolvedValue([]);
+    mocks.logEvent.mockReset();
     // Default slot state: empty and claimable.
     mocks.get.mockReset().mockResolvedValue(null);
     mocks.compareAndSet.mockReset().mockResolvedValue(true);
@@ -120,6 +130,7 @@ describe("runEarnCatalogueSyncIfDue", () => {
           ({
             upsertStrategy: mocks.upsertStrategy,
             deleteUnlistedStrategies: mocks.deleteUnlistedStrategies,
+            listStrategyFigures: mocks.listStrategyFigures,
           }) as never
       );
     installProviders({});
@@ -767,6 +778,141 @@ describe("runEarnCatalogueSyncIfDue", () => {
       expect(mocks.upsertStrategy).not.toHaveBeenCalledWith(
         expect.objectContaining({ providerReference: "rogue-mainnet" })
       );
+    });
+  });
+
+  describe("figure anomalies (PRO-1867, EARN-010)", () => {
+    const storedFigure = (
+      provider_reference: string,
+      current_apy: string | null,
+      host_cluster: "devnet" | "mainnet-beta" = "devnet",
+      tvl_usd: number | null = null
+    ) => ({ provider_reference, host_cluster, status: "active", current_apy, tvl_usd });
+
+    it("emits a figure anomaly on a 10x APY jump against the stored row, and still writes it", async () => {
+      // The sync is a mirror of the provider, not a judge of it: the write
+      // lands, and the event is what gets a human to look at it. Only sandbox
+      // holds a stored row, so production's empty read is a new shelf, not a
+      // vanished one.
+      mocks.listStrategyFigures.mockImplementation(async ({ environment }) =>
+        environment === "sandbox" ? [storedFigure("vault-a", "0.05")] : []
+      );
+      installProviders({
+        ground: makeProvider("ground", async (ctx: EarnRuntimeContext) =>
+          ctx.environment === "production"
+            ? []
+            : [{ ...makeSnapshot("vault-a"), currentApy: "0.5" }]
+        ),
+      });
+
+      expect(await runEarnCatalogueSyncIfDue(env)).toBe("synced");
+
+      expect(mocks.logEvent).toHaveBeenCalledExactlyOnceWith("warn", {
+        event: "sdp_api_earn_catalogue_figure_anomaly",
+        source: "catalogue_sync",
+        provider: "ground",
+        environment: "sandbox",
+        provider_reference: "vault-a",
+        host_cluster: "devnet",
+        metric: "apy",
+        reason: "jump",
+        previous: 0.05,
+        current: 0.5,
+        ratio: 10,
+      });
+      expect(mocks.upsertStrategy).toHaveBeenCalledWith(
+        expect.objectContaining({ providerReference: "vault-a", currentApy: "0.5" })
+      );
+    });
+
+    it("diffs each lane against its own sub-shelf, so the mirror never judges devnet rows", async () => {
+      // Sandbox stores a devnet row and a mirrored mainnet row under different
+      // references; production stores nothing yet. Only the mirror lane's
+      // incoming figure moves.
+      mocks.listStrategyFigures.mockImplementation(async ({ environment }) =>
+        environment === "sandbox"
+          ? [
+              storedFigure("devnet-vault", "0.05", "devnet"),
+              storedFigure("mainnet-vault", "0.04", "mainnet-beta"),
+            ]
+          : []
+      );
+      installProviders({
+        ground: makeProvider("ground", async (ctx: EarnRuntimeContext) =>
+          ctx.environment === "production"
+            ? [{ ...makeSnapshot("mainnet-vault", "mainnet-beta"), currentApy: "0.4" }]
+            : [{ ...makeSnapshot("devnet-vault"), currentApy: "0.05" }]
+        ),
+      });
+
+      await runEarnCatalogueSyncIfDue(env);
+
+      // Production has no stored rows in this fixture (new row, exempt); the
+      // sandbox mirror lane does, and reports the jump there once.
+      const anomalies = mocks.logEvent.mock.calls.filter(
+        ([, payload]) => payload.event === "sdp_api_earn_catalogue_figure_anomaly"
+      );
+      expect(anomalies).toHaveLength(1);
+      expect(anomalies[0]?.[1]).toMatchObject({
+        environment: "sandbox",
+        provider_reference: "mainnet-vault",
+        host_cluster: "mainnet-beta",
+        ratio: 10,
+      });
+    });
+
+    it("reports a fundable shelf the provider reliably stopped listing, and does not delist it", async () => {
+      mocks.listStrategyFigures.mockResolvedValue([
+        storedFigure("vault-a", "0.05"),
+        storedFigure("vault-b", "0.06"),
+      ]);
+      installProviders({
+        ground: makeProvider(
+          "ground",
+          vi.fn(async () => [])
+        ),
+      });
+
+      await runEarnCatalogueSyncIfDue(env);
+
+      // Production's own lane (environment-wide) and sandbox's own devnet lane
+      // both held rows and both received an empty list.
+      expect(mocks.logEvent).toHaveBeenCalledWith("error", {
+        event: "sdp_api_earn_catalogue_shelf_disappeared",
+        source: "catalogue_sync",
+        provider: "ground",
+        environment: "production",
+        delist_scope: "environment",
+        previous_count: 2,
+        will_delist: false,
+      });
+      expect(mocks.logEvent).toHaveBeenCalledWith(
+        "error",
+        expect.objectContaining({
+          environment: "sandbox",
+          delist_scope: "devnet",
+          will_delist: false,
+        })
+      );
+      // The own-shelf refusal to delist on an empty read is untouched.
+      expect(mocks.deleteUnlistedStrategies).not.toHaveBeenCalledWith(
+        expect.objectContaining({ hostCluster: "devnet" })
+      );
+    });
+
+    it("stays quiet on an empty stored shelf and never lets a figure read failure sink the pass", async () => {
+      mocks.listStrategyFigures.mockRejectedValue(new Error("figures table unreadable"));
+      installProviders({
+        ground: makeProvider(
+          "ground",
+          vi.fn(async () => [makeSnapshot("v")])
+        ),
+      });
+
+      expect(await runEarnCatalogueSyncIfDue(env)).toBe("synced");
+
+      expect(mocks.logEvent).not.toHaveBeenCalled();
+      expect(mocks.upsertStrategy).toHaveBeenCalled();
     });
   });
 });

--- a/apps/sdp-api/src/cron/earn-catalogue-sync.ts
+++ b/apps/sdp-api/src/cron/earn-catalogue-sync.ts
@@ -48,6 +48,11 @@ import { createKVStoreSet } from "@/runtime/kv-redis";
 import { getLogger } from "@/runtime/logger";
 import type { Observability } from "@/runtime/observability";
 import { logVendorCallFailure } from "@/runtime/vendor-calls";
+import {
+  reportFigureAnomalies,
+  reportShelfDisappearance,
+  type StoredStrategyFigures,
+} from "@/services/earn/catalogue-anomaly";
 import type { Env } from "@/types/env";
 
 export const EARN_CATALOGUE_SYNC_MONITOR = "sdp-api-sync-earn-catalogue";
@@ -413,6 +418,12 @@ async function writeCatalogueLane(
   const listedProviderReferences: string[] = [...(lane.keepWithoutUpsert ?? [])];
   let upsertFailed = false;
 
+  // Figure anomaly check (PRO-1867) BEFORE the writes: the stored rows are the
+  // "before". Scoped to the lane's sub-shelf, since that is the set this
+  // lane's snapshots are the truth for. Read-only and never fatal: a failed
+  // read costs this pass its diff, not its write.
+  await reportLaneAnomalies(repo, client, lane, listedProviderReferences.length, logContext);
+
   for (const snapshot of lane.snapshots) {
     listedProviderReferences.push(snapshot.providerReference);
 
@@ -463,6 +474,67 @@ async function writeCatalogueLane(
     upsertFailed,
     logContext,
   });
+}
+
+/**
+ * Diff the lane's incoming snapshots against the stored sub-shelf and report
+ * out-of-bounds APY/TVL moves plus a shelf that reliably went empty (PRO-1867,
+ * threat model EARN-010). Emits events only; the write decisions below do not
+ * read its outcome. `keptWithoutUpsertCount` is the collided mirror references:
+ * they are still listed by the source, so a lane whose only survivors are
+ * those has not lost its shelf.
+ */
+async function reportLaneAnomalies(
+  repo: EarnRepository,
+  client: EarnVaultProvider,
+  lane: CatalogueLane,
+  keptWithoutUpsertCount: number,
+  logContext: Record<string, unknown>
+): Promise<void> {
+  let stored: StoredStrategyFigures[];
+  try {
+    const rows = await repo.listStrategyFigures({
+      provider: client.provider,
+      environment: lane.environment,
+    });
+    stored = rows
+      .filter((row) => lane.delistScope === undefined || row.host_cluster === lane.delistScope)
+      .map((row) => ({
+        providerReference: row.provider_reference,
+        hostCluster: row.host_cluster,
+        currentApy: row.current_apy,
+        tvlUsd: row.tvl_usd,
+      }));
+  } catch (err) {
+    getLogger().warn(
+      { ...logContext, error: err instanceof Error ? err.message : String(err) },
+      "syncEarnCatalogue: skipped figure anomaly check, stored figures unreadable"
+    );
+    return;
+  }
+
+  reportFigureAnomalies({
+    source: "catalogue_sync",
+    provider: client.provider,
+    environment: lane.environment,
+    stored,
+    incoming: lane.snapshots.map((snapshot) => ({
+      providerReference: snapshot.providerReference,
+      currentApy: snapshot.currentApy ?? null,
+      tvlUsd: snapshot.riskMetadata?.tvlUsd,
+      hostCluster: snapshot.hostCluster,
+    })),
+  });
+
+  if (stored.length > 0 && lane.snapshots.length === 0 && keptWithoutUpsertCount === 0) {
+    reportShelfDisappearance({
+      provider: client.provider,
+      environment: lane.environment,
+      delistScope: lane.delistScope ?? "environment",
+      previousCount: stored.length,
+      willDelist: lane.allowEmptyKeepSet === true,
+    });
+  }
 }
 
 /**

--- a/apps/sdp-api/src/cron/earn-metrics-refresh.node.test.ts
+++ b/apps/sdp-api/src/cron/earn-metrics-refresh.node.test.ts
@@ -17,6 +17,13 @@ import {
 const mocks = vi.hoisted(() => ({
   providerClients: {} as Record<string, EarnVaultProvider>,
   updateStrategyMetrics: vi.fn(),
+  listStrategyFigures: vi.fn(),
+  logEvent: vi.fn(),
+}));
+
+vi.mock("@/runtime/money-path-events", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/runtime/money-path-events")>()),
+  logEvent: mocks.logEvent,
 }));
 
 vi.mock("@sdp/earn", async (importOriginal) => {
@@ -27,6 +34,7 @@ vi.mock("@sdp/earn", async (importOriginal) => {
 vi.mock("@/db/repositories", () => ({
   createEarnRepository: vi.fn(() => ({
     updateStrategyMetrics: mocks.updateStrategyMetrics,
+    listStrategyFigures: mocks.listStrategyFigures,
   })),
 }));
 
@@ -60,6 +68,7 @@ beforeEach(() => {
     delete mocks.providerClients[key];
   }
   mocks.updateStrategyMetrics.mockResolvedValue(true);
+  mocks.listStrategyFigures.mockResolvedValue([]);
 });
 
 describe("refreshEarnStrategyMetrics", () => {
@@ -81,6 +90,54 @@ describe("refreshEarnStrategyMetrics", () => {
         riskMetadata: { tvlUsd: 1_000_000 },
       });
     }
+  });
+
+  it("emits a figure anomaly on a 10x APY jump against the stored row, and still writes it (PRO-1867)", async () => {
+    mocks.listStrategyFigures.mockResolvedValue([
+      {
+        provider_reference: "vault-a",
+        host_cluster: "mainnet-beta",
+        status: "active",
+        current_apy: "0.051",
+        tvl_usd: 1_000_000,
+      },
+    ]);
+    mocks.providerClients.kamino = liveMetricsProvider("kamino", async () => [
+      metrics("vault-a", "0.51"),
+    ]);
+
+    await refreshEarnStrategyMetrics(env);
+
+    // Once per environment: both refresh passes read the same stored fixture.
+    expect(mocks.logEvent).toHaveBeenCalledTimes(2);
+    expect(mocks.logEvent).toHaveBeenCalledWith("warn", {
+      event: "sdp_api_earn_catalogue_figure_anomaly",
+      source: "metrics_refresh",
+      provider: "kamino",
+      environment: "production",
+      provider_reference: "vault-a",
+      host_cluster: "mainnet-beta",
+      metric: "apy",
+      reason: "jump",
+      previous: 0.051,
+      current: 0.51,
+      ratio: 10,
+    });
+    expect(mocks.updateStrategyMetrics).toHaveBeenCalledWith(
+      expect.objectContaining({ providerReference: "vault-a", currentApy: "0.51" })
+    );
+  });
+
+  it("never lets a stored-figure read failure cost the refresh its write", async () => {
+    mocks.listStrategyFigures.mockRejectedValue(new Error("unreadable"));
+    mocks.providerClients.kamino = liveMetricsProvider("kamino", async () => [
+      metrics("vault-a", "0.051"),
+    ]);
+
+    await refreshEarnStrategyMetrics(env);
+
+    expect(mocks.logEvent).not.toHaveBeenCalled();
+    expect(mocks.updateStrategyMetrics).toHaveBeenCalledTimes(2);
   });
 
   it("skips providers without the live-metrics capability", async () => {

--- a/apps/sdp-api/src/cron/earn-metrics-refresh.ts
+++ b/apps/sdp-api/src/cron/earn-metrics-refresh.ts
@@ -44,6 +44,7 @@ import type { BackgroundRunner } from "@/runtime/background";
 import { getLogger } from "@/runtime/logger";
 import type { Observability } from "@/runtime/observability";
 import { logVendorCallFailure } from "@/runtime/vendor-calls";
+import { reportFigureAnomalies } from "@/services/earn/catalogue-anomaly";
 import type { Env } from "@/types/env";
 
 export const EARN_METRICS_REFRESH_MONITOR = "sdp-api-refresh-earn-metrics";
@@ -193,6 +194,38 @@ async function refreshProviderMetrics(
     return;
   }
 
+  // Figure anomaly check (PRO-1867) against the stored shelf BEFORE the
+  // writes. Read-only and never fatal; entries for references the catalogue
+  // does not hold are skipped exactly as the update below no-ops on them.
+  let anomalies = 0;
+  try {
+    const stored = await repo.listStrategyFigures({
+      provider: client.provider,
+      environment: ctx.environment,
+    });
+    anomalies = reportFigureAnomalies({
+      source: "metrics_refresh",
+      provider: client.provider,
+      environment: ctx.environment,
+      stored: stored.map((row) => ({
+        providerReference: row.provider_reference,
+        hostCluster: row.host_cluster,
+        currentApy: row.current_apy,
+        tvlUsd: row.tvl_usd,
+      })),
+      incoming: metrics.map((entry) => ({
+        providerReference: entry.providerReference,
+        currentApy: entry.currentApy ?? null,
+        tvlUsd: entry.riskMetadata?.tvlUsd,
+      })),
+    });
+  } catch (err) {
+    getLogger().warn(
+      { ...logContext, error: err instanceof Error ? err.message : String(err) },
+      "refreshEarnStrategyMetrics: skipped figure anomaly check, stored figures unreadable"
+    );
+  }
+
   let updated = 0;
   let failed = 0;
   for (const entry of metrics) {
@@ -227,7 +260,7 @@ async function refreshProviderMetrics(
   // hands over its whole shelf and the catalogue holds only the part that
   // cleared the admission gates.
   getLogger().info(
-    { ...logContext, reported: metrics.length, updated, failed },
+    { ...logContext, reported: metrics.length, updated, failed, anomalies },
     "refreshEarnStrategyMetrics: refreshed provider metrics"
   );
 }

--- a/apps/sdp-api/src/db/repositories/earn.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/earn.repository.postgres.ts
@@ -395,6 +395,36 @@ export function createPostgresEarnRepository(db: AppDb): EarnRepository {
       );
     },
 
+    async listStrategyFigures(params) {
+      // Same jsonb_typeof guard as the ranking in listStrategies: the metadata
+      // bag is open, so a non-numeric tvlUsd reads as "no figure", not a 500.
+      const result = await db
+        .prepare(
+          `SELECT provider_reference, host_cluster, status, current_apy, environment,
+                  CASE WHEN jsonb_typeof(risk_metadata->'tvlUsd') = 'number'
+                       THEN (risk_metadata->>'tvlUsd')::numeric END AS tvl_usd
+             FROM earn_strategies
+            WHERE provider = ? AND environment = ?
+            ORDER BY provider_reference ASC`
+        )
+        .bind(params.provider, params.environment)
+        .all<Record<string, unknown>>();
+      return (result.results ?? []).map((row) => {
+        const environment = row.environment as SdpEnvironment;
+        const tvl = row.tvl_usd === null || row.tvl_usd === undefined ? null : Number(row.tvl_usd);
+        return {
+          provider_reference: row.provider_reference as string,
+          // NULL host_cluster reads as the environment's own cluster, the
+          // mapStrategyRow rule.
+          host_cluster:
+            (row.host_cluster as SolanaCluster | null) ?? CLUSTER_BY_SDP_ENVIRONMENT[environment],
+          status: row.status as EarnStrategyStatus,
+          current_apy: row.current_apy as string | null,
+          tvl_usd: tvl !== null && Number.isFinite(tvl) ? tvl : null,
+        };
+      });
+    },
+
     async getProviderWalletById(params) {
       const row = await db
         .prepare(

--- a/apps/sdp-api/src/db/repositories/earn.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/earn.repository.test.ts
@@ -228,6 +228,76 @@ describe("EarnRepository (postgres)", () => {
     });
   });
 
+  /**
+   * The "before" the anomaly check (PRO-1867) diffs against: the whole stored
+   * shelf for one (provider, environment), every status and both clusters.
+   */
+  describe("listStrategyFigures", () => {
+    it("returns every row for the provider and environment with TVL lifted out of the metadata", async () => {
+      await seedStrategy({
+        providerReference: "a",
+        currentApy: "0.05",
+        riskMetadata: { tvlUsd: 1_500_000 },
+      });
+      await seedStrategy({
+        providerReference: "b",
+        currentApy: null,
+        riskMetadata: {},
+        status: "paused",
+      });
+      await seedStrategy({
+        providerReference: "m",
+        hostCluster: "mainnet-beta",
+        riskMetadata: { tvlUsd: 9e7 },
+      });
+      // Other provider and other environment: out of scope.
+      await seedStrategy({ provider: "kamino", providerReference: "a" });
+      await seedStrategy({
+        providerReference: "a",
+        environment: "production",
+        hostCluster: "mainnet-beta",
+      });
+
+      const figures = await repo.listStrategyFigures({ provider: "veda", environment: "sandbox" });
+
+      expect(figures).toEqual([
+        {
+          provider_reference: "a",
+          host_cluster: "devnet",
+          status: "active",
+          current_apy: "0.05",
+          tvl_usd: 1_500_000,
+        },
+        {
+          provider_reference: "b",
+          host_cluster: "devnet",
+          status: "paused",
+          current_apy: null,
+          tvl_usd: null,
+        },
+        {
+          provider_reference: "m",
+          host_cluster: "mainnet-beta",
+          status: "active",
+          current_apy: "0.052",
+          tvl_usd: 90_000_000,
+        },
+      ]);
+    });
+
+    it("reads a non-numeric tvlUsd as no figure and a NULL host_cluster as the environment's cluster", async () => {
+      const seeded = await seedStrategy({ riskMetadata: { tvlUsd: "12M" } });
+      await getDb(env)
+        .prepare("UPDATE earn_strategies SET host_cluster = NULL WHERE id = ?")
+        .bind(seeded.id)
+        .run();
+
+      const [figure] = await repo.listStrategyFigures({ provider: "veda", environment: "sandbox" });
+
+      expect(figure).toMatchObject({ tvl_usd: null, host_cluster: "devnet" });
+    });
+  });
+
   describe("upsertStrategy", () => {
     it("inserts a catalogue row and round-trips the jsonb columns", async () => {
       const row = await seedStrategy();

--- a/apps/sdp-api/src/db/repositories/earn.repository.ts
+++ b/apps/sdp-api/src/db/repositories/earn.repository.ts
@@ -211,6 +211,20 @@ export interface ListEarnStrategiesInput {
   offset: number;
 }
 
+/**
+ * The volatile figures of one stored strategy, as the anomaly check reads them
+ * before a catalogue or metrics write (PRO-1867, threat model EARN-010).
+ * `tvl_usd` is lifted out of the `risk_metadata` bag and is null unless the
+ * stored value is a JSON number, the same guard `listStrategies` ranks by.
+ */
+export interface EarnStrategyFigureRow {
+  provider_reference: string;
+  host_cluster: SolanaCluster;
+  status: EarnStrategyStatus;
+  current_apy: string | null;
+  tvl_usd: number | null;
+}
+
 export interface ListEarnStrategiesResult {
   rows: EarnStrategyRow[];
   total: number;
@@ -259,6 +273,16 @@ export interface EarnRepository {
   updateStrategyMetrics(input: UpdateEarnStrategyMetricsInput): Promise<boolean>;
   getStrategyById(strategyId: string): Promise<EarnStrategyRow | null>;
   listStrategies(input: ListEarnStrategiesInput): Promise<ListEarnStrategiesResult>;
+  /**
+   * Every stored strategy's volatile figures for one (provider, environment),
+   * both clusters and every status: the "before" the catalogue sync and the
+   * metrics refresh diff their incoming figures against (PRO-1867). Whole shelf
+   * on purpose, so a paused row's rate moving 10x is still visible.
+   */
+  listStrategyFigures(params: {
+    provider: string;
+    environment: SdpEnvironment;
+  }): Promise<EarnStrategyFigureRow[]>;
   /**
    * Every catalogued strategy that mints a share token on the given cluster,
    * for share-mint → vault attribution (PRO-1741). The WHOLE stored inventory

--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -1250,6 +1250,14 @@ fail-closed + 4xx-vs-ambiguous outcomes in `../earn.vault.test.ts`, fail-open
   (`src/cron/earn-metrics-refresh.ts`) runs every 5 minutes and is UPDATE-only,
   so it can never admit a row. Cadence and failure behaviour:
   `packages/sdp-earn/README.md` → "Catalogue data".
+- **Provider-reported figures are diffed, never trusted silently** (PRO-1867,
+  EARN-010). Both passes read the stored shelf first and emit
+  `sdp_api_earn_catalogue_figure_anomaly` for an APY/TVL move past
+  `EARN_FIGURE_BOUNDS`, and `sdp_api_earn_catalogue_shelf_disappeared` when a
+  lane that held rows reliably lists none (`services/earn/catalogue-anomaly.ts`).
+  Events only: the check never blocks a write, and a failed figures read costs
+  the pass its diff, not its write. Do not "fix" an anomaly by clamping the
+  write; the alert exists so a human looks at the provider.
 - Whole-stack local setup (ports, flags, Ground key, entitlement, troubleshooting):
   `packages/sdp-earn/CLAUDE.md` → "Local development".
 - **Tests must not depend on which providers are surfaced today.** Ground is the

--- a/apps/sdp-api/src/services/earn/catalogue-anomaly.test.ts
+++ b/apps/sdp-api/src/services/earn/catalogue-anomaly.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it, vi } from "vitest";
+
+const logEvent = vi.fn();
+vi.mock("@/runtime/money-path-events", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/runtime/money-path-events")>()),
+  logEvent,
+}));
+
+const {
+  EARN_FIGURE_BOUNDS,
+  detectFigureAnomalies,
+  reportFigureAnomalies,
+  reportShelfDisappearance,
+} = await import("./catalogue-anomaly");
+
+const stored = (
+  providerReference: string,
+  currentApy: string | null,
+  tvlUsd: number | null = null
+) => ({ providerReference, hostCluster: "mainnet-beta" as const, currentApy, tvlUsd });
+
+describe("detectFigureAnomalies", () => {
+  it("flags a 10x APY jump between passes with the ratio", () => {
+    const anomalies = detectFigureAnomalies(
+      [stored("vault-a", "0.05")],
+      [{ providerReference: "vault-a", currentApy: "0.5" }]
+    );
+
+    expect(anomalies).toEqual([
+      {
+        providerReference: "vault-a",
+        hostCluster: "mainnet-beta",
+        metric: "apy",
+        reason: "jump",
+        previous: 0.05,
+        current: 0.5,
+        ratio: 10,
+      },
+    ]);
+  });
+
+  it("flags a collapse the same way, on the inverse ratio", () => {
+    const [anomaly] = detectFigureAnomalies(
+      [stored("vault-a", "0.06")],
+      [{ providerReference: "vault-a", currentApy: "0.01" }]
+    );
+
+    expect(anomaly).toMatchObject({ metric: "apy", reason: "jump" });
+    expect(anomaly?.ratio).toBeCloseTo(1 / 6, 12);
+  });
+
+  it("ignores ordinary drift and sub-floor noise around zero", () => {
+    expect(
+      detectFigureAnomalies(
+        [stored("vault-a", "0.05"), stored("vault-b", "0.0004")],
+        [
+          { providerReference: "vault-a", currentApy: "0.07" },
+          // 10x, but under the half-point absolute floor.
+          { providerReference: "vault-b", currentApy: "0.004" },
+        ]
+      )
+    ).toEqual([]);
+  });
+
+  it("uses the absolute floor alone when either side is zero", () => {
+    const anomalies = detectFigureAnomalies(
+      [stored("vault-a", "0"), stored("vault-b", "0.05")],
+      [
+        { providerReference: "vault-a", currentApy: "0.05" },
+        { providerReference: "vault-b", currentApy: "0" },
+      ]
+    );
+
+    expect(anomalies.map((a) => [a.providerReference, a.ratio])).toEqual([
+      ["vault-a", null],
+      ["vault-b", null],
+    ]);
+  });
+
+  it("exempts new rows from the jump check but not from the ceiling", () => {
+    const anomalies = detectFigureAnomalies(
+      [],
+      [
+        { providerReference: "new-sane", currentApy: "0.08", hostCluster: "devnet" },
+        { providerReference: "new-absurd", currentApy: "4.2", hostCluster: "devnet" },
+      ]
+    );
+
+    expect(anomalies).toEqual([
+      {
+        providerReference: "new-absurd",
+        hostCluster: "devnet",
+        metric: "apy",
+        reason: "ceiling",
+        previous: null,
+        current: 4.2,
+        ratio: null,
+      },
+    ]);
+  });
+
+  it("reports both a ceiling breach and a jump when one figure does both", () => {
+    const anomalies = detectFigureAnomalies(
+      [stored("vault-a", "0.05")],
+      [{ providerReference: "vault-a", currentApy: "2" }]
+    );
+
+    expect(anomalies.map((a) => a.reason)).toEqual(["ceiling", "jump"]);
+  });
+
+  it("skips a rate that is missing or unparseable on either side", () => {
+    expect(
+      detectFigureAnomalies(
+        [stored("gone", "0.05"), stored("garbage", "n/a"), stored("none", null)],
+        [
+          { providerReference: "gone", currentApy: null },
+          { providerReference: "garbage", currentApy: "0.5" },
+          { providerReference: "none", currentApy: "0.5" },
+        ]
+      )
+    ).toEqual([]);
+  });
+
+  it("flags a TVL jump only when it clears both the ratio and the dollar floor", () => {
+    const anomalies = detectFigureAnomalies(
+      [
+        stored("big", "0.05", 10_000_000),
+        stored("tiny", "0.05", 1_000),
+        stored("steady", "0.05", 10_000_000),
+      ],
+      [
+        { providerReference: "big", currentApy: "0.05", tvlUsd: 1_000_000 },
+        // 40x, but a $39k move.
+        { providerReference: "tiny", currentApy: "0.05", tvlUsd: 40_000 },
+        { providerReference: "steady", currentApy: "0.05", tvlUsd: 12_000_000 },
+      ]
+    );
+
+    expect(anomalies).toEqual([
+      {
+        providerReference: "big",
+        hostCluster: "mainnet-beta",
+        metric: "tvl_usd",
+        reason: "jump",
+        previous: 10_000_000,
+        current: 1_000_000,
+        ratio: 0.1,
+      },
+    ]);
+  });
+
+  it("treats a non-numeric incoming TVL as no figure", () => {
+    expect(
+      detectFigureAnomalies(
+        [stored("vault-a", "0.05", 10_000_000)],
+        [{ providerReference: "vault-a", currentApy: "0.05", tvlUsd: "12M" }]
+      )
+    ).toEqual([]);
+  });
+
+  it("ignores references the catalogue does not hold when no cluster is known", () => {
+    // A metrics entry for an unadmitted vault: the refresh no-ops on it.
+    expect(
+      detectFigureAnomalies([], [{ providerReference: "unadmitted", currentApy: "9" }])
+    ).toEqual([]);
+  });
+});
+
+describe("reportFigureAnomalies", () => {
+  it("emits one warn event per anomaly with the pass's context and returns the count", () => {
+    logEvent.mockClear();
+
+    const count = reportFigureAnomalies({
+      source: "metrics_refresh",
+      provider: "kamino",
+      environment: "production",
+      stored: [stored("vault-a", "0.05", 5_000_000)],
+      incoming: [{ providerReference: "vault-a", currentApy: "0.5", tvlUsd: 50_000_000 }],
+    });
+
+    expect(count).toBe(2);
+    expect(logEvent).toHaveBeenCalledTimes(2);
+    expect(logEvent).toHaveBeenCalledWith("warn", {
+      event: "sdp_api_earn_catalogue_figure_anomaly",
+      source: "metrics_refresh",
+      provider: "kamino",
+      environment: "production",
+      provider_reference: "vault-a",
+      host_cluster: "mainnet-beta",
+      metric: "apy",
+      reason: "jump",
+      previous: 0.05,
+      current: 0.5,
+      ratio: 10,
+    });
+    expect(logEvent).toHaveBeenCalledWith(
+      "warn",
+      expect.objectContaining({ metric: "tvl_usd", ratio: 10 })
+    );
+  });
+
+  it("stays quiet on an unchanged shelf", () => {
+    logEvent.mockClear();
+
+    expect(
+      reportFigureAnomalies({
+        source: "catalogue_sync",
+        provider: "kamino",
+        environment: "sandbox",
+        stored: [stored("vault-a", "0.05")],
+        incoming: [{ providerReference: "vault-a", currentApy: "0.052" }],
+      })
+    ).toBe(0);
+    expect(logEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe("reportShelfDisappearance", () => {
+  it("emits an error event carrying the scope and whether the lane will delist", () => {
+    logEvent.mockClear();
+
+    reportShelfDisappearance({
+      provider: "kamino",
+      environment: "sandbox",
+      delistScope: "devnet",
+      previousCount: 21,
+      willDelist: false,
+    });
+
+    expect(logEvent).toHaveBeenCalledWith("error", {
+      event: "sdp_api_earn_catalogue_shelf_disappeared",
+      source: "catalogue_sync",
+      provider: "kamino",
+      environment: "sandbox",
+      delist_scope: "devnet",
+      previous_count: 21,
+      will_delist: false,
+    });
+  });
+});
+
+describe("EARN_FIGURE_BOUNDS", () => {
+  it("pins the starting bounds so a change is a deliberate diff", () => {
+    expect(EARN_FIGURE_BOUNDS).toEqual({
+      apyJumpRatio: 3,
+      apyMinAbsoluteDelta: 0.005,
+      apyCeiling: 1,
+      tvlJumpRatio: 3,
+      tvlMinAbsoluteDeltaUsd: 50_000,
+    });
+  });
+});

--- a/apps/sdp-api/src/services/earn/catalogue-anomaly.test.ts
+++ b/apps/sdp-api/src/services/earn/catalogue-anomaly.test.ts
@@ -149,6 +149,43 @@ describe("detectFigureAnomalies", () => {
     ]);
   });
 
+  it("never coerces malformed provider values into figures", () => {
+    // Number(true) is 1 and Number("") is 0: either would fabricate a collapse.
+    expect(
+      detectFigureAnomalies(
+        [
+          stored("bool", "0.05", 10_000_000),
+          stored("empty", "0.05", 10_000_000),
+          stored("array", "0.05", 10_000_000),
+          stored("nan", "0.05", 10_000_000),
+        ],
+        [
+          { providerReference: "bool", currentApy: "0.05", tvlUsd: true },
+          { providerReference: "empty", currentApy: "", tvlUsd: "" },
+          { providerReference: "array", currentApy: "0.05", tvlUsd: [] },
+          { providerReference: "nan", currentApy: "NaN", tvlUsd: Number.NaN },
+        ]
+      )
+    ).toEqual([]);
+  });
+
+  it("accepts the numeric string shapes providers actually send", () => {
+    const anomalies = detectFigureAnomalies(
+      [stored("a", "0.05"), stored("b", "0.05"), stored("c", "0.05")],
+      [
+        { providerReference: "a", currentApy: " 0.5 " },
+        { providerReference: "b", currentApy: "5e-1" },
+        { providerReference: "c", currentApy: ".5" },
+      ]
+    );
+
+    expect(anomalies.map((a) => [a.providerReference, a.current])).toEqual([
+      ["a", 0.5],
+      ["b", 0.5],
+      ["c", 0.5],
+    ]);
+  });
+
   it("treats a non-numeric incoming TVL as no figure", () => {
     expect(
       detectFigureAnomalies(

--- a/apps/sdp-api/src/services/earn/catalogue-anomaly.ts
+++ b/apps/sdp-api/src/services/earn/catalogue-anomaly.ts
@@ -1,0 +1,235 @@
+/**
+ * Catalogue figure anomaly detection (PRO-1867, threat model EARN-010).
+ *
+ * The catalogue sync and the metrics refresh both take provider-reported
+ * APY and TVL at face value and write them. A provider bug, a compromised
+ * provider API, or an upstream oracle fault therefore reaches the comparison
+ * table (and whatever a customer decides from it) with no check in between.
+ * This module is that check: it diffs the incoming figures against what the
+ * catalogue already holds and reports every move outside the bounds below as
+ * an alertable event. It never blocks a write. A wrong rate on the shelf for
+ * five minutes with a human paged beats a stale one held indefinitely by a
+ * bound that guessed wrong, and the write paths' own invariants (update-only
+ * refresh, gated admission) stay exactly where they were.
+ *
+ * Two events, both keyed for Grafana (`sdp-infra/kora/alert-rules`):
+ *
+ * - `sdp_api_earn_catalogue_figure_anomaly` (warn), one per strategy and
+ *   metric that moved beyond a bound between two passes, or sits above the
+ *   absolute APY ceiling. New rows are exempt from the diff (there is no
+ *   "before"), never from the ceiling.
+ * - `sdp_api_earn_catalogue_shelf_disappeared` (error), when a lane that
+ *   previously stored rows receives a reliable empty catalogue for the same
+ *   scope. Whether the pass then delists is the lane's business
+ *   (`allowEmptyKeepSet`); the event reports the disappearance either way,
+ *   because a fundable own shelf that the provider stopped listing is the
+ *   more alarming case, not the less.
+ *
+ * The bounds are starting points chosen from what the shelf looks like today
+ * (single-digit stablecoin APYs, seven-to-eight-figure TVLs), not measured
+ * limits. Tighten or loosen them here; the alert rules key on the event, not
+ * the numbers.
+ */
+
+import type { SolanaCluster } from "@sdp/types";
+import { logEvent } from "@/runtime/money-path-events";
+
+export const EARN_FIGURE_BOUNDS = {
+  /** A rate multiplying or dividing by this between passes is a jump. */
+  apyJumpRatio: 3,
+  /** ...unless the absolute move is under half a percentage point (noise around zero). */
+  apyMinAbsoluteDelta: 0.005,
+  /** No stablecoin vault on the shelf pays this; above it the figure is wrong or the vault is not what it claims. */
+  apyCeiling: 1,
+  /** TVL multiplying or dividing by this between passes is a jump. */
+  tvlJumpRatio: 3,
+  /** ...unless the absolute move is under this many dollars (a tiny vault filling up is not an incident). */
+  tvlMinAbsoluteDeltaUsd: 50_000,
+} as const;
+
+export type FigureAnomalySource = "catalogue_sync" | "metrics_refresh";
+
+/** The stored side of the diff: one catalogued strategy's figures. */
+export interface StoredStrategyFigures {
+  providerReference: string;
+  hostCluster: SolanaCluster;
+  currentApy: string | null;
+  tvlUsd: number | null;
+}
+
+/** The incoming side: what a pass is about to write for one reference. */
+export interface IncomingStrategyFigures {
+  providerReference: string;
+  currentApy?: string | null;
+  /** Read out of the incoming risk metadata; anything but a finite number is "no figure". */
+  tvlUsd?: unknown;
+  /** Present on catalogue snapshots, absent on metrics entries (taken from the stored row then). */
+  hostCluster?: SolanaCluster;
+}
+
+export interface FigureAnomaly {
+  providerReference: string;
+  hostCluster: SolanaCluster;
+  metric: "apy" | "tvl_usd";
+  reason: "jump" | "ceiling";
+  previous: number | null;
+  current: number;
+  /** current / previous, null when either side is zero (the absolute delta decided). */
+  ratio: number | null;
+}
+
+/**
+ * Pure diff of incoming figures against stored ones. References with no stored
+ * row are new and exempt from the jump check; a null or unparseable figure on
+ * either side is skipped rather than guessed at (a provider that stops
+ * reporting a rate is the refresh's own documented behaviour, not an anomaly).
+ */
+export function detectFigureAnomalies(
+  stored: readonly StoredStrategyFigures[],
+  incoming: readonly IncomingStrategyFigures[]
+): FigureAnomaly[] {
+  const before = new Map(stored.map((row) => [row.providerReference, row]));
+  const anomalies: FigureAnomaly[] = [];
+
+  for (const next of incoming) {
+    const prev = before.get(next.providerReference);
+    const hostCluster = next.hostCluster ?? prev?.hostCluster;
+    if (hostCluster === undefined) {
+      // A metrics entry for a reference the catalogue does not hold: the
+      // refresh no-ops on it and so does this.
+      continue;
+    }
+    const base = { providerReference: next.providerReference, hostCluster };
+
+    const apy = parseFigure(next.currentApy);
+    if (apy !== null) {
+      if (apy > EARN_FIGURE_BOUNDS.apyCeiling) {
+        anomalies.push({
+          ...base,
+          metric: "apy",
+          reason: "ceiling",
+          previous: parseFigure(prev?.currentApy),
+          current: apy,
+          ratio: null,
+        });
+      }
+      const prevApy = parseFigure(prev?.currentApy);
+      if (prevApy !== null) {
+        const jump = judgeJump(prevApy, apy, {
+          ratio: EARN_FIGURE_BOUNDS.apyJumpRatio,
+          minAbsoluteDelta: EARN_FIGURE_BOUNDS.apyMinAbsoluteDelta,
+        });
+        if (jump) {
+          anomalies.push({
+            ...base,
+            metric: "apy",
+            reason: "jump",
+            previous: prevApy,
+            current: apy,
+            ratio: jump.ratio,
+          });
+        }
+      }
+    }
+
+    const tvl = parseFigure(next.tvlUsd);
+    const prevTvl = prev?.tvlUsd ?? null;
+    if (tvl !== null && prevTvl !== null) {
+      const jump = judgeJump(prevTvl, tvl, {
+        ratio: EARN_FIGURE_BOUNDS.tvlJumpRatio,
+        minAbsoluteDelta: EARN_FIGURE_BOUNDS.tvlMinAbsoluteDeltaUsd,
+      });
+      if (jump) {
+        anomalies.push({
+          ...base,
+          metric: "tvl_usd",
+          reason: "jump",
+          previous: prevTvl,
+          current: tvl,
+          ratio: jump.ratio,
+        });
+      }
+    }
+  }
+
+  return anomalies;
+}
+
+/**
+ * Diff and report in one call, returning how many anomalies were emitted so
+ * a pass can carry the count on its own summary line. Never throws: a
+ * telemetry fault must not cost the pass its write.
+ */
+export function reportFigureAnomalies(args: {
+  source: FigureAnomalySource;
+  provider: string;
+  environment: string;
+  stored: readonly StoredStrategyFigures[];
+  incoming: readonly IncomingStrategyFigures[];
+}): number {
+  const anomalies = detectFigureAnomalies(args.stored, args.incoming);
+  for (const anomaly of anomalies) {
+    logEvent("warn", {
+      event: "sdp_api_earn_catalogue_figure_anomaly",
+      source: args.source,
+      provider: args.provider,
+      environment: args.environment,
+      provider_reference: anomaly.providerReference,
+      host_cluster: anomaly.hostCluster,
+      metric: anomaly.metric,
+      reason: anomaly.reason,
+      previous: anomaly.previous,
+      current: anomaly.current,
+      ratio: anomaly.ratio,
+    });
+  }
+  return anomalies.length;
+}
+
+/**
+ * A lane held `previousCount` rows in its scope and this pass reliably lists
+ * none. Error-level: whichever way the lane resolves it, a shelf vanishing
+ * between hourly passes is either a provider incident or a catalogue-side
+ * regression, and both want a human within the hour.
+ */
+export function reportShelfDisappearance(args: {
+  provider: string;
+  environment: string;
+  delistScope: string;
+  previousCount: number;
+  willDelist: boolean;
+}): void {
+  logEvent("error", {
+    event: "sdp_api_earn_catalogue_shelf_disappeared",
+    source: "catalogue_sync",
+    provider: args.provider,
+    environment: args.environment,
+    delist_scope: args.delistScope,
+    previous_count: args.previousCount,
+    will_delist: args.willDelist,
+  });
+}
+
+function parseFigure(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * A move counts as a jump when it clears BOTH the ratio bound and the absolute
+ * floor. Either alone misfires: ratio alone flags 0.01% → 0.05%, absolute alone
+ * flags every large vault's ordinary daily flow. With a zero on either side the
+ * ratio is undefined, so the absolute floor decides on its own.
+ */
+function judgeJump(
+  previous: number,
+  current: number,
+  bound: { ratio: number; minAbsoluteDelta: number }
+): { ratio: number | null } | null {
+  if (Math.abs(current - previous) < bound.minAbsoluteDelta) return null;
+  if (previous <= 0 || current <= 0) return { ratio: null };
+  const ratio = current / previous;
+  if (ratio >= bound.ratio || ratio <= 1 / bound.ratio) return { ratio };
+  return null;
+}

--- a/apps/sdp-api/src/services/earn/catalogue-anomaly.ts
+++ b/apps/sdp-api/src/services/earn/catalogue-anomaly.ts
@@ -210,11 +210,22 @@ export function reportShelfDisappearance(args: {
   });
 }
 
+/**
+ * A figure is a finite number or a non-empty numeric string, and nothing else.
+ * `Number(...)` alone is too generous for provider-controlled input: `true`
+ * reads as 1, `""` and `[]` as 0, and either would fabricate a collapse event
+ * out of malformed data. Anything not shaped like a figure is "no figure".
+ */
 function parseFigure(value: unknown): number | null {
-  if (value === null || value === undefined) return null;
-  const parsed = typeof value === "number" ? value : Number(value);
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (trimmed === "" || !NUMERIC_STRING.test(trimmed)) return null;
+  const parsed = Number(trimmed);
   return Number.isFinite(parsed) ? parsed : null;
 }
+
+const NUMERIC_STRING = /^[+-]?(\d+\.?\d*|\.\d+)(e[+-]?\d+)?$/i;
 
 /**
  * A move counts as a jump when it clears BOTH the ratio bound and the absolute

--- a/apps/sdp-api/src/services/jobs/reconcile-earn-vault-movements.ts
+++ b/apps/sdp-api/src/services/jobs/reconcile-earn-vault-movements.ts
@@ -21,10 +21,9 @@ const OUTBOX_BATCH_SIZE = 256;
  *
  * A completed tick emits `sdp_api_earn_vault_reconciliation_tick` (PRO-1863,
  * the `sdp_api_sponsorship_reconciliation_tick` precedent): claimed/settled/
- * failed counts plus the post-tick backlog and ages. Those are what a backlog
- * or movement-age rule needs to key on; no such rule exists yet (SDP's alerts
- * live as code in the sdp-infra repo, and PRO-1863 tracks writing them).
- * A chain read failure or a
+ * failed counts plus the post-tick backlog and ages. The backlog, movement-age
+ * and health rules that key on them live as code in the sdp-infra repo
+ * (`kora/alert-rules/sdp-earn-*.json`, PRO-1903). A chain read failure or a
  * per-movement failure still emits the tick (at error level, with the failure
  * counts) and then THROWS, so the cron run reads failed instead of ok while
  * nothing settles (EARN-006: an RPC outage used to be swallowed into an ok

--- a/packages/sdp-earn/README.md
+++ b/packages/sdp-earn/README.md
@@ -526,6 +526,32 @@ refresh is update-only.
   production skip), so orphaned mirror rows never outlive their truth source;
   fundable own shelves keep the absolute empty-keep-set refusal.
 
+### Figure anomaly check (`services/earn/catalogue-anomaly.ts`)
+
+Both passes take provider-reported APY and TVL at face value; this is the
+one check between a provider's number and the comparison table (PRO-1867,
+threat model EARN-010).
+
+- **What it does:** before either pass writes, it reads the stored figures for
+  the (provider, environment) it is about to write (`listStrategyFigures`,
+  the sync scoped to its lane's cluster sub-shelf) and diffs the incoming
+  figures against them. Every APY or TVL move past a bound, or an APY above
+  the absolute ceiling, is one `sdp_api_earn_catalogue_figure_anomaly` warn
+  event; a lane that held rows and reliably received an empty catalogue is
+  one `sdp_api_earn_catalogue_shelf_disappeared` error event, whether or not
+  the lane then delists. New rows are exempt from the diff, never from the
+  ceiling. A missing or unparseable figure on either side is skipped, not
+  guessed.
+- **What it never does:** block or alter a write. The write paths' own
+  invariants (update-only refresh, gated admission, the empty-keep-set
+  refusal) are untouched, and a failure reading the stored figures costs the
+  pass its diff, not its write.
+- **Bounds** live in `EARN_FIGURE_BOUNDS` (3x ratio with an absolute floor
+  for both metrics, 100% APY ceiling) and are starting points, pinned by a
+  test so a change is a deliberate diff. The Grafana rules
+  (`sdp-infra/kora/alert-rules/sdp-earn-catalogue-*.json`) key on the event
+  names, not the numbers.
+
 ## Invariants (do not break)
 
 1. **Money out beats money off.** Money-in gates on environment, strategy,


### PR DESCRIPTION
Provider-reported APY and TVL reached `earn_strategies` with no check in between. Both catalogue passes now diff the incoming figures against the stored shelf and emit alertable events. Linear: [PRO-1867](https://linear.app/solana-fndn/issue/PRO-1867) (threat model EARN-010). Alert rules land in sdp-infra separately.

## What

- `services/earn/catalogue-anomaly.ts`: pure diff + two emitters. `sdp_api_earn_catalogue_figure_anomaly` (warn) per strategy/metric past `EARN_FIGURE_BOUNDS` (3x either way above an absolute floor, or APY above 100%). `sdp_api_earn_catalogue_shelf_disappeared` (error) when a sync lane that held rows reliably lists none.
- Repository: `listStrategyFigures(provider, environment)`, the whole stored shelf with TVL lifted out of the metadata bag under the same `jsonb_typeof` guard the ranking uses.
- Catalogue sync diffs per lane against its cluster sub-shelf before upserting; metrics refresh diffs before updating and carries the count on its summary line.

## Reviewer notes

- **Report-only, by design.** No write is blocked or clamped, and no existing lane, delist or update-only behaviour changes. A failed figures read costs the pass its diff, not its write (tested both crons). Rationale in the module header.
- **New rows are exempt from the diff, never from the ceiling.** A brand-new vault at 400% still fires.
- **Shelf disappearance carries `will_delist`.** The own-lane refusal to delist on an empty read means those rows stay depositable while the provider no longer lists them; that case is the one that pages downstream.
- **Bounds are starting points**, pinned by a test so changing them is a deliberate diff.
- Also fixes the stale "no such rule exists yet" comment in the sweep job (rules shipped in sdp-infra #161).

## Verification

- 20 new test cases: 12 module, 4 sync, 2 refresh, 2 repository (testcontainers). The ticket's exit criterion (synthetic 10x APY jump in a sync test emits the event) is one of them.
- tsc, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
