### PR TITLE
fix(payments): refuse a signature written against superseded unsigned bytes

### DIFF
--- a/apps/sdp-api/src/db/repositories/payment-requests.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/payment-requests.repository.postgres.ts
@@ -221,7 +221,7 @@ export function createPostgresPaymentRequestsRepository(db: AppDb): PaymentReque
     },
 
     async storeSponsoredTransactionSignature(params) {
-      await db
+      const changed = await db
         .prepare(
           `UPDATE payment_requests
              SET sponsored_tx_signed = ?, updated_at = sdp_iso_now()
@@ -229,8 +229,14 @@ export function createPostgresPaymentRequestsRepository(db: AppDb): PaymentReque
              AND sponsored_tx_account = ?
              AND sponsored_tx_unsigned = ?`
         )
-        .bind(params.signedTransaction, params.requestId, params.account, params.unsignedTransaction)
+        .bind(
+          params.signedTransaction,
+          params.requestId,
+          params.account,
+          params.unsignedTransaction
+        )
         .run();
+      return changed > 0;
     },
 
     async getPaymentRequestByPublicToken(publicToken) {

--- a/apps/sdp-api/src/db/repositories/payment-requests.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/payment-requests.repository.postgres.ts
@@ -225,9 +225,11 @@ export function createPostgresPaymentRequestsRepository(db: AppDb): PaymentReque
         .prepare(
           `UPDATE payment_requests
              SET sponsored_tx_signed = ?, updated_at = sdp_iso_now()
-           WHERE id = ? AND sponsored_tx_account = ?`
+           WHERE id = ?
+             AND sponsored_tx_account = ?
+             AND sponsored_tx_unsigned = ?`
         )
-        .bind(params.signedTransaction, params.requestId, params.account)
+        .bind(params.signedTransaction, params.requestId, params.account, params.unsignedTransaction)
         .run();
     },
 

--- a/apps/sdp-api/src/db/repositories/payment-requests.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/payment-requests.repository.test.ts
@@ -485,6 +485,7 @@ describe("PaymentRequestsRepository (postgres)", () => {
       await repo.storeSponsoredTransactionSignature({
         requestId: request.id,
         account: ACCOUNT_B,
+        unsignedTransaction: "dHhB",
         signedTransaction: "c2lnQg==",
       });
       expect((await repo.getSponsoredTransactionClaim(request.id))?.signedTransaction).toBeNull();
@@ -492,10 +493,47 @@ describe("PaymentRequestsRepository (postgres)", () => {
       await repo.storeSponsoredTransactionSignature({
         requestId: request.id,
         account: ACCOUNT_A,
+        unsignedTransaction: "dHhB",
         signedTransaction: "c2lnQQ==",
       });
       expect((await repo.getSponsoredTransactionClaim(request.id))?.signedTransaction).toBe(
         "c2lnQQ=="
+      );
+    });
+
+    it("refuses a stale signature written against superseded unsigned bytes", async () => {
+      const request = await repo.createPaymentRequest(createInput());
+      await repo.claimSponsoredTransactionWindow({
+        requestId: request.id,
+        account: ACCOUNT_A,
+        unsignedTransaction: "dHhPbGQ=",
+        lastValidBlockHeight: 1_000n,
+        currentBlockHeight: 900n,
+      });
+      await repo.claimSponsoredTransactionWindow({
+        requestId: request.id,
+        account: ACCOUNT_A,
+        unsignedTransaction: "dHhOZXc=",
+        lastValidBlockHeight: 1_200n,
+        currentBlockHeight: 1_001n,
+      });
+
+      await repo.storeSponsoredTransactionSignature({
+        requestId: request.id,
+        account: ACCOUNT_A,
+        unsignedTransaction: "dHhPbGQ=",
+        signedTransaction: "c2lnT2xk",
+      });
+      expect((await repo.getSponsoredTransactionClaim(request.id))?.signedTransaction).toBeNull();
+
+      await repo.storeSponsoredTransactionSignature({
+        requestId: request.id,
+        account: ACCOUNT_A,
+        unsignedTransaction: "dHhOZXc=",
+        signedTransaction: "c2lnTmV3",
+      });
+      expect((await repo.getSponsoredTransactionClaim(request.id))?.signedTransaction).toBe(
+        "c2lnTmV3"
       );
     });
 

--- a/apps/sdp-api/src/db/repositories/payment-requests.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/payment-requests.repository.test.ts
@@ -518,20 +518,24 @@ describe("PaymentRequestsRepository (postgres)", () => {
         currentBlockHeight: 1_001n,
       });
 
-      await repo.storeSponsoredTransactionSignature({
-        requestId: request.id,
-        account: ACCOUNT_A,
-        unsignedTransaction: "dHhPbGQ=",
-        signedTransaction: "c2lnT2xk",
-      });
+      expect(
+        await repo.storeSponsoredTransactionSignature({
+          requestId: request.id,
+          account: ACCOUNT_A,
+          unsignedTransaction: "dHhPbGQ=",
+          signedTransaction: "c2lnT2xk",
+        })
+      ).toBe(false);
       expect((await repo.getSponsoredTransactionClaim(request.id))?.signedTransaction).toBeNull();
 
-      await repo.storeSponsoredTransactionSignature({
-        requestId: request.id,
-        account: ACCOUNT_A,
-        unsignedTransaction: "dHhOZXc=",
-        signedTransaction: "c2lnTmV3",
-      });
+      expect(
+        await repo.storeSponsoredTransactionSignature({
+          requestId: request.id,
+          account: ACCOUNT_A,
+          unsignedTransaction: "dHhOZXc=",
+          signedTransaction: "c2lnTmV3",
+        })
+      ).toBe(true);
       expect((await repo.getSponsoredTransactionClaim(request.id))?.signedTransaction).toBe(
         "c2lnTmV3"
       );

--- a/apps/sdp-api/src/db/repositories/payment-requests.repository.ts
+++ b/apps/sdp-api/src/db/repositories/payment-requests.repository.ts
@@ -103,6 +103,7 @@ export interface PaymentRequestsRepository {
   storeSponsoredTransactionSignature(params: {
     requestId: string;
     account: string;
+    unsignedTransaction: string;
     signedTransaction: string;
   }): Promise<void>;
   listPaymentRequests(params: ListPaymentRequestsInput): Promise<ListPaymentRequestsResult>;

--- a/apps/sdp-api/src/db/repositories/payment-requests.repository.ts
+++ b/apps/sdp-api/src/db/repositories/payment-requests.repository.ts
@@ -105,6 +105,6 @@ export interface PaymentRequestsRepository {
     account: string;
     unsignedTransaction: string;
     signedTransaction: string;
-  }): Promise<void>;
+  }): Promise<boolean>;
   listPaymentRequests(params: ListPaymentRequestsInput): Promise<ListPaymentRequestsResult>;
 }

--- a/apps/sdp-api/src/routes/pay.ts
+++ b/apps/sdp-api/src/routes/pay.ts
@@ -161,9 +161,10 @@ pay.post(
       });
       if (!stored) {
         const superseding = await repository.getSponsoredTransactionClaim(request.id);
+        const heightNow = await rpc.getBlockHeight({ commitment: "confirmed" }).send();
         if (
           superseding !== null &&
-          superseding.lastValidBlockHeight >= currentBlockHeight &&
+          superseding.lastValidBlockHeight >= heightNow &&
           superseding.account === payer &&
           superseding.signedTransaction !== null
         ) {

--- a/apps/sdp-api/src/routes/pay.ts
+++ b/apps/sdp-api/src/routes/pay.ts
@@ -156,6 +156,7 @@ pay.post(
       await repository.storeSponsoredTransactionSignature({
         requestId: request.id,
         account: payer,
+        unsignedTransaction: unsignedBase64,
         signedTransaction: signedBase64,
       });
       return respondWithClaim(signedBase64);

--- a/apps/sdp-api/src/routes/pay.ts
+++ b/apps/sdp-api/src/routes/pay.ts
@@ -153,12 +153,24 @@ pay.post(
       const unsignedBytes = new Uint8Array(getBase64Encoder().encode(unsignedBase64));
       const sponsored = await feePayment.signAsFeePayer(unsignedBytes);
       const signedBase64 = getBase64Decoder().decode(sponsored);
-      await repository.storeSponsoredTransactionSignature({
+      const stored = await repository.storeSponsoredTransactionSignature({
         requestId: request.id,
         account: payer,
         unsignedTransaction: unsignedBase64,
         signedTransaction: signedBase64,
       });
+      if (!stored) {
+        const superseding = await repository.getSponsoredTransactionClaim(request.id);
+        if (
+          superseding !== null &&
+          superseding.lastValidBlockHeight >= currentBlockHeight &&
+          superseding.account === payer &&
+          superseding.signedTransaction !== null
+        ) {
+          return respondWithClaim(superseding.signedTransaction);
+        }
+        throw rateLimited("This payment request's sponsored transaction was superseded; retry");
+      }
       return respondWithClaim(signedBase64);
     };
 


### PR DESCRIPTION
Follow-up to #1744, addressing https://github.com/solana-foundation/solana-developer-platform/pull/1744#discussion_r3980965150 which landed after the merge.

The sponsored-transaction signature store guarded on the claiming account alone. A request racing across a window boundary could therefore sign the previous window's bytes and store them under the same payer's fresh claim, after which every same-account retry for the rest of the window received a transaction whose blockhash was already dead.

The store now also matches the exact unsigned bytes the signature was produced from, so a stale write finds no row and the fresh claim keeps waiting for its own signature. The cached-signature column stays: without it every same-payer rescan would cost a signer call, and the per-token limiter was removed with the counter design.

A regression test replays the exact race: a signature for superseded bytes is refused, a signature for the live bytes lands.