### PR TITLE
ci(web): build the stage dashboard from main

### DIFF
--- a/apps/sdp-web/vercel.json
+++ b/apps/sdp-web/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "sh -c '[ \"$VERCEL_GIT_COMMIT_REF\" = main ] || exit 1; [ \"$VERCEL_GIT_COMMIT_AUTHOR_LOGIN\" = \"sdp-release-bot[bot]\" ] && exit 1; exit 0'"
+  "ignoreCommand": "sh -c '[ \"$VERCEL_TARGET_ENV\" = stage ] && exit 1; [ \"$VERCEL_GIT_COMMIT_REF\" = main ] || exit 1; [ \"$VERCEL_GIT_COMMIT_AUTHOR_LOGIN\" = \"sdp-release-bot[bot]\" ] && exit 1; exit 0'"
 }

--- a/scripts/release-production-workflows.test.mjs
+++ b/scripts/release-production-workflows.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
@@ -47,4 +48,63 @@ test("the web ignore command gates production builds on the release bot", () => 
   assert.match(gate, /"\$VERCEL_GIT_COMMIT_AUTHOR_LOGIN" = "sdp-release-bot\[bot\]" \] && exit 1/);
   assert.match(gate, /exit 0'$/);
   assert.doesNotMatch(releaseWorkflow, /deploy-web-production:/);
+});
+
+test("the web ignore command builds the right environments", () => {
+  const gate = webVercelConfig.ignoreCommand;
+  const BUILDS = 1;
+  const SKIPS = 0;
+
+  const cases = [
+    {
+      name: "stage build of a main merge",
+      env: {
+        VERCEL_TARGET_ENV: "stage",
+        VERCEL_GIT_COMMIT_REF: "main",
+        VERCEL_GIT_COMMIT_AUTHOR_LOGIN: "a-human",
+      },
+      expected: BUILDS,
+    },
+    {
+      name: "production build of a non-release main commit",
+      env: {
+        VERCEL_TARGET_ENV: "production",
+        VERCEL_GIT_COMMIT_REF: "main",
+        VERCEL_GIT_COMMIT_AUTHOR_LOGIN: "a-human",
+      },
+      expected: SKIPS,
+    },
+    {
+      name: "production build of a release-bot commit",
+      env: {
+        VERCEL_TARGET_ENV: "production",
+        VERCEL_GIT_COMMIT_REF: "main",
+        VERCEL_GIT_COMMIT_AUTHOR_LOGIN: "sdp-release-bot[bot]",
+      },
+      expected: BUILDS,
+    },
+    {
+      name: "preview build of a feature branch",
+      env: {
+        VERCEL_TARGET_ENV: "preview",
+        VERCEL_GIT_COMMIT_REF: "feature/x",
+        VERCEL_GIT_COMMIT_AUTHOR_LOGIN: "a-human",
+      },
+      expected: BUILDS,
+    },
+    {
+      name: "dev-environment build of the release branch",
+      env: {
+        VERCEL_TARGET_ENV: "dev",
+        VERCEL_GIT_COMMIT_REF: "sdp/release-main",
+        VERCEL_GIT_COMMIT_AUTHOR_LOGIN: "a-human",
+      },
+      expected: BUILDS,
+    },
+  ];
+
+  for (const { name, env, expected } of cases) {
+    const result = spawnSync(gate, { shell: true, env: { PATH: process.env.PATH, ...env } });
+    assert.equal(result.status, expected, name);
+  }
 });


### PR DESCRIPTION
- The Vercel ignore command now lets a `main` commit build when the target is the `stage` custom environment, so `app-preview.solana.com` tracks every merge instead of a hand-pushed branch; production stays release-bot-gated exactly as before.
- Paired Vercel-side changes (already applied via API): the stage custom environment's branch matcher moved from `web-stage` to `main`, and the dev environment's matcher narrowed from `endsWith main` to `equals sdp/release-main` (the only branch it serves) to avoid claiming `main`.

**before** — stage dashboard drifts:

1. Merge to main → GCP stage API deploys and the smoke runs
2. The smoke drives `app-preview.solana.com`, which serves the last manual push of `web-stage` (already 2 commits behind main after one day)
3. The gate vouches for a dashboard build no release would ship

**after** — stage dashboard tracks main:

1. Merge to main → Vercel builds the dashboard in the stage environment (ignore command exits 1 for `VERCEL_TARGET_ENV=stage`)
2. Non-release main commits are still skipped for production and previews (unchanged clauses)
3. The smoke tests the same web code a release would promote; `web-stage` can be deleted

**Verification**

- `sh` evaluation of the ignore command for the four cases: stage/main → build, production/main non-bot → skip, production/main release-bot → build, preview/feature-branch → build
- Vercel API confirms both matcher changes (`stage: equals main`, `dev: equals sdp/release-main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
