### PR TITLE
feat(issuance): meter the RPC-heavy prepare and supply-refresh routes

### DIFF
--- a/apps/sdp-api/src/routes/issuance-metered-quota.test.ts
+++ b/apps/sdp-api/src/routes/issuance-metered-quota.test.ts
@@ -1,0 +1,115 @@
+import { hashString } from "@sdp/payments/hash";
+import { beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import app from "@/index";
+import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
+import {
+  TEST_ACTIVE_TOKEN,
+  TEST_PROJECT,
+  TEST_PROJECT_API_KEY,
+  TEST_PROJECT_CACHED_KEY,
+} from "@/test/fixtures/tokens";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import {
+  clearKVStores,
+  readRateLimitCount,
+  seedCachedApiKey,
+  seedRateLimit,
+} from "@/test/mocks/kv";
+
+const SUPPLY_ACTOR_COUNTER = `metered:issuance-supply:org:${TEST_ORG.id}:key:${TEST_PROJECT_API_KEY.id}`;
+const PREPARE_ACTOR_COUNTER = `metered:issuance-prepare:org:${TEST_ORG.id}:key:${TEST_PROJECT_API_KEY.id}`;
+
+describe("Issuance routes — metered quota", () => {
+  beforeEach(async () => {
+    await seedTestDatabase(env as Parameters<typeof seedTestDatabase>[0]);
+    await clearKVStores(env);
+    const keyHash = await hashString(TEST_PROJECT_API_KEY.raw, env.API_KEY_PEPPER);
+    await seedCachedApiKey(env, keyHash, TEST_PROJECT_CACHED_KEY);
+
+    const db = getDb(env);
+    await db
+      .prepare(
+        "INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active') ON CONFLICT (id) DO NOTHING"
+      )
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
+      .run();
+    await db
+      .prepare(
+        "INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active') ON CONFLICT (id) DO NOTHING"
+      )
+      .bind(TEST_USER.id, TEST_USER.email)
+      .run();
+    await db
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, 'Quota Project', ?, 'sandbox', 'active', ?) ON CONFLICT (id) DO NOTHING`
+      )
+      .bind(TEST_PROJECT.id, TEST_ORG.id, TEST_PROJECT.slug, TEST_USER.id)
+      .run();
+  });
+
+  it("does not charge quota counters for callers the permission gate rejects", async () => {
+    const keyHash = await hashString("sk_test_quota_readonly", env.API_KEY_PEPPER);
+    await seedCachedApiKey(env, keyHash, {
+      ...TEST_PROJECT_CACHED_KEY,
+      id: "key_quota_readonly",
+      role: "api_readonly",
+      permissions: ["payments:read"],
+    });
+
+    const res = await app.request(
+      `/v1/issuance/tokens/${TEST_ACTIVE_TOKEN.id}/supply/refresh`,
+      {
+        method: "POST",
+        headers: { Authorization: "Bearer sk_test_quota_readonly" },
+      },
+      env
+    );
+
+    expect(res.status).toBe(403);
+    expect(
+      await readRateLimitCount(
+        env,
+        `metered:issuance-supply:org:${TEST_ORG.id}:key:key_quota_readonly`
+      )
+    ).toBe(0);
+  });
+
+  it("429s a supply refresh once the actor quota is exhausted", async () => {
+    await seedRateLimit(env, SUPPLY_ACTOR_COUNTER, 120);
+
+    const res = await app.request(
+      `/v1/issuance/tokens/${TEST_ACTIVE_TOKEN.id}/supply/refresh`,
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
+      },
+      env
+    );
+
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("RATE_LIMITED");
+  });
+
+  it("429s a mint prepare once the actor quota is exhausted", async () => {
+    await seedRateLimit(env, PREPARE_ACTOR_COUNTER, 120);
+
+    const res = await app.request(
+      `/v1/issuance/tokens/${TEST_ACTIVE_TOKEN.id}/mint/prepare`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+        },
+        body: JSON.stringify({ mint: { destination: TEST_ACTIVE_TOKEN.mintAddress, amount: "1" } }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(429);
+  });
+});

--- a/apps/sdp-api/src/routes/issuance-metered-quota.test.ts
+++ b/apps/sdp-api/src/routes/issuance-metered-quota.test.ts
@@ -2,6 +2,7 @@ import { hashString } from "@sdp/payments/hash";
 import { beforeEach, describe, expect, it } from "vitest";
 import { getDb } from "@/db";
 import app from "@/index";
+import { ISSUANCE_PREPARE_QUOTA, ISSUANCE_SUPPLY_QUOTA } from "@/routes/issuance";
 import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
 import {
   TEST_ACTIVE_TOKEN,
@@ -18,8 +19,8 @@ import {
   seedRateLimit,
 } from "@/test/mocks/kv";
 
-const SUPPLY_ACTOR_COUNTER = `metered:issuance-supply:org:${TEST_ORG.id}:key:${TEST_PROJECT_API_KEY.id}`;
-const PREPARE_ACTOR_COUNTER = `metered:issuance-prepare:org:${TEST_ORG.id}:key:${TEST_PROJECT_API_KEY.id}`;
+const SUPPLY_ACTOR_COUNTER = `metered:${ISSUANCE_SUPPLY_QUOTA.name}:org:${TEST_ORG.id}:key:${TEST_PROJECT_API_KEY.id}`;
+const PREPARE_ACTOR_COUNTER = `metered:${ISSUANCE_PREPARE_QUOTA.name}:org:${TEST_ORG.id}:key:${TEST_PROJECT_API_KEY.id}`;
 
 describe("Issuance routes — metered quota", () => {
   beforeEach(async () => {
@@ -78,7 +79,7 @@ describe("Issuance routes — metered quota", () => {
   });
 
   it("429s a supply refresh once the actor quota is exhausted", async () => {
-    await seedRateLimit(env, SUPPLY_ACTOR_COUNTER, 120);
+    await seedRateLimit(env, SUPPLY_ACTOR_COUNTER, ISSUANCE_SUPPLY_QUOTA.actorMax);
 
     const res = await app.request(
       `/v1/issuance/tokens/${TEST_ACTIVE_TOKEN.id}/supply/refresh`,
@@ -95,7 +96,7 @@ describe("Issuance routes — metered quota", () => {
   });
 
   it("429s a mint prepare once the actor quota is exhausted", async () => {
-    await seedRateLimit(env, PREPARE_ACTOR_COUNTER, 120);
+    await seedRateLimit(env, PREPARE_ACTOR_COUNTER, ISSUANCE_PREPARE_QUOTA.actorMax);
 
     const res = await app.request(
       `/v1/issuance/tokens/${TEST_ACTIVE_TOKEN.id}/mint/prepare`,

--- a/apps/sdp-api/src/routes/issuance/index.ts
+++ b/apps/sdp-api/src/routes/issuance/index.ts
@@ -3,6 +3,7 @@ import { runWithSystemDatabaseIdentity } from "@/db";
 import { AppError } from "@/lib/errors";
 import { isAssetProfilesEnabled } from "@/lib/feature-flags";
 import { requirePermissions, unifiedAuthMiddleware } from "@/middleware/auth";
+import { meteredQuota } from "@/middleware/metered-quota";
 import { policyGate } from "@/middleware/policy-gate";
 import { projectContextMiddleware } from "@/middleware/project-context";
 import { validateBody } from "@/middleware/validate";
@@ -123,6 +124,7 @@ issuance.get("/tokens/:tokenId/audit", requirePermissions("tokens:read"), getAss
 issuance.post(
   "/tokens/:tokenId/supply/refresh",
   requirePermissions("tokens:read"),
+  meteredQuota({ name: "issuance-supply", actorMax: 10, orgMax: 40 }),
   refreshTokenSupply
 );
 issuance.patch(
@@ -143,6 +145,7 @@ issuance.post(
   "/tokens/:tokenId/deploy/prepare",
   requirePermissions("tokens:write"),
   validateBody(legacyDeployTokenSchema),
+  meteredQuota({ name: "issuance-prepare", actorMax: 30, orgMax: 120 }),
   prepareDeploy
 );
 // Confirmation step for the non-custodial deploy flow: records the mint after
@@ -161,6 +164,7 @@ issuance.post(
   "/tokens/:tokenId/deploy/prepare-metadata",
   requirePermissions("tokens:write"),
   validateBody(legacyDeployTokenSchema),
+  meteredQuota({ name: "issuance-prepare", actorMax: 30, orgMax: 120 }),
   prepareDeployMetadata
 );
 
@@ -169,6 +173,7 @@ issuance.post(
   "/tokens/:tokenId/mint/prepare",
   requirePermissions("tokens:write"),
   validateBody(mintSchema),
+  meteredQuota({ name: "issuance-prepare", actorMax: 30, orgMax: 120 }),
   prepareMint
 );
 issuance.post(
@@ -188,6 +193,7 @@ issuance.post(
   "/tokens/:tokenId/burn/prepare",
   requirePermissions("tokens:write"),
   validateBody(burnSchema),
+  meteredQuota({ name: "issuance-prepare", actorMax: 30, orgMax: 120 }),
   prepareBurn
 );
 issuance.post(
@@ -203,6 +209,7 @@ issuance.post(
   "/tokens/:tokenId/seize/prepare",
   requirePermissions("tokens:admin"),
   validateBody(seizeSchema),
+  meteredQuota({ name: "issuance-prepare", actorMax: 30, orgMax: 120 }),
   prepareSeize
 );
 issuance.post(
@@ -218,6 +225,7 @@ issuance.post(
   "/tokens/:tokenId/force-burn/prepare",
   requirePermissions("tokens:admin"),
   validateBody(forceBurnSchema),
+  meteredQuota({ name: "issuance-prepare", actorMax: 30, orgMax: 120 }),
   prepareForceBurn
 );
 issuance.post(
@@ -233,6 +241,7 @@ issuance.post(
   "/tokens/:tokenId/authority/prepare",
   requirePermissions("tokens:admin"),
   validateBody(updateAuthoritySchema),
+  meteredQuota({ name: "issuance-prepare", actorMax: 30, orgMax: 120 }),
   prepareUpdateAuthority
 );
 issuance.post(

--- a/apps/sdp-api/src/routes/issuance/index.ts
+++ b/apps/sdp-api/src/routes/issuance/index.ts
@@ -83,6 +83,9 @@ import {
   updateTokenSchema,
 } from "./schemas";
 
+export const ISSUANCE_SUPPLY_QUOTA = { name: "issuance-supply", actorMax: 10, orgMax: 40 };
+export const ISSUANCE_PREPARE_QUOTA = { name: "issuance-prepare", actorMax: 30, orgMax: 120 };
+
 const issuance = new Hono<{ Bindings: Env }>();
 
 // Public: SDP-hosted token metadata JSON. Registered BEFORE the auth middleware
@@ -124,7 +127,7 @@ issuance.get("/tokens/:tokenId/audit", requirePermissions("tokens:read"), getAss
 issuance.post(
   "/tokens/:tokenId/supply/refresh",
   requirePermissions("tokens:read"),
-  meteredQuota({ name: "issuance-supply", actorMax: 10, orgMax: 40 }),
+  meteredQuota(ISSUANCE_SUPPLY_QUOTA),
   refreshTokenSupply
 );
 issuance.patch(
@@ -145,7 +148,7 @@ issuance.post(
   "/tokens/:tokenId/deploy/prepare",
   requirePermissions("tokens:write"),
   validateBody(legacyDeployTokenSchema),
-  meteredQuota({ name: "issuance-prepare", actorMax: 30, orgMax: 120 }),
+  meteredQuota(ISSUANCE_PREPARE_QUOTA),
   prepareDeploy
 );
 // Confirmation step for the non-custodial deploy flow: records the mint after
@@ -164,7 +167,7 @@ issuance.post(
   "/tokens/:tokenId/deploy/prepare-metadata",
   requirePermissions("tokens:write"),
   validateBody(legacyDeployTokenSchema),
-  meteredQuota({ name: "issuance-prepare", actorMax: 30, orgMax: 120 }),
+  meteredQuota(ISSUANCE_PREPARE_QUOTA),
   prepareDeployMetadata
 );
 
@@ -173,7 +176,7 @@ issuance.post(
   "/tokens/:tokenId/mint/prepare",
   requirePermissions("tokens:write"),
   validateBody(mintSchema),
-  meteredQuota({ name: "issuance-prepare", actorMax: 30, orgMax: 120 }),
+  meteredQuota(ISSUANCE_PREPARE_QUOTA),
   prepareMint
 );
 issuance.post(
@@ -193,7 +196,7 @@ issuance.post(
   "/tokens/:tokenId/burn/prepare",
   requirePermissions("tokens:write"),
   validateBody(burnSchema),
-  meteredQuota({ name: "issuance-prepare", actorMax: 30, orgMax: 120 }),
+  meteredQuota(ISSUANCE_PREPARE_QUOTA),
   prepareBurn
 );
 issuance.post(
@@ -209,7 +212,7 @@ issuance.post(
   "/tokens/:tokenId/seize/prepare",
   requirePermissions("tokens:admin"),
   validateBody(seizeSchema),
-  meteredQuota({ name: "issuance-prepare", actorMax: 30, orgMax: 120 }),
+  meteredQuota(ISSUANCE_PREPARE_QUOTA),
   prepareSeize
 );
 issuance.post(
@@ -225,7 +228,7 @@ issuance.post(
   "/tokens/:tokenId/force-burn/prepare",
   requirePermissions("tokens:admin"),
   validateBody(forceBurnSchema),
-  meteredQuota({ name: "issuance-prepare", actorMax: 30, orgMax: 120 }),
+  meteredQuota(ISSUANCE_PREPARE_QUOTA),
   prepareForceBurn
 );
 issuance.post(
@@ -241,7 +244,7 @@ issuance.post(
   "/tokens/:tokenId/authority/prepare",
   requirePermissions("tokens:admin"),
   validateBody(updateAuthoritySchema),
-  meteredQuota({ name: "issuance-prepare", actorMax: 30, orgMax: 120 }),
+  meteredQuota(ISSUANCE_PREPARE_QUOTA),
   prepareUpdateAuthority
 );
 issuance.post(


### PR DESCRIPTION
The seven issuance prepare routes (deploy, deploy-metadata, mint, burn, seize, force-burn, authority) and the supply refresh build transactions and read the chain without spending sponsored fees, so neither the sponsorship budget nor any quota bounded them: a single key could fan out unbounded RPC and Mosaic work.

They now sit behind the same tenant- and actor-scoped metered quota the other paid route families already use (payments ramps, places, earn, compliance, custody), with the middleware mounted in the same position: after the permission gate, so a rejected caller charges no counter. Prepare routes share one issuance-prepare pool at 30 per actor / 120 per organization per window; the heavier supply refresh gets its own issuance-supply pool at 10 / 40.

The dvp, private-channels and helius-rings families are also unmetered but are feature-flagged off in production; metering them is deliberately left to a follow-up so this change stays within the surface that is live.

Tests cover a 429 on the exhausted actor pool for both a prepare route and the supply refresh, and that a permission-rejected caller charges no counter.