### PR TITLE
feat(helius-rings): add retry provision for pending private wallets

### DIFF
--- a/apps/sdp-web/messages/en/dashboard-helius-rings.json
+++ b/apps/sdp-web/messages/en/dashboard-helius-rings.json
@@ -87,6 +87,7 @@
       "createWalletPlaceholder": "Select a custody wallet",
       "creating": "Provisioning…",
       "createFailed": "The wallet could not be created. Check the details and try again.",
+      "retry": "Retry provision",
       "noCustodyWallets": "No custody wallets available. Create a wallet under Wallets first.",
       "allCustodyWalletsBound": "Every custody wallet already backs a private wallet.",
       "copyShieldedAddress": "Copy shielded address",

--- a/apps/sdp-web/src/app/dashboard/helius-rings/private-wallets-card.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/private-wallets-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Check, Copy } from "lucide-react";
-import { useCallback, useMemo, useState, type MouseEvent } from "react";
+import { type MouseEvent, useCallback, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Callout } from "@/components/ui/callout";

--- a/apps/sdp-web/src/app/dashboard/helius-rings/private-wallets-card.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/private-wallets-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Check, Copy } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, type MouseEvent } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Callout } from "@/components/ui/callout";
@@ -202,6 +202,67 @@ export function PrivateWalletsCard({
   );
 }
 
+/**
+ * Replays POST /wallets for a pending row. Create is idempotent on the bound
+ * custody wallet, so this is how a failed registration (empty owner balance,
+ * simulation reject) is retried after the owner is funded. The create form
+ * cannot do it: a pending row already holds the slot.
+ */
+function RetryProvisionButton({
+  wallet,
+  onRetried,
+}: {
+  wallet: RingsWallet;
+  onRetried: () => Promise<void>;
+}) {
+  const t = useTranslations();
+  const [retrying, setRetrying] = useState(false);
+  const [retryError, setRetryError] = useState<string | null>(null);
+
+  const handleRetry = useCallback(
+    async (event: MouseEvent) => {
+      event.stopPropagation();
+      setRetrying(true);
+      setRetryError(null);
+      try {
+        const result = await createRingsWallet({
+          walletId: wallet.sdpWalletId,
+          name: wallet.name,
+        });
+        if (!result.wallet) {
+          setRetryError(result.error ?? t("DashboardHeliusRings.wallets.createFailed"));
+        }
+      } catch {
+        setRetryError(t("DashboardHeliusRings.wallets.createFailed"));
+      } finally {
+        setRetrying(false);
+      }
+      await onRetried();
+    },
+    [wallet.sdpWalletId, wallet.name, onRetried, t]
+  );
+
+  return (
+    <div className="flex flex-col items-start gap-1.5">
+      <Button
+        variant="secondary"
+        size="sm"
+        disabled={retrying}
+        onClick={(event) => void handleRetry(event)}
+      >
+        {t(
+          retrying ? "DashboardHeliusRings.wallets.creating" : "DashboardHeliusRings.wallets.retry"
+        )}
+      </Button>
+      {retryError ? (
+        <Callout variant="danger" live>
+          {retryError}
+        </Callout>
+      ) : null}
+    </div>
+  );
+}
+
 function PrivateWalletRow({
   wallet,
   selected,
@@ -239,6 +300,9 @@ function PrivateWalletRow({
             {/* Paused counts as well as pending: a re-key claims the row before
                 it rotates, so a failed rotation leaves a wallet paused with no
                 address, and this check is where an operator sees why. */}
+            {wallet.status === "pending" ? (
+              <RetryProvisionButton wallet={wallet} onRetried={onWalletsChanged} />
+            ) : null}
             {wallet.status === "pending" || wallet.status === "paused" ? (
               <WalletIdentityCheck wallet={wallet} onRekeyed={onWalletsChanged} />
             ) : null}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/private-wallets-card.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/private-wallets-card.unit.test.tsx
@@ -132,7 +132,7 @@ describe("PrivateWalletsCard retry provision", () => {
 
     await userEvent.setup().click(retryButton());
 
-    expect(await screen.findByRole("alert")).toHaveTextContent("owner unfunded");
+    expect((await screen.findByRole("alert")).textContent).toContain("owner unfunded");
     await waitFor(() => expect(onWalletsChanged).toHaveBeenCalledTimes(1));
     expect(retryButton().disabled).toBe(false);
   });

--- a/apps/sdp-web/src/app/dashboard/helius-rings/private-wallets-card.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/private-wallets-card.unit.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getMessages } from "@/i18n/messages";
+import { I18nProvider } from "@/i18n/provider";
+import type { RingsWallet } from "./helius-rings.data";
+import { PrivateWalletsCard } from "./private-wallets-card";
+
+const mocks = vi.hoisted(() => ({ createRingsWallet: vi.fn() }));
+
+vi.mock("./helius-rings.data", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./helius-rings.data")>()),
+  createRingsWallet: mocks.createRingsWallet,
+}));
+
+vi.mock("./wallet-identity-check", () => ({
+  WalletIdentityCheck: () => null,
+}));
+
+vi.mock("./shielded-balance-card", () => ({
+  ShieldedBalanceCard: () => null,
+}));
+
+const PENDING: RingsWallet = {
+  id: "hrw_pending",
+  sdpWalletId: "wal_pending",
+  name: "Treasury",
+  shieldedAddress: null,
+  status: "pending",
+  network: "devnet",
+};
+
+const PAUSED: RingsWallet = {
+  id: "hrw_paused",
+  sdpWalletId: "wal_paused",
+  name: "Payroll",
+  shieldedAddress: null,
+  status: "paused",
+  network: "devnet",
+};
+
+const READY: RingsWallet = {
+  id: "hrw_ready",
+  sdpWalletId: "wal_ready",
+  name: "Ops",
+  shieldedAddress: "rings1ops",
+  status: "ready",
+  network: "devnet",
+};
+
+const CUSTODY = [
+  { walletId: "wal_pending", label: "Treasury custody", publicKey: "Pending111" },
+  { walletId: "wal_paused", label: "Payroll custody", publicKey: "Paused1111" },
+  { walletId: "wal_ready", label: "Ops custody", publicKey: "Ready11111" },
+];
+
+function renderCard(wallets: readonly RingsWallet[], onWalletsChanged = vi.fn(async () => {})) {
+  render(
+    <I18nProvider locale="en" messages={getMessages("en")}>
+      <PrivateWalletsCard
+        wallets={wallets}
+        custodyWallets={CUSTODY}
+        availableCustodyWallets={[]}
+        selectedWalletId={null}
+        onSelect={vi.fn()}
+        balancesTick={0}
+        onWalletsChanged={onWalletsChanged}
+      />
+    </I18nProvider>
+  );
+  return { onWalletsChanged };
+}
+
+function retryButton(): HTMLButtonElement {
+  return screen.getByRole("button", { name: /^(Retry provision|Provisioning…)$/ });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(cleanup);
+
+describe("PrivateWalletsCard retry provision", () => {
+  it("offers retry only on a pending row with no shielded address", () => {
+    renderCard([PENDING, PAUSED, READY]);
+
+    expect(screen.getAllByRole("button", { name: "Retry provision" })).toHaveLength(1);
+    expect(mocks.createRingsWallet).not.toHaveBeenCalled();
+  });
+
+  it("announces the replay in flight and blocks a second click", async () => {
+    let settle: ((result: { wallet: RingsWallet }) => void) | undefined;
+    mocks.createRingsWallet.mockReturnValue(
+      new Promise<{ wallet: RingsWallet }>((resolve) => {
+        settle = resolve;
+      })
+    );
+    renderCard([PENDING]);
+
+    await userEvent.setup().click(retryButton());
+
+    expect(retryButton().textContent).toBe("Provisioning…");
+    expect(retryButton().disabled).toBe(true);
+    expect(mocks.createRingsWallet).toHaveBeenCalledTimes(1);
+
+    settle?.({ wallet: { ...PENDING, status: "ready", shieldedAddress: "rings1treasury" } });
+    expect(await screen.findByRole("button", { name: "Retry provision" })).toBeTruthy();
+    expect(retryButton().disabled).toBe(false);
+  });
+
+  it("replays create on the bound custody wallet and refreshes after success", async () => {
+    const ready = { ...PENDING, status: "ready" as const, shieldedAddress: "rings1treasury" };
+    mocks.createRingsWallet.mockResolvedValue({ wallet: ready });
+    const { onWalletsChanged } = renderCard([PENDING]);
+
+    await userEvent.setup().click(retryButton());
+
+    expect(mocks.createRingsWallet).toHaveBeenCalledExactlyOnceWith({
+      walletId: PENDING.sdpWalletId,
+      name: PENDING.name,
+    });
+    await waitFor(() => expect(onWalletsChanged).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("shows the create error and still refreshes so the row can be retried", async () => {
+    mocks.createRingsWallet.mockResolvedValue({ error: "owner unfunded" });
+    const { onWalletsChanged } = renderCard([PENDING]);
+
+    await userEvent.setup().click(retryButton());
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("owner unfunded");
+    await waitFor(() => expect(onWalletsChanged).toHaveBeenCalledTimes(1));
+    expect(retryButton().disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds a Retry provision button on pending private wallets so a failed registration can be retried.


Made with [Cursor](https://cursor.com)