### PR TITLE
fix(api): classify literal-address hosts in the egress guard and at endpoint submission

### DIFF
--- a/apps/sdp-api/src/openapi/schemas/projects.ts
+++ b/apps/sdp-api/src/openapi/schemas/projects.ts
@@ -1,6 +1,7 @@
 import { PROJECT_RPC_PROVIDERS } from "@sdp/types";
 import {
   addMemberSchema as addMemberSchemaBase,
+  projectRpcEndpointSchema,
   updateMemberSchema as updateMemberSchemaBase,
   updateProjectSchema as updateProjectSchemaBase,
 } from "../../routes/projects/schemas";
@@ -23,8 +24,9 @@ export const projectSettingsSchema = z
         "Preferred RPC provider for this project. Defaults to `default` (round-robin managed providers). Use `custom` with `rpcEndpoint` for a dedicated endpoint.",
       example: "default",
     }),
-    rpcEndpoint: z.string().url().optional().openapi({
-      description: "Custom Solana RPC endpoint for the project (used when rpcProvider=custom).",
+    rpcEndpoint: projectRpcEndpointSchema.optional().openapi({
+      description:
+        "Custom Solana RPC endpoint for the project (used when rpcProvider=custom). Must be https, without embedded credentials, and must not point at a private or reserved address.",
       example: "https://rpc.example.com",
     }),
     webhookUrl: z.string().url().optional().openapi({

--- a/apps/sdp-api/src/routes/projects/schemas.test.ts
+++ b/apps/sdp-api/src/routes/projects/schemas.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { updateProjectSchema } from "@/routes/projects/schemas";
+
+describe("updateProjectSchema settings.rpcEndpoint", () => {
+  const parse = (rpcEndpoint: string) =>
+    updateProjectSchema.safeParse({ settings: { rpcProvider: "custom", rpcEndpoint } });
+
+  it("accepts an ordinary https endpoint", () => {
+    expect(parse("https://rpc.example.com/abc").success).toBe(true);
+  });
+
+  it.each([
+    ["http://rpc.example.com/", "plaintext"],
+    ["https://169.254.169.254/latest/meta-data", "the metadata address"],
+    ["https://127.0.0.1:8899/", "loopback"],
+    ["https://10.0.0.5/", "a private range"],
+    ["https://[::1]/", "IPv6 loopback"],
+    ["https://vault.internal/", "an internal name"],
+    ["https://user:pass@rpc.example.com/", "embedded credentials"],
+  ])("refuses %s (%s)", (endpoint) => {
+    expect(parse(endpoint).success).toBe(false);
+  });
+
+  it("leaves an update without settings untouched", () => {
+    expect(updateProjectSchema.safeParse({ name: "Payments" }).success).toBe(true);
+  });
+});

--- a/apps/sdp-api/src/routes/projects/schemas.ts
+++ b/apps/sdp-api/src/routes/projects/schemas.ts
@@ -1,7 +1,27 @@
+import { assertReachableTenantEndpoint } from "@sdp/rpc/byok";
 import { PROJECT_RPC_PROVIDERS } from "@sdp/types";
 import { z } from "zod";
 
 const projectRpcProviderSchema = z.enum(PROJECT_RPC_PROVIDERS);
+
+/**
+ * The stored value is fetched by the relay and by `/v1/rpc/test`, so it faces
+ * the same submission rules as a BYOK connection endpoint: https, no embedded
+ * credentials, no host the egress guard would refuse to dial.
+ */
+export const projectRpcEndpointSchema = z
+  .string()
+  .max(2048)
+  .superRefine((value, ctx) => {
+    try {
+      assertReachableTenantEndpoint(value);
+    } catch (error) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: error instanceof Error ? error.message : "Invalid RPC endpoint",
+      });
+    }
+  });
 
 export const updateProjectSchema = z.object({
   name: z.string().min(1).max(100).optional(),
@@ -9,7 +29,7 @@ export const updateProjectSchema = z.object({
   settings: z
     .object({
       rpcProvider: projectRpcProviderSchema.optional(),
-      rpcEndpoint: z.string().url().optional(),
+      rpcEndpoint: projectRpcEndpointSchema.optional(),
       webhookUrl: z.string().url().optional(),
       metadata: z.record(z.string(), z.string()).optional(),
     })

--- a/apps/sdp-api/src/services/guarded-egress.test.ts
+++ b/apps/sdp-api/src/services/guarded-egress.test.ts
@@ -163,6 +163,90 @@ describe("guardedFetch", () => {
       guardedFetch("http://example.com/", { method: "POST", headers: {}, body: "{}" })
     ).rejects.toBeInstanceOf(EgressBlockedError);
   });
+
+  it("refuses a blocked IPv4 literal, which never reaches DNS", async () => {
+    // Node skips the lookup hook entirely when the host is written as an
+    // address, so the literal has to be classified before the socket opens.
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ result: "reached" }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    try {
+      await expect(
+        guardedFetch(`https://127.0.0.1:${port}/`, {
+          method: "POST",
+          headers: {},
+          body: "{}",
+        })
+      ).rejects.toBeInstanceOf(EgressBlockedError);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("refuses a blocked IPv6 literal", async () => {
+    await expect(
+      guardedFetch("https://[::1]:1/", { method: "POST", headers: {}, body: "{}" })
+    ).rejects.toBeInstanceOf(EgressBlockedError);
+  });
+
+  it("refuses a redirect that lands on a blocked literal", async () => {
+    const inner = createServer((_req, res) => {
+      res.writeHead(200);
+      res.end("reached");
+    });
+    await new Promise<void>((resolve) => inner.listen(0, "127.0.0.1", resolve));
+    const innerPort = (inner.address() as AddressInfo).port;
+
+    const outer = createServer((_req, res) => {
+      res.writeHead(307, { Location: `https://127.0.0.1:${innerPort}/` });
+      res.end();
+    });
+    await new Promise<void>((resolve) => outer.listen(0, "127.0.0.1", resolve));
+    const outerPort = (outer.address() as AddressInfo).port;
+
+    try {
+      // The first hop is operator-approved the way the Private Channels
+      // sandbox is; the Location it answers with is not, and faces the full
+      // check.
+      await expect(
+        guardedFetch(`http://127.0.0.1:${outerPort}/`, {
+          method: "POST",
+          headers: {},
+          body: "{}",
+          maxRedirects: 1,
+          approvedInsecureDestination: true,
+        })
+      ).rejects.toBeInstanceOf(EgressBlockedError);
+    } finally {
+      await new Promise<void>((resolve) => outer.close(() => resolve()));
+      await new Promise<void>((resolve) => inner.close(() => resolve()));
+    }
+  });
+
+  it("still dials an operator-approved loopback literal", async () => {
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ result: "reached" }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    try {
+      const response = await guardedFetch(`http://127.0.0.1:${port}/`, {
+        method: "POST",
+        headers: {},
+        body: "{}",
+        approvedInsecureDestination: true,
+      });
+      expect(response.status).toBe(200);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
 });
 
 describe("createGuardedFetch", () => {

--- a/apps/sdp-api/src/services/guarded-egress.test.ts
+++ b/apps/sdp-api/src/services/guarded-egress.test.ts
@@ -227,6 +227,30 @@ describe("guardedFetch", () => {
     }
   });
 
+  it("keeps the address check on an approved-plaintext destination", async () => {
+    // approvedPlaintextDestination relaxes only the protocol; the host still
+    // faces the full check, unlike approvedInsecureDestination.
+    const server = createServer((_req, res) => {
+      res.writeHead(200);
+      res.end("reached");
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    try {
+      await expect(
+        guardedFetch(`http://127.0.0.1:${port}/`, {
+          method: "POST",
+          headers: {},
+          body: "{}",
+          approvedPlaintextDestination: true,
+        })
+      ).rejects.toBeInstanceOf(EgressBlockedError);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   it("still dials an operator-approved loopback literal", async () => {
     const server = createServer((_req, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });

--- a/apps/sdp-api/src/services/guarded-egress.ts
+++ b/apps/sdp-api/src/services/guarded-egress.ts
@@ -19,7 +19,10 @@
 import { lookup as dnsLookup } from "node:dns";
 import { request as httpRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
-import type { LookupFunction } from "node:net";
+import { isIP, type LookupFunction } from "node:net";
+import { isBlockedAddress } from "@sdp/rpc/blocked-address";
+
+export { isBlockedAddress };
 
 export class EgressBlockedError extends Error {
   constructor(host: string) {
@@ -30,64 +33,6 @@ export class EgressBlockedError extends Error {
 
 /** Statuses the Response constructor refuses a body for. */
 const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
-
-function isBlockedIpv4(address: string): boolean {
-  const octets = address.split(".").map(Number);
-  if (octets.length !== 4 || octets.some((octet) => !Number.isInteger(octet) || octet < 0)) {
-    // Not a dotted quad we can reason about; refuse rather than guess.
-    return true;
-  }
-
-  const [a, b] = octets as [number, number, number, number];
-
-  if (a === 0 || a === 127) return true; // this host, loopback
-  if (a === 10) return true; // private
-  if (a === 172 && b >= 16 && b <= 31) return true; // private
-  if (a === 192 && b === 168) return true; // private
-  if (a === 169 && b === 254) return true; // link-local, including the metadata address
-  if (a === 100 && b >= 64 && b <= 127) return true; // carrier-grade NAT
-  if (a === 192 && b === 0) return true; // IETF protocol assignments
-  if (a === 198 && (b === 18 || b === 19)) return true; // benchmarking
-  if (a >= 224) return true; // multicast and reserved, 255.255.255.255 included
-
-  return false;
-}
-
-function isBlockedIpv6(address: string): boolean {
-  const host =
-    address
-      .toLowerCase()
-      .replace(/^\[|\]$/g, "")
-      .split("%")[0] ?? "";
-
-  // An IPv4-mapped address is an IPv4 destination wearing IPv6 notation, so it
-  // is classified as one. Node can hand this back in either spelling.
-  const mapped = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/.exec(host);
-  if (mapped?.[1]) {
-    return isBlockedIpv4(mapped[1]);
-  }
-  if (/^::ffff:[0-9a-f]{1,4}:[0-9a-f]{1,4}$/.test(host)) {
-    const parts = host.split(":");
-    const high = Number.parseInt(parts[3] ?? "", 16);
-    const low = Number.parseInt(parts[4] ?? "", 16);
-    if (Number.isInteger(high) && Number.isInteger(low)) {
-      return isBlockedIpv4([high >> 8, high & 0xff, low >> 8, low & 0xff].map(String).join("."));
-    }
-    return true;
-  }
-
-  if (host === "::" || host === "::1") return true; // unspecified, loopback
-  if (/^f[cd][0-9a-f]{2}:/.test(host)) return true; // unique local
-  if (/^fe[89ab][0-9a-f]:/.test(host)) return true; // link-local
-  if (/^ff[0-9a-f]{2}:/.test(host)) return true; // multicast
-
-  return false;
-}
-
-/** Whether SDP refuses to open a connection to this resolved address. */
-export function isBlockedAddress(address: string): boolean {
-  return address.includes(":") ? isBlockedIpv6(address) : isBlockedIpv4(address);
-}
 
 /**
  * A `dns.lookup` replacement that drops every blocked address before the
@@ -255,6 +200,13 @@ async function guardedRequest(target: URL, init: GuardedFetchInit): Promise<Resp
   // request still refuses redirects and still bounds what it reads back.
   const request = target.protocol === "http:" ? httpRequest : httpsRequest;
   const lookup = init.approvedInsecureDestination ? undefined : guardedLookup;
+
+  // A host written as an address never reaches the lookup hook — Node dials a
+  // literal directly — so it is classified here, before the socket exists.
+  const literalHost = target.hostname.replace(/^\[|\]$/g, "");
+  if (!init.approvedInsecureDestination && isIP(literalHost) && isBlockedAddress(literalHost)) {
+    throw new EgressBlockedError(target.hostname);
+  }
 
   return new Promise<Response>((resolve, reject) => {
     const req = request(

--- a/apps/sdp-api/src/services/rpc-byok-target.test.ts
+++ b/apps/sdp-api/src/services/rpc-byok-target.test.ts
@@ -187,6 +187,31 @@ describe("assertReachableTenantEndpoint", () => {
     expect(() => assertReachableTenantEndpoint("https://[2606:4700::1111]/rpc")).not.toThrow();
   });
 
+  it("refuses every range the connect-time guard refuses", () => {
+    // Write-time and connect-time classification must agree, or a row can
+    // exist that every relay call then rejects — or worse, the reverse.
+    for (const host of [
+      "https://100.64.0.1/rpc",
+      "https://198.18.0.1/rpc",
+      "https://192.0.0.170/rpc",
+      "https://224.0.0.1/rpc",
+      "https://255.255.255.255/rpc",
+      "https://0.1.2.3/rpc",
+      "https://[ff02::1]/rpc",
+    ]) {
+      expect(() => assertReachableTenantEndpoint(host)).toThrow(/not reachable/i);
+    }
+  });
+
+  it("refuses credentials embedded in the URL", () => {
+    expect(() => assertReachableTenantEndpoint("https://user:pass@rpc.example.com/")).toThrow(
+      /credential/i
+    );
+    expect(() => assertReachableTenantEndpoint("https://token@rpc.example.com/")).toThrow(
+      /credential/i
+    );
+  });
+
   it("refuses plaintext http", () => {
     expect(() => assertReachableTenantEndpoint("http://rpc.example.com")).toThrow(/https/i);
   });

--- a/packages/sdp-rpc/package.json
+++ b/packages/sdp-rpc/package.json
@@ -9,6 +9,11 @@
       "import": "./src/index.ts",
       "default": "./src/index.ts"
     },
+    "./blocked-address": {
+      "types": "./src/blocked-address.ts",
+      "import": "./src/blocked-address.ts",
+      "default": "./src/blocked-address.ts"
+    },
     "./byok": {
       "types": "./src/byok.ts",
       "import": "./src/byok.ts",

--- a/packages/sdp-rpc/src/blocked-address.ts
+++ b/packages/sdp-rpc/src/blocked-address.ts
@@ -1,0 +1,65 @@
+/**
+ * Address classification shared by the write-time endpoint check
+ * (`assertReachableTenantEndpoint`) and the connect-time egress guard in
+ * sdp-api. One list, so a URL that passes submission cannot name an address
+ * the transport then refuses, and the transport cannot dial one submission
+ * would have blocked.
+ */
+
+function isBlockedIpv4(address: string): boolean {
+  const octets = address.split(".").map(Number);
+  if (octets.length !== 4 || octets.some((octet) => !Number.isInteger(octet) || octet < 0)) {
+    // Not a dotted quad we can reason about; refuse rather than guess.
+    return true;
+  }
+
+  const [a, b] = octets as [number, number, number, number];
+
+  if (a === 0 || a === 127) return true; // this host, loopback
+  if (a === 10) return true; // private
+  if (a === 172 && b >= 16 && b <= 31) return true; // private
+  if (a === 192 && b === 168) return true; // private
+  if (a === 169 && b === 254) return true; // link-local, including the metadata address
+  if (a === 100 && b >= 64 && b <= 127) return true; // carrier-grade NAT
+  if (a === 192 && b === 0) return true; // IETF protocol assignments
+  if (a === 198 && (b === 18 || b === 19)) return true; // benchmarking
+  if (a >= 224) return true; // multicast and reserved, 255.255.255.255 included
+
+  return false;
+}
+
+function isBlockedIpv6(address: string): boolean {
+  const host =
+    address
+      .toLowerCase()
+      .replace(/^\[|\]$/g, "")
+      .split("%")[0] ?? "";
+
+  // An IPv4-mapped address is an IPv4 destination wearing IPv6 notation, so it
+  // is classified as one. Node can hand this back in either spelling.
+  const mapped = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/.exec(host);
+  if (mapped?.[1]) {
+    return isBlockedIpv4(mapped[1]);
+  }
+  if (/^::ffff:[0-9a-f]{1,4}:[0-9a-f]{1,4}$/.test(host)) {
+    const parts = host.split(":");
+    const high = Number.parseInt(parts[3] ?? "", 16);
+    const low = Number.parseInt(parts[4] ?? "", 16);
+    if (Number.isInteger(high) && Number.isInteger(low)) {
+      return isBlockedIpv4([high >> 8, high & 0xff, low >> 8, low & 0xff].map(String).join("."));
+    }
+    return true;
+  }
+
+  if (host === "::" || host === "::1") return true; // unspecified, loopback
+  if (/^f[cd][0-9a-f]{2}:/.test(host)) return true; // unique local
+  if (/^fe[89ab][0-9a-f]:/.test(host)) return true; // link-local
+  if (/^ff[0-9a-f]{2}:/.test(host)) return true; // multicast
+
+  return false;
+}
+
+/** Whether SDP refuses to open a connection to this address. */
+export function isBlockedAddress(address: string): boolean {
+  return address.includes(":") ? isBlockedIpv6(address) : isBlockedIpv4(address);
+}

--- a/packages/sdp-rpc/src/byok.ts
+++ b/packages/sdp-rpc/src/byok.ts
@@ -1,5 +1,7 @@
+import { isIP } from "node:net";
 import type { OrganizationRpcProvider } from "@sdp/types";
 import { rpcProviderNeedsEndpoint } from "@sdp/types";
+import { isBlockedAddress } from "./blocked-address";
 import {
   applyApiKeyTemplate,
   withAlchemyApiKey,
@@ -136,7 +138,8 @@ export function resolveTenantEndpoint(
  * status and timing. Blocking at submission keeps such a row from existing.
  *
  * Literal-address matching only: a hostname that resolves to a private address
- * still passes here, which is the deeper hardening HOO-1009 covers.
+ * still passes here and is caught at connect time by the egress guard, which
+ * shares the address classification in `blocked-address.ts`.
  */
 const BLOCKED_HOST_PATTERNS: RegExp[] = [
   /^localhost$/i,
@@ -206,6 +209,10 @@ export function assertReachableTenantEndpoint(endpointUrl: string): void {
     throw new SdpRpcError("BAD_REQUEST", "An RPC endpoint must use https");
   }
 
+  if (parsed.username || parsed.password) {
+    throw new SdpRpcError("BAD_REQUEST", "An RPC endpoint URL must not embed credentials");
+  }
+
   const { host, mappedIpv4 } = normalizeHost(parsed.hostname);
   const candidates = mappedIpv4 ? [host, mappedIpv4] : [host];
 
@@ -213,6 +220,10 @@ export function assertReachableTenantEndpoint(endpointUrl: string): void {
     BLOCKED_IPV6_PATTERNS.some((pattern) => pattern.test(host)) ||
     candidates.some((candidate) => BLOCKED_HOST_PATTERNS.some((pattern) => pattern.test(candidate)))
   ) {
+    throw new SdpRpcError("BAD_REQUEST", "That RPC endpoint host is not reachable from SDP");
+  }
+
+  if (candidates.some((candidate) => isIP(candidate) !== 0 && isBlockedAddress(candidate))) {
     throw new SdpRpcError("BAD_REQUEST", "That RPC endpoint host is not reachable from SDP");
   }
 }

--- a/packages/sdp-rpc/src/byok.ts
+++ b/packages/sdp-rpc/src/byok.ts
@@ -130,49 +130,23 @@ export function resolveTenantEndpoint(
 }
 
 /**
- * Hosts a tenant endpoint may never point at.
+ * Names a tenant endpoint may never point at.
  *
  * Activation and the relay both fetch whatever URL the tenant stored, so
  * without this a connection could aim SDP's server at loopback, a private
  * range, or a cloud metadata service and read back coarse reachability from the
  * status and timing. Blocking at submission keeps such a row from existing.
  *
- * Literal-address matching only: a hostname that resolves to a private address
- * still passes here and is caught at connect time by the egress guard, which
- * shares the address classification in `blocked-address.ts`.
+ * Name matching only: the URL parser canonicalises every literal-address
+ * spelling, and those go through `isBlockedAddress`, the same classification
+ * the egress guard applies at connect time. A hostname that resolves to a
+ * private address passes here and is caught by that guard instead.
  */
 const BLOCKED_HOST_PATTERNS: RegExp[] = [
   /^localhost$/i,
   /\.localhost$/i,
-  /^127\./,
-  /^0\./,
-  /^10\./,
-  /^192\.168\./,
-  /^172\.(1[6-9]|2\d|3[01])\./,
-  // 169.254.0.0/16 covers the 169.254.169.254 metadata address.
-  /^169\.254\./,
   /\.internal$/i,
   /\.local$/i,
-];
-
-/**
- * IPv6 literals, tested against the bracket-stripped host.
- *
- * `URL.hostname` returns an IPv6 literal still wrapped in brackets
- * (`https://[fd00::1]/` -> `"[fd00::1]"`), so a pattern anchored with `^fd`
- * silently matches nothing. Stripping first is what makes these anchors mean
- * what they read as.
- */
-const BLOCKED_IPV6_PATTERNS: RegExp[] = [
-  // Loopback, in the compressed form the URL parser always normalises to.
-  /^::1$/,
-  // Unspecified address: on many stacks a connect() to it reaches loopback.
-  /^::$/,
-  // fc00::/7 unique local. Exactly four hex digits: a shorter group such as
-  // `fd0:` is 0x0fd0, a different address that must not be caught here.
-  /^f[cd][0-9a-f]{2}:/i,
-  // fe80::/10 link local, which is where the IPv6 metadata endpoint lives.
-  /^fe[89ab][0-9a-f]:/i,
 ];
 
 /**
@@ -217,13 +191,12 @@ export function assertReachableTenantEndpoint(endpointUrl: string): void {
   const candidates = mappedIpv4 ? [host, mappedIpv4] : [host];
 
   if (
-    BLOCKED_IPV6_PATTERNS.some((pattern) => pattern.test(host)) ||
-    candidates.some((candidate) => BLOCKED_HOST_PATTERNS.some((pattern) => pattern.test(candidate)))
+    candidates.some(
+      (candidate) =>
+        BLOCKED_HOST_PATTERNS.some((pattern) => pattern.test(candidate)) ||
+        (isIP(candidate) !== 0 && isBlockedAddress(candidate))
+    )
   ) {
-    throw new SdpRpcError("BAD_REQUEST", "That RPC endpoint host is not reachable from SDP");
-  }
-
-  if (candidates.some((candidate) => isIP(candidate) !== 0 && isBlockedAddress(candidate))) {
     throw new SdpRpcError("BAD_REQUEST", "That RPC endpoint host is not reachable from SDP");
   }
 }


### PR DESCRIPTION
The connect-time egress guard filtered destinations through a custom DNS lookup, but Node never invokes that hook when the host is written as an address, so a literal host reached the socket without classification — on the first dial and on any redirect hop. `guardedRequest` now classifies a literal host before the socket opens, with the existing operator-approved destination semantics unchanged: `approvedInsecureDestination` still dials its configured origin, `approvedPlaintextDestination` relaxes only the protocol.

The address classification moves verbatim into `@sdp/rpc/blocked-address` so submission-time validation and the transport share one list. `assertReachableTenantEndpoint` now runs literal hosts through it (the URL parser canonicalises every literal spelling first), refuses credentials embedded in the URL, and keeps only the name-based patterns of its own. The same validation now applies to a project's `settings.rpcEndpoint`, which was previously accepted as any well-formed URL; stored rows are unaffected and remain subject to the connect-time guard.

Part of HOO-1009.

## Tests

- `guardedFetch` refuses blocked IPv4 and IPv6 literals and a redirect that lands on one; approved destinations keep their documented behaviour.
- Write-time validation agrees with the connect-time classifier across the reserved ranges, and rejects embedded credentials.
- `updateProjectSchema` accept/reject matrix for `settings.rpcEndpoint`.
- Full sdp-api suite: 5705 passed, 14 skipped.