### PR TITLE
fix(smoke): retry external smoke tests twice

### DIFF
--- a/apps/sdp-web/playwright.config.ts
+++ b/apps/sdp-web/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   testDir: "./playwright/tests",
   fullyParallel: false,
   forbidOnly: Boolean(process.env.CI),
-  retries: useExternalApi ? 2 : 0,
+  retries: 0,
   timeout: 180_000,
   workers: 1,
   reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : [["list"]],
@@ -86,6 +86,7 @@ export default defineConfig({
     {
       name: "auth-setup",
       testMatch: /auth\.global\.setup\.ts/,
+      retries: useExternalApi ? 2 : 0,
       use: {
         ...devices["Desktop Chrome"],
       },
@@ -125,6 +126,7 @@ export default defineConfig({
       name: "gcp-read-only",
       testMatch: /.*gcp-read-only.*\.e2e\.spec\.ts/,
       dependencies: ["auth-setup"],
+      retries: useExternalApi ? 2 : 0,
       use: {
         ...devices["Desktop Chrome"],
         storageState: authStatePath,

--- a/apps/sdp-web/playwright.config.ts
+++ b/apps/sdp-web/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   testDir: "./playwright/tests",
   fullyParallel: false,
   forbidOnly: Boolean(process.env.CI),
-  retries: 0,
+  retries: useExternalApi ? 2 : 0,
   timeout: 180_000,
   workers: 1,
   reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : [["list"]],


### PR DESCRIPTION
- The external GCP smoke (`PLAYWRIGHT_USE_EXTERNAL_API=1`) now retries a failed test up to twice; local Playwright runs keep `retries: 0`.

**before** — deployment swap aborts the gate:

1. Two merges land back to back; each triggers a stage dashboard build on Vercel
2. The first merge's smoke is mid-navigation when the second build goes READY and Vercel swaps `app-preview.solana.com`
3. `page.goto: net::ERR_ABORTED` fails one test and the whole gate goes red (run 34532232880, 2026-09-10 21:26Z)

**after** — transient aborts self-heal:

1. The aborted test retries on the freshly swapped deployment and passes
2. A genuinely broken stage still fails: three identical failures exhaust the retries
3. Local runs are unchanged, so real flakes in development stay loud

**Verification**

- `playwright test --project=gcp-read-only --list` in external mode — config resolves, 18 tests
- `playwright test --project=public --list` in local mode — config resolves, retries stay 0
- `biome check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
