### PR TITLE
ci: pass release inputs to deploy steps through the environment

### DIFF
--- a/.github/workflows/deploy-sdp-api-gcp-prod.yml
+++ b/.github/workflows/deploy-sdp-api-gcp-prod.yml
@@ -136,7 +136,10 @@ jobs:
 
       - name: Verify release identity
         if: ${{ inputs.release_sha != '' }}
-        run: .github/scripts/verify-release-identity.sh "${{ inputs.release_tag }}" "${{ inputs.release_sha }}"
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: .github/scripts/verify-release-identity.sh "${RELEASE_TAG}" "${RELEASE_SHA}"
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
@@ -168,6 +171,8 @@ jobs:
       - name: Verify and promote release image
         if: ${{ inputs.release_sha != '' }}
         timeout-minutes: 75
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
           SRC_BASE="ghcr.io/${{ github.repository_owner }}/sdp/sdp-api"
@@ -176,21 +181,21 @@ jobs:
           # before treating a missing tag or signature as a failure.
           SRC_DIGEST=""
           for attempt in $(seq 1 130); do
-            if SRC_DIGEST="$(crane digest "${SRC_BASE}:${{ inputs.release_tag }}" 2>/dev/null)"; then
+            if SRC_DIGEST="$(crane digest "${SRC_BASE}:${RELEASE_TAG}" 2>/dev/null)"; then
               break
             fi
             echo "release image tag not in GHCR yet (attempt ${attempt}/130); retrying in 30s"
             sleep 30
           done
           if [[ -z "${SRC_DIGEST}" ]]; then
-            echo "release image ${SRC_BASE}:${{ inputs.release_tag }} never appeared in GHCR." >&2
+            echo "release image ${SRC_BASE}:${RELEASE_TAG} never appeared in GHCR." >&2
             exit 1
           fi
           verified=""
           for attempt in $(seq 1 10); do
             if cosign verify "${SRC_BASE}@${SRC_DIGEST}" \
               --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-              --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/release-images.yml@refs/tags/${{ inputs.release_tag }}" \
+              --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/release-images.yml@refs/tags/${RELEASE_TAG}" \
               --certificate-github-workflow-sha "${DEPLOY_IMAGE_SHA}"; then
               verified=true
               break


### PR DESCRIPTION
The prod deploy workflow interpolated `release_tag` and `release_sha` directly into `run:` blocks. Both now reach the shell as step-level environment variables expanded under quoting, so the steps receive them as data regardless of content. Behaviour is otherwise unchanged: the same values feed the release-identity check, the GHCR digest wait loop, and the cosign certificate identity, and every `uses:` pin stays as it was.

Part of HOO-976 hardening follow-ups.

actionlint clean.