### PR TITLE
fix(api): deliver workflow webhooks through the guarded egress transport

### DIFF
--- a/apps/sdp-api/src/services/workflows/actions/webhook.test.ts
+++ b/apps/sdp-api/src/services/workflows/actions/webhook.test.ts
@@ -24,6 +24,33 @@ vi.mock("node:dns/promises", () => ({
       : [{ address: "93.184.216.34", family: 4 }],
 }));
 
+// The delivery transport is delegated to the test's fetch stub so delivery
+// behavior stays assertable without sockets; the transport's own rules
+// (connect-time address filtering, literal refusal) are asserted in
+// guarded-egress.test.ts. The recorder proves delivery goes through the
+// guard rather than a bare fetch.
+const guardedTransport = vi.hoisted(() => ({
+  calls: [] as Array<{ url: string; init: Record<string, unknown> }>,
+}));
+vi.mock("@/services/guarded-egress", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/guarded-egress")>();
+  return {
+    ...actual,
+    guardedFetch: (
+      url: string,
+      init: { method: string; headers: Record<string, string>; body: string; signal?: AbortSignal }
+    ) => {
+      guardedTransport.calls.push({ url, init: init as unknown as Record<string, unknown> });
+      return fetch(url, {
+        method: init.method,
+        headers: init.headers,
+        body: init.body,
+        signal: init.signal,
+      });
+    },
+  };
+});
+
 import { runSendWebhook } from "./webhook";
 
 const env = {} as Env;
@@ -56,6 +83,7 @@ function executionFixture(): WorkflowExecutionRow {
 describe("runSendWebhook", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    guardedTransport.calls.length = 0;
   });
 
   afterEach(() => {
@@ -132,6 +160,21 @@ describe("runSendWebhook", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(outcome).toMatchObject({ status: "failed", retryable: false });
     expect(String((outcome as { error: string }).error)).toContain("BLOCKED_URL");
+  });
+
+  it("delivers through the guarded egress transport with a bounded read", async () => {
+    // The pre-flight lookup is advisory; the transport is the boundary that
+    // holds when a DNS record flips between validation and connect.
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 200 })));
+
+    const outcome = await runSendWebhook(env, executionFixture(), {
+      params: { url: "https://example.com/hook" },
+    });
+
+    expect(outcome).toMatchObject({ status: "succeeded" });
+    expect(guardedTransport.calls).toHaveLength(1);
+    expect(guardedTransport.calls[0]?.url).toBe("https://example.com/hook");
+    expect(Number(guardedTransport.calls[0]?.init.maxResponseBytes)).toBeGreaterThan(0);
   });
 
   it("POSTs the trigger event and signs the body when a secret is set", async () => {

--- a/apps/sdp-api/src/services/workflows/actions/webhook.test.ts
+++ b/apps/sdp-api/src/services/workflows/actions/webhook.test.ts
@@ -177,6 +177,27 @@ describe("runSendWebhook", () => {
     expect(Number(guardedTransport.calls[0]?.init.maxResponseBytes)).toBeGreaterThan(0);
   });
 
+  it("fails permanently when the transport refuses the connection", async () => {
+    // A record that flips to a private address after the pre-flight lookup is
+    // refused by the transport; retrying re-runs the same refusal, so the
+    // failure must be permanent, exactly like a pre-flight block.
+    const { EgressBlockedError } = await import("@/services/guarded-egress");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new EgressBlockedError("rebound.example.net"))
+    );
+
+    const outcome = await runSendWebhook(env, executionFixture(), {
+      params: { url: "https://example.com/hook" },
+    });
+
+    expect(outcome).toMatchObject({
+      status: "failed",
+      retryable: false,
+      error: "BLOCKED_URL:PRIVATE_HOST",
+    });
+  });
+
   it("POSTs the trigger event and signs the body when a secret is set", async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
     vi.stubGlobal("fetch", fetchMock);

--- a/apps/sdp-api/src/services/workflows/actions/webhook.ts
+++ b/apps/sdp-api/src/services/workflows/actions/webhook.ts
@@ -1,5 +1,5 @@
 import type { WorkflowExecutionRow } from "@/db/repositories";
-import { guardedFetch } from "@/services/guarded-egress";
+import { EgressBlockedError, guardedFetch } from "@/services/guarded-egress";
 import type { Env } from "@/types/env";
 import { readActionSecret } from "../action-secret";
 import { resolveWebhookUrl } from "../webhook-url";
@@ -51,13 +51,23 @@ async function deliver(
     // The transport is the boundary: it resolves again at connect time, so a
     // record that flips between the check and the connection is still refused,
     // and its response is buffered under the cap, so no drain is needed.
-    const response = await guardedFetch(checked.url.toString(), {
-      method: init.method,
-      headers: init.headers,
-      body: init.body,
-      signal,
-      maxResponseBytes: MAX_RESPONSE_BYTES,
-    });
+    let response: Response;
+    try {
+      response = await guardedFetch(checked.url.toString(), {
+        method: init.method,
+        headers: init.headers,
+        body: init.body,
+        signal,
+        maxResponseBytes: MAX_RESPONSE_BYTES,
+      });
+    } catch (error) {
+      // The transport refusing the dialled address is the same condition as a
+      // pre-flight block — a retry re-runs the same refusal.
+      if (error instanceof EgressBlockedError) {
+        return { ok: false, result: permanentFail("BLOCKED_URL:PRIVATE_HOST") };
+      }
+      throw error;
+    }
     if (response.status < 300 || response.status >= 400) {
       return { ok: true, response };
     }

--- a/apps/sdp-api/src/services/workflows/actions/webhook.ts
+++ b/apps/sdp-api/src/services/workflows/actions/webhook.ts
@@ -1,4 +1,5 @@
 import type { WorkflowExecutionRow } from "@/db/repositories";
+import { guardedFetch } from "@/services/guarded-egress";
 import type { Env } from "@/types/env";
 import { readActionSecret } from "../action-secret";
 import { resolveWebhookUrl } from "../webhook-url";
@@ -9,6 +10,9 @@ const REQUEST_TIMEOUT_MS = 10_000;
 // Deliveries are one-shot POSTs; a chain of redirects is far more likely to be an
 // SSRF pivot than a real endpoint move, so we follow at most one and re-validate it.
 const MAX_REDIRECTS = 1;
+// The delivery reads nothing but the status; a receiver's body is buffered only to
+// release the socket, so it gets a hard cap.
+const MAX_RESPONSE_BYTES = 64 * 1024;
 const encoder = new TextEncoder();
 
 // HMAC-SHA256 hex signature over the payload — the outbound mirror of the inbound
@@ -32,7 +36,7 @@ async function signPayload(secret: string, payload: string): Promise<string> {
 // against the SSRF rules before we connect to it.
 async function deliver(
   target: string,
-  init: RequestInit,
+  init: { method: string; headers: Record<string, string>; body: string },
   signal: AbortSignal
 ): Promise<{ ok: true; response: Response } | { ok: false; result: ActionExecutionResult }> {
   let current = target;
@@ -43,13 +47,21 @@ async function deliver(
       // retrying re-runs the same lookup, so fail permanently.
       return { ok: false, result: permanentFail(`BLOCKED_URL:${checked.reason}`) };
     }
-    const response = await fetch(checked.url, { ...init, redirect: "manual", signal });
+    // The lookup above is advisory — it gives the issuer a readable rejection.
+    // The transport is the boundary: it resolves again at connect time, so a
+    // record that flips between the check and the connection is still refused,
+    // and its response is buffered under the cap, so no drain is needed.
+    const response = await guardedFetch(checked.url.toString(), {
+      method: init.method,
+      headers: init.headers,
+      body: init.body,
+      signal,
+      maxResponseBytes: MAX_RESPONSE_BYTES,
+    });
     if (response.status < 300 || response.status >= 400) {
       return { ok: true, response };
     }
     const location = response.headers.get("location");
-    // Drain before abandoning the connection.
-    await response.arrayBuffer().catch(() => undefined);
     if (!location) {
       return { ok: true, response };
     }
@@ -112,8 +124,6 @@ export async function runSendWebhook(
       return delivery.result;
     }
     const { response } = delivery;
-    // The body is never used, but leaving it unread holds the socket open.
-    await response.arrayBuffer().catch(() => undefined);
     if (!response.ok) {
       // 5xx / 408 / 429 may clear on their own — retry with backoff. Other 4xx are
       // endpoint config errors (bad path, auth) that retrying can't fix.

--- a/apps/sdp-api/src/services/workflows/webhook-url.ts
+++ b/apps/sdp-api/src/services/workflows/webhook-url.ts
@@ -11,10 +11,11 @@
 //     is the actual security boundary: the save-time check can't see where a hostname
 //     points, and the answer can change between save and send.
 //
-// A DNS-rebinding attacker can still flip a public hostname to a private address in the
-// window between our lookup and the runtime's own connect. Closing that needs a
-// pinned-IP connect (custom agent/socket), which is out of scope here; the metadata
-// endpoint and every literal private address are blocked either way.
+// Neither check is the final boundary: delivery goes through `guardedFetch`
+// (`services/guarded-egress.ts`), which filters the addresses actually dialled at
+// connect time, so a record that flips between the lookup here and the connection is
+// still refused. What these layers add is a readable rejection for the issuer and a
+// hostname denylist the address-level guard cannot express.
 
 import { lookup } from "node:dns/promises";
 


### PR DESCRIPTION
Workflow webhook delivery validated the target hostname's resolution and then let the runtime resolve it again for the connect — a window the module's own comment acknowledged. Delivery now goes through `guardedFetch`: the addresses actually dialled are filtered at connect time, literal private hosts are refused, and the response is buffered under a 64 KiB cap, which also removes the manual body drains. The pre-flight lookup stays as the issuer's readable rejection, and the manual one-redirect loop still re-validates each hop. A target the transport refuses maps to the same permanent `BLOCKED_URL` outcome as a pre-flight rejection, so retries are not spent on a connection that fails the same way every time.

Part of HOO-976 hardening follow-ups.

## Tests

- Delivery goes through the guarded transport with a bounded read; the caller's timeout signal is preserved.
- A transport-refused connection fails permanently as `BLOCKED_URL`.
- Existing coverage holds: scheme/literal/hostname pre-flight rejections, redirect re-validation, signing, retry classification.
- Full sdp-api suite green.