### PR TITLE
fix(api): workflow actions honor the token's freeze-support flag and operational status

### DIFF
--- a/apps/sdp-api/src/services/workflows/actions/lifecycle.test.ts
+++ b/apps/sdp-api/src/services/workflows/actions/lifecycle.test.ts
@@ -32,6 +32,8 @@ const mirrorUnfreezeWrite = vi.hoisted(() => vi.fn());
 const applySettledTokenStatus = vi.hoisted(() => vi.fn());
 const reconcileObservedTokenPauseState = vi.hoisted(() => vi.fn());
 const recordWorkflowTransaction = vi.hoisted(() => vi.fn());
+// What the token row says about freeze support; the flag the API handler enforces.
+const tokenRow = vi.hoisted(() => ({ isFreezable: true }));
 
 vi.mock("@solana-program/token-2022", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@solana-program/token-2022")>()),
@@ -65,6 +67,7 @@ vi.mock("./onchain", async (importOriginal) => {
     prepareOnchain: async () => ({
       ok: true,
       ctx: {
+        token: tokenRow,
         mintAddress: TOKEN_ACCOUNT,
         signer: { address: WALLET },
         mosaic: { freezeAccount, thawAccount, pauseToken, unpauseToken },
@@ -113,6 +116,7 @@ function chainSays(state: "frozen" | "thawed") {
 describe("freeze/unfreeze converge on chain state, not the DB mirror", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    tokenRow.isFreezable = true;
     freezeAccount.mockResolvedValue({ signature: "sig_freeze", slot: 1 });
     thawAccount.mockResolvedValue({ signature: "sig_thaw", slot: 2 });
     mirrorFreezeWrite.mockResolvedValue(undefined);
@@ -144,6 +148,23 @@ describe("freeze/unfreeze converge on chain state, not the DB mirror", () => {
     expect(freezeAccount).toHaveBeenCalledTimes(1);
     expect(result.status).toBe("succeeded");
     expect(result.result).not.toMatchObject({ alreadyFrozen: true });
+  });
+
+  // The API's freeze handler refuses a token declared not-freezable; a rule-driven
+  // freeze is the same operation with a different trigger and must honor the same flag.
+  it("refuses to freeze when the token does not support freeze operations", async () => {
+    tokenRow.isFreezable = false;
+    isAccountFrozen.mockResolvedValue(false);
+    chainSays("thawed");
+
+    const result = await runFreeze(env, executionFixture(), action);
+
+    expect(freezeAccount).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      status: "failed",
+      retryable: false,
+      error: "TOKEN_NOT_FREEZABLE",
+    });
   });
 
   // Idempotency still holds where it should — this is what the pre-check exists for, so

--- a/apps/sdp-api/src/services/workflows/actions/lifecycle.ts
+++ b/apps/sdp-api/src/services/workflows/actions/lifecycle.ts
@@ -278,6 +278,12 @@ export async function runFreeze(
   }
   const { mintAddress, signer, mosaic } = prep.ctx;
 
+  // The same flag the direct freeze endpoint enforces: a rule-driven freeze is
+  // that operation with a different trigger, not an exemption from it.
+  if (!prep.ctx.token.isFreezable) {
+    return permanentFail("TOKEN_NOT_FREEZABLE");
+  }
+
   const targetRaw = resolveTargetWallet(execution, action);
   if (!targetRaw) {
     return permanentFail("MISSING_PARAM:wallet");

--- a/apps/sdp-api/src/services/workflows/actions/preflight.ts
+++ b/apps/sdp-api/src/services/workflows/actions/preflight.ts
@@ -20,7 +20,11 @@ import {
   resolvePolicyCustodyWallet,
 } from "@/services/policy/enforcement.service";
 import { TokenService } from "@/services/token.service";
-import { resolveMintOperationAmount } from "@/services/token-operation.service";
+import {
+  assertTokenAllowsOperation,
+  resolveMintOperationAmount,
+  type TokenOperation,
+} from "@/services/token-operation.service";
 import type { Env } from "@/types/env";
 import type { OnchainContext } from "./onchain";
 import { errorMessage, permanentFail } from "./onchain";
@@ -36,6 +40,22 @@ export type PreflightOutcome = { ok: true } | { ok: false; result: ActionExecuti
 
 // Supply + mintability, using the same helper the HTTP mint route uses. Returns the
 // base-unit amount so the caller doesn't parse twice.
+// The operational-status gate every direct supply handler runs
+// (`assertTokenAllowsOperation`): paused and non-active tokens accept none of
+// these operations, and a rule must not reach the chain where the endpoint
+// would have refused.
+export function preflightTokenOperation(
+  ctx: OnchainContext,
+  operation: TokenOperation
+): { ok: true } | { ok: false; result: ActionExecutionResult } {
+  try {
+    assertTokenAllowsOperation(ctx.token as Token, operation);
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, result: permanentFail(errorMessage(error)) };
+  }
+}
+
 export function preflightMintAmount(
   ctx: OnchainContext,
   amount: string

--- a/apps/sdp-api/src/services/workflows/actions/supply.test.ts
+++ b/apps/sdp-api/src/services/workflows/actions/supply.test.ts
@@ -71,7 +71,7 @@ vi.mock("./onchain", async (importOriginal) => {
     prepareOnchain: async () => ({
       ok: true,
       ctx: {
-        token: { id: "tok_1", symbol: "TKN", ...tokenOverrides.value },
+        token: { id: "tok_1", symbol: "TKN", status: "active", ...tokenOverrides.value },
         decimals: 2,
         mintAddress: MINT,
         signer: { address: DEST },
@@ -325,5 +325,40 @@ describe("custody actions enforce the signing wallet's operation policy", () => 
     expect(forceTransfer).toHaveBeenCalledTimes(1);
     expect(result.status).toBe("succeeded");
     expect(result.result).toMatchObject({ signature: "sig_seize" });
+  });
+});
+
+describe("supply actions honor the token's operational status", () => {
+  beforeEach(() => {
+    tokenOverrides.value = { status: "paused" };
+  });
+
+  // The direct handlers refuse these operations on a paused token via
+  // assertTokenAllowsOperation; a rule is the same operation with a different
+  // trigger and must fail the same way, before any chain call.
+  it("refuses to force-burn from a paused token", async () => {
+    const result = await runForceBurn(env, executionFixture(), {
+      params: { amount: "1" },
+    } as never);
+
+    expect(forceBurn).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ status: "failed", retryable: false });
+    expect(String((result as { error: string }).error)).toContain("paused");
+  });
+
+  it("refuses to seize from a paused token", async () => {
+    const result = await runSeize(env, executionFixture(), {
+      params: { amount: "1", destination: TREASURY },
+    } as never);
+
+    expect(forceTransfer).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ status: "failed", retryable: false });
+  });
+
+  it("refuses to mint on a paused token", async () => {
+    const result = await runMint(env, executionFixture(), { params: { amount: "1" } } as never);
+
+    expect(mintTo).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ status: "failed", retryable: false });
   });
 });

--- a/apps/sdp-api/src/services/workflows/actions/supply.test.ts
+++ b/apps/sdp-api/src/services/workflows/actions/supply.test.ts
@@ -361,4 +361,30 @@ describe("supply actions honor the token's operational status", () => {
     expect(mintTo).not.toHaveBeenCalled();
     expect(result).toMatchObject({ status: "failed", retryable: false });
   });
+
+  it("refuses to burn from a paused token", async () => {
+    const result = await runBurn(env, executionFixture(), { params: { amount: "1" } } as never);
+
+    expect(burn).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ status: "failed", retryable: false });
+  });
+
+  // Paused is one refusal branch; a token that never reached active (or was
+  // revoked) is the other, and both must stop short of the chain call.
+  it("refuses every supply operation on a non-active token", async () => {
+    tokenOverrides.value = { status: "revoked" };
+
+    const seize = await runSeize(env, executionFixture(), {
+      params: { amount: "1", destination: TREASURY },
+    } as never);
+    const forced = await runForceBurn(env, executionFixture(), {
+      params: { amount: "1" },
+    } as never);
+
+    expect(forceTransfer).not.toHaveBeenCalled();
+    expect(forceBurn).not.toHaveBeenCalled();
+    expect(seize).toMatchObject({ status: "failed", retryable: false });
+    expect(forced).toMatchObject({ status: "failed", retryable: false });
+    expect(String((seize as { error: string }).error)).toContain("active");
+  });
 });

--- a/apps/sdp-api/src/services/workflows/actions/supply.ts
+++ b/apps/sdp-api/src/services/workflows/actions/supply.ts
@@ -21,6 +21,7 @@ import {
 import {
   preflightDestinationAllowed,
   preflightMintAmount,
+  preflightTokenOperation,
   preflightWalletPolicy,
 } from "./preflight";
 import { recordWorkflowTransaction } from "./record-transaction";
@@ -117,8 +118,13 @@ export async function runMint(
   }
 
   // Everything the HTTP mint route checks, checked here too and BEFORE the chain call:
-  // mintability + max supply, the token's control list, and the wallet policy. Running
-  // the supply check after the mint is what allowed a rule to mint past `maxSupply`.
+  // operational status, mintability + max supply, the token's control list, and the
+  // wallet policy. Running the supply check after the mint is what allowed a rule to
+  // mint past `maxSupply`.
+  const status = preflightTokenOperation(prep.ctx, "mint");
+  if (!status.ok) {
+    return status.result;
+  }
   const supplyCheck = preflightMintAmount(prep.ctx, amount.amountStr);
   if (!supplyCheck.ok) {
     return supplyCheck.result;
@@ -222,6 +228,11 @@ export async function runBurn(
     return permanentFail("MISSING_OR_INVALID_PARAM:amount");
   }
 
+  const status = preflightTokenOperation(prep.ctx, "burn");
+  if (!status.ok) {
+    return status.result;
+  }
+
   // The signing wallet's operation policy (amount/velocity limits, custody approval)
   // binds every custody-signed op, checked BEFORE the chain call — a rule must not be
   // a way to destroy supply past limits the org configured for the key.
@@ -278,6 +289,11 @@ export async function runForceBurn(
   const amount = parseAmount(action, decimals);
   if (!amount) {
     return permanentFail("MISSING_OR_INVALID_PARAM:amount");
+  }
+
+  const status = preflightTokenOperation(prep.ctx, "force_burn");
+  if (!status.ok) {
+    return status.result;
   }
 
   // Wallet policy for the permanent-delegate key, BEFORE the chain call (see runBurn).
@@ -339,6 +355,11 @@ export async function runSeize(
   const amount = parseAmount(action, decimals);
   if (!amount) {
     return permanentFail("MISSING_OR_INVALID_PARAM:amount");
+  }
+
+  const status = preflightTokenOperation(prep.ctx, "seize");
+  if (!status.ok) {
+    return status.result;
   }
 
   // The HTTP seize route checks the destination against the token's control list before


### PR DESCRIPTION
The direct issuance endpoints run two token-level gates the workflow engine skipped: the freeze endpoint refuses a token declared not-freezable, and mint, burn, force-burn and seize refuse a paused or non-active token through `assertTokenAllowsOperation`. A rule-driven action is the same operation with a different trigger, so it now runs the same gates before any preflight or chain call — `runFreeze` fails permanently with `TOKEN_NOT_FREEZABLE`, and the four supply actions run a shared `preflightTokenOperation` mirroring the handlers.

Unfreeze intentionally stays ungated, matching the direct unfreeze endpoint: thawing is the remediation path even for a token later marked not-freezable.

Part of HOO-976 hardening follow-ups.

## Tests

- A rule freeze on a not-freezable token fails permanently without touching the chain.
- Force-burn, seize and mint on a paused token fail permanently without a chain call.
- Existing lifecycle/supply coverage holds (chain-state convergence, policy preflights, supply reservation).
- Full sdp-api suite: 5741 passed.