### PR TITLE
fix(helius-rings): pin custom-ring deploy to alpha.2 program

### DIFF
--- a/scripts/deploy-custom-ring.sh
+++ b/scripts/deploy-custom-ring.sh
@@ -30,9 +30,9 @@ set -euo pipefail
 #
 # Prerequisites: solana CLI 4.x, curl, jq, shasum.
 
-RELEASE_TAG="v0.1.0-alpha.6"
+RELEASE_TAG="v0.1.0-alpha.2"
 RING_SO_URL="https://github.com/helius-labs/zolana/releases/download/${RELEASE_TAG}/custom-ring-program-${RELEASE_TAG}.so"
-RING_SO_SHA256="a2a9e85c9677b26f9ee8bf60151dca5ce76b3984e00ac16dc8bd159acc591fae"
+RING_SO_SHA256="041b94f53ff0ee291473b3cf407b7c8b535d87f2beb7a18c48e2034aa2235d81"
 DEPLOY_BALANCE_SOL="1.4"   # ~1.23 SOL programdata rent + fees, with headroom
 BRINGUP_FUND_SOL="0.05"    # rents config, ring-auth, reader record, lookup table
 


### PR DESCRIPTION
`scripts/deploy-custom-ring.sh` pins `RELEASE_TAG=v0.1.0-alpha.6`, which breaks ring bring-up. Revert `RELEASE_TAG` and `RING_SO_SHA256` to alpha.2.

- The pinned SDK `@heliuslabs/zolana@0.1.6-alpha` still emits the alpha.2 create-config wire format: `[tag=1][auditor_key:33]`, 33 bytes after the tag.
- alpha.4 appended `has_policy: u8` to `CreateConfigIxData`, so alpha.6's `create_config` handler wants 34 bytes and fails `wincode::deserialize_exact` → `CustomRingError::InvalidInstructionData` (8100) on the first instruction, before any account work.
- alpha.2 is the newest program tag that both speaks the pinned SDK's create-config layout **and** ships a downloadable `.so`. alpha.3 has the right layout but publishes no custom-ring `.so`; alpha.4/alpha.6 have the `.so` but the incompatible layout. No published SDK matches alpha.4+.
- Tags 2/4 (`init_spp_ring_config`, `grant_read_access`) are byte-identical across versions, so the rest of bring-up is unaffected. This reverts only the two pin lines.

Verified end-to-end on local devnet: fresh DB, alpha.2 deploy via this script, custody-rooted wallet bring-up, and all four ring ops (shield, withdraw, registered transfer) finalized on-chain.