### PR TITLE
feat(earn): quote Kamino trailing 7d APY as the catalogue rate, carry spot in risk metadata

### DIFF
--- a/apps/sdp-api/scripts/inventory-kamino-catalogue.ts
+++ b/apps/sdp-api/scripts/inventory-kamino-catalogue.ts
@@ -292,7 +292,9 @@ async function runFetch(): Promise<void> {
       tokenMint: vault.state.tokenMint,
       tokenSymbol: WELL_KNOWN_TOKEN_BY_MINT.get(vault.state.tokenMint)?.symbol ?? null,
       tvlUsd,
-      apy: metrics?.apy ?? null,
+      // The trailing 7d rate, which is what the shelf stores as `current_apy`
+      // (PRO-1922); the census must show the number the catalogue quotes.
+      apy: metrics?.apy7d ?? null,
       holders: metrics?.numberOfHolders ?? null,
       outcome: distilled.outcome,
       dropReason: distilled.outcome === "dropped" ? distilled.reason : null,

--- a/packages/sdp-earn/CLAUDE.md
+++ b/packages/sdp-earn/CLAUDE.md
@@ -254,6 +254,17 @@ page it links is fetchable as raw markdown):
   404s for devnet pubkeys, so `listStrategyMetrics` returns `[]` there and
   sandbox rows render no rate. Computing one would mean blending devnet Klend
   reserve rates (an SDK-sized job) for a number that is ≈0 anyway.
+- **The shelf quotes the TRAILING 7d rate, never the spot rate.** The metrics
+  row carries both: `apy` is the instantaneous blended rate and tracks Klend
+  reserve utilization minute to minute, `apy7d` is the trailing week. On
+  2026-09-10 the Main Market USDC reserve hit ~97% utilization and `apy` read
+  18-23% on six USDC vaults whose `apy7d` sat at 3-7%, which fired the
+  PRO-1867 anomaly alert 15 times on a number that was true for the hour and
+  useless as a yield quote. So `currentApy` is `apy7d` at both call sites
+  (`distillKaminoVault` and `listStrategyMetrics`), the spot figure rides along
+  as `riskMetadata.spotApy` for a future "current" column, and a missing
+  `apy7d` is "no rate", not a fallback to `apy` (PRO-1922). Kamino's own vault
+  page headline is a trailing figure too; do not quote hotter than the provider.
 - **The registry is permissionless**, so `GET /kvaults/vaults` is a census of
   everything ever created — 173 vaults, of which ~90 stablecoin ones are dust or
   literal test vaults (`testfail4`, `vkjm_test`). `KAMINO_MIN_TVL_USD` ($100k)

--- a/packages/sdp-earn/src/providers/kamino/client.test.ts
+++ b/packages/sdp-earn/src/providers/kamino/client.test.ts
@@ -69,7 +69,10 @@ const vault = (
 
 const metrics = (overrides: Partial<KaminoVaultMetrics> = {}): KaminoVaultMetrics => ({
   kvault: "VaULt1111111111111111111111111111111111111",
-  apy: "0.04",
+  // Spot above trailing on purpose: every assertion on `currentApy` below
+  // proves the shelf quotes the 7d figure, never the instantaneous one.
+  apy: "0.05",
+  apy7d: "0.04",
   tokensAvailableUsd: "1000000",
   tokensInvestedUsd: "9000000",
   numberOfHolders: 42,
@@ -184,10 +187,39 @@ describe("distillKaminoVault", () => {
     // key here is a figure Kamino itself reports.
     assert.deepEqual(result.outcome === "catalogued" ? result.snapshot.riskMetadata : undefined, {
       tvlUsd: 10_000_000,
+      spotApy: "0.05",
       holders: 42,
       managementFeeBps: 25,
       performanceFeeBps: 0,
     });
+  });
+
+  it("quotes the trailing 7d rate even when the spot rate is 10x it (PRO-1922)", () => {
+    // 2026-09-10: the Main Market USDC reserve hit ~97% utilization and `apy`
+    // read 18-23% on vaults whose `apy7d` sat at 3-7%. The shelf must not
+    // follow that spike; the spot figure rides along as metadata instead.
+    const result = distillKaminoVault(vault(), metrics({ apy: "0.227338", apy7d: "0.035914" }));
+    assert.equal(result.outcome, "catalogued");
+    const snapshot = result.outcome === "catalogued" ? result.snapshot : undefined;
+    assert.equal(snapshot?.currentApy, "0.035914");
+    assert.equal(snapshot?.riskMetadata?.spotApy, "0.227338");
+  });
+
+  it("reports no rate, not the spot rate, when the trailing figure is missing", () => {
+    const result = distillKaminoVault(vault(), metrics({ apy7d: null }));
+    assert.equal(result.outcome, "catalogued");
+    const snapshot = result.outcome === "catalogued" ? result.snapshot : undefined;
+    assert.equal(snapshot?.currentApy, undefined);
+    assert.equal(snapshot?.riskMetadata?.spotApy, "0.05");
+  });
+
+  it("carries no spotApy key when Kamino reports no spot rate", () => {
+    // An absent key, not a null: the refresh MERGES risk metadata, so a null
+    // here would overwrite a figure the sync stored.
+    const result = distillKaminoVault(vault(), metrics({ apy: null }));
+    assert.equal(result.outcome, "catalogued");
+    const meta = result.outcome === "catalogued" ? result.snapshot.riskMetadata : undefined;
+    assert.equal(Object.hasOwn(meta ?? {}, "spotApy"), false);
   });
 
   it("never reports a redemption delay — a K-Vault withdrawal is atomic", () => {
@@ -467,7 +499,14 @@ describe("KaminoEarnClient.listStrategyMetrics", () => {
     // for the 348KB list on every five-minute tick.
     const fetchMock = stubKaminoFetch({
       body: {
-        result: [metrics({ kvault: "vault-a", apy: "0.0512345678", numberOfHolders: 7 })],
+        result: [
+          metrics({
+            kvault: "vault-a",
+            apy: "0.2273387040956072",
+            apy7d: "0.0512345678",
+            numberOfHolders: 7,
+          }),
+        ],
         paginationToken: null,
       },
     });
@@ -480,7 +519,7 @@ describe("KaminoEarnClient.listStrategyMetrics", () => {
       {
         providerReference: "vault-a",
         currentApy: "0.051234",
-        riskMetadata: { tvlUsd: 10_000_000, holders: 7 },
+        riskMetadata: { tvlUsd: 10_000_000, spotApy: "0.227338", holders: 7 },
       },
     ]);
   });
@@ -507,14 +546,16 @@ describe("KaminoEarnClient.listStrategyMetrics", () => {
     );
   });
 
-  it("omits the rate rather than inventing one when the provider reports none", async () => {
+  it("omits the rate rather than inventing one when the provider reports no trailing figure", async () => {
+    // `apy` is still present: the spot rate is NOT a fallback for the shelf figure.
     stubKaminoFetch({
-      body: { result: [metrics({ apy: null })], paginationToken: null },
+      body: { result: [metrics({ apy7d: null })], paginationToken: null },
     });
 
     const [entry] = await client.listStrategyMetrics(productionCtx);
 
     assert.equal(entry.currentApy, undefined);
+    assert.equal(entry.riskMetadata?.spotApy, "0.05");
   });
 
   it("carries no field that could change what a strategy IS", async () => {

--- a/packages/sdp-earn/src/providers/kamino/client.ts
+++ b/packages/sdp-earn/src/providers/kamino/client.ts
@@ -122,8 +122,23 @@ export interface KaminoVault {
 export interface KaminoVaultMetrics {
   /** Vault pubkey this row describes — the join key back to `KaminoVault`. */
   kvault: string;
-  /** Current blended APY as a decimal fraction string ("0.0592…" = 5.92%). */
+  /**
+   * INSTANTANEOUS blended APY as a decimal fraction string ("0.0592…" = 5.92%).
+   * Tracks Klend reserve utilization minute to minute: on 2026-09-10 the Main
+   * Market USDC reserve hit ~97% utilization and this read 18-23% on six USDC
+   * vaults whose trailing figures sat at 3-7% (PRO-1922). Carried as
+   * `riskMetadata.spotApy`, never as the shelf's `currentApy`.
+   */
   apy?: string | null;
+  /**
+   * Trailing seven-day APY, same units. THE figure the shelf stores as
+   * `currentApy`: it is what a depositor actually accrues over a horizon that
+   * matters, it is at least as smooth as Kamino's own vault-page headline
+   * ("quoted APYs are trailing averages"), and it makes the 3x jump bound in
+   * `EARN_FIGURE_BOUNDS` mean something. A missing `apy7d` is "no rate", not a
+   * cue to fall back to the spot figure.
+   */
+  apy7d?: string | null;
   /** Idle balance, USD. */
   tokensAvailableUsd?: string | null;
   /** Balance deployed into Klend reserves, USD. */
@@ -290,6 +305,18 @@ export function kaminoTvlUsd(metrics: KaminoVaultMetrics): number | undefined {
   return Number.isFinite(total) ? total : undefined;
 }
 
+/**
+ * The instantaneous rate as a risk-metadata fragment, so the UI can one day
+ * show "current" beside the trailing headline the way Kamino's vault page
+ * does. Kept OUT of `currentApy` on purpose (see `KaminoVaultMetrics.apy`).
+ * Empty when Kamino reports none, so the merge on refresh does not write a
+ * null over a figure the sync stored.
+ */
+function kaminoSpotApy(metrics: KaminoVaultMetrics): { spotApy?: string } {
+  const spotApy = truncateKaminoApy(metrics.apy);
+  return spotApy === undefined ? {} : { spotApy };
+}
+
 // --- Distillation ---
 
 /** Why distillation kept a raw Kamino vault out of the strategy catalogue. */
@@ -382,7 +409,7 @@ export function distillKaminoVault(
       ...(shareMint ? { shareMint } : {}),
       hostCluster: KAMINO_HOST_CLUSTER,
       apyType: "variable",
-      currentApy: truncateKaminoApy(metrics.apy),
+      currentApy: truncateKaminoApy(metrics.apy7d),
       // A K-Vault withdrawal is atomic in one transaction and auto-disinvests
       // from a Klend reserve when the vault's idle balance is short — Kamino's
       // withdraw docs are explicit, and there is no redemption queue and no
@@ -396,6 +423,7 @@ export function distillKaminoVault(
       // the protocol itself reports.
       riskMetadata: {
         tvlUsd,
+        ...kaminoSpotApy(metrics),
         ...(metrics.numberOfHolders == null ? {} : { holders: metrics.numberOfHolders }),
         ...(vault.state.managementFeeBps == null
           ? {}
@@ -623,8 +651,8 @@ export class KaminoEarnClient extends StubEarnClient implements EarnLiveMetricsP
   /**
    * Live figures for the whole shelf — the short-cadence half of the catalogue.
    *
-   * Kamino is a natural fit for this capability: `apy` moves continuously with
-   * the underlying Klend reserve rates, and the BULK metrics endpoint carries
+   * Kamino is a natural fit for this capability: the rates move continuously
+   * with the underlying Klend reserve rates, and the BULK metrics endpoint carries
    * every figure for every vault in two requests. There is no vault-list fetch
    * here at all (the 348KB call `listStrategies` makes) because none of what it
    * returns can change between hourly syncs — name, mints and share mint are
@@ -653,9 +681,10 @@ export class KaminoEarnClient extends StubEarnClient implements EarnLiveMetricsP
       const tvlUsd = kaminoTvlUsd(metrics);
       return {
         providerReference: metrics.kvault,
-        currentApy: truncateKaminoApy(metrics.apy),
+        currentApy: truncateKaminoApy(metrics.apy7d),
         riskMetadata: {
           ...(tvlUsd === undefined ? {} : { tvlUsd }),
+          ...kaminoSpotApy(metrics),
           ...(metrics.numberOfHolders == null ? {} : { holders: metrics.numberOfHolders }),
         },
       };


### PR DESCRIPTION
Kamino's catalogue rate is now the trailing 7d APY (`apy7d`), not the instantaneous blended rate (`apy`). Closes PRO-1922, follow-up to the PRO-1867 anomaly alert.

## Why

- On 2026-09-10 the Kamino Main Market USDC reserve hit ~97% utilization. The spot `apy` read 18-23% on six catalogued USDC vaults while Kamino's own `apy24h` / `apy7d` for the same vaults sat at 3-7%.
- The new anomaly alert fired 15 times in dev on a figure that was accurate for the hour and useless as a yield quote.
- A depositor accrues the trailing rate, and Kamino's vault page headline is itself a trailing figure. We should not quote hotter than the provider.

## What changed

- **`currentApy` is `apy7d`** at both call sites: `distillKaminoVault` (hourly sync) and `listStrategyMetrics` (5-minute refresh).
- **Spot rides along as `riskMetadata.spotApy`**, truncated the same way, so a UI can later show "current" beside the headline. The key is omitted when Kamino reports none, because the refresh merges risk metadata and a null would overwrite a stored value.
- **Missing `apy7d` means no rate.** It never falls back to spot.
- Inventory script's APY column follows `apy7d` so the census matches what the catalogue quotes.
- Kamino section of `packages/sdp-earn/CLAUDE.md` records the rule and the incident.

**before**: metrics row → `currentApy = apy` → a one-hour utilization spike lands on the comparison table and trips the 3x anomaly bound.

**after**: metrics row → `currentApy = apy7d`, `riskMetadata.spotApy = apy` → the table quotes the week, the spike is still visible in metadata, and a 3x move in `currentApy` between passes is a real signal.

## Reviewer notes

- **One more dev alert on the way down.** Stored rows currently hold the ~22% spot figure. The first pass after deploy writes ~3.7% and re-fires the jump alert once. Expected, not a regression.
- **No schema or API contract change.** `spotApy` lives in the open `risk_metadata` JSONB.
- Veda is untouched; it has its own APY source.

## Verification

- `pnpm --filter @sdp/earn test`: 201 pass (3 new cases: 10x spot vs 7d quotes 7d, missing `apy7d` gives no rate, missing `apy` carries no `spotApy` key)
- `vitest run` on `earn-metrics-refresh`, `earn-catalogue-sync`, `catalogue-anomaly`: 55 pass
- typecheck `@sdp/earn` + `@sdp/api`, biome on changed files: clean
- Live read through the patched client against `api.kamino.finance`: Solana Mobile USDC vault `currentApy` 0.036668, `spotApy` 0.035671 (spike already over)
- Not run: local API end to end. The change is inside the provider client; the cron tests above cover the write path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
