### PR TITLE
fix(web): give Helius Rings and the members redirect their own loading skeletons

### DIFF
--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-skeleton.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-skeleton.tsx
@@ -1,0 +1,377 @@
+import { Card, CardAction, CardContent, CardHeader } from "@/components/ui/card";
+import { SkeletonBlock } from "@/components/ui/skeleton-block";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+
+// Mirrors the configured workspace with one private wallet selected, which is
+// the page most visits settle into. Built on the same Card and Table parts as
+// the settled page so padding, gaps and row heights match by construction.
+
+// "RPC", "Prover", "Photon indexer".
+const HEALTH_LABEL_WIDTHS = ["w-7", "w-10", "w-24"];
+// Withdraw, Private transfer, Merge, Move: each inactive tab's label width.
+const COMPOSER_TAB_LABEL_WIDTHS = ["w-[62px]", "w-[100px]", "w-[42px]", "w-[35px]"];
+const WALLET_HEAD_WIDTHS = [
+  { cell: "w-[22%]", label: "w-10" },
+  { cell: "w-[20%]", label: "w-24" },
+  { cell: "w-[22%]", label: "w-28" },
+  { cell: "w-[22%]", label: "w-12" },
+  { cell: "w-[14%]", label: "w-9" },
+];
+const WALLET_ROWS = [
+  { id: "wallet-1", name: "w-28", backing: "w-12", badge: "w-[53px]" },
+  { id: "wallet-2", name: "w-24", backing: "w-10", badge: "w-[60px]" },
+];
+const BALANCE_ROWS = [
+  { id: "balance-1", amount: "w-12", notes: false, usd: "w-14" },
+  { id: "balance-2", amount: "w-16", notes: true, usd: "w-14" },
+];
+const ACTIVITY_HEADS = [
+  { id: "operation", width: "w-16" },
+  { id: "state", width: "w-9" },
+  { id: "amount", width: "w-14" },
+  { id: "ring", width: "w-8" },
+  { id: "created", width: "w-14" },
+  { id: "action", width: "w-12" },
+];
+const ACTIVITY_ROWS = [
+  { id: "activity-1", op: "w-10", state: "w-[79px]", action: false },
+  { id: "activity-2", op: "w-14", state: "w-[51px]", action: true },
+  { id: "activity-3", op: "w-28", state: "w-[79px]", action: false },
+];
+
+/** One line of text-sm copy: a 20px line box holding a bar where the glyphs sit. */
+function TextLine({ className }: { className: string }) {
+  return (
+    <span className="flex h-5 items-center">
+      <SkeletonBlock className={cn("h-3.5", className)} />
+    </span>
+  );
+}
+
+/** A card title's 24px line. */
+function TitleLine({ className }: { className: string }) {
+  return (
+    <span className="flex h-6 items-center">
+      <SkeletonBlock className={cn("h-5", className)} />
+    </span>
+  );
+}
+
+/**
+ * A labelled input or select: label, then the 40px control with its value and
+ * chevron. `compact` matches the `Label` component, whose line is 14px rather
+ * than the 20px of a plain text-sm label.
+ */
+function FieldSkeleton({
+  className,
+  label = "text",
+  labelWidth,
+  valueWidth,
+  chevron = false,
+}: {
+  className: string;
+  label?: "text" | "compact";
+  labelWidth: string;
+  valueWidth: string;
+  chevron?: boolean;
+}) {
+  return (
+    <div className={cn("flex flex-col gap-1.5", className)}>
+      {label === "compact" ? (
+        <span className="flex h-3.5 items-center">
+          <SkeletonBlock className={cn("h-3", labelWidth)} />
+        </span>
+      ) : (
+        <TextLine className={labelWidth} />
+      )}
+      <div className="flex h-10 items-center justify-between gap-2 rounded-[10px] bg-fill px-3">
+        <SkeletonBlock className={cn("h-3.5", valueWidth)} />
+        {chevron ? <SkeletonBlock className="size-3.5 rounded-sm" /> : null}
+      </div>
+    </div>
+  );
+}
+
+function HealthStripSkeleton() {
+  return (
+    <div
+      className="rounded-[var(--sdp-surface-radius)] bg-surface-raised px-4 py-2.5 shadow-sm ring-1 ring-border-default"
+      data-loading-section="health"
+    >
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-1">
+        <TextLine className="w-12" />
+        {HEALTH_LABEL_WIDTHS.map((width) => (
+          <div className="flex items-center gap-2" key={width}>
+            <SkeletonBlock className="size-2 rounded-full" />
+            <TextLine className={width} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function RingCardSkeleton() {
+  return (
+    <Card data-loading-section="rings">
+      <CardHeader>
+        <TitleLine className="w-32" />
+        <div>
+          <TextLine className="w-full" />
+          <TextLine className="w-full" />
+          <TextLine className="w-3/5" />
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {/* "View custom rings" with its count badge. */}
+        <div className="flex h-10 w-fit items-center gap-2 rounded-[10px] bg-fill px-[18px]">
+          <SkeletonBlock className="h-3.5 w-32" />
+          <SkeletonBlock className="h-5 w-6 rounded-sm" />
+        </div>
+        <div className="flex flex-col gap-2">
+          <div>
+            <TextLine className="w-full" />
+            <TextLine className="w-1/4" />
+          </div>
+          <div className="flex flex-wrap items-end gap-3">
+            <FieldSkeleton
+              className="min-w-48"
+              label="compact"
+              labelWidth="w-16"
+              valueWidth="w-14"
+            />
+            <FieldSkeleton
+              className="min-w-96"
+              label="compact"
+              labelWidth="w-24"
+              valueWidth="w-64"
+            />
+            <SkeletonBlock className="h-10 w-[179px] rounded-[10px]" />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function PrivateWalletsSkeleton() {
+  return (
+    <Card className="min-w-0" data-loading-section="wallets">
+      <CardHeader>
+        <TitleLine className="w-36" />
+        <TextLine className="w-72 max-w-full" />
+      </CardHeader>
+      <CardContent className="flex min-w-0 flex-col gap-4">
+        <div className="flex flex-wrap items-end gap-3">
+          <FieldSkeleton className="min-w-56" labelWidth="w-32" valueWidth="w-28" chevron />
+          <FieldSkeleton className="min-w-48" label="compact" labelWidth="w-20" valueWidth="w-24" />
+          <SkeletonBlock className="h-10 w-[84px] rounded-[10px]" />
+        </div>
+        <hr className="border-border-default" role="presentation" />
+        <div className="min-w-0 overflow-x-auto">
+          <Table className="min-w-0 [&_table]:table-fixed">
+            <TableHeader>
+              <TableRow>
+                {WALLET_HEAD_WIDTHS.map(({ cell, label }) => (
+                  <TableHead className={cell} key={cell + label}>
+                    <TextLine className={label} />
+                  </TableHead>
+                ))}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {WALLET_ROWS.map((row) => (
+                <TableRow data-loading-row="wallet" key={row.id}>
+                  <TableCell>
+                    <TextLine className={row.name} />
+                  </TableCell>
+                  <TableCell>
+                    <TextLine className={row.backing} />
+                  </TableCell>
+                  <TableCell>
+                    {/* Shortened shielded address, then its copy button. */}
+                    <span className="flex items-center gap-1">
+                      <TextLine className="w-24" />
+                      <span className="flex size-7 items-center justify-center">
+                        <SkeletonBlock className="size-3 rounded-sm" />
+                      </span>
+                    </span>
+                  </TableCell>
+                  <TableCell>
+                    <TextLine className="w-14" />
+                  </TableCell>
+                  <TableCell>
+                    <SkeletonBlock className={cn("h-5 rounded-sm", row.badge)} />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function WalletOverviewSkeleton() {
+  return (
+    <Card data-loading-section="overview">
+      <CardHeader>
+        <TitleLine className="w-36" />
+        <CardAction>
+          {/* The refresh icon button. */}
+          <span className="flex size-7 items-center justify-center">
+            <SkeletonBlock className="size-4 rounded-sm" />
+          </span>
+        </CardAction>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        <hr className="border-border-default" role="presentation" />
+        <span className="flex h-4 items-center">
+          <SkeletonBlock className="h-3 w-28" />
+        </span>
+        <div className="flex flex-col gap-2">
+          <span className="flex h-8 items-center">
+            <SkeletonBlock className="h-7 w-32" />
+          </span>
+          <div className="flex flex-col gap-0.5">
+            {BALANCE_ROWS.map((row) => (
+              <div className="flex items-center justify-between gap-x-3" key={row.id}>
+                <span className="flex items-center gap-2">
+                  <TextLine className={row.amount} />
+                  {row.notes ? <SkeletonBlock className="h-3 w-12" /> : null}
+                </span>
+                <TextLine className={row.usd} />
+              </div>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ComposerSkeleton() {
+  return (
+    <Card data-loading-section="composer">
+      <CardHeader>
+        <TitleLine className="w-28" />
+        <TextLine className="w-80 max-w-full" />
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <div className="inline-flex w-fit rounded-md border border-border-default p-0.5">
+          <SkeletonBlock className="h-8 w-16 rounded-sm" />
+          {COMPOSER_TAB_LABEL_WIDTHS.map((width) => (
+            <span className="flex h-8 items-center px-3" key={width}>
+              <SkeletonBlock className={cn("h-3.5", width)} />
+            </span>
+          ))}
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <FieldSkeleton className="min-w-48" labelWidth="w-10" valueWidth="w-8" chevron />
+          <FieldSkeleton className="min-w-48" labelWidth="w-14" valueWidth="w-8" />
+          <FieldSkeleton className="min-w-48" labelWidth="w-8" valueWidth="w-20" chevron />
+        </div>
+        <TextLine className="w-56" />
+        <SkeletonBlock className="h-10 w-[86px] rounded-[10px]" />
+      </CardContent>
+    </Card>
+  );
+}
+
+function ActivitySkeleton() {
+  return (
+    <Card data-loading-section="activity">
+      <CardHeader>
+        <TitleLine className="w-20" />
+        <TextLine className="w-72 max-w-full" />
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {ACTIVITY_HEADS.map(({ id, width }) => (
+                <TableHead key={id}>
+                  <TextLine className={width} />
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {ACTIVITY_ROWS.map((row) => (
+              <TableRow data-loading-row="activity" key={row.id}>
+                <TableCell>
+                  <TextLine className={row.op} />
+                </TableCell>
+                <TableCell>
+                  <SkeletonBlock className={cn("h-5 rounded-sm", row.state)} />
+                </TableCell>
+                <TableCell>
+                  <TextLine className="w-14" />
+                </TableCell>
+                <TableCell>
+                  <TextLine className="w-20" />
+                </TableCell>
+                <TableCell>
+                  <TextLine className="w-36" />
+                </TableCell>
+                <TableCell>
+                  {/* The small Retry button, 36px tall. */}
+                  {row.action ? <SkeletonBlock className="h-9 w-[60px] rounded-lg" /> : null}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * Everything below the devnet banner. The workspace shows this while it reads
+ * its setup, so the route skeleton carries straight through to the data.
+ */
+export function HeliusRingsWorkspaceSkeleton() {
+  return (
+    <div className="flex flex-col gap-6" aria-busy="true" data-loading-section="workspace">
+      <HealthStripSkeleton />
+      <RingCardSkeleton />
+      <PrivateWalletsSkeleton />
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <WalletOverviewSkeleton />
+        <ComposerSkeleton />
+      </div>
+      <ActivitySkeleton />
+    </div>
+  );
+}
+
+/** The whole route: page frame, devnet banner, then the workspace. */
+export function HeliusRingsSkeleton() {
+  return (
+    <div
+      className="mx-auto flex max-w-5xl flex-col gap-6 px-6 py-8"
+      data-loading-layout="helius-rings"
+      aria-busy="true"
+    >
+      <div className="flex flex-col gap-6">
+        <div
+          className="rounded-xl border border-border-default px-4 py-3"
+          data-loading-section="devnet-banner"
+        >
+          <TextLine className="w-[38rem] max-w-full" />
+        </div>
+        <HeliusRingsWorkspaceSkeleton />
+      </div>
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-skeleton.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-skeleton.unit.test.tsx
@@ -54,12 +54,12 @@ describe("Helius Rings loading state", () => {
       ...renderToStaticMarkup(<HeliusRingsLoading />).matchAll(
         /class="([^"]*animate-pulse[^"]*)"/g
       ),
-    ].map((match) => match[1] ?? "");
+    ];
 
     expect(pulses.length).toBeGreaterThan(0);
-    expect(pulses.every((className) => className.includes("motion-reduce:animate-none"))).toBe(
-      true
-    );
+    for (const [, className] of pulses) {
+      expect(className).toContain("motion-reduce:animate-none");
+    }
   });
 });
 

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-skeleton.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-skeleton.unit.test.tsx
@@ -1,0 +1,73 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import MembersLoading from "../members/loading";
+import { HeliusRingsWorkspaceSkeleton } from "./helius-rings-skeleton";
+import HeliusRingsLoading from "./loading";
+
+const SECTIONS = ["health", "rings", "wallets", "overview", "composer", "activity"];
+
+describe("Helius Rings loading state", () => {
+  it("paints its own layout instead of inheriting the Home skeleton", () => {
+    const markup = renderToStaticMarkup(<HeliusRingsLoading />);
+
+    expect(markup).toContain('data-loading-layout="helius-rings"');
+    expect(markup).toContain('aria-busy="true"');
+    expect(markup).not.toContain('data-loading-layout="home"');
+  });
+
+  it("draws every section of the settled workspace, banner first", () => {
+    const markup = renderToStaticMarkup(<HeliusRingsLoading />);
+
+    const order = ["devnet-banner", ...SECTIONS].map((section) =>
+      markup.indexOf(`data-loading-section="${section}"`)
+    );
+    expect(order.every((position) => position >= 0)).toBe(true);
+    expect([...order].sort((a, b) => a - b)).toEqual(order);
+  });
+
+  it("keeps the rows the tables settle into", () => {
+    const markup = renderToStaticMarkup(<HeliusRingsLoading />);
+
+    expect(markup.match(/data-loading-row="wallet"/g)).toHaveLength(2);
+    expect(markup.match(/data-loading-row="activity"/g)).toHaveLength(3);
+  });
+
+  it("uses the page's own frame so the skeleton sits where the workspace will", () => {
+    const markup = renderToStaticMarkup(<HeliusRingsLoading />);
+
+    expect(markup).toContain("mx-auto flex max-w-5xl flex-col gap-6 px-6 py-8");
+    expect(markup).toContain("lg:grid-cols-2");
+  });
+
+  it("leaves the banner and page frame to the workspace when it reuses the body", () => {
+    const markup = renderToStaticMarkup(<HeliusRingsWorkspaceSkeleton />);
+
+    expect(markup).not.toContain('data-loading-section="devnet-banner"');
+    expect(markup).not.toContain("px-6 py-8");
+    for (const section of SECTIONS) {
+      expect(markup).toContain(`data-loading-section="${section}"`);
+    }
+  });
+
+  it("stops every pulse when reduced motion is requested", () => {
+    const pulses = [
+      ...renderToStaticMarkup(<HeliusRingsLoading />).matchAll(
+        /class="([^"]*animate-pulse[^"]*)"/g
+      ),
+    ].map((match) => match[1] ?? "");
+
+    expect(pulses.length).toBeGreaterThan(0);
+    expect(pulses.every((className) => className.includes("motion-reduce:animate-none"))).toBe(
+      true
+    );
+  });
+});
+
+describe("Members loading state", () => {
+  it("loads as Settings, the page it redirects to", () => {
+    const markup = renderToStaticMarkup(<MembersLoading />);
+
+    expect(markup).toContain('data-loading-layout="settings"');
+    expect(markup).not.toContain('data-loading-layout="home"');
+  });
+});

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
@@ -197,7 +197,10 @@ export function HeliusRingsWorkspace({
       {loadError ? <Callout variant="danger">{loadError}</Callout> : null}
 
       {setup === null ? (
-        <HeliusRingsWorkspaceSkeleton />
+        // A failed first read leaves setup unset; the error above is then the settled state.
+        loadError ? null : (
+          <HeliusRingsWorkspaceSkeleton />
+        )
       ) : setup.source !== "database" ? (
         <RingsConfigurationCard setup={setup} onConfigured={refresh} />
       ) : null}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
@@ -21,6 +21,7 @@ import {
 } from "./helius-rings.data";
 import { healthAlerts, isSettling } from "./helius-rings.utils";
 import { fetchRingsSetupStatus, type RingsSetupStatus } from "./helius-rings-configuration.data";
+import { HeliusRingsWorkspaceSkeleton } from "./helius-rings-skeleton";
 import { OperationComposer } from "./operation-composer";
 import { OperationDetailDrawer } from "./operation-detail-drawer";
 import { type CustodyWalletOption, PrivateWalletsCard } from "./private-wallets-card";
@@ -196,11 +197,7 @@ export function HeliusRingsWorkspace({
       {loadError ? <Callout variant="danger">{loadError}</Callout> : null}
 
       {setup === null ? (
-        <Card>
-          <CardContent className="py-8 text-center text-sm text-secondary">
-            {t("DashboardHeliusRings.setup.loading")}
-          </CardContent>
-        </Card>
+        <HeliusRingsWorkspaceSkeleton />
       ) : setup.source !== "database" ? (
         <RingsConfigurationCard setup={setup} onConfigured={refresh} />
       ) : null}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/loading.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/loading.tsx
@@ -1,0 +1,5 @@
+import { HeliusRingsSkeleton } from "./helius-rings-skeleton";
+
+export default function HeliusRingsLoading() {
+  return <HeliusRingsSkeleton />;
+}

--- a/apps/sdp-web/src/app/dashboard/members/loading.tsx
+++ b/apps/sdp-web/src/app/dashboard/members/loading.tsx
@@ -1,0 +1,7 @@
+import { SettingsPageSkeleton } from "../operations-card-page-skeletons";
+
+// The route only redirects into Settings, so it loads as Settings instead of
+// inheriting the Home skeleton from the dashboard segment.
+export default function MembersLoading() {
+  return <SettingsPageSkeleton />;
+}

--- a/apps/sdp-web/src/components/dashboard-header.tsx
+++ b/apps/sdp-web/src/components/dashboard-header.tsx
@@ -844,7 +844,11 @@ export function getDashboardPageConfig(
   if (integrationsConfig) {
     return integrationsConfig;
   }
-  if (pathname.startsWith("/dashboard/settings")) {
+  if (pathname === "/dashboard/helius-rings") {
+    return { title: t("Shared.dashboardShell.heliusRings") };
+  }
+  // Members only redirects into Settings, so its loading frame carries the Settings title.
+  if (pathname.startsWith("/dashboard/settings") || pathname === "/dashboard/members") {
     // Settings was the only route left on the `max-w-5xl` default, which stranded a
     // wide empty gutter beside its cards. Widened rather than set to `max-w-none`:
     // the members table and the RPC form are label/value rows, and letting them span

--- a/apps/sdp-web/src/components/dashboard-shell-cold-load-skeleton.unit.test.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell-cold-load-skeleton.unit.test.tsx
@@ -61,9 +61,13 @@ function renderColdLoad(pathname: string): string {
   );
 }
 
+// SAFETY: the page config only ever calls t(key) and uses the returned string,
+// so an identity function stands in for the translator in these assertions.
+const identityTranslate = ((key: string) => key) as Parameters<typeof getDashboardPageConfig>[1];
+
 /** What the settled shell puts on its centred content column, per dashboard-shell.tsx. */
 function settledContentWidthClassFor(pathname: string): string {
-  const config = getDashboardPageConfig(pathname, ((key: string) => key) as never, false, false);
+  const config = getDashboardPageConfig(pathname, identityTranslate, false, false);
   return config.contentWidthClass ?? "max-w-5xl";
 }
 
@@ -92,10 +96,25 @@ describe("dashboard cold load", () => {
     expect(transactions).not.toBe(policies);
   });
 
+  it("paints Helius Rings and the Members redirect with their own skeletons, not Home's", () => {
+    const helius = renderColdLoad("/dashboard/helius-rings");
+    const members = renderColdLoad("/dashboard/members");
+
+    expect(helius).toContain('data-loading-layout="helius-rings"');
+    expect(helius).not.toContain('data-loading-layout="home"');
+    expect(members).toContain('data-loading-layout="settings"');
+    expect(members).not.toContain('data-loading-layout="home"');
+  });
+
   it("holds the skeleton to the same content width the settled route uses", () => {
     // A hardcoded width here paints the skeleton at a different measure from the
     // page that follows, which is the layout jump wearing a different costume.
-    for (const pathname of ["/dashboard", "/dashboard/policies", "/dashboard/api-keys/new"]) {
+    for (const pathname of [
+      "/dashboard",
+      "/dashboard/policies",
+      "/dashboard/api-keys/new",
+      "/dashboard/helius-rings",
+    ]) {
       const settledWidth = settledContentWidthClassFor(pathname);
 
       expect(contentWidthClassOf(renderColdLoad(pathname))).toBe(settledWidth);
@@ -107,6 +126,17 @@ describe("dashboard cold load", () => {
 
     expect(markup).toContain("px-3 py-5 md:p-6");
     expect(markup).not.toContain("px-6 py-8");
+  });
+
+  it("titles Helius Rings and the Members redirect instead of falling through to Home", () => {
+    const t = identityTranslate;
+
+    expect(getDashboardPageConfig("/dashboard/helius-rings", t, false, false).title).toBe(
+      "Shared.dashboardShell.heliusRings"
+    );
+    expect(getDashboardPageConfig("/dashboard/members", t, false, false).title).toBe(
+      "Shared.dashboardShell.settings"
+    );
   });
 
   it("keeps the generic silhouette for callers that have no route in scope", () => {

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -13,6 +13,7 @@ import {
   ApprovalDetailSkeleton,
   ApprovalInboxSkeleton,
 } from "@/app/dashboard/approvals/approval-page-skeletons";
+import { HeliusRingsSkeleton } from "@/app/dashboard/helius-rings/helius-rings-skeleton";
 import {
   IntegrationDetailSkeleton,
   IntegrationsSkeleton,
@@ -204,6 +205,8 @@ function resolvePageLoadingComponent(
       return ApprovalDetailSkeleton;
     case "settings":
       return SettingsPageSkeleton;
+    case "helius-rings":
+      return HeliusRingsSkeleton;
     case "allowlist":
       return AllowlistLoading;
   }

--- a/apps/sdp-web/src/lib/dashboard-navigation-loading.ts
+++ b/apps/sdp-web/src/lib/dashboard-navigation-loading.ts
@@ -77,6 +77,7 @@ export type DashboardLoadingRoute =
   | "integrations"
   | "integration-detail"
   | "private-channels-setup"
+  | "helius-rings"
   | "allowlist";
 
 function normalizePathname(pathname: string): string {
@@ -130,6 +131,18 @@ function resolveMarketsLoadingRoute(pathname: string): DashboardLoadingRoute | n
   return null;
 }
 
+function resolveOperationsLoadingRoute(pathname: string): DashboardLoadingRoute | null {
+  if (pathname === "/dashboard/api-keys") return "api-keys-list";
+  if (pathname === "/dashboard/api-keys/new") return "api-key-new";
+  if (/^\/dashboard\/api-keys\/[^/]+\/edit$/.test(pathname)) return "api-key-edit";
+  if (pathname === "/dashboard/policies") return "policies";
+  if (pathname === "/dashboard/approvals") return "approvals-list";
+  if (/^\/dashboard\/approvals\/[^/]+$/.test(pathname)) return "approval-detail";
+  // Members only redirects into Settings, so it loads as the page it lands on.
+  if (pathname === "/dashboard/settings" || pathname === "/dashboard/members") return "settings";
+  return null;
+}
+
 /** Resolves a dashboard pathname to the exact canonical route loading surface. */
 export function resolveDashboardLoadingRoute(rawPathname: string): DashboardLoadingRoute | null {
   const pathname = normalizePathname(rawPathname);
@@ -162,13 +175,10 @@ export function resolveDashboardLoadingRoute(rawPathname: string): DashboardLoad
     return "recurring-payment-detail";
   }
 
-  if (pathname === "/dashboard/api-keys") return "api-keys-list";
-  if (pathname === "/dashboard/api-keys/new") return "api-key-new";
-  if (/^\/dashboard\/api-keys\/[^/]+\/edit$/.test(pathname)) return "api-key-edit";
-  if (pathname === "/dashboard/policies") return "policies";
-  if (pathname === "/dashboard/approvals") return "approvals-list";
-  if (/^\/dashboard\/approvals\/[^/]+$/.test(pathname)) return "approval-detail";
-  if (pathname === "/dashboard/settings") return "settings";
+  const operationsRoute = resolveOperationsLoadingRoute(pathname);
+  if (operationsRoute) return operationsRoute;
+
+  if (pathname === DASHBOARD_SIDE_NAV_HREFS.heliusRings) return "helius-rings";
   if (pathname === "/dashboard/integrations") return "integrations";
   if (pathname === "/dashboard/integrations/private-channels/setup") {
     return "private-channels-setup";

--- a/apps/sdp-web/src/lib/dashboard-navigation-loading.unit.test.ts
+++ b/apps/sdp-web/src/lib/dashboard-navigation-loading.unit.test.ts
@@ -43,6 +43,8 @@ describe("dashboard loading route", () => {
     ["/dashboard/approvals", "approvals-list"],
     ["/dashboard/approvals/request-1", "approval-detail"],
     ["/dashboard/settings", "settings"],
+    ["/dashboard/members", "settings"],
+    ["/dashboard/helius-rings", "helius-rings"],
     ["/dashboard/integrations", "integrations"],
     ["/dashboard/integrations/privy", "integration-detail"],
     ["/dashboard/integrations/private-channels/setup", "private-channels-setup"],


### PR DESCRIPTION
Clicking Helius Rings painted the Home skeleton (balance hero and activity table) for about 300 ms before a page that looks nothing like it, and the header titled it "Home". /dashboard/members did the same on its way to Settings. Neither route had a loading.tsx, the cold-load map had no entry for them, and getDashboardPageConfig fell through to Home.

What changed
- helius-rings-skeleton.tsx: a detailed skeleton of the configured workspace (health strip, rings form, wallets table, balance, composer tabs and fields, activity rows), built on the same Card and Table parts so padding and row heights line up
- the workspace shows it while reading setup, instead of a "loading setup" text card, so the shape holds from click to data
- loading.tsx for both routes, cold-load entries, and header titles
- the operations branch of resolveDashboardLoadingRoute moved into a helper to stay under the complexity limit

Checked
- skeleton vs settled page at 1440 px in light and dark: health, rings, overview and composer match exactly, activity is 3 px short
- typecheck, Biome on changed files, web unit suite

Notes
- DashboardHeliusRings.setup.loading is now unused and left in the catalogs
- a project with no Rings connection still goes from this skeleton to the setup form once

HOO-1627
