### PR TITLE
feat(dvp): admit the settlement authority on create, keep the authorized wallet on close

### DIFF
--- a/apps/sdp-api/src/routes/dvp/handlers.ts
+++ b/apps/sdp-api/src/routes/dvp/handlers.ts
@@ -500,7 +500,7 @@ const closeTrade = (action: DvpCloseAction) => async (c: AppContext) => {
     "payments:write",
   ]);
 
-  const result = await closeDvpTrade(c, trade, action);
+  const result = await closeDvpTrade(c, trade, action, settlement);
 
   // We broadcast it, so we know the outcome — not `closed_unknown` from the sweep.
   const closed = await createDvpTradeRepository(c.env).recordClose(

--- a/apps/sdp-api/src/services/dvp/create.test.ts
+++ b/apps/sdp-api/src/services/dvp/create.test.ts
@@ -36,7 +36,7 @@ import {
   signatureBytes,
 } from "@solana/kit";
 import { generateKeyPairSigner } from "@solana/signers";
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
 import type { DvpTradeRow } from "@/db/repositories";
 import type { AppError } from "@/lib/errors";
@@ -55,10 +55,6 @@ const sendTransaction = vi.hoisted(() => vi.fn());
 // ordering. The last case below still proves create is wired to it.
 const validateDvpMints = vi.hoisted(() => vi.fn());
 const inspectDvpMint = vi.hoisted(() => vi.fn());
-// The settlement wallet is a per-project custody wallet provisioned on first
-// use. Its own behaviour is covered in settlement-wallet.test.ts; here it is
-// stubbed so these tests stay about broadcast ordering.
-const getOrCreateDvpSettlementWallet = vi.hoisted(() => vi.fn());
 
 vi.mock("@/services/sponsorship.service", async () => {
   const actual = await vi.importActual<typeof import("@/services/sponsorship.service")>(
@@ -68,7 +64,6 @@ vi.mock("@/services/sponsorship.service", async () => {
 });
 vi.mock("./mints", () => ({ validateDvpMints }));
 vi.mock("./inspect-mint", () => ({ inspectDvpMint }));
-vi.mock("./settlement-wallet", () => ({ getOrCreateDvpSettlementWallet }));
 // The immediate chain read after a send is the reconciler's contract, tested in
 // observe-now.test.ts; here it is stubbed so these tests stay about the claim,
 // sign and send ordering. Null means "nothing observed yet".
@@ -172,17 +167,13 @@ describe("createDvpTrade", () => {
   let custodyWalletAddress: string;
   let sponsor: Awaited<ReturnType<typeof generateKeyPairSigner>>;
   let originalSettlementAuthority: string | undefined;
-
-  beforeAll(async () => {
-    await seedTestDatabase(env as Parameters<typeof seedTestDatabase>[0]);
-  });
-
-  afterAll(async () => {
-    await seedTestDatabase(env as Parameters<typeof seedTestDatabase>[0]);
-  });
+  let originalByok: string | undefined;
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    await seedTestDatabase(env);
+    originalByok = env.PRIVY_BYOK_ENABLED;
+    env.PRIVY_BYOK_ENABLED = "false";
     validateDvpMints.mockResolvedValue([]);
     // Carried onto the row so later surfaces can show the trade in the units
     // somebody typed, with the token named.
@@ -190,10 +181,6 @@ describe("createDvpTrade", () => {
       decimals: 6,
       symbol: "ATD",
       name: "Acme Treasury Debt",
-    });
-    getOrCreateDvpSettlementWallet.mockResolvedValue({
-      custodyWalletId: "cwlt_settlement",
-      address: SETTLEMENT_AUTHORITY,
     });
     sponsor = await generateKeyPairSigner();
     getFeePayer.mockResolvedValue(sponsor.address);
@@ -223,19 +210,16 @@ describe("createDvpTrade", () => {
     env.DVP_SETTLEMENT_AUTHORITY = SETTLEMENT_AUTHORITY;
 
     const db = getDb(env);
-    await db.prepare("DELETE FROM dvp_trades").run();
-    await db.prepare("DELETE FROM custody_wallets").run();
-    await db.prepare("DELETE FROM custody_configs").run();
-    await db.prepare("DELETE FROM counterparty_accounts").run();
-    await db.prepare("DELETE FROM counterparties").run();
-    await db.prepare("DELETE FROM projects").run();
-
     await db
       .prepare(
         "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
       )
       .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
       .run();
+    await db.execute("UPDATE organizations SET settings = ? WHERE id = ?", [
+      JSON.stringify({ providerOverrides: { custody: { local: true } } }),
+      TEST_ORG.id,
+    ]);
     await db
       .prepare(
         "INSERT OR REPLACE INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')"
@@ -258,10 +242,10 @@ describe("createDvpTrade", () => {
       .run();
     await db
       .prepare(
-        `INSERT INTO custody_configs (id, organization_id, provider, config_encrypted, status)
-         VALUES (?, ?, 'local', 'x', 'active')`
+        `INSERT INTO custody_configs (id, organization_id, project_id, provider, config_encrypted, status)
+         VALUES (?, ?, ?, 'local', 'x', 'active')`
       )
-      .bind(CUSTODY_CONFIG_ID, TEST_ORG.id)
+      .bind(CUSTODY_CONFIG_ID, TEST_ORG.id, TEST_PROJECT_ID)
       .run();
 
     const signer = await generateKeyPairSigner();
@@ -274,10 +258,144 @@ describe("createDvpTrade", () => {
       )
       .bind(CUSTODY_WALLET_ID, CUSTODY_CONFIG_ID, custodyWalletAddress)
       .run();
+    await db.execute(
+      `INSERT INTO custody_wallets (id, custody_config_id, wallet_id, public_key, status)
+       VALUES ('cwlt_settlement', ?, 'provider_settlement', ?, 'active')`,
+      [CUSTODY_CONFIG_ID, SETTLEMENT_AUTHORITY]
+    );
+    await db.execute(
+      `INSERT INTO dvp_settlement_wallets (project_id, organization_id, custody_wallet_id)
+       VALUES (?, ?, 'cwlt_settlement')`,
+      [TEST_PROJECT_ID, TEST_ORG.id]
+    );
   });
 
   afterEach(() => {
     env.DVP_SETTLEMENT_AUTHORITY = originalSettlementAuthority;
+    env.PRIVY_BYOK_ENABLED = originalByok;
+  });
+
+  async function useConnectionAuthority() {
+    const db = getDb(env);
+    await db.execute(
+      `INSERT INTO provider_credentials
+       (id, organization_id, project_id, provider, label, scope, source, storage_backend, status, created_by)
+       VALUES ('pcred_dvp', ?, ?, 'privy', 'DvP authority', 'project', 'runtime', 'runtime_env', 'active', ?)`,
+      [TEST_ORG.id, TEST_PROJECT_ID, TEST_USER.id]
+    );
+    await db.execute(
+      `INSERT INTO custody_connections
+       (id, organization_id, project_id, provider, scope, provider_credential_id,
+        provider_credential_scope_key, status, provider_account_fingerprint, created_by)
+       VALUES ('cconn_dvp', ?, ?, 'privy', 'project', 'pcred_dvp', ?, 'pending', 'sha256:dvp', ?)`,
+      [TEST_ORG.id, TEST_PROJECT_ID, TEST_PROJECT_ID, TEST_USER.id]
+    );
+    await db.execute(`UPDATE custody_wallets SET custody_config_id = NULL,
+      custody_connection_id = 'cconn_dvp' WHERE id = 'cwlt_settlement'`);
+    await db.execute(`UPDATE custody_connections SET default_custody_wallet_id = 'cwlt_settlement',
+      status = 'active', last_check_status = 'success', last_check_at = sdp_iso_now(),
+      activated_at = sdp_iso_now() WHERE id = 'cconn_dvp'`);
+  }
+
+  it("refuses a paused authority before creating a trade, replacement or sponsor request", async () => {
+    await useConnectionAuthority();
+
+    await expect(createDvpTrade(env, tradeInput())).rejects.toMatchObject({
+      statusCode: 403,
+      details: { reason: "runtime_execution_paused" },
+    });
+    expect(await rowsInDb()).toEqual([]);
+    expect(createProjectSponsorshipFeePayment).not.toHaveBeenCalled();
+    expect(sendTransaction).not.toHaveBeenCalled();
+    expect(
+      await getDb(env).queryMany("SELECT custody_wallet_id FROM dvp_settlement_wallets")
+    ).toEqual([{ custody_wallet_id: "cwlt_settlement" }]);
+    expect(await getDb(env).queryMany("SELECT id FROM custody_wallets")).toHaveLength(2);
+  });
+
+  it.each(["connection", "credential", "entitlement"] as const)(
+    "refuses an authority with unavailable %s before recording or sponsoring a trade",
+    async (unavailable) => {
+      await useConnectionAuthority();
+      env.PRIVY_BYOK_ENABLED = "true";
+      const db = getDb(env);
+      if (unavailable === "connection") {
+        await db.execute(`UPDATE custody_connections SET status = 'deactivated',
+          deactivated_at = sdp_iso_now() WHERE id = 'cconn_dvp'`);
+      } else if (unavailable === "credential") {
+        await db.execute(
+          "UPDATE provider_credentials SET status = 'retired' WHERE id = 'pcred_dvp'"
+        );
+      } else {
+        await db.execute("UPDATE organizations SET settings = ? WHERE id = ?", [
+          JSON.stringify({ providerOverrides: { custody: { local: true, privy: false } } }),
+          TEST_ORG.id,
+        ]);
+      }
+
+      await expect(createDvpTrade(env, tradeInput())).rejects.toMatchObject({
+        statusCode: unavailable === "entitlement" ? 403 : 409,
+      });
+      expect(await rowsInDb()).toEqual([]);
+      expect(createProjectSponsorshipFeePayment).not.toHaveBeenCalled();
+      expect(await db.queryMany("SELECT custody_wallet_id FROM dvp_settlement_wallets")).toEqual([
+        { custody_wallet_id: "cwlt_settlement" },
+      ]);
+      expect(await db.queryMany("SELECT id FROM custody_wallets")).toHaveLength(2);
+    }
+  );
+
+  it("creates with an admitted nondefault Connection authority", async () => {
+    await useConnectionAuthority();
+    env.PRIVY_BYOK_ENABLED = "true";
+    await getDb(env).execute(
+      `INSERT INTO custody_scope_defaults
+       (id, organization_id, project_id, default_custody_config_id)
+       VALUES ('csd_dvp', ?, ?, ?)`,
+      [TEST_ORG.id, TEST_PROJECT_ID, CUSTODY_CONFIG_ID]
+    );
+
+    const trade = await createDvpTrade(env, tradeInput());
+
+    expect(trade.settlementAuthority).toBe(SETTLEMENT_AUTHORITY);
+    expect(sendTransaction).toHaveBeenCalledOnce();
+    expect(createProjectSponsorshipFeePayment).toHaveBeenCalledWith(
+      env,
+      expect.objectContaining({ actor: { type: "wallet", id: "cwlt_settlement" } })
+    );
+  });
+
+  it("replays the recorded create after BYOK is paused without sponsoring again", async () => {
+    await useConnectionAuthority();
+    env.PRIVY_BYOK_ENABLED = "true";
+    const input = { ...tradeInput(), idempotencyKey: "byok-replay" };
+    const original = await createDvpTrade(env, input);
+    env.PRIVY_BYOK_ENABLED = "false";
+
+    expect((await createDvpTrade(env, input)).id).toBe(original.id);
+    await expect(createDvpTrade(env, { ...input, amountA: 2000n })).rejects.toMatchObject({
+      statusCode: 409,
+    });
+    expect(await rowsInDb()).toHaveLength(1);
+    expect(sendTransaction).toHaveBeenCalledOnce();
+    expect(createProjectSponsorshipFeePayment).toHaveBeenCalledOnce();
+  });
+
+  it("admits a new attempt after a failed create instead of replaying through a paused authority", async () => {
+    await useConnectionAuthority();
+    env.PRIVY_BYOK_ENABLED = "true";
+    const input = { ...tradeInput(), idempotencyKey: "byok-failed-retry" };
+    createProjectSponsorshipFeePayment.mockRejectedValueOnce(new Error("Sponsor unavailable"));
+    await expect(createDvpTrade(env, input)).rejects.toThrow("Sponsor unavailable");
+    env.PRIVY_BYOK_ENABLED = "false";
+
+    await expect(createDvpTrade(env, input)).rejects.toMatchObject({
+      statusCode: 403,
+      details: { reason: "runtime_execution_paused" },
+    });
+    expect(await rowsInDb()).toMatchObject([{ status: "create_failed" }]);
+    expect(createProjectSponsorshipFeePayment).toHaveBeenCalledOnce();
+    expect(sendTransaction).not.toHaveBeenCalled();
   });
 
   it("has the trade durably recorded at `creating` before the bytes go out", async () => {

--- a/apps/sdp-api/src/services/dvp/create.ts
+++ b/apps/sdp-api/src/services/dvp/create.ts
@@ -357,6 +357,11 @@ export async function createDvpTrade(env: Env, input: CreateDvpTradeInput): Prom
     organizationId: input.organizationId,
     projectId: input.projectId,
   });
+  await new CustodyRuntimeTargets(getDb(env), env, new Map()).admitRuntimeExecution({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    custodyWalletId: settlement.custodyWalletId,
+  });
   const settlementAuthority = settlement.address;
 
   const userA = resolvedA.address;

--- a/apps/sdp-api/src/services/dvp/settle.test.ts
+++ b/apps/sdp-api/src/services/dvp/settle.test.ts
@@ -35,7 +35,6 @@ const getFeePayer = vi.hoisted(() => vi.fn());
 const prepareOwnedSubmission = vi.hoisted(() => vi.fn());
 const releaseDefinitelyUnbroadcast = vi.hoisted(() => vi.fn());
 const sendTransaction = vi.hoisted(() => vi.fn());
-const getOrCreateDvpSettlementWallet = vi.hoisted(() => vi.fn());
 const readDvpAccounts = vi.hoisted(() => vi.fn());
 const getRecentBlockhash = vi.hoisted(() =>
   vi.fn(async () => ({
@@ -60,7 +59,6 @@ vi.mock("@/services/sponsorship.service", async () => {
     }),
   };
 });
-vi.mock("./settlement-wallet", () => ({ getOrCreateDvpSettlementWallet }));
 vi.mock("./read-chain", () => ({ readDvpAccounts }));
 vi.mock("@sdp/rpc/solana", () => ({
   createRpc: () => ({}),
@@ -185,21 +183,12 @@ describe("closeDvpTrade", () => {
         return submission;
       }
     );
-    getOrCreateDvpSettlementWallet.mockResolvedValue({
-      custodyWalletId: "cwlt_settlement",
-      address: SETTLEMENT_AUTHORITY,
-    });
     sendTransaction.mockImplementation(async (_rpc: unknown, bytes: Uint8Array) =>
       getSignatureFromTransaction(getTransactionDecoder().decode(bytes))
     );
   });
 
-  it("keeps the authorized wallet when the project selects another record at the same address", async () => {
-    getOrCreateDvpSettlementWallet.mockResolvedValue({
-      ...settlement,
-      custodyWalletId: "cwlt_replacement",
-    });
-
+  it("requests the signer for the wallet the handler authorized", async () => {
     await closeDvpTrade(context, trade(), "settle", settlement);
 
     expect(createOrgSignerForCustodyWallet).toHaveBeenCalledWith(
@@ -208,11 +197,10 @@ describe("closeDvpTrade", () => {
       "prj_x",
       "cwlt_settlement"
     );
-    expect(getOrCreateDvpSettlementWallet).not.toHaveBeenCalled();
   });
 
   it.each(["settle", "cancel"] as const)(
-    "refuses %s without provisioning or sponsorship when the authorized wallet becomes unavailable",
+    "refuses %s without sponsorship when the authorized wallet becomes unavailable",
     async (action) => {
       const denial = conflict("Custody wallet is unavailable", {
         reason: "runtime_execution_unavailable",
@@ -221,7 +209,6 @@ describe("closeDvpTrade", () => {
 
       await expect(closeDvpTrade(context, trade(), action, settlement)).rejects.toBe(denial);
 
-      expect(getOrCreateDvpSettlementWallet).not.toHaveBeenCalled();
       expect(getFeePayer).not.toHaveBeenCalled();
       expect(sendTransaction).not.toHaveBeenCalled();
     }

--- a/apps/sdp-api/src/services/dvp/settle.test.ts
+++ b/apps/sdp-api/src/services/dvp/settle.test.ts
@@ -24,10 +24,11 @@ import { generateKeyPairSigner } from "@solana/signers";
 import { ASSOCIATED_TOKEN_PROGRAM_ADDRESS } from "@solana-program/token-2022";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { DvpTradeRow } from "@/db/repositories";
-import type { AppError } from "@/lib/errors";
+import { type AppError, conflict } from "@/lib/errors";
 import type { SponsorshipFeePayment } from "@/services/sponsorship.service";
 import { env } from "@/test/helpers/env";
 import { deriveDvpSettleAtas } from "./settle-atas";
+import type { DvpSettlementWallet } from "./settlement-wallet";
 
 const createOrgSignerForCustodyWallet = vi.hoisted(() => vi.fn());
 const getFeePayer = vi.hoisted(() => vi.fn());
@@ -69,7 +70,7 @@ vi.mock("@sdp/rpc/solana", () => ({
 
 const { closeDvpTrade } = await import("./settle");
 
-const SETTLEMENT_AUTHORITY = "9BvXsTHgFvS31NLpVN4hpAoHCTfwvVX1XkgFq7fJEZxY";
+let SETTLEMENT_AUTHORITY = "9BvXsTHgFvS31NLpVN4hpAoHCTfwvVX1XkgFq7fJEZxY";
 const USER_A = "5vJRzKtcp4b3Ptw9c8s3s2LrCC1cvJUY4Y3xvJXfj3Zn";
 const USER_B = "7WLcnnT1nnPuHiWaVnAY3Uz8Y2SgFy2VMg2t7GAoxnpg";
 const T22 = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb";
@@ -149,6 +150,7 @@ function preflightError(): SolanaError {
 describe("closeDvpTrade", () => {
   let authority: Awaited<ReturnType<typeof generateKeyPairSigner>>;
   let sponsor: Awaited<ReturnType<typeof generateKeyPairSigner>>;
+  let settlement: DvpSettlementWallet;
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -158,6 +160,12 @@ describe("closeDvpTrade", () => {
       legB: { exists: true, amount: 2000n, frozen: false },
     });
     authority = await generateKeyPairSigner();
+    SETTLEMENT_AUTHORITY = authority.address;
+    settlement = {
+      custodyWalletId: "cwlt_settlement",
+      address: authority.address,
+      providerWalletId: "provider_settlement",
+    };
     sponsor = await generateKeyPairSigner();
     createOrgSignerForCustodyWallet.mockResolvedValue(authority);
     getFeePayer.mockResolvedValue(sponsor.address);
@@ -186,9 +194,52 @@ describe("closeDvpTrade", () => {
     );
   });
 
+  it("keeps the authorized wallet when the project selects another record at the same address", async () => {
+    getOrCreateDvpSettlementWallet.mockResolvedValue({
+      ...settlement,
+      custodyWalletId: "cwlt_replacement",
+    });
+
+    await closeDvpTrade(context, trade(), "settle", settlement);
+
+    expect(createOrgSignerForCustodyWallet).toHaveBeenCalledWith(
+      env,
+      "org_x",
+      "prj_x",
+      "cwlt_settlement"
+    );
+    expect(getOrCreateDvpSettlementWallet).not.toHaveBeenCalled();
+  });
+
+  it.each(["settle", "cancel"] as const)(
+    "refuses %s without provisioning or sponsorship when the authorized wallet becomes unavailable",
+    async (action) => {
+      const denial = conflict("Custody wallet is unavailable", {
+        reason: "runtime_execution_unavailable",
+      });
+      createOrgSignerForCustodyWallet.mockRejectedValueOnce(denial);
+
+      await expect(closeDvpTrade(context, trade(), action, settlement)).rejects.toBe(denial);
+
+      expect(getOrCreateDvpSettlementWallet).not.toHaveBeenCalled();
+      expect(getFeePayer).not.toHaveBeenCalled();
+      expect(sendTransaction).not.toHaveBeenCalled();
+    }
+  );
+
+  it("refuses a signer whose current address differs from the trade before sponsorship", async () => {
+    createOrgSignerForCustodyWallet.mockResolvedValueOnce(await generateKeyPairSigner());
+
+    await expect(closeDvpTrade(context, trade(), "settle", settlement)).rejects.toThrow(
+      "no longer matches the trade's authority"
+    );
+    expect(getFeePayer).not.toHaveBeenCalled();
+    expect(sendTransaction).not.toHaveBeenCalled();
+  });
+
   it("refuses to settle a trade that is already closed", async () => {
     for (const status of ["settled", "cancelled", "closed_unknown", "create_failed"] as const) {
-      await expect(closeDvpTrade(context, trade({ status }), "settle")).rejects.toThrow(
+      await expect(closeDvpTrade(context, trade({ status }), "settle", settlement)).rejects.toThrow(
         /can no longer be settled/
       );
     }
@@ -199,7 +250,7 @@ describe("closeDvpTrade", () => {
   // trade costs a signature to learn what the status already said.
   it("refuses to settle a trade that is not fully funded", async () => {
     await expect(
-      closeDvpTrade(context, trade({ status: "partially_funded" }), "settle")
+      closeDvpTrade(context, trade({ status: "partially_funded" }), "settle", settlement)
     ).rejects.toThrow(/requires both legs funded/);
     expect(sendTransaction).not.toHaveBeenCalled();
   });
@@ -207,7 +258,12 @@ describe("closeDvpTrade", () => {
   // Cancel is the escape hatch. Requiring funding would make an abandoned
   // half-funded trade impossible to unwind, which is the opposite of the point.
   it("cancels a partially funded trade", async () => {
-    const result = await closeDvpTrade(context, trade({ status: "partially_funded" }), "cancel");
+    const result = await closeDvpTrade(
+      context,
+      trade({ status: "partially_funded" }),
+      "cancel",
+      settlement
+    );
 
     // The owned sponsorship path returns the signature in the submitted bytes.
     expect(result.signature).toEqual(expect.any(String));
@@ -218,14 +274,13 @@ describe("closeDvpTrade", () => {
   // rotated settlement wallet cannot sign for older trades and saying so beats
   // sending a transaction the program will reject.
   it("refuses when the project's settlement wallet is not the trade's authority", async () => {
-    getOrCreateDvpSettlementWallet.mockResolvedValue({
-      custodyWalletId: "cwlt_new",
-      address: USER_B,
-    });
-
-    await expect(closeDvpTrade(context, trade(), "settle")).rejects.toThrow(
-      /part of the trade's address and cannot be changed/
-    );
+    await expect(
+      closeDvpTrade(context, trade(), "settle", {
+        ...settlement,
+        address: address(USER_B),
+      })
+    ).rejects.toThrow(/part of the trade's address and cannot be changed/);
+    expect(createOrgSignerForCustodyWallet).not.toHaveBeenCalled();
     expect(sendTransaction).not.toHaveBeenCalled();
   });
 
@@ -234,7 +289,7 @@ describe("closeDvpTrade", () => {
       const row = trade();
       const atas = await deriveDvpSettleAtas(row);
 
-      await closeDvpTrade(context, row, "settle");
+      await closeDvpTrade(context, row, "settle", settlement);
 
       const transaction = getTransactionDecoder().decode(sendTransaction.mock.calls[0][1]);
       const message = getCompiledTransactionMessageDecoder().decode(transaction.messageBytes);
@@ -265,7 +320,7 @@ describe("closeDvpTrade", () => {
       const row = trade();
       const atas = await deriveDvpSettleAtas(row);
 
-      await closeDvpTrade(context, row, "cancel");
+      await closeDvpTrade(context, row, "cancel", settlement);
 
       const transaction = getTransactionDecoder().decode(sendTransaction.mock.calls[0][1]);
       const message = getCompiledTransactionMessageDecoder().decode(transaction.messageBytes);
@@ -330,7 +385,7 @@ describe("closeDvpTrade", () => {
 
   describe("sponsorship", () => {
     it("uses the sponsor as fee payer and collects both required signatures", async () => {
-      await closeDvpTrade(context, trade(), "settle");
+      await closeDvpTrade(context, trade(), "settle", settlement);
 
       const bytes = sendTransaction.mock.calls[0][1];
       const transaction = getTransactionDecoder().decode(bytes);
@@ -345,7 +400,7 @@ describe("closeDvpTrade", () => {
     });
 
     it("uses the sponsor as payer for every create-ATA instruction", async () => {
-      await closeDvpTrade(context, trade(), "settle");
+      await closeDvpTrade(context, trade(), "settle", settlement);
 
       const transaction = getTransactionDecoder().decode(sendTransaction.mock.calls[0][1]);
       const message = getCompiledTransactionMessageDecoder().decode(transaction.messageBytes);
@@ -359,7 +414,7 @@ describe("closeDvpTrade", () => {
     it("does not broadcast when the sponsor refuses to sign", async () => {
       prepareOwnedSubmission.mockRejectedValueOnce(new Error("sponsor rate limited"));
 
-      await expect(closeDvpTrade(context, trade(), "settle")).rejects.toThrow(
+      await expect(closeDvpTrade(context, trade(), "settle", settlement)).rejects.toThrow(
         "sponsor rate limited"
       );
       expect(sendTransaction).not.toHaveBeenCalled();
@@ -368,7 +423,7 @@ describe("closeDvpTrade", () => {
     it("maps a preflight rejection and releases the sponsorship reservation", async () => {
       sendTransaction.mockRejectedValue(preflightError());
 
-      await expect(closeDvpTrade(context, trade(), "settle")).rejects.toMatchObject({
+      await expect(closeDvpTrade(context, trade(), "settle", settlement)).rejects.toMatchObject({
         code: "TRANSACTION_FAILED",
         statusCode: 400,
       } satisfies Partial<AppError>);
@@ -379,17 +434,17 @@ describe("closeDvpTrade", () => {
       const error = new Error("socket hang up");
       sendTransaction.mockRejectedValue(error);
 
-      await expect(closeDvpTrade(context, trade(), "settle")).rejects.toBe(error);
+      await expect(closeDvpTrade(context, trade(), "settle", settlement)).rejects.toBe(error);
       expect(releaseDefinitelyUnbroadcast).not.toHaveBeenCalled();
     });
 
     it("fetches a fresh blockhash for every attempt", async () => {
       sendTransaction.mockRejectedValueOnce(preflightError());
 
-      await expect(closeDvpTrade(context, trade(), "settle")).rejects.toMatchObject({
+      await expect(closeDvpTrade(context, trade(), "settle", settlement)).rejects.toMatchObject({
         code: "TRANSACTION_FAILED",
       } satisfies Partial<AppError>);
-      await closeDvpTrade(context, trade(), "settle");
+      await closeDvpTrade(context, trade(), "settle", settlement);
 
       expect(getRecentBlockhash).toHaveBeenCalledTimes(2);
     });

--- a/apps/sdp-api/src/services/dvp/settle.ts
+++ b/apps/sdp-api/src/services/dvp/settle.ts
@@ -1,9 +1,8 @@
 /**
  * Settling and cancelling a DvP trade.
  *
- * The same safety order as create: build, sign, record intent, send. Here the
- * "record" step is the approved-operation effect fence, which is what makes a
- * crash mid-broadcast recoverable rather than ambiguous.
+ * The handler authorizes the settlement wallet. Kora sponsors the transaction
+ * fees and ATA rent; closing never selects or provisions another wallet.
  */
 
 import * as solanaRpc from "@sdp/rpc/solana";
@@ -36,7 +35,7 @@ import {
   buildRequiredAtaInstructions,
   buildSettleInstruction,
 } from "./settle-instructions";
-import { getOrCreateDvpSettlementWallet } from "./settlement-wallet";
+import type { DvpSettlementWallet } from "./settlement-wallet";
 
 /** Statuses from which a trade can still be acted on. */
 const OPEN: ReadonlySet<DvpTradeStatus> = new Set([
@@ -52,11 +51,12 @@ export interface DvpCloseResult {
   signature: Signature;
 }
 
-/** Settles or cancels a trade on chain. `c` carries the approved-operation fence context. */
+/** Settles or cancels a trade using the wallet already authorized by the handler. */
 export async function closeDvpTrade(
   c: Context<{ Bindings: Env }>,
   trade: DvpTradeRow,
-  action: DvpCloseAction
+  action: DvpCloseAction,
+  settlement: DvpSettlementWallet
 ): Promise<DvpCloseResult> {
   const env = c.env;
 
@@ -75,10 +75,6 @@ export async function closeDvpTrade(
     );
   }
 
-  const settlement = await getOrCreateDvpSettlementWallet(env, {
-    organizationId: trade.organizationId,
-    projectId: trade.projectId,
-  });
   // The authority is a PDA seed, so a project that rotated its settlement
   // wallet cannot settle trades created under the old one. Better to say that
   // than to send a transaction the program will reject.
@@ -94,6 +90,9 @@ export async function closeDvpTrade(
     trade.projectId,
     settlement.custodyWalletId
   );
+  if (signer.address !== trade.settlementAuthority) {
+    throw badRequest("DvP settlement wallet no longer matches the trade's authority");
+  }
   const atas = await deriveDvpSettleAtas({
     userA: trade.userA,
     userB: trade.userB,


### PR DESCRIPTION
## What changed

- **Create** admits the project's settlement authority (`CustodyRuntimeTargets.admitRuntimeExecution`) right after it is resolved and before the trade row is claimed or Kora is asked to sponsor. Paused BYOK, deactivated connection, retired credential, inactive config or lost provider entitlement → `403`/`409`, nothing written, nothing spent.
- **Settle / cancel** sign with the settlement wallet the handler already read and authorized. The service no longer re-reads (or provisions) the project mapping, and the resolved signer must match the trade's authority address before sponsorship.
- **Tests**: create tests run on real settlement-wallet rows (Config and Connection) instead of a stub; new cases for paused / unavailable / entitlement, replay after pause, retry after a failed create, and close wallet continuity. Dead settlement-wallet mock dropped from the settle tests.

## Why

- Create is signed by Kora, not by the authority, so nothing checked whether the authority could execute. A trade created under a paused or unavailable authority was born unsettleable: Kora budget spent, settle/cancel refused later.
- Close asserted API-key access on wallet A in the handler, then let the service pick the project's *current* mapping — which could be another record at the same address, or a freshly provisioned replacement.
- Both are the rules the other signing paths already follow: admit before new work; keep one exact wallet id from authorization to signature.

## Impact

- API only (`apps/sdp-api`). No migration, env var, flag or UI change. Rollback = redeploy the previous build.
- `POST /v1/dvp/trades` gains early refusals: `403 runtime_execution_paused`, `409 runtime_execution_unavailable`, `403` provider not entitled — the same codes fund/settle/cancel already return.
- Config wallets in a healthy state (config + wallet active, provider entitled): unchanged. `PRIVY_BYOK_ENABLED` does not apply to them.

## Pre/post release actions

- No migration, flag flip or backfill.
- **Post**: create one DvP trade in a fresh project on dev. First-use provisioning followed by admission is the only path without an automated test.

## Result Validation

- `pnpm -C apps/sdp-api exec tsc --noEmit` — pass
- `pnpm -C apps/sdp-api exec biome check <changed files>` — pass
- `node scripts/check-module-boundaries.mjs` — pass
- CI=true pnpm -C apps/sdp-api exec vitest run --maxWorkers=6 — pass

## Does it affect current flows & behavior and how

**Create** — one new gate, after the replay exit and before anything is written or paid:

```mermaid
flowchart LR
    A[POST /v1/dvp/trades] --> B{recorded replay for<br/>Idempotency-Key?}
    B -- yes --> R[return recorded trade]
    B -- no --> C[validate mints] --> D[read or provision<br/>settlement authority]
    D --> E{NEW: admitRuntimeExecution<br/>may the authority execute now?}
    E -- no --> F[403 / 409<br/>no row, no Kora]
    E -- yes --> G[validate terms] --> H[claim trade row] --> K[Kora signs and sends]
    style E fill:#fff3cd,stroke:#d39e00
```

**Close — before**

1. Handler reads the project's active settlement wallet A and asserts API-key access to A.
2. Service re-reads the mapping via get-or-create: could return another record at the same address, or provision a replacement if A went inactive.
3. Signer built for whatever step 2 returned; Kora sponsors.

**Close — after**

1. Handler reads A and asserts access, as before.
2. Service receives A; `A.address` must equal the trade's authority (`400` if the project rotated).
3. Signer for `A.custodyWalletId` (runtime admission runs inside); `signer.address` must equal the trade's authority (`400`). All before sponsorship.
4. Kora sponsors settle/cancel.

| Scenario | Before | After |
| --- | --- | --- |
| Authority paused (BYOK off), connection deactivated, credential retired | trade created, Kora paid, settle/cancel `403`/`409` later | create `403`/`409`, no row, no Kora |
| Provider entitlement removed after the wallet was provisioned | same as above | create `403` |
| Replay with the same Idempotency-Key while paused | returns the recorded trade | same |
| Retry after `create_failed` while paused | new trade created | `403`, no Kora |
| Close while the mapping points at another record with the same address | could sign with the other record | signs with the authorized one |
| Healthy Config or Connection authority | ok | ok |

**API before/after** (reconstructed) — `POST /v1/dvp/trades`, project whose settlement authority is a paused Connection wallet:

```jsonc
// before: 201 — trade recorded, never settleable
{ "data": { "trade": { "id": "dvp_…", "status": "created", "settlementAuthority": "…" } }, "meta": { … } }

// after: 403
{ "error": { "code": "FORBIDDEN",
             "message": "Wallet execution is paused. Retry after wallet execution is available.",
             "details": { "reason": "runtime_execution_paused" } } }
```

## Known gaps

- OpenAPI error lists for create/settle/cancel omit the `409`s; pre-existing (create's idempotency `409` was already undocumented).
- `settle.ts` answers `400` on signer/authority mismatch; the same condition inside the runtime target answers `409 runtime_execution_unavailable`. Follow-up.

## Notes

- Out of scope: fund (its signer already admits), DvP policy/Approval, Reclaim/Reject, production BYOK enablement.
- Degraded config wallets (config inactive, or entitlement removed after provisioning) now fail at create instead of at settle/cancel — intended.