### PR TITLE
feat(private-channels): authorize the exact custody wallet before signing and replay

### DIFF
--- a/apps/sdp-api/src/db/migrations/postgres/0094_private_channel_transfer_signed_reservation.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0094_private_channel_transfer_signed_reservation.sql
@@ -1,0 +1,13 @@
+-- Commit 6f0c3e04e added signature-before-send but left the original CHECK intact.
+-- The transfer service records a signature before send while it still owns the
+-- pending reservation. A crash in that window must remain observable by replay
+-- recovery; the original constraint rejected this write and prevented any send.
+ALTER TABLE private_channel_transfers
+    DROP CONSTRAINT private_channel_transfers_result_check,
+    ADD CONSTRAINT private_channel_transfers_result_check
+        CHECK (
+            (status = 'pending' AND failure_reason IS NULL)
+            OR (status = 'submitted' AND signature IS NOT NULL AND failure_reason IS NULL)
+            OR (status = 'confirmed' AND signature IS NOT NULL AND failure_reason IS NULL)
+            OR (status = 'failed' AND failure_reason IS NOT NULL)
+        );

--- a/apps/sdp-api/src/openapi/paths/private-channels.ts
+++ b/apps/sdp-api/src/openapi/paths/private-channels.ts
@@ -269,7 +269,7 @@ export function registerPrivateChannelsPaths(registry: OpenAPIRegistry) {
     summary: "Create a deposit into the channel escrow",
     operationId: "createPrivateChannelDeposit",
     description:
-      "Builds, server-signs, and broadcasts an escrow deposit from a custody wallet to the instance chain (devnet), crediting `recipient` (defaults to the depositor) in the channel. Returns the deposit with its current status (submitted/confirmed, or failed). The credit (`credited`) is detected asynchronously via the gateway balance. Accepts a dashboard session or an API key. The source `walletId` must be a custody wallet enrolled under the project's Private Channels principal on this instance (and, for a wallet-scoped API key, one the key is bound to), and `recipient` must be an address verified on it. The `Idempotency-Key` header is REQUIRED: an identical retry returns the original deposit without a second escrow transfer, while reusing the key for a different request returns 409.",
+      "Builds, server-signs, and broadcasts an escrow deposit from a custody wallet to the instance chain (devnet), crediting `recipient` (defaults to the depositor) in the channel. Returns the deposit with its current status (submitted/confirmed, or failed). The credit (`credited`) is detected asynchronously via the gateway balance. Accepts a dashboard session or an API key. The source `walletId` must be a custody wallet enrolled under the project's Private Channels principal on this instance (and, for a wallet-scoped API key, one the key is bound to), and `recipient` must be an address verified on it. The `Idempotency-Key` header is REQUIRED: an identical retry returns the original deposit without a second escrow transfer, while reusing the key for a different request returns 409. New execution requires current payments:write, authorization for one unambiguous source custody wallet, and runtime admission before signing setup or an SPC session. Every POST, including a matching replay, requires current payments:write and authorization for the original source. A matching recorded result returns without a new signer or runtime admission; read-only access remains on the history GET endpoints. Separately authorized recovery of an abandoned operation may update its recorded state without a new custody signature.",
     security: [{ apiKeyAuth: [] }, { sessionCookie: [] }],
     request: {
       headers: projectScopeWithRequiredIdempotencyHeaders,
@@ -327,7 +327,7 @@ export function registerPrivateChannelsPaths(registry: OpenAPIRegistry) {
     summary: "Create a withdrawal from the channel balance",
     operationId: "createPrivateChannelWithdrawal",
     description:
-      "Server-signs a burn of the custody wallet's channel-chain balance and broadcasts it to the gateway; the operator later releases the matching real USDC on devnet to `destination` (defaults to the owner). Returns the withdrawal with its current status (submitted/burn_confirmed, or failed). The release (`released`) is detected asynchronously from the devnet release on the instance ATA. Accepts a dashboard session or an API key. The burn owner named by `walletId` must be a custody wallet enrolled under the project's Private Channels principal on this instance (and, for a wallet-scoped API key, one the key is bound to), and the balance is checked before the burn is broadcast. The `Idempotency-Key` header is REQUIRED: a burn cannot be undone, so an identical retry returns the original withdrawal, while reusing the key for a different request returns 409.",
+      "Server-signs a burn of the custody wallet's channel-chain balance and broadcasts it to the gateway; the operator later releases the matching real USDC on devnet to `destination` (defaults to the owner). Returns the withdrawal with its current status (submitted/burn_confirmed, or failed). The release (`released`) is detected asynchronously from the devnet release on the instance ATA. Accepts a dashboard session or an API key. The burn owner named by `walletId` must be a custody wallet enrolled under the project's Private Channels principal on this instance (and, for a wallet-scoped API key, one the key is bound to), and the balance is checked before the burn is broadcast. The `Idempotency-Key` header is REQUIRED: a burn cannot be undone, so an identical retry returns the original withdrawal, while reusing the key for a different request returns 409. New execution requires current payments:write, authorization for one unambiguous source custody wallet, and runtime admission before signing setup or an SPC session. Every POST, including a matching replay, requires current payments:write and authorization for the original source. A matching recorded result returns without a new signer or runtime admission; read-only access remains on the history GET endpoints. Separately authorized recovery of an abandoned operation may update its recorded state without a new custody signature.",
     security: [{ apiKeyAuth: [] }, { sessionCookie: [] }],
     request: {
       headers: projectScopeWithRequiredIdempotencyHeaders,
@@ -407,7 +407,7 @@ export function registerPrivateChannelsPaths(registry: OpenAPIRegistry) {
     summary: "Create a verified principal-to-principal channel transfer",
     operationId: "createPrivateChannelTransfer",
     description:
-      "Accepts a dashboard session or an API key (a wallet-scoped key must be bound to the source wallet). Server-signs with the project's default principal's verified SDP custody wallet and sends only to an opaque verified-wallet recipient returned by the channel recipient endpoint. Records the transfer as `pending` before broadcast, `submitted` once SPC accepts it, then `confirmed` once a signature-status read shows it executed. `failed` covers preparation errors, ingress rejection and execution errors, and may be retried by the caller. Returns once the confirm read resolves; a transfer still `submitted` in the response means that read returned no verdict. The `Idempotency-Key` header is REQUIRED: an identical retry returns the original transfer instead of spending the balance again, while reusing the key for a different request returns 409.",
+      "Accepts a dashboard session or an API key (a wallet-scoped key must be bound to the source wallet). Server-signs with the project's default principal's verified SDP custody wallet and sends only to an opaque verified-wallet recipient returned by the channel recipient endpoint. Records the transfer as `pending` before broadcast, `submitted` once SPC accepts it, then `confirmed` once a signature-status read shows it executed. `failed` covers preparation errors, ingress rejection and execution errors, and may be retried by the caller. Returns once the confirm read resolves; a transfer still `submitted` in the response means that read returned no verdict. The `Idempotency-Key` header is REQUIRED: an identical retry returns the original transfer instead of spending the balance again, while reusing the key for a different request returns 409. New execution requires current payments:write, authorization for one unambiguous source custody wallet, and runtime admission before signing setup or an SPC session. Every POST, including a matching replay, requires current payments:write and authorization for the original source. A matching recorded result returns without a new signer or runtime admission; read-only access remains on the history GET endpoints. Separately authorized recovery of an abandoned operation may update its recorded state without a new custody signature.",
     security: [{ apiKeyAuth: [] }, { sessionCookie: [] }],
     request: {
       headers: projectScopeWithRequiredIdempotencyHeaders,
@@ -632,8 +632,8 @@ export function registerPrivateChannelsPaths(registry: OpenAPIRegistry) {
     summary: "Verify a custody wallet with the SPC auth service",
     operationId: "verifyPrivateChannelWallet",
     description:
-      "Runs the SPC challenge → sign → verify handshake for a custody wallet (any SDP provider), then records the verification for the selected project principal (or the default principal when omitted). A principal may verify many wallets; idempotent per (principal, instance, wallet).",
-    security: [{ sessionCookie: [] }],
+      "Runs the SPC challenge → sign → verify handshake for a custody wallet (any SDP provider), then records the verification for the selected project principal (or the default principal when omitted). Requires current payments:write and authorization for the specific custody wallet. The exact wallet is admitted before an SPC session or challenge is created. Each request signs a fresh challenge; the resulting verification record is idempotent per (principal, instance, wallet).",
+    security: [{ apiKeyAuth: [] }, { sessionCookie: [] }],
     request: {
       headers: projectScopeHeaders,
       params: privateChannelVerifyWalletParamSchema,
@@ -646,7 +646,7 @@ export function registerPrivateChannelsPaths(registry: OpenAPIRegistry) {
           successResponseSchema(z.object({ wallet: privateChannelVerifiedWalletSchema }))
         ),
       },
-      ...errorResponses(errorResponseSchema, [400, 401, 403, 404, 500, 503]),
+      ...errorResponses(errorResponseSchema, [400, 401, 403, 404, 409, 500, 503]),
     },
   });
 

--- a/apps/sdp-api/src/routes/private-channels.transfers.test.ts
+++ b/apps/sdp-api/src/routes/private-channels.transfers.test.ts
@@ -1,9 +1,12 @@
 import { hashString } from "@sdp/payments/hash";
 import type { CachedApiKey, PrivateChannelTransfer } from "@sdp/types";
+import { PrivySigner } from "@solana/keychain-privy";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
+import { createPrivateChannelTransferRepository } from "@/db/repositories";
 import app from "@/index";
-import * as solanaServices from "@/services/solana";
+import { buildPrivateChannelTransferFingerprint } from "@/lib/idempotency";
+import { getPrivyProviderAccountFingerprint } from "@/services/custody/privy-credential";
 import { TEST_PRODUCTION_API_KEY } from "@/test/fixtures/api-keys";
 import { seedProjectApiKey } from "@/test/helpers/api-keys";
 import { env } from "@/test/helpers/env";
@@ -15,7 +18,10 @@ const { createChannelTransferMock, resolveGatewayAuthMock } = vi.hoisted(() => (
   createChannelTransferMock: vi.fn(),
   resolveGatewayAuthMock: vi.fn(),
 }));
-const createOrgSignerMock = vi.spyOn(solanaServices, "createOrgSigner");
+const createProviderSigner = PrivySigner.create;
+const createOrgSignerMock = vi.spyOn(PrivySigner, "create");
+const providerFetch = vi.fn<typeof fetch>();
+const originalPrivy = { appId: env.PRIVY_APP_ID, appSecret: env.PRIVY_APP_SECRET };
 
 vi.mock("@/services/private-channels", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/services/private-channels")>();
@@ -77,6 +83,55 @@ const UNSAFE_RECIPIENTS = [
 ] as const;
 
 let originalPrivateChannelsEnabled: string | undefined;
+let originalByok: string | undefined;
+
+async function useConnectionSource() {
+  const db = getDb(env);
+  await db.batch([
+    db
+      .prepare("UPDATE custody_configs SET default_wallet_id = ? WHERE id = 'cust-pct'")
+      .bind(OTHER_USER_WALLET_ID),
+    db
+      .prepare(`INSERT INTO provider_credentials
+      (id, organization_id, project_id, provider, label, scope, source, storage_backend, status, created_by)
+      VALUES ('pcred-pct', ?, ?, 'privy', 'PC', 'project', 'runtime', 'runtime_env', 'active', ?)`)
+      .bind(ORGANIZATION_ID, PROJECT_ID, ACTOR_USER_ID),
+    db
+      .prepare(`INSERT INTO custody_connections
+      (id, organization_id, project_id, provider, scope, provider_credential_id, provider_credential_scope_key, status, created_by)
+      VALUES ('conn-pct', ?, ?, 'privy', 'project', 'pcred-pct', ?, 'pending', ?)`)
+      .bind(ORGANIZATION_ID, PROJECT_ID, PROJECT_ID, ACTOR_USER_ID),
+    db.prepare(
+      "UPDATE custody_wallets SET custody_config_id = NULL, custody_connection_id = 'conn-pct' WHERE id = 'cw-pct-actor'"
+    ),
+    db
+      .prepare(`UPDATE custody_connections SET default_custody_wallet_id = 'cw-pct-actor', status = 'active',
+      provider_account_fingerprint = ?, activated_at = sdp_iso_now(), last_check_status = 'success', last_check_at = sdp_iso_now()
+      WHERE id = 'conn-pct'`)
+      .bind(await getPrivyProviderAccountFingerprint("pc-transfer-app")),
+  ]);
+}
+
+async function keyTransfer(id: string, pending = false) {
+  await seedTransfer({ id, status: pending ? "pending" : "submitted" });
+  await getDb(env)
+    .prepare(`UPDATE private_channel_transfers SET idempotency_key = ?, idempotency_fingerprint = ?,
+    updated_at = ? WHERE id = ?`)
+    .bind(
+      "idem_route_transfer",
+      buildPrivateChannelTransferFingerprint({
+        instanceId: INSTANCE_ID,
+        channelId: CHANNEL_ID,
+        walletId: ACTOR_WALLET_ID,
+        recipientVerifiedWalletId: RECIPIENT_VERIFIED_WALLET_ID,
+        mint: OUTSIDER_ADDRESS,
+        amount: "1.5",
+      }),
+      new Date(Date.now() - 11 * 60_000).toISOString(),
+      id
+    )
+    .run();
+}
 
 function sessionHeaders(extra: Record<string, string> = {}) {
   return {
@@ -221,6 +276,23 @@ async function seedRouteState(): Promise<void> {
         ESCROW_INSTANCE_ADDRESS
       ),
     db
+      .prepare(`INSERT INTO api_keys
+      (id, organization_id, project_id, created_by, name, key_prefix, key_hash, role, permissions, status)
+      VALUES (?, ?, ?, ?, 'Scoped PC key', ?, ?, 'api_admin', ?, 'active')`)
+      .bind(
+        SCOPED_API_KEY.id,
+        ORGANIZATION_ID,
+        PROJECT_ID,
+        ACTOR_USER_ID,
+        SCOPED_API_KEY.prefix,
+        await hashString(SCOPED_API_KEY.raw, env.API_KEY_PEPPER),
+        JSON.stringify(cachedApiKey.permissions)
+      ),
+    db
+      .prepare(`INSERT INTO api_key_wallet_permissions (id, api_key_id, wallet_id, permissions)
+      VALUES ('akwp-pct', ?, ?, ?)`)
+      .bind(SCOPED_API_KEY.id, OTHER_USER_WALLET_ID, JSON.stringify(["payments:write"])),
+    db
       .prepare(
         `INSERT INTO private_channels
            (id, organization_id, project_id, instance_id, name, is_default)
@@ -285,7 +357,7 @@ async function seedRouteState(): Promise<void> {
       .prepare(
         `INSERT INTO custody_configs
            (id, organization_id, project_id, provider, config_encrypted, default_wallet_id, status)
-         VALUES ('cust-pct', ?, ?, 'turnkey', '{}', ?, 'active')`
+         VALUES ('cust-pct', ?, ?, 'privy', '{}', ?, 'active')`
       )
       .bind(ORGANIZATION_ID, PROJECT_ID, ACTOR_WALLET_ID),
     db
@@ -368,7 +440,7 @@ async function seedTransfer(input: {
          sender_private_channel_user_id, recipient_private_channel_user_id,
          sender_wallet_id, recipient_verified_wallet_id, sender, recipient,
          mint, amount, status, signature
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '1.5', ?, 'sig-read')`
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '1.5', ?, ?)`
     )
     .bind(
       input.id,
@@ -383,7 +455,8 @@ async function seedTransfer(input: {
       ACTOR_ADDRESS,
       RECIPIENT_ADDRESS,
       OUTSIDER_ADDRESS,
-      input.status ?? "submitted"
+      input.status ?? "submitted",
+      input.status === "pending" ? null : "sig-read"
     )
     .run();
 }
@@ -406,18 +479,29 @@ async function postTransfer(
 describe("Private Channels — transfer access and routes", () => {
   afterAll(() => {
     createOrgSignerMock.mockRestore();
+    env.PRIVY_APP_ID = originalPrivy.appId;
+    env.PRIVY_APP_SECRET = originalPrivy.appSecret;
   });
 
   beforeEach(async () => {
+    originalByok = env.PRIVY_BYOK_ENABLED;
     originalPrivateChannelsEnabled = env.PRIVATE_CHANNELS_ENABLED;
     env.PRIVATE_CHANNELS_ENABLED = "true";
+    env.PRIVY_APP_ID = "pc-transfer-app";
+    env.PRIVY_APP_SECRET = "pc-transfer-secret";
     await seedTestDatabase(env);
     await seedRouteState();
     createChannelTransferMock.mockReset();
     resolveGatewayAuthMock.mockReset();
     createOrgSignerMock.mockReset();
     createChannelTransferMock.mockResolvedValue(transferDto());
-    createOrgSignerMock.mockResolvedValue({ address: ACTOR_ADDRESS } as never);
+    createOrgSignerMock.mockImplementation(createProviderSigner);
+    providerFetch
+      .mockReset()
+      .mockImplementation(async () =>
+        Response.json({ address: ACTOR_ADDRESS, chain_type: "solana", id: ACTOR_WALLET_ID })
+      );
+    vi.stubGlobal("fetch", providerFetch);
     resolveGatewayAuthMock.mockResolvedValue({
       current: "jwt-route",
       pcUserId: ACTOR_PC_USER_ID,
@@ -426,8 +510,185 @@ describe("Private Channels — transfer access and routes", () => {
   });
 
   afterEach(async () => {
+    vi.unstubAllGlobals();
+    env.PRIVY_BYOK_ENABLED = originalByok;
     env.PRIVATE_CHANNELS_ENABLED = originalPrivateChannelsEnabled;
     await clearKVStores(env);
+  });
+
+  it.each([false, true])(
+    "uses role permissions for transfer execution and replay (replay=%s)",
+    async (replay) => {
+      if (replay) await keyTransfer("pct_role_replay");
+      await getDb(env)
+        .prepare("UPDATE api_keys SET permissions = NULL WHERE id = ?")
+        .bind(API_KEY.id)
+        .run();
+      await clearKVStores(env);
+
+      const response = await postTransfer(
+        {
+          walletId: ACTOR_WALLET_ID,
+          recipientVerifiedWalletId: RECIPIENT_VERIFIED_WALLET_ID,
+          amount: "1.5",
+        },
+        { ...apiKeyHeaders(), "Idempotency-Key": "idem_route_transfer" }
+      );
+
+      expect(response.status).toBe(200);
+      if (replay) {
+        expect(await response.json()).toMatchObject({ data: { id: "pct_role_replay" } });
+        expect(createOrgSignerMock).not.toHaveBeenCalled();
+      }
+    }
+  );
+
+  it("requires the original source for transfer replay while history remains readable", async () => {
+    await seedTransfer({ id: "pct_replay" });
+    await getDb(env).batch([
+      getDb(env)
+        .prepare(
+          `UPDATE private_channel_transfers SET idempotency_key = ?, idempotency_fingerprint = ? WHERE id = 'pct_replay'`
+        )
+        .bind(
+          "idem_route_transfer",
+          buildPrivateChannelTransferFingerprint({
+            instanceId: INSTANCE_ID,
+            channelId: CHANNEL_ID,
+            walletId: ACTOR_WALLET_ID,
+            recipientVerifiedWalletId: RECIPIENT_VERIFIED_WALLET_ID,
+            mint: OUTSIDER_ADDRESS,
+            amount: "1.5",
+          })
+        ),
+      getDb(env).prepare(
+        "UPDATE custody_wallets SET status = 'inactive' WHERE id = 'cw-pct-actor'"
+      ),
+    ]);
+    const response = await postTransfer({
+      walletId: ACTOR_WALLET_ID,
+      recipientVerifiedWalletId: RECIPIENT_VERIFIED_WALLET_ID,
+      amount: "1.500",
+    });
+    expect(response.status).toBe(404);
+    const history = await app.request(
+      "/v1/private-channels/transfers/pct_replay",
+      { headers: sessionHeaders() },
+      env
+    );
+    expect(history.status).toBe(200);
+    expect(await history.json()).toMatchObject({
+      data: { id: "pct_replay", status: "submitted" },
+    });
+    expect(createOrgSignerMock).not.toHaveBeenCalled();
+    expect(resolveGatewayAuthMock).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])(
+    "admits an explicitly chosen nondefault Connection before transfer setup (enabled=%s)",
+    async (enabled) => {
+      await useConnectionSource();
+      env.PRIVY_BYOK_ENABLED = String(enabled);
+      const response = await postTransfer({
+        walletId: ACTOR_WALLET_ID,
+        recipientVerifiedWalletId: RECIPIENT_VERIFIED_WALLET_ID,
+        amount: "1.5",
+      });
+      expect(response.status).toBe(enabled ? 200 : 403);
+      expect(createOrgSignerMock).toHaveBeenCalledTimes(enabled ? 1 : 0);
+      expect(resolveGatewayAuthMock).toHaveBeenCalledTimes(enabled ? 1 : 0);
+    }
+  );
+
+  it.each([true, false])(
+    "requires write for abandoned transfer recovery without a signer (write=%s)",
+    async (write) => {
+      await keyTransfer("pct_abandoned", true);
+      await useConnectionSource();
+      env.PRIVY_BYOK_ENABLED = "false";
+      await getDb(env)
+        .prepare("UPDATE api_keys SET permissions = ? WHERE id = ?")
+        .bind(
+          JSON.stringify(write ? ["payments:read", "payments:write"] : ["payments:read"]),
+          API_KEY.id
+        )
+        .run();
+      const response = await postTransfer(
+        {
+          walletId: ACTOR_WALLET_ID,
+          recipientVerifiedWalletId: RECIPIENT_VERIFIED_WALLET_ID,
+          amount: "1.5",
+        },
+        { ...apiKeyHeaders(), "Idempotency-Key": "idem_route_transfer" }
+      );
+      expect(response.status).toBe(write ? 200 : 403);
+      const history = await app.request(
+        "/v1/private-channels/transfers/pct_abandoned",
+        { headers: apiKeyHeaders() },
+        env
+      );
+      expect(history.status).toBe(200);
+      expect(await history.json()).toMatchObject({
+        data: { id: "pct_abandoned", status: write ? "failed" : "pending" },
+      });
+      expect(createOrgSignerMock).not.toHaveBeenCalled();
+      expect(resolveGatewayAuthMock).toHaveBeenCalledTimes(write ? 1 : 0);
+    }
+  );
+
+  it.each(['["payments:write"]', '["payments:read", "payments:write"]'])(
+    "rechecks the winner's original source after losing an idempotency reservation (%s)",
+    async (permissions) => {
+      await getDb(env)
+        .prepare("UPDATE api_keys SET permissions = ? WHERE id = ?")
+        .bind(permissions, API_KEY.id)
+        .run();
+      createChannelTransferMock.mockImplementationOnce(async (_env, input) => {
+        await keyTransfer("pct_race_winner");
+        await getDb(env)
+          .prepare("UPDATE private_channel_transfers SET sender = ? WHERE id = 'pct_race_winner'")
+          .bind(OTHER_USER_ADDRESS)
+          .run();
+        const winner = await createPrivateChannelTransferRepository(env).getTransferById({
+          organizationId: ORGANIZATION_ID,
+          projectId: PROJECT_ID,
+          id: "pct_race_winner",
+        });
+        return input.onReplay(winner);
+      });
+      const response = await postTransfer(
+        {
+          walletId: ACTOR_WALLET_ID,
+          recipientVerifiedWalletId: RECIPIENT_VERIFIED_WALLET_ID,
+          amount: "1.5",
+        },
+        { ...apiKeyHeaders(), "Idempotency-Key": "idem_route_transfer" }
+      );
+      expect(response.status).toBe(409);
+      // Preparatory signer construction is allowed before the losing INSERT;
+      // the winner must still be separately authorized before its result leaves.
+      expect(createOrgSignerMock).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it("keeps the selected source when the default changes during signer preparation", async () => {
+    createOrgSignerMock.mockImplementationOnce(async (config) => {
+      await getDb(env)
+        .prepare("UPDATE custody_configs SET default_wallet_id = ? WHERE id = 'cust-pct'")
+        .bind(OTHER_USER_WALLET_ID)
+        .run();
+      return createProviderSigner(config);
+    });
+    const response = await postTransfer({
+      walletId: ACTOR_WALLET_ID,
+      recipientVerifiedWalletId: RECIPIENT_VERIFIED_WALLET_ID,
+      amount: "1.5",
+    });
+    expect(response.status).toBe(200);
+    expect(createOrgSignerMock).toHaveBeenCalledTimes(1);
+    expect(createOrgSignerMock).toHaveBeenCalledWith(
+      expect.objectContaining({ walletId: ACTOR_WALLET_ID })
+    );
   });
 
   it("allows API keys to use the project's default identity", async () => {
@@ -594,10 +855,7 @@ describe("Private Channels — transfer access and routes", () => {
 
     expect(response.status).toBe(503);
     expect(createOrgSignerMock).toHaveBeenCalledWith(
-      expect.anything(),
-      ORGANIZATION_ID,
-      PROJECT_ID,
-      ACTOR_WALLET_ID
+      expect.objectContaining({ walletId: ACTOR_WALLET_ID })
     );
     expect(createChannelTransferMock).not.toHaveBeenCalled();
     const persisted = await getDb(env)
@@ -607,7 +865,9 @@ describe("Private Channels — transfer access and routes", () => {
   });
 
   it("rejects a signer whose address does not match the verified source wallet", async () => {
-    createOrgSignerMock.mockResolvedValueOnce({ address: RECIPIENT_ADDRESS } as never);
+    providerFetch.mockImplementationOnce(async () =>
+      Response.json({ address: RECIPIENT_ADDRESS, chain_type: "solana", id: ACTOR_WALLET_ID })
+    );
 
     const response = await postTransfer({
       walletId: ACTOR_WALLET_ID,
@@ -615,7 +875,7 @@ describe("Private Channels — transfer access and routes", () => {
       amount: "1.5",
     });
 
-    expect(response.status).toBe(400);
+    expect(response.status).toBe(409);
     expect(createChannelTransferMock).not.toHaveBeenCalled();
     const persisted = await getDb(env)
       .prepare("SELECT COUNT(*)::int AS count FROM private_channel_transfers")

--- a/apps/sdp-api/src/routes/private-channels.value-movement.test.ts
+++ b/apps/sdp-api/src/routes/private-channels.value-movement.test.ts
@@ -22,9 +22,20 @@
 
 import { hashString } from "@sdp/payments/hash";
 import type { CachedApiKey, PrivateChannelDeposit, PrivateChannelWithdrawal } from "@sdp/types";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PrivySigner } from "@solana/keychain-privy";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
+import {
+  createPrivateChannelDepositRepository,
+  createPrivateChannelWithdrawalRepository,
+} from "@/db/repositories";
 import app from "@/index";
+import {
+  buildPrivateChannelDepositFingerprint,
+  buildPrivateChannelWithdrawalFingerprint,
+} from "@/lib/idempotency";
+import { getPrivyProviderAccountFingerprint } from "@/services/custody/privy-credential";
+import { CustodyRuntimeTargets } from "@/services/domain/signing/custody-runtime-target";
 import { env } from "@/test/helpers/env";
 import { seedDefaultProjects } from "@/test/helpers/projects";
 import { seedTestDatabase } from "@/test/mocks/db";
@@ -36,6 +47,9 @@ const { createChannelDepositMock, createChannelWithdrawalMock, resolveGatewayAut
     createChannelWithdrawalMock: vi.fn(),
     resolveGatewayAuthMock: vi.fn(),
   }));
+const createProviderSigner = PrivySigner.create;
+const providerSignerMock = vi.spyOn(PrivySigner, "create");
+const originalPrivy = { appId: env.PRIVY_APP_ID, appSecret: env.PRIVY_APP_SECRET };
 
 vi.mock("@/services/private-channels", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/services/private-channels")>();
@@ -97,6 +111,34 @@ const UNSAFE_ADDRESSES = [
 ] as const;
 
 let originalPrivateChannelsEnabled: string | undefined;
+let originalByokEnabled: string | undefined;
+
+async function useConnectionSource() {
+  const db = getDb(env);
+  await db.batch([
+    db
+      .prepare("UPDATE custody_configs SET default_wallet_id = ? WHERE id = 'cust-pcv'")
+      .bind(COLLEAGUE_WALLET_ID),
+    db
+      .prepare(`INSERT INTO provider_credentials
+      (id, organization_id, project_id, provider, label, scope, source, storage_backend, status, created_by)
+      VALUES ('pcred-pcv', ?, ?, 'privy', 'PC', 'project', 'runtime', 'runtime_env', 'active', ?)`)
+      .bind(ORGANIZATION_ID, PROJECT_ID, ACTOR_USER_ID),
+    db
+      .prepare(`INSERT INTO custody_connections
+      (id, organization_id, project_id, provider, scope, provider_credential_id, provider_credential_scope_key, status, created_by)
+      VALUES ('conn-pcv', ?, ?, 'privy', 'project', 'pcred-pcv', ?, 'pending', ?)`)
+      .bind(ORGANIZATION_ID, PROJECT_ID, PROJECT_ID, ACTOR_USER_ID),
+    db.prepare(`UPDATE custody_wallets SET custody_config_id = NULL, custody_connection_id = 'conn-pcv'
+      WHERE id = 'cw-pcv-actor'`),
+    db
+      .prepare(`UPDATE custody_connections SET default_custody_wallet_id = 'cw-pcv-actor',
+      status = 'active', provider_account_fingerprint = ?, activated_at = sdp_iso_now(),
+      last_check_status = 'success', last_check_at = sdp_iso_now()
+      WHERE id = 'conn-pcv'`)
+      .bind(await getPrivyProviderAccountFingerprint("pc-value-app")),
+  ]);
+}
 
 function sessionHeaders(extra: Record<string, string> = {}) {
   return {
@@ -277,6 +319,23 @@ async function seedRouteState(): Promise<void> {
         ESCROW_INSTANCE_ADDRESS
       ),
     db
+      .prepare(`INSERT INTO api_keys
+      (id, organization_id, project_id, created_by, name, key_prefix, key_hash, role, permissions, status)
+      VALUES (?, ?, ?, ?, 'Scoped PC key', ?, ?, 'api_admin', ?, 'active')`)
+      .bind(
+        SCOPED_API_KEY.id,
+        ORGANIZATION_ID,
+        PROJECT_ID,
+        ACTOR_USER_ID,
+        SCOPED_API_KEY.prefix,
+        await hashString(SCOPED_API_KEY.raw, env.API_KEY_PEPPER),
+        JSON.stringify(cachedApiKey.permissions)
+      ),
+    db
+      .prepare(`INSERT INTO api_key_wallet_permissions (id, api_key_id, wallet_id, permissions)
+      VALUES ('akwp-pcv', ?, ?, ?)`)
+      .bind(SCOPED_API_KEY.id, COLLEAGUE_WALLET_ID, JSON.stringify(["payments:write"])),
+    db
       .prepare(
         // Principals are project-scoped and instance-scoped since 0073: `user_id`
         // is nullable and carries no meaning here, so these rows are seeded the
@@ -307,7 +366,7 @@ async function seedRouteState(): Promise<void> {
       .prepare(
         `INSERT INTO custody_configs
            (id, organization_id, project_id, provider, config_encrypted, default_wallet_id, status)
-         VALUES ('cust-pcv', ?, ?, 'turnkey', '{}', ?, 'active')`
+         VALUES ('cust-pcv', ?, ?, 'privy', '{}', ?, 'active')`
       )
       .bind(ORGANIZATION_ID, PROJECT_ID, ACTOR_WALLET_ID),
     db
@@ -381,10 +440,87 @@ async function postWithdrawal(
   );
 }
 
+async function recordedDeposit() {
+  return createPrivateChannelDepositRepository(env).createDeposit({
+    organizationId: ORGANIZATION_ID,
+    projectId: PROJECT_ID,
+    instanceId: INSTANCE_ID,
+    walletId: ACTOR_WALLET_ID,
+    depositor: ACTOR_ADDRESS,
+    recipient: ACTOR_ADDRESS,
+    mint: EXTERNAL_ADDRESS,
+    amount: "1.5",
+    context: {},
+    idempotencyKey: "idem_pc_value",
+    idempotencyFingerprint: buildPrivateChannelDepositFingerprint({
+      instanceId: INSTANCE_ID,
+      walletId: ACTOR_WALLET_ID,
+      recipient: ACTOR_ADDRESS,
+      mint: EXTERNAL_ADDRESS,
+      amount: "1.5",
+    }),
+  });
+}
+
+async function recordedWithdrawal() {
+  const row = await createPrivateChannelWithdrawalRepository(env).createWithdrawal({
+    organizationId: ORGANIZATION_ID,
+    projectId: PROJECT_ID,
+    instanceId: INSTANCE_ID,
+    walletId: ACTOR_WALLET_ID,
+    owner: ACTOR_ADDRESS,
+    destination: ACTOR_ADDRESS,
+    mint: EXTERNAL_ADDRESS,
+    amount: "1.5",
+    context: {},
+    idempotencyKey: "idem_pc_value",
+    idempotencyFingerprint: buildPrivateChannelWithdrawalFingerprint({
+      instanceId: INSTANCE_ID,
+      walletId: ACTOR_WALLET_ID,
+      destination: ACTOR_ADDRESS,
+      mint: EXTERNAL_ADDRESS,
+      amount: "1.5",
+    }),
+  });
+  if (!row) throw new Error("Failed to seed withdrawal");
+  return row;
+}
+
+async function abandonedWithdrawal() {
+  const row = await recordedWithdrawal();
+  await getDb(env)
+    .prepare("UPDATE private_channel_withdrawals SET updated_at = ? WHERE id = ?")
+    .bind(new Date(Date.now() - 11 * 60_000).toISOString(), row.id)
+    .run();
+  return row;
+}
+
+async function setKeyPermissions(permissions: string[]) {
+  await getDb(env)
+    .prepare("UPDATE api_keys SET permissions = ? WHERE id = ?")
+    .bind(JSON.stringify(permissions), API_KEY.id)
+    .run();
+}
+
 describe("Private Channels — deposit and withdrawal access", () => {
+  afterAll(() => {
+    providerSignerMock.mockRestore();
+    env.PRIVY_APP_ID = originalPrivy.appId;
+    env.PRIVY_APP_SECRET = originalPrivy.appSecret;
+  });
   beforeEach(async () => {
     originalPrivateChannelsEnabled = env.PRIVATE_CHANNELS_ENABLED;
+    originalByokEnabled = env.PRIVY_BYOK_ENABLED;
     env.PRIVATE_CHANNELS_ENABLED = "true";
+    env.PRIVY_APP_ID = "pc-value-app";
+    env.PRIVY_APP_SECRET = "pc-value-secret";
+    providerSignerMock.mockReset().mockImplementation(createProviderSigner);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () =>
+        Response.json({ address: ACTOR_ADDRESS, chain_type: "solana", id: ACTOR_WALLET_ID })
+      )
+    );
     await seedTestDatabase(env);
     await seedRouteState();
     createChannelDepositMock.mockReset();
@@ -400,8 +536,502 @@ describe("Private Channels — deposit and withdrawal access", () => {
   });
 
   afterEach(async () => {
+    vi.unstubAllGlobals();
     env.PRIVATE_CHANNELS_ENABLED = originalPrivateChannelsEnabled;
+    env.PRIVY_BYOK_ENABLED = originalByokEnabled;
     await clearKVStores(env);
+  });
+
+  it.each([false, true])(
+    "uses role permissions when explicit permissions are absent (replay=%s)",
+    async (replay) => {
+      if (replay) {
+        await recordedDeposit();
+        await recordedWithdrawal();
+      }
+      await getDb(env)
+        .prepare("UPDATE api_keys SET permissions = NULL WHERE id = ?")
+        .bind(API_KEY.id)
+        .run();
+      await clearKVStores(env);
+
+      for (const post of [postDeposit, postWithdrawal]) {
+        const response = await post({ walletId: ACTOR_WALLET_ID, amount: "1.5" }, apiKeyHeaders());
+        expect(response.status).toBe(200);
+      }
+      if (replay) expect(providerSignerMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it("uses the current role instead of the cached role when permissions are absent", async () => {
+    const original = await recordedDeposit();
+    await getDb(env)
+      .prepare("UPDATE api_keys SET role = 'api_readonly', permissions = NULL WHERE id = ?")
+      .bind(API_KEY.id)
+      .run();
+    const body = { walletId: ACTOR_WALLET_ID, amount: "1.5" };
+    expect((await postWithdrawal(body, apiKeyHeaders())).status).toBe(403);
+    expect((await postDeposit(body, apiKeyHeaders())).status).toBe(403);
+    const history = await app.request(
+      `/v1/private-channels/deposits/${original?.id}`,
+      { headers: apiKeyHeaders() },
+      env
+    );
+    expect(history.status).toBe(200);
+    expect(providerSignerMock).not.toHaveBeenCalled();
+    expect(resolveGatewayAuthMock).not.toHaveBeenCalled();
+  });
+
+  it.each([{ permissions: [] }, { permissions: ["wallets:read"] }])(
+    "does not inherit role permissions for explicit permissions $permissions",
+    async ({ permissions }) => {
+      await recordedDeposit();
+      await setKeyPermissions(permissions);
+      const body = { walletId: ACTOR_WALLET_ID, amount: "1.5" };
+      expect((await postWithdrawal(body, apiKeyHeaders())).status).toBe(403);
+      expect((await postDeposit(body, apiKeyHeaders())).status).toBe(403);
+      expect(providerSignerMock).not.toHaveBeenCalled();
+      expect(resolveGatewayAuthMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([
+    "not json",
+    '"payments:write"',
+    "{}",
+    "null",
+    '["payments:write", 42]',
+    '["payments:write", "unknown:permission"]',
+  ])("rejects malformed stored permissions before execution: %s", async (permissions) => {
+    await getDb(env)
+      .prepare("UPDATE api_keys SET permissions = ? WHERE id = ?")
+      .bind(permissions, API_KEY.id)
+      .run();
+
+    for (const replay of [false, true]) {
+      if (replay) await recordedDeposit();
+      const response = await postDeposit(
+        { walletId: ACTOR_WALLET_ID, amount: "1.5" },
+        apiKeyHeaders()
+      );
+      expect(response.status).toBe(500);
+      expect(await response.json()).toMatchObject({
+        error: { code: "INTERNAL_ERROR", message: "Stored API key permissions are invalid" },
+      });
+    }
+    expect(providerSignerMock).not.toHaveBeenCalled();
+    expect(resolveGatewayAuthMock).not.toHaveBeenCalled();
+  });
+
+  it("requires write for deposit replay and keeps history readable", async () => {
+    const repo = createPrivateChannelDepositRepository(env);
+    const original = await repo.createDeposit({
+      organizationId: ORGANIZATION_ID,
+      projectId: PROJECT_ID,
+      instanceId: INSTANCE_ID,
+      walletId: ACTOR_WALLET_ID,
+      depositor: ACTOR_ADDRESS,
+      recipient: ACTOR_ADDRESS,
+      mint: EXTERNAL_ADDRESS,
+      amount: "1.5",
+      context: {},
+      idempotencyKey: "idem_pc_value",
+      idempotencyFingerprint: buildPrivateChannelDepositFingerprint({
+        instanceId: INSTANCE_ID,
+        walletId: ACTOR_WALLET_ID,
+        recipient: ACTOR_ADDRESS,
+        mint: EXTERNAL_ADDRESS,
+        amount: "1.5",
+      }),
+    });
+    await getDb(env).batch([
+      getDb(env).prepare(
+        "UPDATE custody_wallets SET status = 'inactive' WHERE id = 'cw-pcv-actor'"
+      ),
+      getDb(env)
+        .prepare("UPDATE private_channel_instances SET is_active = false WHERE id = ?")
+        .bind(INSTANCE_ID),
+      getDb(env)
+        .prepare("UPDATE api_keys SET permissions = ? WHERE id = ?")
+        .bind(JSON.stringify(["payments:read"]), API_KEY.id),
+    ]);
+    await clearKVStores(env);
+
+    const response = await postDeposit(
+      { walletId: ACTOR_WALLET_ID, amount: "1.500" },
+      apiKeyHeaders()
+    );
+
+    expect(response.status).toBe(403);
+    const history = await app.request(
+      `/v1/private-channels/deposits/${original?.id}`,
+      { headers: apiKeyHeaders() },
+      env
+    );
+    expect(history.status).toBe(200);
+    expect(await history.json()).toMatchObject({ data: { id: original?.id, status: "pending" } });
+    expect(providerSignerMock).not.toHaveBeenCalled();
+    expect(resolveGatewayAuthMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses verification of a wallet outside the key's current wallet grants", async () => {
+    const response = await app.request(
+      `/v1/private-channels/wallets/${ACTOR_WALLET_ID}/verify`,
+      {
+        method: "POST",
+        headers: scopedApiKeyHeaders(),
+        body: "{}",
+      },
+      env
+    );
+    expect(response.status).toBe(403);
+    expect(JSON.stringify(await response.json())).toContain(
+      "not authorized for the requested wallet"
+    );
+  });
+
+  it("requires the original source for withdrawal replay while history remains readable", async () => {
+    const original = await createPrivateChannelWithdrawalRepository(env).createWithdrawal({
+      organizationId: ORGANIZATION_ID,
+      projectId: PROJECT_ID,
+      instanceId: INSTANCE_ID,
+      walletId: ACTOR_WALLET_ID,
+      owner: ACTOR_ADDRESS,
+      destination: ACTOR_ADDRESS,
+      mint: EXTERNAL_ADDRESS,
+      amount: "1.5",
+      context: {},
+      idempotencyKey: "idem_pc_value",
+      idempotencyFingerprint: buildPrivateChannelWithdrawalFingerprint({
+        instanceId: INSTANCE_ID,
+        walletId: ACTOR_WALLET_ID,
+        destination: ACTOR_ADDRESS,
+        mint: EXTERNAL_ADDRESS,
+        amount: "1.5",
+      }),
+    });
+    await getDb(env)
+      .prepare("UPDATE custody_wallets SET status = 'inactive' WHERE id = 'cw-pcv-actor'")
+      .run();
+    const response = await postWithdrawal({ walletId: ACTOR_WALLET_ID, amount: "1.500" });
+    expect(response.status).toBe(404);
+    const history = await app.request(
+      `/v1/private-channels/withdrawals/${original?.id}`,
+      { headers: sessionHeaders() },
+      env
+    );
+    expect(history.status).toBe(200);
+    expect(await history.json()).toMatchObject({ data: { id: original?.id, status: "pending" } });
+    expect(providerSignerMock).not.toHaveBeenCalled();
+    expect(resolveGatewayAuthMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects new Connection deposits and withdrawals before opening an SPC session when BYOK is off", async () => {
+    await useConnectionSource();
+    env.PRIVY_BYOK_ENABLED = "false";
+    for (const post of [postDeposit, postWithdrawal]) {
+      const response = await post({ walletId: ACTOR_WALLET_ID, amount: "1.5" });
+      expect(response.status).toBe(403);
+      expect(await response.json()).toMatchObject({
+        error: { details: { reason: "runtime_execution_paused" } },
+      });
+    }
+    expect(resolveGatewayAuthMock).not.toHaveBeenCalled();
+    expect(providerSignerMock).not.toHaveBeenCalled();
+  });
+
+  it("uses an active nondefault Connection for both movements", async () => {
+    await useConnectionSource();
+    env.PRIVY_BYOK_ENABLED = "true";
+    for (const post of [postDeposit, postWithdrawal]) {
+      expect((await post({ walletId: ACTOR_WALLET_ID, amount: "1.5" })).status).toBe(200);
+    }
+    expect(providerSignerMock).toHaveBeenCalledTimes(2);
+    expect(providerSignerMock).toHaveBeenCalledWith(
+      expect.objectContaining({ walletId: ACTOR_WALLET_ID, appId: "pc-value-app" })
+    );
+  });
+
+  it("preserves Config execution when BYOK is disabled", async () => {
+    env.PRIVY_BYOK_ENABLED = "false";
+    expect((await postDeposit({ walletId: ACTOR_WALLET_ID, amount: "1.5" })).status).toBe(200);
+    expect((await postWithdrawal({ walletId: ACTOR_WALLET_ID, amount: "1.5" })).status).toBe(200);
+  });
+
+  it.each(["credential", "entitlement"])(
+    "denies unavailable Connection %s before signer and SPC access",
+    async (reason) => {
+      await useConnectionSource();
+      env.PRIVY_BYOK_ENABLED = "true";
+      if (reason === "credential") {
+        await getDb(env)
+          .prepare("UPDATE provider_credentials SET status = 'retired' WHERE id = 'pcred-pcv'")
+          .run();
+      } else {
+        await getDb(env)
+          .prepare("UPDATE organizations SET settings = ? WHERE id = ?")
+          .bind(
+            JSON.stringify({ providerOverrides: { custody: { privy: false } } }),
+            ORGANIZATION_ID
+          )
+          .run();
+      }
+      for (const post of [postDeposit, postWithdrawal]) {
+        expect((await post({ walletId: ACTOR_WALLET_ID, amount: "1.5" })).status).toBe(
+          reason === "credential" ? 409 : 403
+        );
+      }
+      expect(providerSignerMock).not.toHaveBeenCalled();
+      expect(resolveGatewayAuthMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([ACTOR_WALLET_ID, ACTOR_ADDRESS])(
+    "rejects ambiguous source %s before provider access",
+    async (selector) => {
+      await useConnectionSource();
+      env.PRIVY_BYOK_ENABLED = "true";
+      await getDb(env)
+        .prepare(`INSERT INTO custody_wallets
+      (id, custody_config_id, wallet_id, public_key, status) VALUES ('cw-pcv-duplicate', 'cust-pcv', ?, ?, 'active')`)
+        .bind(ACTOR_WALLET_ID, ACTOR_ADDRESS)
+        .run();
+      expect((await postDeposit({ walletId: selector, amount: "1.5" })).status).toBe(409);
+      expect((await postWithdrawal({ walletId: selector, amount: "1.5" })).status).toBe(409);
+      expect(providerSignerMock).not.toHaveBeenCalled();
+      expect(resolveGatewayAuthMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(["wallet", "owner", "provider ID"])(
+    "rejects an address selector colliding with an inactive Connection %s instead of selecting Config",
+    async (inactive) => {
+      await useConnectionSource();
+      env.PRIVY_BYOK_ENABLED = "true";
+      const db = getDb(env);
+      await db
+        .prepare(`INSERT INTO custody_wallets
+        (id, custody_config_id, wallet_id, public_key, status)
+        VALUES ('cw-pcv-address-replacement', 'cust-pcv', 'wallet_address_replacement', ?, 'active')`)
+        .bind(ACTOR_ADDRESS)
+        .run();
+      await db
+        .prepare(
+          inactive !== "owner"
+            ? "UPDATE custody_wallets SET status = 'inactive' WHERE id = 'cw-pcv-actor'"
+            : "UPDATE custody_connections SET status = 'deactivated', deactivated_at = sdp_iso_now() WHERE id = 'conn-pcv'"
+        )
+        .run();
+      if (inactive === "provider ID") {
+        await db
+          .prepare(
+            "UPDATE custody_wallets SET wallet_id = ?, public_key = ? WHERE id = 'cw-pcv-actor'"
+          )
+          .bind(ACTOR_ADDRESS, COLLEAGUE_ADDRESS)
+          .run();
+      }
+      await db
+        .prepare(
+          "UPDATE private_channel_verified_wallets SET wallet_id = 'wallet_address_replacement' WHERE pubkey = ?"
+        )
+        .bind(ACTOR_ADDRESS)
+        .run();
+      for (const post of [postDeposit, postWithdrawal]) {
+        expect((await post({ walletId: ACTOR_ADDRESS, amount: "1.5" })).status).toBe(409);
+      }
+      expect(providerSignerMock).not.toHaveBeenCalled();
+      expect(resolveGatewayAuthMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it("accepts a counterparty address shared by custody records when the destination address is unambiguous", async () => {
+    await getDb(env)
+      .prepare(`INSERT INTO custody_wallets (id, custody_config_id, wallet_id, public_key, status)
+      VALUES ('cw-pcv-shared-recipient', 'cust-pcv', 'wallet_shared_recipient', ?, 'active')`)
+      .bind(COLLEAGUE_ADDRESS)
+      .run();
+    expect(
+      (
+        await postDeposit({
+          walletId: ACTOR_WALLET_ID,
+          amount: "1.5",
+          recipient: COLLEAGUE_ADDRESS,
+        })
+      ).status
+    ).toBe(200);
+    expect(
+      (
+        await postWithdrawal({
+          walletId: ACTOR_WALLET_ID,
+          amount: "1.5",
+          destination: COLLEAGUE_ADDRESS,
+        })
+      ).status
+    ).toBe(200);
+  });
+
+  it("denies stale all-wallet access after the key is restricted in the database", async () => {
+    await recordedDeposit();
+    await getDb(env)
+      .prepare(`INSERT INTO api_key_wallet_permissions (id, api_key_id, wallet_id, permissions)
+      VALUES ('akwp-pcv-restricted', ?, ?, '["payments:write"]')`)
+      .bind(API_KEY.id, COLLEAGUE_WALLET_ID)
+      .run();
+    expect(
+      (await postDeposit({ walletId: ACTOR_WALLET_ID, amount: "1.5" }, apiKeyHeaders())).status
+    ).toBe(403);
+    expect(
+      (await postWithdrawal({ walletId: ACTOR_WALLET_ID, amount: "1.5" }, apiKeyHeaders())).status
+    ).toBe(403);
+    expect(providerSignerMock).not.toHaveBeenCalled();
+  });
+
+  it("denies revoked API keys even when their cached permissions allow replay", async () => {
+    await recordedDeposit();
+    await getDb(env)
+      .prepare("UPDATE api_keys SET status = 'revoked', permissions = NULL WHERE id = ?")
+      .bind(API_KEY.id)
+      .run();
+    expect(
+      (await postDeposit({ walletId: ACTOR_WALLET_ID, amount: "1.5" }, apiKeyHeaders())).status
+    ).toBe(403);
+    expect(providerSignerMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects recovery after authorization discovers that the key was revoked", async () => {
+    const original = await abandonedWithdrawal();
+    const listWallets = CustodyRuntimeTargets.prototype.listWallets;
+    const inventory = vi
+      .spyOn(CustodyRuntimeTargets.prototype, "listWallets")
+      .mockImplementationOnce(async function (this: CustodyRuntimeTargets, params) {
+        await getDb(env)
+          .prepare("UPDATE api_keys SET status = 'revoked' WHERE id = ?")
+          .bind(API_KEY.id)
+          .run();
+        return listWallets.call(this, params);
+      });
+    try {
+      const response = await postWithdrawal(
+        { walletId: ACTOR_WALLET_ID, amount: "1.5" },
+        apiKeyHeaders()
+      );
+      expect(response.status).toBe(403);
+      expect(resolveGatewayAuthMock).not.toHaveBeenCalled();
+      expect(
+        await createPrivateChannelWithdrawalRepository(env).getWithdrawalById({
+          organizationId: ORGANIZATION_ID,
+          projectId: PROJECT_ID,
+          id: original.id,
+        })
+      ).toMatchObject({ status: "pending" });
+    } finally {
+      inventory.mockRestore();
+    }
+  });
+
+  it("does not create new work for a read-only key", async () => {
+    await setKeyPermissions(["payments:read"]);
+    expect(
+      (await postDeposit({ walletId: ACTOR_WALLET_ID, amount: "1.5" }, apiKeyHeaders())).status
+    ).toBe(403);
+    expect(
+      (await postWithdrawal({ walletId: ACTOR_WALLET_ID, amount: "1.5" }, apiKeyHeaders())).status
+    ).toBe(403);
+    expect(providerSignerMock).not.toHaveBeenCalled();
+    expect(resolveGatewayAuthMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves write-only deposit and withdrawal replay while Connection execution is paused", async () => {
+    const deposit = await recordedDeposit();
+    const withdrawal = await recordedWithdrawal();
+    await useConnectionSource();
+    env.PRIVY_BYOK_ENABLED = "false";
+    await setKeyPermissions(["payments:write"]);
+    for (const { post, id } of [
+      { post: postDeposit, id: deposit?.id },
+      { post: postWithdrawal, id: withdrawal.id },
+    ]) {
+      const response = await post({ walletId: ACTOR_WALLET_ID, amount: "1.5" }, apiKeyHeaders());
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ data: { id, status: "pending" } });
+    }
+    expect(providerSignerMock).not.toHaveBeenCalled();
+    expect(resolveGatewayAuthMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses to authorize a replacement source for replay while history remains readable", async () => {
+    const original = await recordedDeposit();
+    await useConnectionSource();
+    await getDb(env).batch([
+      getDb(env).prepare(
+        "UPDATE custody_wallets SET status = 'inactive' WHERE id = 'cw-pcv-actor'"
+      ),
+      getDb(env)
+        .prepare(`INSERT INTO custody_wallets (id, custody_config_id, wallet_id, public_key, status)
+        VALUES ('cw-pcv-replacement', 'cust-pcv', ?, ?, 'active')`)
+        .bind(ACTOR_WALLET_ID, EXTERNAL_ADDRESS),
+    ]);
+    const body = { walletId: ACTOR_WALLET_ID, amount: "1.5" };
+    expect((await postDeposit(body, apiKeyHeaders())).status).toBe(409);
+    const read = await app.request(
+      `/v1/private-channels/deposits/${original?.id}`,
+      { headers: apiKeyHeaders() },
+      env
+    );
+    expect(read.status).toBe(200);
+    expect(await read.json()).toMatchObject({
+      data: { id: original?.id, depositor: ACTOR_ADDRESS },
+    });
+    expect(providerSignerMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { amount: "2" },
+    { mint: COLLEAGUE_ADDRESS },
+    { recipient: COLLEAGUE_ADDRESS },
+    { walletId: COLLEAGUE_WALLET_ID },
+    { recipient: COLLEAGUE_WALLET_ID },
+  ])("conflicts on changed or unprovable historical payload %j", async (changed) => {
+    await recordedDeposit();
+    expect(
+      (await postDeposit({ walletId: ACTOR_WALLET_ID, amount: "1.5", ...changed })).status
+    ).toBe(409);
+    expect(providerSignerMock).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])(
+    "requires write for abandoned withdrawal recovery (write=%s)",
+    async (write) => {
+      const original = await abandonedWithdrawal();
+      await useConnectionSource();
+      env.PRIVY_BYOK_ENABLED = "false";
+      await setKeyPermissions(write ? ["payments:read", "payments:write"] : ["payments:read"]);
+      const response = await postWithdrawal(
+        { walletId: ACTOR_WALLET_ID, amount: "1.5" },
+        apiKeyHeaders()
+      );
+      expect(response.status).toBe(write ? 200 : 403);
+      const history = await app.request(
+        `/v1/private-channels/withdrawals/${original.id}`,
+        { headers: apiKeyHeaders() },
+        env
+      );
+      expect(history.status).toBe(200);
+      expect(await history.json()).toMatchObject({
+        data: { id: original.id, status: write ? "failed" : "pending" },
+      });
+      expect(resolveGatewayAuthMock).toHaveBeenCalledTimes(write ? 1 : 0);
+      expect(providerSignerMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it("fails signer setup before opening an SPC session", async () => {
+    providerSignerMock.mockRejectedValue(new Error("provider unavailable"));
+    expect((await postDeposit({ walletId: ACTOR_WALLET_ID, amount: "1.5" })).status).toBe(503);
+    expect((await postWithdrawal({ walletId: ACTOR_WALLET_ID, amount: "1.5" })).status).toBe(503);
+    expect(resolveGatewayAuthMock).not.toHaveBeenCalled();
+    expect(createChannelDepositMock).not.toHaveBeenCalled();
+    expect(createChannelWithdrawalMock).not.toHaveBeenCalled();
   });
 
   /**

--- a/apps/sdp-api/src/routes/private-channels.value-movement.test.ts
+++ b/apps/sdp-api/src/routes/private-channels.value-movement.test.ts
@@ -440,14 +440,14 @@ async function postWithdrawal(
   );
 }
 
-async function recordedDeposit() {
+async function recordedDeposit(recipient = ACTOR_ADDRESS) {
   return createPrivateChannelDepositRepository(env).createDeposit({
     organizationId: ORGANIZATION_ID,
     projectId: PROJECT_ID,
     instanceId: INSTANCE_ID,
     walletId: ACTOR_WALLET_ID,
     depositor: ACTOR_ADDRESS,
-    recipient: ACTOR_ADDRESS,
+    recipient,
     mint: EXTERNAL_ADDRESS,
     amount: "1.5",
     context: {},
@@ -455,21 +455,21 @@ async function recordedDeposit() {
     idempotencyFingerprint: buildPrivateChannelDepositFingerprint({
       instanceId: INSTANCE_ID,
       walletId: ACTOR_WALLET_ID,
-      recipient: ACTOR_ADDRESS,
+      recipient,
       mint: EXTERNAL_ADDRESS,
       amount: "1.5",
     }),
   });
 }
 
-async function recordedWithdrawal() {
+async function recordedWithdrawal(destination = ACTOR_ADDRESS) {
   const row = await createPrivateChannelWithdrawalRepository(env).createWithdrawal({
     organizationId: ORGANIZATION_ID,
     projectId: PROJECT_ID,
     instanceId: INSTANCE_ID,
     walletId: ACTOR_WALLET_ID,
     owner: ACTOR_ADDRESS,
-    destination: ACTOR_ADDRESS,
+    destination,
     mint: EXTERNAL_ADDRESS,
     amount: "1.5",
     context: {},
@@ -477,7 +477,7 @@ async function recordedWithdrawal() {
     idempotencyFingerprint: buildPrivateChannelWithdrawalFingerprint({
       instanceId: INSTANCE_ID,
       walletId: ACTOR_WALLET_ID,
-      destination: ACTOR_ADDRESS,
+      destination,
       mint: EXTERNAL_ADDRESS,
       amount: "1.5",
     }),
@@ -997,6 +997,51 @@ describe("Private Channels — deposit and withdrawal access", () => {
       (await postDeposit({ walletId: ACTOR_WALLET_ID, amount: "1.5", ...changed })).status
     ).toBe(409);
     expect(providerSignerMock).not.toHaveBeenCalled();
+  });
+
+  it("replays a deposit whose recipient was named by walletId", async () => {
+    const original = await recordedDeposit(COLLEAGUE_ADDRESS);
+    const response = await postDeposit({
+      walletId: ACTOR_WALLET_ID,
+      amount: "1.5",
+      recipient: COLLEAGUE_WALLET_ID,
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      data: { id: original?.id, recipient: COLLEAGUE_ADDRESS },
+    });
+    expect(providerSignerMock).not.toHaveBeenCalled();
+    expect(createChannelDepositMock).not.toHaveBeenCalled();
+  });
+
+  it("replays a deposit whose recipient is the source named by walletId", async () => {
+    const original = await recordedDeposit();
+    const response = await postDeposit({
+      walletId: ACTOR_WALLET_ID,
+      amount: "1.5",
+      recipient: ACTOR_WALLET_ID,
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      data: { id: original?.id, recipient: ACTOR_ADDRESS },
+    });
+    expect(providerSignerMock).not.toHaveBeenCalled();
+    expect(createChannelDepositMock).not.toHaveBeenCalled();
+  });
+
+  it("replays a withdrawal whose destination was named by walletId", async () => {
+    const original = await recordedWithdrawal(COLLEAGUE_ADDRESS);
+    const response = await postWithdrawal({
+      walletId: ACTOR_WALLET_ID,
+      amount: "1.5",
+      destination: COLLEAGUE_WALLET_ID,
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      data: { id: original.id, destination: COLLEAGUE_ADDRESS },
+    });
+    expect(providerSignerMock).not.toHaveBeenCalled();
+    expect(createChannelWithdrawalMock).not.toHaveBeenCalled();
   });
 
   it.each([true, false])(

--- a/apps/sdp-api/src/routes/private-channels/handlers/deposits.ts
+++ b/apps/sdp-api/src/routes/private-channels/handlers/deposits.ts
@@ -43,13 +43,15 @@ export async function createPrivateChannelDeposit(
     await requireMovementWrite(c);
     const auth = getAuth(c);
     const onReplay = async (row: PrivateChannelDepositRow) => {
-      matchesDepositReplay(row, body);
-      await authorizeMovementReplay(c, row, () =>
+      // Source from the recorded row, never the body's wallet; recipient from the
+      // body, resolved by the same seam as the first request.
+      const context = await authorizeMovementReplay(c, row, () =>
         resolveDepositCreateContext(c, {
           walletId: row.wallet_id,
-          recipient: row.recipient,
+          recipient: body.recipient,
         })
       );
+      matchesDepositReplay(row, { ...body, recipient: context.recipient });
       return mapPrivateChannelDepositRow(row);
     };
     const replay = await getPrivateChannelDepositRepository(c).findDepositByIdempotency({

--- a/apps/sdp-api/src/routes/private-channels/handlers/deposits.ts
+++ b/apps/sdp-api/src/routes/private-channels/handlers/deposits.ts
@@ -1,3 +1,4 @@
+import { mapPrivateChannelDepositRow, type PrivateChannelDepositRow } from "@/db/repositories";
 import { getAuth, requireProjectId } from "@/lib/auth";
 import { badRequest, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
@@ -9,9 +10,11 @@ import {
   mapPrivateChannelError,
 } from "@/services/private-channels";
 import { resolveGatewayAuth } from "@/services/private-channels/auth/gateway-auth";
+import { createPrivateChannelSigner } from "@/services/private-channels/wallet-access";
 import type { AppContext } from "../context";
-import { loadPrivateChannelProjectRpcClient } from "../context";
+import { getPrivateChannelDepositRepository, loadPrivateChannelProjectRpcClient } from "../context";
 import { requireIdempotencyKey } from "../helpers";
+import { authorizeMovementReplay, matchesDepositReplay, requireMovementWrite } from "../replay";
 import { type createDepositBodySchema, depositIdParamSchema } from "../schemas";
 import { resolveDepositCreateContext } from "../value-movement-access";
 
@@ -37,10 +40,34 @@ export async function createPrivateChannelDeposit(
 
   try {
     const idempotencyKey = requireIdempotencyKey(c, "Private Channels deposits");
+    await requireMovementWrite(c);
+    const auth = getAuth(c);
+    const onReplay = async (row: PrivateChannelDepositRow) => {
+      matchesDepositReplay(row, body);
+      await authorizeMovementReplay(c, row, () =>
+        resolveDepositCreateContext(c, {
+          walletId: row.wallet_id,
+          recipient: row.recipient,
+        })
+      );
+      return mapPrivateChannelDepositRow(row);
+    };
+    const replay = await getPrivateChannelDepositRepository(c).findDepositByIdempotency({
+      organizationId: auth.organizationId,
+      projectId: requireProjectId(c),
+      idempotencyKey,
+    });
+    if (replay) return success(c, await onReplay(replay));
     const context = await resolveDepositCreateContext(c, {
       walletId: body.walletId,
       recipient: body.recipient,
     });
+    const signer = await createPrivateChannelSigner(
+      c.env,
+      context.auth.organizationId,
+      context.projectId,
+      context.wallet
+    );
     const projectRpc = await loadPrivateChannelProjectRpcClient(c);
 
     // Auth-enabled instances JWT-gate the gateway baseline read.
@@ -60,6 +87,8 @@ export async function createPrivateChannelDeposit(
       projectId: context.projectId,
       userId: context.auth.userId ?? null,
       wallet: context.wallet,
+      signer,
+      onReplay,
       amount: body.amount,
       mint: body.mint,
       recipient: context.recipient,

--- a/apps/sdp-api/src/routes/private-channels/handlers/transfers.ts
+++ b/apps/sdp-api/src/routes/private-channels/handlers/transfers.ts
@@ -1,16 +1,20 @@
-import { mapPrivateChannelTransferRow } from "@/db/repositories";
+import { mapPrivateChannelTransferRow, type PrivateChannelTransferRow } from "@/db/repositories";
 import { getAuth, requireProjectId } from "@/lib/auth";
-import { badRequest, notFound } from "@/lib/errors";
+import { badRequest, conflict, notFound } from "@/lib/errors";
+import { isAbandonedReservation } from "@/lib/idempotency";
 import { success } from "@/lib/response";
 import type { ValidatedBodyContext } from "@/middleware/validate";
 import { createChannelTransfer, mapPrivateChannelError } from "@/services/private-channels";
 import { resolveGatewayAuth } from "@/services/private-channels/auth/gateway-auth";
+import { resolveAbandonedTransferReservation } from "@/services/private-channels/transfer";
+import { createPrivateChannelSigner } from "@/services/private-channels/wallet-access";
 import type { AppContext } from "../context";
 import {
   getPrivateChannelTransferRepository,
   loadPrivateChannelProjectRpcClient,
 } from "../context";
 import { requireIdempotencyKey } from "../helpers";
+import { authorizeMovementReplay, matchesTransferReplay, requireMovementWrite } from "../replay";
 import {
   type createTransferBodySchema,
   transferChannelIdParamSchema,
@@ -49,11 +53,58 @@ export async function createPrivateChannelTransfer(
 
   try {
     const idempotencyKey = requireIdempotencyKey(c, "Private Channels transfers");
+    await requireMovementWrite(c);
+    const auth = getAuth(c);
+    const repo = getPrivateChannelTransferRepository(c);
+    const onReplay = async (row: PrivateChannelTransferRow) => {
+      matchesTransferReplay(row, { ...body, channelId });
+      const context = await authorizeMovementReplay(c, row, async () => {
+        const original = await resolveTransferCreateContext(c, {
+          channelId: row.channel_id,
+          walletId: row.sender_wallet_id,
+          recipientVerifiedWalletId: row.recipient_verified_wallet_id,
+        });
+        if (
+          original.actor.id !== row.sender_private_channel_user_id ||
+          original.recipient.pubkey !== row.recipient ||
+          original.recipient.privateChannelUserId !== row.recipient_private_channel_user_id
+        ) {
+          throw conflict("The original transfer's participants cannot be authorized");
+        }
+        return original;
+      });
+      if (isAbandonedReservation(row)) {
+        const gatewayAuth = await resolveGatewayAuth(c.env, {
+          instance: context.instance,
+          organizationId: auth.organizationId,
+          projectId: context.projectId,
+          userId: auth.userId,
+        });
+        return resolveAbandonedTransferReservation(c.env, repo, row, {
+          gatewayUrl: context.instance.gatewayUrl,
+          gatewayAuth,
+          sdpUserId: auth.id,
+        });
+      }
+      return mapPrivateChannelTransferRow(row);
+    };
+    const replay = await repo.findTransferByIdempotency({
+      organizationId: auth.organizationId,
+      projectId: requireProjectId(c),
+      idempotencyKey,
+    });
+    if (replay) return success(c, await onReplay(replay));
     const context = await resolveTransferCreateContext(c, {
       channelId,
       walletId: body.walletId,
       recipientVerifiedWalletId: body.recipientVerifiedWalletId,
     });
+    const signer = await createPrivateChannelSigner(
+      c.env,
+      context.auth.organizationId,
+      context.projectId,
+      context.wallet
+    );
     const gatewayAuth = await resolveGatewayAuth(c.env, {
       instance: context.instance,
       organizationId: context.auth.organizationId,
@@ -68,7 +119,8 @@ export async function createPrivateChannelTransfer(
       channelId,
       sdpUserId: context.auth.id,
       wallet: context.wallet,
-      signer: context.signer,
+      signer,
+      onReplay,
       recipient: context.recipient,
       amount: body.amount,
       mint: body.mint,

--- a/apps/sdp-api/src/routes/private-channels/handlers/withdrawals.ts
+++ b/apps/sdp-api/src/routes/private-channels/handlers/withdrawals.ts
@@ -1,5 +1,10 @@
+import {
+  mapPrivateChannelWithdrawalRow,
+  type PrivateChannelWithdrawalRow,
+} from "@/db/repositories";
 import { getAuth, requireProjectId } from "@/lib/auth";
 import { badRequest, notFound } from "@/lib/errors";
+import { isAbandonedReservation } from "@/lib/idempotency";
 import { success } from "@/lib/response";
 import type { ValidatedBodyContext } from "@/middleware/validate";
 import {
@@ -9,9 +14,15 @@ import {
   mapPrivateChannelError,
 } from "@/services/private-channels";
 import { resolveGatewayAuth } from "@/services/private-channels/auth/gateway-auth";
+import { createPrivateChannelSigner } from "@/services/private-channels/wallet-access";
+import { resolveAbandonedWithdrawalReservation } from "@/services/private-channels/withdraw";
 import type { AppContext } from "../context";
-import { loadPrivateChannelProjectRpcClient } from "../context";
+import {
+  getPrivateChannelWithdrawalRepository,
+  loadPrivateChannelProjectRpcClient,
+} from "../context";
 import { requireIdempotencyKey } from "../helpers";
+import { authorizeMovementReplay, matchesWithdrawalReplay, requireMovementWrite } from "../replay";
 import { type createWithdrawalBodySchema, withdrawalIdParamSchema } from "../schemas";
 import { resolveWithdrawalCreateContext } from "../value-movement-access";
 
@@ -39,10 +50,47 @@ export async function createPrivateChannelWithdrawal(
 
   try {
     const idempotencyKey = requireIdempotencyKey(c, "Private Channels withdrawals");
+    await requireMovementWrite(c);
+    const auth = getAuth(c);
+    const repo = getPrivateChannelWithdrawalRepository(c);
+    const onReplay = async (row: PrivateChannelWithdrawalRow) => {
+      matchesWithdrawalReplay(row, body);
+      const context = await authorizeMovementReplay(c, row, () =>
+        resolveWithdrawalCreateContext(c, {
+          walletId: row.wallet_id,
+          destination: row.destination,
+        })
+      );
+      if (isAbandonedReservation(row)) {
+        const gatewayAuth = await resolveGatewayAuth(c.env, {
+          instance: context.instance,
+          organizationId: auth.organizationId,
+          projectId: context.projectId,
+          userId: auth.userId,
+        });
+        return resolveAbandonedWithdrawalReservation(c.env, repo, row, {
+          gatewayUrl: context.instance.gatewayUrl,
+          gatewayAuth,
+        });
+      }
+      return mapPrivateChannelWithdrawalRow(row);
+    };
+    const replay = await repo.findWithdrawalByIdempotency({
+      organizationId: auth.organizationId,
+      projectId: requireProjectId(c),
+      idempotencyKey,
+    });
+    if (replay) return success(c, await onReplay(replay));
     const context = await resolveWithdrawalCreateContext(c, {
       walletId: body.walletId,
       destination: body.destination,
     });
+    const signer = await createPrivateChannelSigner(
+      c.env,
+      context.auth.organizationId,
+      context.projectId,
+      context.wallet
+    );
     const projectRpc = await loadPrivateChannelProjectRpcClient(c);
 
     // Auth-enabled instances JWT-gate the burn broadcast (write) + confirm (read).
@@ -61,6 +109,8 @@ export async function createPrivateChannelWithdrawal(
       // is null on every principal created since 0073.
       userId: context.auth.userId ?? null,
       wallet: context.wallet,
+      signer,
+      onReplay,
       amount: body.amount,
       mint: body.mint,
       destination: context.destination,

--- a/apps/sdp-api/src/routes/private-channels/handlers/withdrawals.ts
+++ b/apps/sdp-api/src/routes/private-channels/handlers/withdrawals.ts
@@ -54,13 +54,15 @@ export async function createPrivateChannelWithdrawal(
     const auth = getAuth(c);
     const repo = getPrivateChannelWithdrawalRepository(c);
     const onReplay = async (row: PrivateChannelWithdrawalRow) => {
-      matchesWithdrawalReplay(row, body);
+      // Source from the recorded row, never the body's wallet; destination from
+      // the body, resolved by the same seam as the first request.
       const context = await authorizeMovementReplay(c, row, () =>
         resolveWithdrawalCreateContext(c, {
           walletId: row.wallet_id,
-          destination: row.destination,
+          destination: body.destination,
         })
       );
+      matchesWithdrawalReplay(row, { ...body, destination: context.destination });
       if (isAbandonedReservation(row)) {
         const gatewayAuth = await resolveGatewayAuth(c.env, {
           instance: context.instance,

--- a/apps/sdp-api/src/routes/private-channels/replay.ts
+++ b/apps/sdp-api/src/routes/private-channels/replay.ts
@@ -1,0 +1,118 @@
+import { hasAllPermissions } from "@sdp/types";
+import type {
+  PrivateChannelDepositRow,
+  PrivateChannelTransferRow,
+  PrivateChannelWithdrawalRow,
+} from "@/db/repositories";
+import { getAuth, requireProjectId } from "@/lib/auth";
+import { AppError, conflict } from "@/lib/errors";
+import {
+  buildPrivateChannelDepositFingerprint,
+  buildPrivateChannelTransferFingerprint,
+  buildPrivateChannelWithdrawalFingerprint,
+} from "@/lib/idempotency";
+import { refreshPrivateChannelAuth } from "@/services/private-channels/wallet-access";
+import type { CustodyWallet } from "@/services/stores/custody-config.store";
+import type { AppContext } from "./context";
+
+/** Every movement POST, including replay, requires current write access. */
+export async function requireMovementWrite(c: AppContext): Promise<void> {
+  const auth = getAuth(c);
+  if (auth.authType === "api_key") {
+    const current = await refreshPrivateChannelAuth(c.env, auth, requireProjectId(c));
+    const key = c.get("apiKey");
+    if (key) c.set("apiKey", { ...key, permissions: current.permissions });
+  }
+  if (!hasAllPermissions(getAuth(c).permissions, ["payments:write"])) {
+    throw new AppError("INSUFFICIENT_PERMISSIONS", "Required permissions: payments:write");
+  }
+}
+
+type MovementRow =
+  | PrivateChannelDepositRow
+  | PrivateChannelWithdrawalRow
+  | PrivateChannelTransferRow;
+
+/** Replay and recovery authorize the historical source, never its replacement. */
+export async function authorizeMovementReplay<
+  T extends { wallet: CustodyWallet; instance: { id: string } },
+>(c: AppContext, row: MovementRow, authorizeWrite: () => Promise<T>): Promise<T> {
+  await requireMovementWrite(c);
+  const context = await authorizeWrite();
+  const walletId = "sender_wallet_id" in row ? row.sender_wallet_id : row.wallet_id;
+  const publicKey = "depositor" in row ? row.depositor : "owner" in row ? row.owner : row.sender;
+  if (
+    context.wallet.walletId !== walletId ||
+    context.wallet.publicKey !== publicKey ||
+    context.instance.id !== row.instance_id
+  ) {
+    throw conflict("The original operation's source wallet cannot be authorized");
+  }
+  return context;
+}
+
+export function matchesWithdrawalReplay(
+  row: PrivateChannelWithdrawalRow,
+  input: { walletId: string; amount: string; mint?: string; destination?: string }
+): void {
+  const destination = input.destination === row.wallet_id ? row.owner : input.destination;
+  if (
+    (input.walletId !== row.wallet_id && input.walletId !== row.owner) ||
+    row.idempotency_fingerprint !==
+      buildPrivateChannelWithdrawalFingerprint({
+        instanceId: row.instance_id,
+        walletId: row.wallet_id,
+        destination: destination ?? row.owner,
+        mint: input.mint ?? row.mint,
+        amount: input.amount,
+      })
+  ) {
+    throw conflict("Idempotency key already used with different request payload");
+  }
+}
+
+export function matchesTransferReplay(
+  row: PrivateChannelTransferRow,
+  input: {
+    channelId: string;
+    walletId: string;
+    recipientVerifiedWalletId: string;
+    amount: string;
+    mint?: string;
+  }
+): void {
+  if (
+    input.walletId !== row.sender_wallet_id ||
+    row.idempotency_fingerprint !==
+      buildPrivateChannelTransferFingerprint({
+        instanceId: row.instance_id,
+        channelId: input.channelId,
+        walletId: input.walletId,
+        recipientVerifiedWalletId: input.recipientVerifiedWalletId,
+        mint: input.mint ?? row.mint,
+        amount: input.amount,
+      })
+  ) {
+    throw conflict("Idempotency key already used with different request payload");
+  }
+}
+
+export function matchesDepositReplay(
+  row: PrivateChannelDepositRow,
+  input: { walletId: string; amount: string; mint?: string; recipient?: string }
+): void {
+  const recipient = input.recipient === row.wallet_id ? row.depositor : input.recipient;
+  if (
+    (input.walletId !== row.wallet_id && input.walletId !== row.depositor) ||
+    row.idempotency_fingerprint !==
+      buildPrivateChannelDepositFingerprint({
+        instanceId: row.instance_id,
+        walletId: row.wallet_id,
+        recipient: recipient ?? row.depositor,
+        mint: input.mint ?? row.mint,
+        amount: input.amount,
+      })
+  ) {
+    throw conflict("Idempotency key already used with different request payload");
+  }
+}

--- a/apps/sdp-api/src/routes/private-channels/replay.ts
+++ b/apps/sdp-api/src/routes/private-channels/replay.ts
@@ -53,16 +53,21 @@ export async function authorizeMovementReplay<
 
 export function matchesWithdrawalReplay(
   row: PrivateChannelWithdrawalRow,
-  input: { walletId: string; amount: string; mint?: string; destination?: string }
+  input: {
+    walletId: string;
+    amount: string;
+    mint?: string;
+    /** Resolved by the access seam from the body, exactly as on the first request. */
+    destination: string;
+  }
 ): void {
-  const destination = input.destination === row.wallet_id ? row.owner : input.destination;
   if (
     (input.walletId !== row.wallet_id && input.walletId !== row.owner) ||
     row.idempotency_fingerprint !==
       buildPrivateChannelWithdrawalFingerprint({
         instanceId: row.instance_id,
         walletId: row.wallet_id,
-        destination: destination ?? row.owner,
+        destination: input.destination,
         mint: input.mint ?? row.mint,
         amount: input.amount,
       })
@@ -99,16 +104,21 @@ export function matchesTransferReplay(
 
 export function matchesDepositReplay(
   row: PrivateChannelDepositRow,
-  input: { walletId: string; amount: string; mint?: string; recipient?: string }
+  input: {
+    walletId: string;
+    amount: string;
+    mint?: string;
+    /** Resolved by the access seam from the body, exactly as on the first request. */
+    recipient: string;
+  }
 ): void {
-  const recipient = input.recipient === row.wallet_id ? row.depositor : input.recipient;
   if (
     (input.walletId !== row.wallet_id && input.walletId !== row.depositor) ||
     row.idempotency_fingerprint !==
       buildPrivateChannelDepositFingerprint({
         instanceId: row.instance_id,
         walletId: row.wallet_id,
-        recipient: recipient ?? row.depositor,
+        recipient: input.recipient,
         mint: input.mint ?? row.mint,
         amount: input.amount,
       })

--- a/apps/sdp-api/src/routes/private-channels/transfer-access.ts
+++ b/apps/sdp-api/src/routes/private-channels/transfer-access.ts
@@ -1,20 +1,16 @@
 import type { PrivateChannelInstance, PrivateChannelTransferRecipientDto } from "@sdp/types";
 import { mapPrivateChannelInstanceRow, type PrivateChannelUserRow } from "@/db/repositories";
 import { type ApiKeyContext, getAuth, requireProjectId } from "@/lib/auth";
-import { badRequest, forbidden, notFound, providerUnavailable, walletNotFound } from "@/lib/errors";
-import { assertApiKeyWalletAccess } from "@/services/api-key-scope.service";
-import { createSigningService } from "@/services/domain/signing.service";
-import { createOrgSigner } from "@/services/solana";
+import { badRequest, forbidden, notFound } from "@/lib/errors";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import type { AppContext } from "./context";
 import {
   getPrivateChannelRepository,
   getPrivateChannelTransferRepository,
   getPrivateChannelUserRepository,
-  getPrivateChannelVerifiedWalletRepository,
 } from "./context";
 import { requireActiveInstance } from "./helpers";
-import { unsafeAddresses } from "./value-movement-access";
+import { resolveVerifiedSourceWallet, unsafeAddresses } from "./value-movement-access";
 
 interface TransferActorContext {
   auth: ApiKeyContext;
@@ -31,12 +27,6 @@ export interface TransferCreateContext extends TransferActorContext {
     verifiedWalletId: string;
     pubkey: string;
   };
-  /**
-   * Resolved here and handed to the service so a transfer derives its signer once.
-   * This is also the stricter check of the two: it holds the signer against BOTH
-   * the custody wallet and the member's verified pubkey.
-   */
-  signer: Awaited<ReturnType<typeof createOrgSigner>>;
 }
 
 async function resolveTransferActor(
@@ -96,31 +86,13 @@ export async function resolveTransferCreateContext(
   }
 ): Promise<TransferCreateContext> {
   const context = await resolveTransferActor(c, input.channelId);
-  const wallets = await createSigningService(c.env).getWalletsWithProviders(
-    context.auth.organizationId,
-    context.projectId,
-    { includeAllProviders: true }
+  const { wallet } = await resolveVerifiedSourceWallet(
+    c,
+    context,
+    input.walletId,
+    undefined,
+    false
   );
-  const wallet = wallets.find((candidate) => candidate.walletId === input.walletId);
-  if (!wallet) {
-    throw walletNotFound();
-  }
-  // Same second line as the deposit/withdrawal seam: enrolment alone would let
-  // an API key bound to one wallet spend any wallet enrolled in the project.
-  assertApiKeyWalletAccess(context.auth, wallet.walletId, ["payments:write"]);
-
-  const verifiedWallets = await getPrivateChannelVerifiedWalletRepository(c).listByUserAndInstance(
-    context.actor.id,
-    context.instance.id
-  );
-  const verifiedSource = verifiedWallets.find(
-    (verified) => verified.wallet_id === wallet.walletId && verified.pubkey === wallet.publicKey
-  );
-  if (!verifiedSource) {
-    throw forbidden(
-      "The source custody wallet must be enrolled under the project's Private Channels principal."
-    );
-  }
 
   const match = context.recipients.find(
     (candidate) => candidate.id === input.recipientVerifiedWalletId
@@ -146,20 +118,5 @@ export async function resolveTransferCreateContext(
     throw badRequest("System, program, and connected instance addresses cannot be used.");
   }
 
-  let signer: Awaited<ReturnType<typeof createOrgSigner>>;
-  try {
-    signer = await createOrgSigner(
-      c.env,
-      context.auth.organizationId,
-      context.projectId,
-      wallet.walletId
-    );
-  } catch {
-    throw providerUnavailable("The source custody wallet is not currently signable.");
-  }
-  if (signer.address !== wallet.publicKey || signer.address !== verifiedSource.pubkey) {
-    throw badRequest("Resolved signer does not match the verified source custody wallet.");
-  }
-
-  return { ...context, wallet, recipient, signer };
+  return { ...context, wallet, recipient };
 }

--- a/apps/sdp-api/src/routes/private-channels/value-movement-access.ts
+++ b/apps/sdp-api/src/routes/private-channels/value-movement-access.ts
@@ -29,9 +29,11 @@ import {
   type PrivateChannelVerifiedWalletRow,
 } from "@/db/repositories";
 import { type ApiKeyContext, getAuth, requireProjectId } from "@/lib/auth";
-import { badRequest, forbidden, walletNotFound } from "@/lib/errors";
-import { assertApiKeyWalletAccess } from "@/services/api-key-scope.service";
-import { createSigningService } from "@/services/domain/signing.service";
+import { badRequest, conflict, forbidden } from "@/lib/errors";
+import {
+  listPrivateChannelCustodyWallets,
+  resolvePrivateChannelCustodyWallet,
+} from "@/services/private-channels/wallet-access";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import type { AppContext } from "./context";
 import {
@@ -107,11 +109,7 @@ function loadProjectWallets(
   c: AppContext,
   context: PrivateChannelActorContext
 ): Promise<CustodyWallet[]> {
-  return createSigningService(c.env).getWalletsWithProviders(
-    context.auth.organizationId,
-    context.projectId,
-    { includeAllProviders: true }
-  );
+  return listPrivateChannelCustodyWallets(c.env, context.auth.organizationId, context.projectId);
 }
 
 /**
@@ -128,19 +126,21 @@ export async function resolveVerifiedSourceWallet(
   c: AppContext,
   context: PrivateChannelActorContext,
   walletId: string,
-  wallets: CustodyWallet[]
+  wallets?: CustodyWallet[],
+  allowAddress = true
 ): Promise<{ wallet: CustodyWallet; verified: PrivateChannelVerifiedWalletRow }> {
-  const wallet = wallets.find(
-    (candidate) => candidate.walletId === walletId || candidate.publicKey === walletId
+  const wallet = await resolvePrivateChannelCustodyWallet(
+    c.env,
+    context.auth,
+    context.projectId,
+    walletId,
+    wallets,
+    allowAddress
   );
-  if (!wallet) {
-    throw walletNotFound();
-  }
   // Enrolment answers whether the wallet may move value on this instance at
   // all; the key's wallet bindings answer whether THIS credential may spend
   // from it. Every other money route holds the second line too, and skipping
   // it here would let a key bound to one wallet spend any enrolled wallet.
-  assertApiKeyWalletAccess(context.auth, wallet.walletId, ["payments:write"]);
 
   const verifiedWallets = await getPrivateChannelVerifiedWalletRepository(c).listByUserAndInstance(
     context.actor.id,
@@ -179,9 +179,13 @@ async function resolveCounterpartyAddress(
     requireVerifiedOnInstance: boolean;
   }
 ): Promise<string> {
-  const matched = wallets.find(
+  const matches = wallets.filter(
     (candidate) => candidate.walletId === input.value || candidate.publicKey === input.value
   );
+  if (new Set(matches.map((wallet) => wallet.publicKey)).size > 1) {
+    throw conflict("Counterparty address is ambiguous");
+  }
+  const matched = matches[0];
   const resolved = matched?.publicKey ?? input.value;
 
   if (!matched && !isAddress(resolved)) {

--- a/apps/sdp-api/src/security/value-moving-conformance.node.test.ts
+++ b/apps/sdp-api/src/security/value-moving-conformance.node.test.ts
@@ -253,10 +253,10 @@ const contracts: ValueMovingContract[] = [
       evidence: "const scope = { organizationId: auth.organizationId, projectId }",
     },
     authorization: {
-      file: "apps/sdp-api/src/routes/private-channels/transfer-access.ts",
-      section: "export async function resolveTransferCreateContext",
-      before: "if (!verifiedSource)",
-      after: "signer = await createOrgSigner(",
+      file: "apps/sdp-api/src/routes/private-channels/handlers/transfers.ts",
+      section: "export async function createPrivateChannelTransfer",
+      before: "const context = await resolveTransferCreateContext(",
+      after: "const signer = await createPrivateChannelSigner(",
     },
     replay: [
       {

--- a/apps/sdp-api/src/services/domain/signing/custody-runtime-target.ts
+++ b/apps/sdp-api/src/services/domain/signing/custody-runtime-target.ts
@@ -447,7 +447,13 @@ export class CustodyRuntimeTargets {
     organizationId: string;
     projectId?: string;
     walletId: string;
+    /** Include retained address aliases when checking source-selector ambiguity. */
+    publicKey?: string;
   }): Promise<CustodyOwnedWallet | null> {
+    const selector = params.publicKey ? "(w.wallet_id = ? OR w.public_key = ?)" : "w.wallet_id = ?";
+    const selectorValues = params.publicKey
+      ? [params.walletId, params.publicKey]
+      : [params.walletId];
     const [configs, connections] = await Promise.all([
       this.db.queryMany<{
         id: string;
@@ -460,10 +466,10 @@ export class CustodyRuntimeTargets {
          JOIN custody_configs c ON c.id = w.custody_config_id
          WHERE c.organization_id = ?
            AND ${params.projectId ? "(c.project_id = ? OR c.project_id IS NULL)" : "c.project_id IS NULL"}
-           AND w.wallet_id = ?`,
+           AND ${selector}`,
         params.projectId
-          ? [params.organizationId, params.projectId, params.walletId]
-          : [params.organizationId, params.walletId]
+          ? [params.organizationId, params.projectId, ...selectorValues]
+          : [params.organizationId, ...selectorValues]
       ),
       params.projectId
         ? this.db.queryMany<{
@@ -477,8 +483,8 @@ export class CustodyRuntimeTargets {
              JOIN custody_connections c ON c.id = w.custody_connection_id
              WHERE c.organization_id = ?
                AND c.project_id = ?
-               AND w.wallet_id = ?`,
-            [params.organizationId, params.projectId, params.walletId]
+               AND ${selector}`,
+            [params.organizationId, params.projectId, ...selectorValues]
           )
         : Promise.resolve([]),
     ]);

--- a/apps/sdp-api/src/services/private-channels/deposit.ts
+++ b/apps/sdp-api/src/services/private-channels/deposit.ts
@@ -39,6 +39,7 @@ import {
   type Signature,
   setTransactionMessageFeePayerSigner,
   setTransactionMessageLifetimeUsingBlockhash,
+  type TransactionSigner,
 } from "@solana/kit";
 import { signTransactionMessageWithSigners } from "@solana/signers";
 import { isPostgresUniqueViolation } from "@/db/postgres-utils";
@@ -49,9 +50,8 @@ import {
   type PrivateChannelDepositRow,
 } from "@/db/repositories";
 import { AppError, badRequest } from "@/lib/errors";
-import { buildPrivateChannelDepositFingerprint, resolveIdempotencyReplay } from "@/lib/idempotency";
+import { buildPrivateChannelDepositFingerprint } from "@/lib/idempotency";
 import { getLogger } from "@/runtime/logger";
-import * as solanaServices from "@/services/solana";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import type { Env } from "@/types/env";
 import type { SpcAuthContext } from "./auth/gateway-auth";
@@ -80,6 +80,9 @@ export interface CreateChannelDepositInput {
   userId: string | null;
   /** Custody wallet the deposit is signed from (the escrow `user`). */
   wallet: CustodyWallet;
+  signer: TransactionSigner;
+  /** Authorize and match the winning operation again after an idempotency race. */
+  onReplay: (row: PrivateChannelDepositRow) => Promise<PrivateChannelDeposit>;
   /** UI decimal amount (e.g. "1.5"). */
   amount: string;
   /** Mint to deposit; must be on the instance's allowlist. Defaults to its first entry. */
@@ -104,34 +107,27 @@ export interface CreateChannelDepositInput {
  * Build, sign, broadcast, and confirm a deposit on the instance chain. Returns
  * the built transaction signature.
  */
-async function broadcastDeposit(
-  env: Env,
-  input: {
-    instance: DepositInstance;
-    organizationId: string;
-    projectId: string;
-    wallet: CustodyWallet;
-    mint: Address;
-    /** Program owning the mint; seeds the escrow's `userAta`/`instanceAta` derivation. */
-    tokenProgram: Address;
-    recipient: Address;
-    amountBaseUnits: bigint;
-    projectRpc: PrivateChannelProjectRpcClient;
-    /**
-     * Called with the transaction's signature after signing and before the
-     * send, so the outcome of a request that dies mid-send stays resolvable:
-     * a persisted signature is what lets the reconciler ask the chain what
-     * happened instead of failing the row as never-broadcast.
-     */
-    onSigned: (signature: Signature) => Promise<void>;
-  }
-): Promise<Signature> {
-  const signer = await solanaServices.createOrgSigner(
-    env,
-    input.organizationId,
-    input.projectId,
-    input.wallet.walletId
-  );
+async function broadcastDeposit(input: {
+  instance: DepositInstance;
+  organizationId: string;
+  projectId: string;
+  wallet: CustodyWallet;
+  signer: TransactionSigner;
+  mint: Address;
+  /** Program owning the mint; seeds the escrow's `userAta`/`instanceAta` derivation. */
+  tokenProgram: Address;
+  recipient: Address;
+  amountBaseUnits: bigint;
+  projectRpc: PrivateChannelProjectRpcClient;
+  /**
+   * Called with the transaction's signature after signing and before the
+   * send, so the outcome of a request that dies mid-send stays resolvable:
+   * a persisted signature is what lets the reconciler ask the chain what
+   * happened instead of failing the row as never-broadcast.
+   */
+  onSigned: (signature: Signature) => Promise<void>;
+}): Promise<Signature> {
+  const signer = input.signer;
   if (signer.address !== input.wallet.publicKey) {
     throw badRequest("Resolved signing wallet does not match the deposit wallet");
   }
@@ -177,8 +173,7 @@ async function broadcastDeposit(
  * fail: a concurrent duplicate loses it and reads the winner's row instead of
  * broadcasting a second escrow transfer. The pre-insert lookup only saves the
  * common (sequential retry) case a round trip through a failed insert. Both
- * paths go through `resolveIdempotencyReplay`, so a key reused with a DIFFERENT
- * request is a 409 rather than a quiet answer about someone else's deposit.
+ * paths delegate matching and authorization of the winning row to the caller.
  */
 async function reserveDeposit(
   repo: PrivateChannelDepositRepository,
@@ -209,7 +204,7 @@ async function reserveDeposit(
       idempotencyKey: input.idempotencyKey,
     });
 
-  const existing = await resolveIdempotencyReplay(findExisting, fingerprint);
+  const existing = await findExisting();
   if (existing) {
     return { row: existing, replayed: true };
   }
@@ -233,7 +228,7 @@ async function reserveDeposit(
     if (!isPostgresUniqueViolation(error)) {
       throw error;
     }
-    const raced = await resolveIdempotencyReplay(findExisting, fingerprint);
+    const raced = await findExisting();
     if (!raced) {
       throw error;
     }
@@ -271,9 +266,8 @@ export async function createChannelDeposit(
   }
 
   const repo = createPrivateChannelDepositRepository(env);
-  // The reservation is taken BEFORE the signer is derived or anything is
-  // broadcast, so a retry — or a second request racing the first — can only ever
-  // reach the row the winner created.
+  // The route has admitted and prepared its exact signer. Only the request that
+  // wins this reservation may sign or send; a loser must authorize the winner.
   const { row: created, replayed } = await reserveDeposit(repo, {
     organizationId,
     projectId,
@@ -295,7 +289,7 @@ export async function createChannelDeposit(
     idempotencyKey: input.idempotencyKey,
   });
   if (replayed) {
-    return mapPrivateChannelDepositRow(created);
+    return input.onReplay(created);
   }
 
   let latest: PrivateChannelDepositRow = created;
@@ -305,11 +299,12 @@ export async function createChannelDeposit(
   let signature: Signature;
   let recordedSignature: Signature | null = null;
   try {
-    signature = await broadcastDeposit(env, {
+    signature = await broadcastDeposit({
       instance,
       organizationId,
       projectId,
       wallet,
+      signer: input.signer,
       mint: address(mint),
       tokenProgram: address(tokenProgram),
       recipient: address(recipient),

--- a/apps/sdp-api/src/services/private-channels/transfer.node.test.ts
+++ b/apps/sdp-api/src/services/private-channels/transfer.node.test.ts
@@ -30,12 +30,18 @@ import type {
   UpdatePrivateChannelTransferInput,
 } from "@/db/repositories";
 import * as repositories from "@/db/repositories";
+import { isAbandonedReservation } from "@/lib/idempotency";
+import { matchesTransferReplay } from "@/routes/private-channels/replay";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import type { Env } from "@/types/env";
 import type { SpcAuthContext } from "./auth/gateway-auth";
 import * as gatewayAuthService from "./auth/gateway-auth";
 import * as balanceService from "./balance";
-import { buildTokenTransferInstructions, createChannelTransfer } from "./transfer";
+import {
+  buildTokenTransferInstructions,
+  createChannelTransfer,
+  resolveAbandonedTransferReservation,
+} from "./transfer";
 import * as transferEvents from "./transfer-events";
 
 const TEST_ENV = {} as Env;
@@ -86,7 +92,7 @@ function makePendingRow(input: CreatePrivateChannelTransferInput): PrivateChanne
 }
 
 function makeInput(overrides: Partial<Parameters<typeof createChannelTransfer>[1]> = {}) {
-  return {
+  const input: Parameters<typeof createChannelTransfer>[1] = {
     instance: {
       id: INSTANCE_ID,
       gatewayUrl: GATEWAY_URL,
@@ -100,6 +106,22 @@ function makeInput(overrides: Partial<Parameters<typeof createChannelTransfer>[1
     wallet,
     // Resolved by the route's access seam in production; the service never derives it.
     signer: senderSigner,
+    onReplay: async (row) => {
+      matchesTransferReplay(row, {
+        channelId: input.channelId,
+        walletId: input.wallet.walletId,
+        recipientVerifiedWalletId: input.recipient.verifiedWalletId,
+        amount: input.amount,
+        mint: input.mint,
+      });
+      return isAbandonedReservation(row)
+        ? resolveAbandonedTransferReservation(TEST_ENV, repo, row, {
+            gatewayUrl: input.instance.gatewayUrl,
+            gatewayAuth: input.gatewayAuth,
+            sdpUserId: input.sdpUserId,
+          })
+        : repositories.mapPrivateChannelTransferRow(row);
+    },
     recipient: {
       privateChannelUserId: RECIPIENT_PC_USER_ID,
       verifiedWalletId: RECIPIENT_VERIFIED_WALLET_ID,
@@ -120,6 +142,7 @@ function makeInput(overrides: Partial<Parameters<typeof createChannelTransfer>[1
     },
     ...overrides,
   };
+  return input;
 }
 
 function makeBalance(amount = "10000000"): PrivateChannelBalance {

--- a/apps/sdp-api/src/services/private-channels/transfer.ts
+++ b/apps/sdp-api/src/services/private-channels/transfer.ts
@@ -32,11 +32,7 @@ import {
   type PrivateChannelTransferRow,
 } from "@/db/repositories";
 import { AppError, badRequest } from "@/lib/errors";
-import {
-  buildPrivateChannelTransferFingerprint,
-  isAbandonedReservation,
-  resolveIdempotencyReplay,
-} from "@/lib/idempotency";
+import { buildPrivateChannelTransferFingerprint } from "@/lib/idempotency";
 import { getLogger } from "@/runtime/logger";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import type { Env } from "@/types/env";
@@ -63,11 +59,13 @@ export interface CreateChannelTransferInput {
   /** The already-resolved SDP custody wallet selected by the acting user. */
   wallet: CustodyWallet;
   /**
-   * Signer for `wallet`, derived once by the route's access seam, which also holds
+   * Signer for `wallet`, derived once after route replay and admission, which holds
    * it against the member's verified pubkey. Passed in rather than re-derived so a
    * transfer makes one custody-provider round trip instead of two.
    */
   signer: TransactionSigner;
+  /** Authorize and match the winning operation again after an idempotency race. */
+  onReplay: (row: PrivateChannelTransferRow) => Promise<PrivateChannelTransfer>;
   /** The already-resolved verified wallet of another channel member. */
   recipient: {
     privateChannelUserId: string;
@@ -295,7 +293,7 @@ async function reserveTransfer(
     if (!isPostgresUniqueViolation(error)) {
       throw error;
     }
-    const raced = await resolveIdempotencyReplay(findExisting, fingerprint);
+    const raced = await findExisting();
     if (!raced) {
       throw error;
     }
@@ -319,7 +317,7 @@ async function reserveTransfer(
  * The `pending` CAS in `settleTransfer` means a still-live original wins the
  * race and these writes are no-ops.
  */
-async function resolveAbandonedReservation(
+export async function resolveAbandonedTransferReservation(
   env: Env,
   repo: PrivateChannelTransferRepository,
   row: PrivateChannelTransferRow,
@@ -423,16 +421,9 @@ export async function createChannelTransfer(
   // The replay lookup comes FIRST, ahead of the balance read, because a retry of
   // an already-executed transfer must return that transfer — the balance it spent
   // is gone, so re-checking would reject the caller's own success.
-  const replay = await resolveIdempotencyReplay(findReplay, fingerprint);
+  const replay = await findReplay();
   if (replay) {
-    if (isAbandonedReservation(replay)) {
-      return resolveAbandonedReservation(env, repo, replay, {
-        gatewayUrl: input.instance.gatewayUrl,
-        gatewayAuth: input.gatewayAuth,
-        sdpUserId: input.sdpUserId,
-      });
-    }
-    return mapPrivateChannelTransferRow(replay);
+    return input.onReplay(replay);
   }
 
   const balance = await getChannelBalance(env, {
@@ -466,14 +457,7 @@ export async function createChannelTransfer(
     idempotencyKey: input.idempotencyKey,
   });
   if (reserved.replayed) {
-    if (isAbandonedReservation(reserved.row)) {
-      return resolveAbandonedReservation(env, repo, reserved.row, {
-        gatewayUrl: input.instance.gatewayUrl,
-        gatewayAuth: input.gatewayAuth,
-        sdpUserId: input.sdpUserId,
-      });
-    }
-    return mapPrivateChannelTransferRow(reserved.row);
+    return input.onReplay(reserved.row);
   }
   const pending = reserved.row;
 

--- a/apps/sdp-api/src/services/private-channels/value-movement.node.test.ts
+++ b/apps/sdp-api/src/services/private-channels/value-movement.node.test.ts
@@ -1,0 +1,255 @@
+import * as spc from "@sdp/private-channels";
+import * as solanaRpc from "@sdp/rpc/solana";
+import { PRIVATE_CHANNEL_ESCROW_PROGRAM_ADDRESS } from "@sdp/spc-escrow";
+import {
+  blockhash,
+  generateKeyPairSigner,
+  getSignatureFromTransaction,
+  getTransactionDecoder,
+} from "@solana/kit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getDb } from "@/db";
+import {
+  createPrivateChannelTransferRepository,
+  mapPrivateChannelDepositRow,
+  mapPrivateChannelTransferRow,
+  mapPrivateChannelWithdrawalRow,
+} from "@/db/repositories";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import { createChannelDeposit, listChannelDeposits } from "./deposit";
+import type { PrivateChannelProjectRpcClient } from "./project-rpc";
+import { createChannelTransfer } from "./transfer";
+import { createChannelWithdrawal, listChannelWithdrawals } from "./withdraw";
+
+const scope = { organizationId: "org_pc_execution", projectId: "prj_pc_execution" };
+const instanceId = "pci_pc_execution";
+const recipient = "So11111111111111111111111111111111111111112";
+let signer: Awaited<ReturnType<typeof generateKeyPairSigner>>;
+let signTransactions: ReturnType<
+  typeof vi.fn<Awaited<ReturnType<typeof generateKeyPairSigner>>["signTransactions"]>
+>;
+let refresh: ReturnType<typeof vi.fn<() => Promise<string>>>;
+let projectRpc: PrivateChannelProjectRpcClient;
+let failSend: Error | undefined;
+let signedBeforeSend: string[];
+
+beforeEach(async () => {
+  await seedTestDatabase(env);
+  const generated = await generateKeyPairSigner();
+  signTransactions = vi.fn(generated.signTransactions);
+  signer = { ...generated, signTransactions };
+  refresh = vi.fn(async () => "fresh-jwt");
+  failSend = undefined;
+  signedBeforeSend = [];
+  projectRpc = {
+    cluster: "devnet",
+    target: {
+      providerId: "custom",
+      projectId: scope.projectId,
+      endpoint: "https://rpc.pc-execution.test",
+      endpointLabel: "PC execution test",
+      headers: {},
+      selectionMode: "project_custom_provider",
+    },
+    probe: async () => ({ ok: true, latencyMs: 0, version: "test" }),
+    rpc: solanaRpc.createRpcFromTransport(
+      vi.fn().mockResolvedValue({
+        jsonrpc: "2.0",
+        id: "pc-execution",
+        result: {
+          context: { slot: 0 },
+          value: {
+            owner: PRIVATE_CHANNEL_ESCROW_PROGRAM_ADDRESS,
+            data: ["", "base64"],
+            executable: false,
+            lamports: 0,
+            rentEpoch: 0,
+            space: 0,
+          },
+        },
+      })
+    ),
+  };
+  const db = getDb(env);
+  await db.batch([
+    db
+      .prepare(
+        "INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, 'PC execution', 'pc-execution', 'enterprise', 'active')"
+      )
+      .bind(scope.organizationId),
+    db.prepare(
+      "INSERT INTO users (id, email, status) VALUES ('usr_pc_execution', 'pc-execution@example.com', 'active')"
+    ),
+    db
+      .prepare(
+        "INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by) VALUES (?, ?, 'PC', 'pc-execution', 'sandbox', 'active', 'usr_pc_execution')"
+      )
+      .bind(scope.projectId, scope.organizationId),
+    db
+      .prepare(`INSERT INTO private_channel_instances
+      (id, organization_id, project_id, gateway_url, auth_url, escrow_program_id, withdraw_program_id, escrow_instance_addr, is_active)
+      VALUES (?, ?, ?, 'https://gateway.example', 'https://auth.example', ?, ?, ?, true)`)
+      .bind(
+        instanceId,
+        scope.organizationId,
+        scope.projectId,
+        PRIVATE_CHANNEL_ESCROW_PROGRAM_ADDRESS,
+        signer.address,
+        signer.address
+      ),
+    db
+      .prepare(`INSERT INTO private_channels (id, organization_id, project_id, instance_id, name)
+      VALUES ('pch_execution', ?, ?, ?, 'PC')`)
+      .bind(scope.organizationId, scope.projectId, instanceId),
+    db
+      .prepare(`INSERT INTO private_channel_users
+      (id, organization_id, project_id, instance_id, spc_user_id, spc_username, spc_credential_ciphertext)
+      VALUES ('pcu_execution', ?, ?, ?, 'spc_sender', 'sender', 'test'), ('pcu_recipient', ?, ?, ?, 'spc_recipient', 'recipient', 'test')`)
+      .bind(
+        scope.organizationId,
+        scope.projectId,
+        instanceId,
+        scope.organizationId,
+        scope.projectId,
+        instanceId
+      ),
+    db
+      .prepare(`INSERT INTO private_channel_verified_wallets (id, organization_id, project_id, user_id, instance_id, wallet_id, pubkey)
+      VALUES ('pcvw_execution', ?, ?, 'pcu_recipient', ?, 'wallet_recipient', ?)`)
+      .bind(scope.organizationId, scope.projectId, instanceId, recipient),
+  ]);
+  vi.spyOn(spc, "getChannelTokenBalance").mockResolvedValue({
+    tokenAccount: signer.address,
+    balance: { amount: "10000000", decimals: 6, uiAmountString: "10" },
+  });
+  vi.spyOn(solanaRpc, "getRecentBlockhash").mockResolvedValue({
+    blockhash: blockhash("11111111111111111111111111111111"),
+    lastValidBlockHeight: 100n,
+  });
+  vi.spyOn(solanaRpc, "sendTransaction").mockImplementation(async (_rpc, bytes) => {
+    const signature = getSignatureFromTransaction(getTransactionDecoder().decode(bytes));
+    const rows = [
+      ...(await listChannelDeposits(env, scope)),
+      ...(await listChannelWithdrawals(env, scope)),
+      ...(await createPrivateChannelTransferRepository(env).listTransfersByProject(scope)).map(
+        mapPrivateChannelTransferRow
+      ),
+    ];
+    // Observe through the history interface at the network boundary: crash recovery
+    // must already be able to find the transaction that is about to leave SDP.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].signature).toBe(signature);
+    signedBeforeSend.push(signature);
+    if (failSend) throw failSend;
+    return signature;
+  });
+  vi.spyOn(solanaRpc, "confirmTransaction").mockImplementation(async (_rpc, signature) => ({
+    signature,
+    slot: 42n,
+    confirmationStatus: "finalized",
+    err: null,
+  }));
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+function execute(kind: "deposit" | "withdrawal" | "transfer") {
+  const input = {
+    ...scope,
+    instance: {
+      id: instanceId,
+      gatewayUrl: "https://gateway.example",
+      escrowProgramId: PRIVATE_CHANNEL_ESCROW_PROGRAM_ADDRESS,
+      escrowInstanceAddr: signer.address,
+    },
+    userId: "usr_pc_execution",
+    wallet: {
+      id: "cw_execution",
+      custodyConfigId: "cfg_execution",
+      walletId: "wallet_execution",
+      publicKey: signer.address,
+      status: "active" as const,
+      label: null,
+      purpose: null,
+      createdAt: new Date().toISOString(),
+    },
+    signer,
+    amount: "1.5",
+    idempotencyKey: "idem_execution",
+    gatewayAuth: { current: "jwt", refresh, pcUserId: "pcu_execution" },
+    projectRpc,
+  };
+  if (kind === "transfer") {
+    return createChannelTransfer(env, {
+      ...input,
+      channelId: "pch_execution",
+      sdpUserId: "usr_pc_execution",
+      recipient: {
+        privateChannelUserId: "pcu_recipient",
+        verifiedWalletId: "pcvw_execution",
+        pubkey: recipient,
+      },
+      onReplay: async (row) => mapPrivateChannelTransferRow(row),
+    });
+  }
+  return kind === "deposit"
+    ? createChannelDeposit(env, {
+        ...input,
+        recipient: signer.address,
+        onReplay: async (row) => mapPrivateChannelDepositRow(row),
+      })
+    : createChannelWithdrawal(env, {
+        ...input,
+        destination: signer.address,
+        onReplay: async (row) => mapPrivateChannelWithdrawalRow(row),
+      });
+}
+
+describe.each(["deposit", "withdrawal", "transfer"] as const)(
+  "Private Channels %s execution",
+  (kind) => {
+    it("uses its prepared signer and persists the signature before sending", async () => {
+      const result = await execute(kind);
+      expect(result.status).toBe("confirmed");
+      expect(result.signature).toBe(signedBeforeSend[0]);
+      expect(signTransactions).toHaveBeenCalledTimes(1);
+    });
+
+    it("only lets one simultaneous request sign and send under the same key", async () => {
+      const results = await Promise.all([execute(kind), execute(kind)]);
+      expect(results[0].id).toBe(results[1].id);
+      expect(signTransactions).toHaveBeenCalledTimes(1);
+      expect(solanaRpc.sendTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it("retains a submitted signature after an unknown send result without signing again", async () => {
+      failSend = Object.assign(new Error("connection reset"), { code: "ECONNRESET" });
+      vi.mocked(solanaRpc.confirmTransaction).mockRejectedValue(new Error("network error"));
+      const result = await execute(kind);
+      expect(result.status).toBe("submitted");
+      expect(result.signature).toBe(signedBeforeSend[0]);
+      expect(signTransactions).toHaveBeenCalledTimes(1);
+      expect(solanaRpc.sendTransaction).toHaveBeenCalledTimes(1);
+    });
+  }
+);
+
+it("keeps the withdrawal signer across one 401 refresh and records the new signature before resending", async () => {
+  failSend = Object.assign(new Error("Unauthorized"), { context: { statusCode: 401 } });
+  refresh.mockImplementation(async () => {
+    failSend = undefined;
+    vi.mocked(solanaRpc.getRecentBlockhash).mockResolvedValue({
+      blockhash: blockhash(signer.address),
+      lastValidBlockHeight: 200n,
+    });
+    return "fresh-jwt";
+  });
+  const result = await execute("withdrawal");
+  expect(result.status).toBe("confirmed");
+  expect(refresh).toHaveBeenCalledTimes(1);
+  expect(signTransactions).toHaveBeenCalledTimes(2);
+  expect(signedBeforeSend).toHaveLength(2);
+  expect(signedBeforeSend[0]).not.toBe(signedBeforeSend[1]);
+  expect(result.signature).toBe(signedBeforeSend[1]);
+});

--- a/apps/sdp-api/src/services/private-channels/wallet-access.ts
+++ b/apps/sdp-api/src/services/private-channels/wallet-access.ts
@@ -1,0 +1,143 @@
+import {
+  type ApiKeyRole,
+  getPermissionsForApiKeyRole,
+  hasAllPermissions,
+  PERMISSIONS,
+  type Permission,
+} from "@sdp/types";
+import { z } from "zod";
+import { getDb } from "@/db";
+import { parsePostgresJson } from "@/db/postgres-utils";
+import type { ApiKeyContext } from "@/lib/auth";
+import {
+  AppError,
+  conflict,
+  forbidden,
+  internalError,
+  providerUnavailable,
+  walletNotFound,
+} from "@/lib/errors";
+import {
+  assertFreshApiKeyActive,
+  assertFreshApiKeyCustodyWalletAccess,
+} from "@/services/api-key-scope.service";
+import { loadApiKeyWalletAuthorization } from "@/services/api-key-wallets.service";
+import { CustodyRuntimeTargets } from "@/services/domain/signing/custody-runtime-target";
+import { createSigningService } from "@/services/domain/signing.service";
+import { createOrgSignerForCustodyWallet } from "@/services/solana";
+import type { CustodyWallet } from "@/services/stores/custody-config.store";
+import type { Env } from "@/types/env";
+
+const explicitPermissionsSchema = z.array(z.enum(PERMISSIONS));
+
+/** Refresh coarse access before authorizing a specific operation or wallet. */
+export async function refreshPrivateChannelAuth(
+  env: Env,
+  auth: ApiKeyContext,
+  projectId: string
+): Promise<ApiKeyContext> {
+  if (auth.authType !== "api_key") return auth;
+  const db = getDb(env);
+  await assertFreshApiKeyActive(db, auth);
+  const current = await db.queryOne<{
+    role: ApiKeyRole;
+    permissions: string | null;
+    signing_wallet_id: string | null;
+  }>(
+    "SELECT role, permissions, signing_wallet_id FROM api_keys WHERE id = ? AND organization_id = ? AND project_id = ?",
+    [auth.apiKeyId, auth.organizationId, projectId]
+  );
+  if (!current) throw forbidden("API key is not authorized for this project");
+  let permissions: Permission[];
+  try {
+    // SQL NULL inherits the current role; an explicit empty array grants nothing.
+    permissions =
+      current.permissions === null
+        ? getPermissionsForApiKeyRole(current.role)
+        : explicitPermissionsSchema.parse(parsePostgresJson<unknown>(current.permissions));
+  } catch {
+    throw internalError("Stored API key permissions are invalid");
+  }
+  return {
+    ...auth,
+    role: current.role,
+    permissions,
+    signingWalletId: current.signing_wallet_id,
+  };
+}
+
+export function listPrivateChannelCustodyWallets(
+  env: Env,
+  organizationId: string,
+  projectId: string
+) {
+  return new CustodyRuntimeTargets(getDb(env), env, new Map()).listWallets({
+    organizationId,
+    projectId,
+    includeAllProviders: true,
+  });
+}
+
+export async function resolvePrivateChannelCustodyWallet(
+  env: Env,
+  auth: ApiKeyContext,
+  projectId: string,
+  selector: string,
+  wallets?: CustodyWallet[],
+  allowAddress = false
+): Promise<CustodyWallet> {
+  const current = await refreshPrivateChannelAuth(env, auth, projectId);
+  if (!hasAllPermissions(current.permissions, ["payments:write"])) {
+    throw new AppError("INSUFFICIENT_PERMISSIONS", "Required permissions: payments:write");
+  }
+  const candidates =
+    wallets ?? (await listPrivateChannelCustodyWallets(env, auth.organizationId, projectId));
+  const matches = candidates.filter(
+    (wallet) => wallet.walletId === selector || (allowAddress && wallet.publicKey === selector)
+  );
+  if (matches.length > 1) throw conflict("Custody wallet ownership is ambiguous");
+  const wallet = matches[0];
+  if (!wallet) throw walletNotFound();
+
+  // Retained records must not silently disappear into an active replacement.
+  const owned = await new CustodyRuntimeTargets(
+    getDb(env),
+    env,
+    new Map()
+  ).findOwnedWalletForMutation({
+    organizationId: auth.organizationId,
+    projectId,
+    walletId: selector,
+    publicKey: allowAddress ? selector : undefined,
+  });
+  if (owned?.id !== wallet.id) throw conflict("Custody wallet ownership is ambiguous");
+  if (current.authType === "api_key") {
+    const bindings = await loadApiKeyWalletAuthorization(
+      getDb(env),
+      current.apiKeyId,
+      current.organizationId,
+      projectId,
+      current.signingWalletId
+    );
+    await assertFreshApiKeyCustodyWalletAccess(getDb(env), { ...current, ...bindings }, wallet.id, [
+      "payments:write",
+    ]);
+  }
+  return wallet;
+}
+
+/** Admit and prepare the same exact wallet before a new SPC session or intent. */
+export async function createPrivateChannelSigner(
+  env: Env,
+  organizationId: string,
+  projectId: string,
+  wallet: CustodyWallet
+) {
+  await createSigningService(env).admitRuntimeExecution(organizationId, projectId, wallet.id);
+  try {
+    return await createOrgSignerForCustodyWallet(env, organizationId, projectId, wallet.id);
+  } catch (error) {
+    if (error instanceof AppError) throw error;
+    throw providerUnavailable("The source custody wallet is not currently signable.");
+  }
+}

--- a/apps/sdp-api/src/services/private-channels/wallets.test.ts
+++ b/apps/sdp-api/src/services/private-channels/wallets.test.ts
@@ -1,11 +1,14 @@
-import { SigningError } from "@sdp/custody/signing";
 import { PrivateChannelError } from "@sdp/private-channels";
 import * as authPkg from "@sdp/private-channels/auth";
+import { PrivySigner } from "@solana/keychain-privy";
+import { address, signatureBytes } from "@solana/kit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getDb } from "@/db";
 import * as repositories from "@/db/repositories";
 import type { ApiKeyContext } from "@/lib/auth";
-import * as solana from "@/services/solana";
-import type { Env } from "@/types/env";
+import { getPrivyProviderAccountFingerprint } from "@/services/custody/privy-credential";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
 import * as gatewayAuth from "./auth/gateway-auth";
 import * as spcSession from "./auth/spc-session";
 import {
@@ -18,14 +21,32 @@ import {
 // widely-used modules like @/db/repositories: spies are transient and restored
 // per test, so this file's mocking cannot reach any other.
 
-const PUBKEY = "So11111111111111111111111111111111111111112";
+const PUBKEY = address("So11111111111111111111111111111111111111112");
 const WALLET_ID = "wal_1";
 
-const auth = {
+const auth: ApiKeyContext = {
+  id: "usr_1",
   organizationId: "org_1",
+  projectId: "prj_1",
   userId: "usr_1",
+  apiKeyId: null,
   authType: "session",
-} as unknown as ApiKeyContext;
+  role: "session",
+  environment: "sandbox",
+  permissions: ["*"],
+  signingWalletId: null,
+  signingWalletIds: [],
+  walletBindings: [],
+};
+const keyAuth: ApiKeyContext = {
+  ...auth,
+  id: "key_pc_verify",
+  authType: "api_key",
+  apiKeyId: "key_pc_verify",
+  userId: null,
+  role: "api_admin",
+  walletScope: "all",
+};
 
 const instance = {
   id: "pci_1",
@@ -40,7 +61,8 @@ const pcUser = {
   disabled_at: null,
 } as unknown as repositories.PrivateChannelUserRow;
 
-const env = {} as Env;
+const originalPrivy = { appId: env.PRIVY_APP_ID, appSecret: env.PRIVY_APP_SECRET };
+let originalByok: string | undefined;
 
 let client: {
   challengeWallet: ReturnType<typeof vi.fn>;
@@ -61,9 +83,38 @@ let principalRepo: {
   findDefaultPrincipal: ReturnType<typeof vi.fn>;
   getById: ReturnType<typeof vi.fn>;
 };
-let signMessages: ReturnType<typeof vi.fn>;
+let signMessages: ReturnType<typeof vi.fn<PrivySigner["signMessages"]>>;
 
-beforeEach(() => {
+beforeEach(async () => {
+  originalByok = env.PRIVY_BYOK_ENABLED;
+  await seedTestDatabase(env);
+  env.PRIVY_APP_ID = "pc-verification-app";
+  env.PRIVY_APP_SECRET = "pc-verification-secret";
+  const db = getDb(env);
+  await db.batch([
+    db.prepare(
+      "INSERT INTO organizations (id, name, slug, tier, status) VALUES ('org_1', 'PC', 'pc-verify', 'enterprise', 'active')"
+    ),
+    db.prepare(
+      "INSERT INTO users (id, email, status) VALUES ('usr_1', 'pc-verify@example.com', 'active')"
+    ),
+    db.prepare(
+      "INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by) VALUES ('prj_1', 'org_1', 'PC', 'pc-verify', 'sandbox', 'active', 'usr_1')"
+    ),
+    db
+      .prepare(
+        "INSERT INTO custody_configs (id, organization_id, project_id, provider, config_encrypted, default_wallet_id, status) VALUES ('cfg_verify', 'org_1', 'prj_1', 'privy', '{}', ?, 'active')"
+      )
+      .bind(WALLET_ID),
+    db
+      .prepare(
+        "INSERT INTO custody_wallets (id, custody_config_id, wallet_id, public_key, status) VALUES ('cw_verify', 'cfg_verify', ?, ?, 'active')"
+      )
+      .bind(WALLET_ID, PUBKEY),
+    db.prepare(`INSERT INTO api_keys
+      (id, organization_id, project_id, created_by, name, key_prefix, key_hash, role, permissions, status)
+      VALUES ('key_pc_verify', 'org_1', 'prj_1', 'usr_1', 'PC verification', 'pcverify', 'pcverify', 'api_admin', NULL, 'active')`),
+  ]);
   verifiedRepo = {
     upsert: vi.fn().mockResolvedValue({
       id: "pcvw_1",
@@ -102,7 +153,9 @@ beforeEach(() => {
     deleteWallet: vi.fn().mockResolvedValue(undefined),
     login: vi.fn(),
   };
-  signMessages = vi.fn().mockResolvedValue([{ [PUBKEY]: new Uint8Array(64) }]);
+  signMessages = vi
+    .fn<PrivySigner["signMessages"]>()
+    .mockResolvedValue([{ [PUBKEY]: signatureBytes(new Uint8Array(64)) }]);
 
   vi.spyOn(repositories, "createPrivateChannelInstanceRepository").mockReturnValue({
     getActiveByProject: vi.fn().mockResolvedValue(instance),
@@ -115,17 +168,113 @@ beforeEach(() => {
   );
   vi.spyOn(authPkg, "createAuthClient").mockReturnValue(client as never);
   vi.spyOn(spcSession, "getSpcSession").mockResolvedValue({ token: "jwt", username: "u" });
-  vi.spyOn(solana, "createOrgSigner").mockResolvedValue({
-    address: PUBKEY,
-    signMessages,
-  } as never);
+  vi.stubGlobal(
+    "fetch",
+    vi.fn<typeof fetch>(async () =>
+      Response.json({ address: PUBKEY, chain_type: "solana", id: WALLET_ID })
+    )
+  );
+  vi.spyOn(PrivySigner, "create");
+  vi.spyOn(PrivySigner.prototype, "signMessages").mockImplementation(signMessages);
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  env.PRIVY_APP_ID = originalPrivy.appId;
+  env.PRIVY_APP_SECRET = originalPrivy.appSecret;
+  env.PRIVY_BYOK_ENABLED = originalByok;
 });
 
 describe("verifyPrivateChannelWallet", () => {
+  it("verifies with role permissions when explicit permissions are absent", async () => {
+    const { row } = await verifyPrivateChannelWallet(env, keyAuth, "prj_1", WALLET_ID);
+    expect(row.pubkey).toBe(PUBKEY);
+    expect(signMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["[]", '["payments:read"]'])(
+    "does not inherit role permissions over explicit permissions %s",
+    async (permissions) => {
+      await getDb(env)
+        .prepare("UPDATE api_keys SET permissions = ? WHERE id = ?")
+        .bind(permissions, keyAuth.apiKeyId)
+        .run();
+      await expect(
+        verifyPrivateChannelWallet(env, keyAuth, "prj_1", WALLET_ID)
+      ).rejects.toMatchObject({ code: "INSUFFICIENT_PERMISSIONS" });
+      expect(PrivySigner.create).not.toHaveBeenCalled();
+      expect(client.challengeWallet).not.toHaveBeenCalled();
+    }
+  );
+
+  it("rejects malformed permissions before verification can sign", async () => {
+    await getDb(env)
+      .prepare("UPDATE api_keys SET permissions = ? WHERE id = ?")
+      .bind('"payments:write"', keyAuth.apiKeyId)
+      .run();
+    await expect(
+      verifyPrivateChannelWallet(env, keyAuth, "prj_1", WALLET_ID)
+    ).rejects.toMatchObject({
+      code: "INTERNAL_ERROR",
+      message: "Stored API key permissions are invalid",
+    });
+    expect(PrivySigner.create).not.toHaveBeenCalled();
+    expect(client.challengeWallet).not.toHaveBeenCalled();
+  });
+
+  it("rejects revoked keys even when their role would allow verification", async () => {
+    await getDb(env)
+      .prepare("UPDATE api_keys SET status = 'revoked' WHERE id = ?")
+      .bind(keyAuth.apiKeyId)
+      .run();
+    await expect(
+      verifyPrivateChannelWallet(env, keyAuth, "prj_1", WALLET_ID)
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(PrivySigner.create).not.toHaveBeenCalled();
+    expect(client.challengeWallet).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])(
+    "uses the exact Connection for verification only when admitted (enabled=%s)",
+    async (enabled) => {
+      env.PRIVY_BYOK_ENABLED = String(enabled);
+      const db = getDb(env);
+      await db.batch([
+        db.prepare("UPDATE custody_configs SET default_wallet_id = NULL WHERE id = 'cfg_verify'"),
+        db.prepare(`INSERT INTO provider_credentials
+        (id, organization_id, project_id, provider, label, scope, source, storage_backend, status, created_by)
+        VALUES ('pcred_verify', 'org_1', 'prj_1', 'privy', 'PC', 'project', 'runtime', 'runtime_env', 'active', 'usr_1')`),
+        db.prepare(`INSERT INTO custody_connections
+        (id, organization_id, project_id, provider, scope, provider_credential_id, provider_credential_scope_key, status, created_by)
+        VALUES ('conn_verify', 'org_1', 'prj_1', 'privy', 'project', 'pcred_verify', 'prj_1', 'pending', 'usr_1')`),
+        db.prepare(
+          "UPDATE custody_wallets SET custody_config_id = NULL, custody_connection_id = 'conn_verify' WHERE id = 'cw_verify'"
+        ),
+        db
+          .prepare(`UPDATE custody_connections SET default_custody_wallet_id = 'cw_verify', status = 'active',
+        provider_account_fingerprint = ?, activated_at = sdp_iso_now(), last_check_status = 'success', last_check_at = sdp_iso_now()
+        WHERE id = 'conn_verify'`)
+          .bind(await getPrivyProviderAccountFingerprint("pc-verification-app")),
+      ]);
+      if (enabled) {
+        expect((await verifyPrivateChannelWallet(env, auth, "prj_1", WALLET_ID)).row.pubkey).toBe(
+          PUBKEY
+        );
+        expect(PrivySigner.create).toHaveBeenCalledWith(
+          expect.objectContaining({ walletId: WALLET_ID, appId: "pc-verification-app" })
+        );
+        expect(signMessages).toHaveBeenCalledTimes(1);
+      } else {
+        await expect(
+          verifyPrivateChannelWallet(env, auth, "prj_1", WALLET_ID)
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+        expect(PrivySigner.create).not.toHaveBeenCalled();
+        expect(spcSession.getSpcSession).not.toHaveBeenCalled();
+        expect(client.challengeWallet).not.toHaveBeenCalled();
+      }
+    }
+  );
   it("treats an SPC 409 (already verified) as success and still upserts the mirror", async () => {
     client.verifyWallet.mockRejectedValue(
       new PrivateChannelError("CONFLICT", "wallet already verified")
@@ -169,7 +318,7 @@ describe("verifyPrivateChannelWallet", () => {
       "fresh",
       expect.objectContaining({ nonce: "nB" })
     );
-    expect(solana.createOrgSigner).toHaveBeenCalledTimes(1);
+    expect(PrivySigner.create).toHaveBeenCalledTimes(1);
     expect(signMessages).toHaveBeenCalledTimes(2);
     expect(verifiedRepo.upsert).toHaveBeenCalledTimes(1);
   });
@@ -276,19 +425,16 @@ describe("verifyPrivateChannelWallet", () => {
 
   it("resolves the signer before requesting the SPC challenge", async () => {
     await verifyPrivateChannelWallet(env, auth, "prj_1", WALLET_ID);
-    const signerOrder = vi.mocked(solana.createOrgSigner).mock.invocationCallOrder[0];
+    const signerOrder = vi.mocked(PrivySigner.create).mock.invocationCallOrder[0];
     const challengeOrder = client.challengeWallet.mock.invocationCallOrder[0];
     expect(signerOrder).toBeLessThan(challengeOrder);
   });
 
-  it("propagates a SigningError unwrapped (so onError maps it, e.g. 404) and skips the challenge", async () => {
-    vi.spyOn(solana, "createOrgSigner").mockRejectedValue(
-      new SigningError("Custody wallet not found", "WALLET_NOT_FOUND")
-    );
-
+  it("rejects a missing custody wallet before opening the session or challenge", async () => {
     await expect(
       verifyPrivateChannelWallet(env, auth, "prj_1", "wal_missing")
-    ).rejects.toBeInstanceOf(SigningError);
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(spcSession.getSpcSession).not.toHaveBeenCalled();
     expect(client.challengeWallet).not.toHaveBeenCalled();
   });
 

--- a/apps/sdp-api/src/services/private-channels/wallets.ts
+++ b/apps/sdp-api/src/services/private-channels/wallets.ts
@@ -2,12 +2,13 @@
  * SPC wallet-verification orchestration (the write path) + the default-identity read.
  *
  * Drives the SPC auth handshake for one SDP custody wallet:
- *   1. resolve the connected instance + the selected project identity's SPC user
- *   2. open an SPC JWT handle (KV-cached via ./auth/gateway-auth)
- *   3. `challenge-wallet` → sign the challenge with THAT wallet → `verify-wallet`
- *   4. persist the verification (idempotent per (user, instance, pubkey))
+ *   1. authorize/admit the exact custody wallet and prepare its signer
+ *   2. resolve the connected instance + the selected project identity's SPC user
+ *   3. open an SPC JWT handle (KV-cached via ./auth/gateway-auth)
+ *   4. `challenge-wallet` → sign the challenge with THAT wallet → `verify-wallet`
+ *   5. persist the verification (idempotent per (user, instance, pubkey))
  *
- * Signing is wallet-specific via `createOrgSigner(...walletId)` (not
+ * Signing is exact-wallet-specific via `createOrgSignerForCustodyWallet` (not
  * `SigningService.sign`, which signs with the scope-default wallet). The
  * resolved signer is a message-partial-signer at runtime; we sign the challenge
  * as raw bytes — matching SPC's `signature.verify(pubkey, message.as_bytes())` —
@@ -31,9 +32,9 @@ import {
 import type { ApiKeyContext } from "@/lib/auth";
 import { AppError, forbidden, notFound, providerNotConfigured } from "@/lib/errors";
 import { getLogger } from "@/runtime/logger";
-import { createOrgSigner } from "@/services/solana";
 import type { Env } from "@/types/env";
 import { openSpcAuthContext, type SpcAuthContext, withSpcAuth } from "./auth/gateway-auth";
+import { createPrivateChannelSigner, resolvePrivateChannelCustodyWallet } from "./wallet-access";
 
 const base58 = getBase58Codec();
 
@@ -161,6 +162,11 @@ export async function verifyPrivateChannelWallet(
   walletId: string,
   principalId?: string
 ): Promise<{ row: PrivateChannelVerifiedWalletRow; instance: PrivateChannelInstanceRow }> {
+  const wallet = await resolvePrivateChannelCustodyWallet(env, auth, projectId, walletId);
+  const signer = await createPrivateChannelSigner(env, auth.organizationId, projectId, wallet);
+  if (!isMessagePartialSigner(signer)) {
+    throw new AppError("SIGNING_FAILED", "This wallet cannot sign verification messages.");
+  }
   const { scope, instance, pcUser, client, spcAuth } = await resolveWalletSession(
     env,
     auth,
@@ -168,13 +174,7 @@ export async function verifyPrivateChannelWallet(
     principalId
   );
 
-  // Resolve the wallet to a signer BEFORE the SPC challenge, so an
-  // invalid/unsignable wallet fails without minting a nonce. Kept outside
-  // withSpcAuth so a 401 retry does not re-derive the signer.
-  const signer = await createOrgSigner(env, auth.organizationId, projectId, walletId);
-  if (!isMessagePartialSigner(signer)) {
-    throw new AppError("SIGNING_FAILED", "This wallet cannot sign verification messages.");
-  }
+  // The exact signer is retained across the challenge retry.
   const pubkey = signer.address;
 
   // Retry unit is challenge → sign → verify (restarted from challenge on 401).

--- a/apps/sdp-api/src/services/private-channels/withdraw.ts
+++ b/apps/sdp-api/src/services/private-channels/withdraw.ts
@@ -41,6 +41,7 @@ import {
   type Signature,
   setTransactionMessageFeePayerSigner,
   setTransactionMessageLifetimeUsingBlockhash,
+  type TransactionSigner,
 } from "@solana/kit";
 import { signTransactionMessageWithSigners } from "@solana/signers";
 import { isPostgresUniqueViolation } from "@/db/postgres-utils";
@@ -51,13 +52,8 @@ import {
   type PrivateChannelWithdrawalRow,
 } from "@/db/repositories";
 import { AppError, badRequest } from "@/lib/errors";
-import {
-  buildPrivateChannelWithdrawalFingerprint,
-  isAbandonedReservation,
-  resolveIdempotencyReplay,
-} from "@/lib/idempotency";
+import { buildPrivateChannelWithdrawalFingerprint } from "@/lib/idempotency";
 import { getLogger } from "@/runtime/logger";
-import * as solanaServices from "@/services/solana";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import type { Env } from "@/types/env";
 import { type SpcAuthContext, withGatewayRpc } from "./auth/gateway-auth";
@@ -87,6 +83,9 @@ export interface CreateChannelWithdrawalInput {
   userId: string | null;
   /** Custody wallet the burn is signed from (the burn `user` / balance owner). */
   wallet: CustodyWallet;
+  signer: TransactionSigner;
+  /** Authorize and match the winning operation again after an idempotency race. */
+  onReplay: (row: PrivateChannelWithdrawalRow) => Promise<PrivateChannelWithdrawal>;
   /** UI decimal amount (e.g. "1.5"). */
   amount: string;
   /** Mint to withdraw; must be on the instance's allowlist. Defaults to its first entry. */
@@ -122,6 +121,7 @@ async function broadcastWithdrawal(
     organizationId: string;
     projectId: string;
     wallet: CustodyWallet;
+    signer: TransactionSigner;
     mint: Address;
     /** Program owning the mint; seeds the burn's `tokenAccount` derivation. */
     tokenProgram: Address;
@@ -141,12 +141,7 @@ async function broadcastWithdrawal(
   // Signer derivation + the (blockhash-independent) burn instruction are built ONCE,
   // outside the retried gateway unit — a 401 retry re-signs against a fresh blockhash
   // but must not re-derive the signer.
-  const signer = await solanaServices.createOrgSigner(
-    env,
-    input.organizationId,
-    input.projectId,
-    input.wallet.walletId
-  );
+  const signer = input.signer;
   if (signer.address !== input.wallet.publicKey) {
     throw badRequest("Resolved signing wallet does not match the withdrawal wallet");
   }
@@ -229,7 +224,7 @@ async function reserveWithdrawal(
     if (!isPostgresUniqueViolation(error)) {
       throw error;
     }
-    const raced = await resolveIdempotencyReplay(findExisting, fingerprint);
+    const raced = await findExisting();
     if (!raced) {
       throw error;
     }
@@ -253,7 +248,7 @@ async function reserveWithdrawal(
  * The `pending` CAS means a still-live original wins the race and these writes
  * are no-ops.
  */
-async function resolveAbandonedReservation(
+export async function resolveAbandonedWithdrawalReservation(
   env: Env,
   repo: PrivateChannelWithdrawalRepository,
   row: PrivateChannelWithdrawalRow,
@@ -364,15 +359,9 @@ export async function createChannelWithdrawal(
   // The replay lookup comes FIRST, ahead of the balance read, because a retry of
   // an already-burned withdrawal must return that withdrawal — the balance it
   // spent is gone, so re-checking would reject the caller's own success.
-  const replay = await resolveIdempotencyReplay(findReplay, fingerprint);
+  const replay = await findReplay();
   if (replay) {
-    if (isAbandonedReservation(replay)) {
-      return resolveAbandonedReservation(env, repo, replay, {
-        gatewayUrl: instance.gatewayUrl,
-        gatewayAuth: input.gatewayAuth,
-      });
-    }
-    return mapPrivateChannelWithdrawalRow(replay);
+    return input.onReplay(replay);
   }
 
   // Reject an over-withdrawal before it reaches the chain. The burn program would
@@ -390,9 +379,8 @@ export async function createChannelWithdrawal(
     throw new AppError("INSUFFICIENT_TOKEN_BALANCE");
   }
 
-  // The reservation is taken BEFORE the signer is derived or the burn is
-  // broadcast, so a retry — or a second request racing the first — can only ever
-  // reach the row the winner created.
+  // The route has admitted and prepared its exact signer. Only the request that
+  // wins this reservation may sign or send; a loser must authorize the winner.
   const { row: created, replayed } = await reserveWithdrawal(repo, fingerprint, findReplay, {
     organizationId,
     projectId,
@@ -414,13 +402,7 @@ export async function createChannelWithdrawal(
     idempotencyKey: input.idempotencyKey,
   });
   if (replayed) {
-    if (isAbandonedReservation(created)) {
-      return resolveAbandonedReservation(env, repo, created, {
-        gatewayUrl: instance.gatewayUrl,
-        gatewayAuth: input.gatewayAuth,
-      });
-    }
-    return mapPrivateChannelWithdrawalRow(created);
+    return input.onReplay(created);
   }
 
   let latest: PrivateChannelWithdrawalRow = created;
@@ -438,6 +420,7 @@ export async function createChannelWithdrawal(
       organizationId,
       projectId,
       wallet,
+      signer: input.signer,
       mint: address(mint),
       tokenProgram: address(tokenProgram),
       destination: address(destination),


### PR DESCRIPTION
## What changed

**Authorization order for value movement** — `POST /v1/private-channels/{deposits, withdrawals, channels/:id/transfers, wallets/:id/verify}`
- The exact custody wallet record is resolved (409 when two records match the selector), its API-key wallet bindings are re-read from the DB, it is admitted through the custody runtime (`admitRuntimeExecution`), and the signer is derived for that record — all **before** any SPC session, balance read or idempotency reservation. New seam: `services/private-channels/wallet-access.ts`.
- Coarse access is fresh too: key status/expiry and role-or-explicit permissions are read from `api_keys` on every one of these POSTs, not from the KV snapshot. `permissions = NULL` inherits the *current* role; `[]` grants nothing.

**Replay and recovery** — `routes/private-channels/replay.ts`
- A replay by `Idempotency-Key` requires current `payments:write` and authorizes the *recorded* source: walletId, public key and instance must still resolve for the caller. The recorded result is returned with no new signer and no SPC session.
- Abandoned `pending` rows (>10 min) are recovered under the same rule by the existing resolvers: failed if never signed, otherwise settled from the recorded signature through a gateway read. Still no signer.
- A counterparty `recipient` / `destination` address that matches custody records with different keys → 409 instead of first match.

**Transfers unblocked**
- Migration `0094`: a `pending` transfer row may carry `signature` (signature-before-send). The 0040 CHECK rejected that write.

**Tests**
- Route suites run the real app and authorization seam on Postgres/Redis testcontainers with the Privy HTTP API stubbed; execution below the service boundary stays mocked there.
- New `value-movement.node.test.ts` executes deposit, withdrawal and transfer against real Postgres: the `sendTransaction` stub asserts the signature is already visible in history before the bytes leave; one signer under concurrent identical keys; an unknown send outcome stays `submitted`.

## Why

- **Wrong order.** Deposits and withdrawals derived the signer inside the broadcast step, after the reservation and the gateway session. A provider failure there — or a Connection wallet refused by the BYOK flag — was caught and stored as a `failed` row, answered 200 with `status: failed`, and consumed the caller's idempotency key.
- **Inexact source.** The source was the first match by walletId or address in a provider wallet list, signed through `createOrgSigner(walletId)` rather than the exact custody record. Retained or duplicate records were invisible.
- **Stale authority.** Permissions and bindings came from the cached key (up to 1 h): a key revoked or narrowed in the DB kept moving value until the cache expired or was swept.
- **Replay trusted the retry.** A replay was authorized against whatever record the retry's walletId resolves to *now* — a replacement record with the same walletId passed — then returned the recorded operation.
- **Transfers were broken.** Transfer path records the signature on the still-pending row; the 0040 CHECK rejects that write, so every member transfer failed before send. Service tests mock the repository; the new real-Postgres execution test is what caught it.

## Impact

- **API consumers and dashboard sessions:** same routes and bodies. Failures move earlier and get stricter (table below). Keys with `permissions = NULL` follow the DB role, not the cached one.
- **BYOK:** a Connection wallet enrolled in a Private Channels principal can deposit, withdraw, transfer and verify when `PRIVY_BYOK_ENABLED=true`. With the flag off it is refused with 403 `runtime_execution_paused` before any SPC session. Config wallets are unaffected by the flag.
- **Cost:** a few extra small DB reads per money POST, and the Privy signer round-trip now precedes the balance check, so a request that then fails validation still costs one provider call.
- Feature stays behind `PRIVATE_CHANNELS_ENABLED`, devnet only.

## Pre/post release actions

1. **Migrate.** `0094_private_channel_transfer_signed_reservation.sql` — transactional constraint swap that validates existing rows (small table). The runner applies by filename set; verified it applies on a DB already at 0096.
2. **Audit stored permissions.** Rows with non-array `api_keys.permissions` now fail PC POSTs with 500 `Stored API key permissions are invalid`:
  ```sql
    SELECT id
    FROM api_keys
    WHERE permissions IS NOT NULL
      AND CASE
        WHEN NOT pg_input_is_valid(permissions, 'jsonb') THEN true
        WHEN jsonb_typeof(permissions::jsonb) <> 'array' THEN true
        ELSE EXISTS (
          SELECT 1
          FROM jsonb_array_elements(permissions::jsonb) AS item(value)
          WHERE jsonb_typeof(item.value) <> 'string'
            OR (item.value #>> '{}') <> ALL (ARRAY[
              'tokens:read', 'tokens:write', 'tokens:admin',
              'payments:read', 'payments:write', 'earn:read',
              'earn:write', 'counterparties:read', 'counterparties:write',
              'wallets:read', 'wallets:write', 'compliance:read',
              'compliance:write', 'webhooks:read', 'webhooks:write',
              'transactions:read', 'transactions:write', 'audit:read',
              'org:read', 'org:write', 'org:admin',
              'api-keys:read', 'api-keys:write', 'projects:read',
              'projects:write', 'projects:admin', 'project-members:read',
              'project-members:write', 'sessions:read', 'sessions:write',
              'custody:read', 'custody:write', 'custody:admin',
              '*'
            ]::text[])
        )
      END;
  ```
   Unknown permission names inside the array fail the same way.
3. **After release, watch** 409 `Custody wallet ownership is ambiguous` (duplicate `custody_wallets` for one selector → data fix) and 500 `Stored API key permissions are invalid`.
4. **Rollback** = revert the app. The relaxed CHECK accepts everything the old one did, so 0094 can stay.

## Result validation

| Check | Result |
|---|---|
| `pnpm --filter @sdp/api typecheck` | clean |
| `pnpm --filter @sdp/api lint` | clean for the diff; 1 pre-existing warning in untouched `api-key-scope.service.ts:630` |
| `pnpm --filter @sdp/api exec vitest run private-channels` | 23 files, 314 tests passed (the 6 changed files: 186). Needs Docker: Postgres 16 + Redis 7 testcontainers; SPC gateway and Privy HTTP stubbed |
| `vitest run src/security/value-moving-conformance.node.test.ts` | passed; the contract now points at the handler-level authorization seam |
| Schema before/after | `psql \d` on a throwaway `postgres:16-alpine`: main's migrations, then the branch's |
| Live local API against a real SPC gateway / devnet | **not run** (external services). Route tests exercise the real app end-to-end below the gateway boundary |

## Does it affect current flows & behavior and how

**before** — deposit / withdrawal on `main`:
1. `payments:write` from the cached key; source = first provider-list match; bindings from the cache
2. SPC session, balance read, reserve `pending` row
3. derive signer → sign → record signature → send. A signer failure here becomes a `failed` row under the caller's key.

**after** — every value-moving POST:

```mermaid
flowchart TD
  A[POST deposit / withdrawal / transfer] --> B[requireMovementWrite<br/>key status + role/permissions from DB]
  B --> C{row for Idempotency-Key?}
  C -- yes --> R1[authorize the recorded source<br/>exact record, fresh bindings]
  R1 --> R2[fingerprint match]
  R2 --> R3{abandoned pending?}
  R3 -- yes --> R4[fail if never signed,<br/>else settle from the recorded signature] --> Z[200 recorded result<br/>no signer]
  R3 -- no --> Z
  C -- no --> N1[resolve exact source wallet<br/>409 if ambiguous, fresh bindings]
  N1 --> N2[admitRuntimeExecution + signer for the record<br/>403 BYOK paused · 503 provider]
  N2 --> N3[SPC session, balance read]
  N3 --> N4[reserve pending row<br/>lost race → authorize the winner via onReplay]
  N4 --> N5[sign → record signature on the pending row → send]
```

**Status changes** (reconstructed from the route tests; live API not run):

| Situation | before | after |
|---|---|---|
| Key revoked / narrowed in DB, cache still valid | 200 | 403 |
| Two custody records match the source selector | silently picks one | 409 |
| Address selector collides with a retained record | silently picks the active one | 409 |
| Replay when the original record is inactive and a replacement shares its walletId | replacement authorized | 409 |
| Signer provider unavailable (deposit / withdrawal) | 200 with `status: failed`, key consumed | 503, nothing recorded |
| Connection source, `PRIVY_BYOK_ENABLED=false` | same `failed` row, after reservation | 403 before any session |
| Transfer: signer address ≠ verified source | 400 | 409 |
| Malformed `api_keys.permissions` | not validated | 500 |
| Any member transfer | `failed` before send (CHECK) | submitted / confirmed |

**Schema before/after** — `psql \d private_channel_transfers`, trimmed to the changed constraint:

```text
before  "private_channel_transfers_result_check" CHECK (status = 'pending' AND signature IS NULL AND failure_reason IS NULL OR …)
after   "private_channel_transfers_result_check" CHECK (status = 'pending' AND failure_reason IS NULL OR …)
```

## Known gaps

- No `policyGate` on Private Channels value movement and no private-channel family in `WALLET_OPERATION_FAMILIES` (pre-existing; product decision).
- The four signing POSTs are not behind `meteredQuota`; the Privy call now precedes the balance check (pre-existing; mirror `dvp-fund`).
- `api_keys.permissions` is parsed in three places with different tolerance (cache loader, approved-operation replay, this PR); consolidate into one strict parser.
- Fresh-auth reads repeat up to 3× per POST; thread the refreshed context (perf only).
- Deposits have no abandoned-reservation recovery (pre-existing; withdrawals and transfers do).
- Lost-race re-authorization has a route test for transfers only; deposits and withdrawals share the code path.

## Notes

- Three commits: the migration comes first so the feature commit runs against the relaxed CHECK. The `0094` prefix is shared with `0094_dvp_…`; the runner selects by filename, not by cursor.

## Beyond spec

- `POST /wallets/:walletId/verify` OpenAPI: `security` now lists `apiKeyAuth` (runtime already accepted keys through the router auth; the spec now matches) and adds 409.
- Transfer signer / verified-source mismatch: 400 → 409 (the check moved into `CustodyRuntimeTargets.assertSignerMatchesWallet`).
- Malformed `api_keys.permissions` → 500 `INTERNAL_ERROR` on PC POSTs instead of lenient parsing; failing loudly at the boundary.
- Migration 0094 relaxes `private_channel_transfers_result_check` — forced: transfers were broken
- Counterparty `recipient` / `destination` matching several custody records with different keys → 409 (was first match).